### PR TITLE
Feat : 게임 소켓 이벤트 핸들러 구현 + Zustand + Immer 기반 게임 상태 스토어 구현

### DIFF
--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,6 +1,8 @@
 import { http, HttpResponse } from 'msw'
+import { gameHandlers } from './handlers/game.handler'
 
 export const handlers = [
+  ...gameHandlers,
   http.get('/api/health', () => {
     return HttpResponse.json({ status: 'ok' })
   }),

--- a/src/mocks/handlers/game.handler.ts
+++ b/src/mocks/handlers/game.handler.ts
@@ -7,7 +7,7 @@ export const gameHandlers = [
    * Emits SOCK-010 (dice_rolled) and SOCK-011 (player_moved) payloads according to spec.
    */
   http.post('/api/game/roll-dice', async ({ request }) => {
-    const { playerId } = (await request.json()) as { playerId: string }
+    const { player_id } = (await request.json()) as { player_id: string }
 
     const dice1 = Math.floor(Math.random() * 6) + 1
     const dice2 = Math.floor(Math.random() * 6) + 1
@@ -16,7 +16,6 @@ export const gameHandlers = [
 
     // Simulate server emitting events
     setTimeout(() => {
-      // Use cast to access listeners without creating lint errors
       const socketWithListeners = socket as unknown as {
         listeners: (e: string) => Array<(d: unknown) => void>
       }
@@ -24,7 +23,7 @@ export const gameHandlers = [
 
       diceListeners.forEach((cb) =>
         cb({
-          player_id: playerId,
+          player_id,
           dice: [dice1, dice2],
           is_double: isDouble,
           double_count: isDouble ? 1 : 0,
@@ -35,7 +34,7 @@ export const gameHandlers = [
         const moveListeners = socketWithListeners.listeners('player_moved')
         moveListeners.forEach((cb) =>
           cb({
-            player_id: playerId,
+            player_id,
             from_index: 0,
             to_index: total,
             trigger: 'dice',

--- a/src/mocks/handlers/game.handler.ts
+++ b/src/mocks/handlers/game.handler.ts
@@ -1,0 +1,44 @@
+import { http, HttpResponse } from 'msw'
+import { socket } from '../../lib/socket'
+
+export const gameHandlers = [
+  /**
+   * Mocking dice roll
+   * Since this is MSW (HTTP), we simulate the server receiving a roll-dice request
+   * and subsequently emitting socket events to all players.
+   */
+  http.post('/api/game/roll-dice', async ({ request }) => {
+    const { playerId } = (await request.json()) as { playerId: string }
+
+    const dice1 = Math.floor(Math.random() * 6) + 1
+    const dice2 = Math.floor(Math.random() * 6) + 1
+    const total = dice1 + dice2
+
+    // Simulate server emitting events
+    setTimeout(() => {
+      // Use a type-safe way to access listeners if possible, otherwise use a more specific cast
+      // @ts-expect-error - socket.listeners is not in the type definition but exists in socket.io-client
+      const listeners = (
+        socket as unknown as {
+          listeners: (e: string) => Array<(d: unknown) => void>
+        }
+      ).listeners('dice_rolled')
+      listeners.forEach((cb) => cb({ playerId, dice: [dice1, dice2] }))
+
+      setTimeout(() => {
+        // @ts-expect-error - socket.listeners is not in the type definition
+        const moveListeners = (
+          socket as unknown as {
+            listeners: (e: string) => Array<(d: unknown) => void>
+          }
+        ).listeners('player_moved')
+        moveListeners.forEach((cb) => cb({ playerId, position: total }))
+      }, 500)
+    }, 100)
+
+    return HttpResponse.json({
+      success: true,
+      dice: [dice1, dice2],
+    })
+  }),
+]

--- a/src/mocks/handlers/game.handler.ts
+++ b/src/mocks/handlers/game.handler.ts
@@ -4,26 +4,32 @@ import { socket } from '../../lib/socket'
 export const gameHandlers = [
   /**
    * Mocking dice roll
-   * Since this is MSW (HTTP), we simulate the server receiving a roll-dice request
-   * and subsequently emitting socket events to all players.
+   * Emits SOCK-010 (dice_rolled) and SOCK-011 (player_moved) payloads according to spec.
    */
   http.post('/api/game/roll-dice', async ({ request }) => {
     const { playerId } = (await request.json()) as { playerId: string }
 
     const dice1 = Math.floor(Math.random() * 6) + 1
     const dice2 = Math.floor(Math.random() * 6) + 1
+    const isDouble = dice1 === dice2
     const total = dice1 + dice2
 
     // Simulate server emitting events
     setTimeout(() => {
-      // Use a type-safe way to access listeners if possible, otherwise use a more specific cast
       // @ts-expect-error - socket.listeners is not in the type definition but exists in socket.io-client
-      const listeners = (
+      const diceListeners = (
         socket as unknown as {
           listeners: (e: string) => Array<(d: unknown) => void>
         }
       ).listeners('dice_rolled')
-      listeners.forEach((cb) => cb({ playerId, dice: [dice1, dice2] }))
+      diceListeners.forEach((cb) =>
+        cb({
+          player_id: playerId,
+          dice: [dice1, dice2],
+          is_double: isDouble,
+          double_count: isDouble ? 1 : 0,
+        })
+      )
 
       setTimeout(() => {
         // @ts-expect-error - socket.listeners is not in the type definition
@@ -32,8 +38,17 @@ export const gameHandlers = [
             listeners: (e: string) => Array<(d: unknown) => void>
           }
         ).listeners('player_moved')
-        moveListeners.forEach((cb) => cb({ playerId, position: total }))
-      }, 500)
+        moveListeners.forEach((cb) =>
+          cb({
+            player_id: playerId,
+            from_index: 0,
+            to_index: total,
+            trigger: 'dice',
+            pass_go: false,
+            pass_go_salary: 200000,
+          })
+        )
+      }, 800)
     }, 100)
 
     return HttpResponse.json({

--- a/src/mocks/handlers/game.handler.ts
+++ b/src/mocks/handlers/game.handler.ts
@@ -16,12 +16,12 @@ export const gameHandlers = [
 
     // Simulate server emitting events
     setTimeout(() => {
-      // @ts-expect-error - socket.listeners is not in the type definition but exists in socket.io-client
-      const diceListeners = (
-        socket as unknown as {
-          listeners: (e: string) => Array<(d: unknown) => void>
-        }
-      ).listeners('dice_rolled')
+      // Use cast to access listeners without creating lint errors
+      const socketWithListeners = socket as unknown as {
+        listeners: (e: string) => Array<(d: unknown) => void>
+      }
+      const diceListeners = socketWithListeners.listeners('dice_rolled')
+
       diceListeners.forEach((cb) =>
         cb({
           player_id: playerId,
@@ -32,12 +32,7 @@ export const gameHandlers = [
       )
 
       setTimeout(() => {
-        // @ts-expect-error - socket.listeners is not in the type definition
-        const moveListeners = (
-          socket as unknown as {
-            listeners: (e: string) => Array<(d: unknown) => void>
-          }
-        ).listeners('player_moved')
+        const moveListeners = socketWithListeners.listeners('player_moved')
         moveListeners.forEach((cb) =>
           cb({
             player_id: playerId,

--- a/src/services/socket/game.handler.ts
+++ b/src/services/socket/game.handler.ts
@@ -1,0 +1,127 @@
+import { socket } from '../../lib/socket'
+import { useGameStore } from '../../stores/game.store'
+import { Player, Tile, BuildingLevel } from '../../types/domain'
+
+export const setupGameHandlers = () => {
+  const gameStore = useGameStore.getState()
+
+  socket.on(
+    'game_state',
+    (state: {
+      players: Player[]
+      tiles: Tile[]
+      currentTurnId: string
+      round: number
+    }) => {
+      gameStore.setGameState({
+        players: state.players,
+        tiles: state.tiles,
+        currentTurnId: state.currentTurnId,
+        round: state.round,
+      })
+    }
+  )
+
+  socket.on(
+    'turn_start',
+    ({ playerId, round }: { playerId: string; round: number }) => {
+      gameStore.setGameState({
+        currentTurnId: playerId,
+        round,
+      })
+    }
+  )
+
+  socket.on(
+    'dice_rolled',
+    ({ playerId, dice }: { playerId: string; dice: number[] }) => {
+      console.log(`Player ${playerId} rolled: ${dice[0]}, ${dice[1]}`)
+    }
+  )
+
+  socket.on(
+    'player_moved',
+    ({ playerId, position }: { playerId: string; position: number }) => {
+      gameStore.updatePlayer(playerId, { position })
+    }
+  )
+
+  socket.on(
+    'tile_purchased',
+    ({
+      playerId,
+      tileId,
+      buildingLevel,
+      money,
+    }: {
+      playerId: string
+      tileId: number
+      buildingLevel: BuildingLevel
+      money: number
+    }) => {
+      // Assuming tileId refers to tile index for now, or we should find by id
+      gameStore.updateTile(tileId, { ownerId: playerId, buildingLevel })
+      gameStore.updatePlayer(playerId, { money })
+      gameStore.setModal(null)
+    }
+  )
+
+  socket.on(
+    'toll_paid',
+    ({
+      payerId,
+      receiverId,
+      amount,
+      payerMoney,
+      receiverMoney,
+    }: {
+      payerId: string
+      receiverId: string
+      amount: number
+      payerMoney: number
+      receiverMoney: number
+    }) => {
+      gameStore.updatePlayer(payerId, { money: payerMoney })
+      if (receiverId) {
+        gameStore.updatePlayer(receiverId, { money: receiverMoney })
+      }
+      console.log(`Toll paid: ${amount}`)
+    }
+  )
+
+  socket.on(
+    'card_drawn',
+    ({ playerId, cardType }: { playerId: string; cardType: string }) => {
+      gameStore.setModal('card')
+      console.log(`Player ${playerId} drew card: ${cardType}`)
+    }
+  )
+
+  socket.on(
+    'player_sent_to_jail',
+    ({ playerId, position }: { playerId: string; position: number }) => {
+      gameStore.updatePlayer(playerId, { position, isJailed: true })
+    }
+  )
+
+  socket.on('player_bankrupt', ({ playerId }: { playerId: string }) => {
+    gameStore.updatePlayer(playerId, { isBankrupt: true })
+    gameStore.setModal('bankrupt')
+  })
+
+  socket.on('game_over', ({ winnerId }: { winnerId: string }) => {
+    gameStore.setGameState({ isGameOver: true, winnerId })
+  })
+
+  socket.on('ai_penalty_loading', () => {
+    console.log('AI Penalty loading...')
+  })
+
+  socket.on(
+    'ai_penalty',
+    ({ playerId, amount }: { playerId: string; amount: number }) => {
+      gameStore.setModal('penalty')
+      console.log(`AI Penalty for ${playerId}: ${amount}`)
+    }
+  )
+}

--- a/src/services/socket/game.handler.ts
+++ b/src/services/socket/game.handler.ts
@@ -11,11 +11,11 @@ export const setupGameHandlers = () => {
     ({
       game_state,
     }: {
-      game_id: string
+      game_id: string // Used in type but not in logic, usually fine in TS destruction if needed for shape
       game_state: {
         players: Player[]
         tiles: Tile[]
-        current_turn: string
+        current_turn: string | null
         round: number
       }
     }) => {
@@ -34,7 +34,7 @@ export const setupGameHandlers = () => {
     (state: {
       players: Player[]
       tiles: Tile[]
-      current_turn: string
+      current_turn: string | null
       round: number
     }) => {
       gameStore.setGameState({
@@ -98,8 +98,6 @@ export const setupGameHandlers = () => {
     }) => {
       gameStore.updatePlayer(player_id, { position: to_index })
       if (pass_go) {
-        // Updated balance logic could be here if we tracked it,
-        // but typically the server sends periodic game_state or specific updates
         console.log(
           `Player ${player_id} passed GO and earned ${pass_go_salary}`
         )
@@ -137,8 +135,6 @@ export const setupGameHandlers = () => {
       tile_index: number
       amount: number
     }) => {
-      // Balance updates usually come through game_state or separate syncs
-      // in this specific spec, but we can log it.
       console.log(`Player ${payer_id} paid ${amount} to ${owner_id}`)
     }
   )

--- a/src/services/socket/game.handler.ts
+++ b/src/services/socket/game.handler.ts
@@ -1,127 +1,213 @@
 import { socket } from '../../lib/socket'
 import { useGameStore } from '../../stores/game.store'
-import { Player, Tile, BuildingLevel } from '../../types/domain'
+import { Player, Tile, Card, GameResult } from '../../types/domain'
 
 export const setupGameHandlers = () => {
   const gameStore = useGameStore.getState()
 
+  // SOCK-028: game_start
+  socket.on(
+    'game_start',
+    ({
+      game_state,
+    }: {
+      game_id: string
+      game_state: {
+        players: Player[]
+        tiles: Tile[]
+        current_turn: string
+        round: number
+      }
+    }) => {
+      gameStore.setGameState({
+        players: game_state.players,
+        tiles: game_state.tiles,
+        current_turn: game_state.current_turn,
+        round: game_state.round,
+      })
+    }
+  )
+
+  // SOCK-012: game_state
   socket.on(
     'game_state',
     (state: {
       players: Player[]
       tiles: Tile[]
-      currentTurnId: string
+      current_turn: string
       round: number
     }) => {
       gameStore.setGameState({
         players: state.players,
         tiles: state.tiles,
-        currentTurnId: state.currentTurnId,
+        current_turn: state.current_turn,
         round: state.round,
       })
     }
   )
 
+  // SOCK-009: turn_start
   socket.on(
     'turn_start',
-    ({ playerId, round }: { playerId: string; round: number }) => {
+    ({
+      player_id,
+      round,
+    }: {
+      player_id: string
+      round: number
+      timeout_sec: number
+    }) => {
       gameStore.setGameState({
-        currentTurnId: playerId,
+        current_turn: player_id,
         round,
       })
     }
   )
 
+  // SOCK-010: dice_rolled
   socket.on(
     'dice_rolled',
-    ({ playerId, dice }: { playerId: string; dice: number[] }) => {
-      console.log(`Player ${playerId} rolled: ${dice[0]}, ${dice[1]}`)
+    ({
+      player_id,
+      dice,
+    }: {
+      player_id: string
+      dice: number[]
+      is_double: boolean
+      double_count: number
+    }) => {
+      console.log(`Player ${player_id} rolled: ${dice[0]}, ${dice[1]}`)
     }
   )
 
+  // SOCK-011: player_moved
   socket.on(
     'player_moved',
-    ({ playerId, position }: { playerId: string; position: number }) => {
-      gameStore.updatePlayer(playerId, { position })
+    ({
+      player_id,
+      to_index,
+      pass_go,
+      pass_go_salary,
+    }: {
+      player_id: string
+      from_index: number
+      to_index: number
+      trigger: string
+      pass_go: boolean
+      pass_go_salary: number
+    }) => {
+      gameStore.updatePlayer(player_id, { position: to_index })
+      if (pass_go) {
+        // Updated balance logic could be here if we tracked it,
+        // but typically the server sends periodic game_state or specific updates
+        console.log(
+          `Player ${player_id} passed GO and earned ${pass_go_salary}`
+        )
+      }
     }
   )
 
+  // SOCK-013: tile_purchased
   socket.on(
     'tile_purchased',
     ({
-      playerId,
-      tileId,
-      buildingLevel,
-      money,
+      player_id,
+      tile_index,
     }: {
-      playerId: string
-      tileId: number
-      buildingLevel: BuildingLevel
-      money: number
+      player_id: string
+      tile_index: number
+      tile_name: string
+      price: number
     }) => {
-      // Assuming tileId refers to tile index for now, or we should find by id
-      gameStore.updateTile(tileId, { ownerId: playerId, buildingLevel })
-      gameStore.updatePlayer(playerId, { money })
+      gameStore.updateTile(tile_index, { owner_id: player_id })
       gameStore.setModal(null)
     }
   )
 
+  // SOCK-014: toll_paid
   socket.on(
     'toll_paid',
     ({
-      payerId,
-      receiverId,
+      payer_id,
+      owner_id,
       amount,
-      payerMoney,
-      receiverMoney,
     }: {
-      payerId: string
-      receiverId: string
+      payer_id: string
+      owner_id: string
+      tile_index: number
       amount: number
-      payerMoney: number
-      receiverMoney: number
     }) => {
-      gameStore.updatePlayer(payerId, { money: payerMoney })
-      if (receiverId) {
-        gameStore.updatePlayer(receiverId, { money: receiverMoney })
-      }
-      console.log(`Toll paid: ${amount}`)
+      // Balance updates usually come through game_state or separate syncs
+      // in this specific spec, but we can log it.
+      console.log(`Player ${payer_id} paid ${amount} to ${owner_id}`)
     }
   )
 
-  socket.on(
-    'card_drawn',
-    ({ playerId, cardType }: { playerId: string; cardType: string }) => {
-      gameStore.setModal('card')
-      console.log(`Player ${playerId} drew card: ${cardType}`)
-    }
-  )
+  // SOCK-015, SOCK-029: event_card_drawn, chance_card_drawn
+  const handleCardDrawn = ({
+    player_id,
+    card,
+  }: {
+    player_id: string
+    card: Card
+  }) => {
+    gameStore.setModal('card')
+    console.log(`Player ${player_id} drew: ${card.title} - ${card.description}`)
+  }
+  socket.on('event_card_drawn', handleCardDrawn)
+  socket.on('chance_card_drawn', handleCardDrawn)
 
+  // SOCK-016: player_sent_to_jail
   socket.on(
     'player_sent_to_jail',
-    ({ playerId, position }: { playerId: string; position: number }) => {
-      gameStore.updatePlayer(playerId, { position, isJailed: true })
+    ({ player_id }: { player_id: string; source: string }) => {
+      gameStore.updatePlayer(player_id, { is_in_jail: true })
     }
   )
 
-  socket.on('player_bankrupt', ({ playerId }: { playerId: string }) => {
-    gameStore.updatePlayer(playerId, { isBankrupt: true })
-    gameStore.setModal('bankrupt')
+  // SOCK-017: player_bankrupt
+  socket.on(
+    'player_bankrupt',
+    ({
+      player_id,
+    }: {
+      player_id: string
+      reason: string
+      released_tiles: number[]
+    }) => {
+      gameStore.updatePlayer(player_id, { is_bankrupt: true })
+      gameStore.setModal('bankrupt')
+    }
+  )
+
+  // SOCK-018: game_over
+  socket.on('game_over', (payload: GameResult) => {
+    const winner = payload.rankings.find((r) => r.is_winner)
+    gameStore.setGameState({
+      gameResult: payload,
+      isGameOver: true,
+      winnerId: winner?.player_id || null,
+    })
   })
 
-  socket.on('game_over', ({ winnerId }: { winnerId: string }) => {
-    gameStore.setGameState({ isGameOver: true, winnerId })
+  // SOCK-019: ai_penalty_loading
+  socket.on('ai_penalty_loading', ({ player_id }: { player_id: string }) => {
+    console.log(`AI Penalty loading for ${player_id}...`)
   })
 
-  socket.on('ai_penalty_loading', () => {
-    console.log('AI Penalty loading...')
-  })
-
+  // SOCK-020: ai_penalty
   socket.on(
     'ai_penalty',
-    ({ playerId, amount }: { playerId: string; amount: number }) => {
+    ({
+      player_id,
+      penalty,
+    }: {
+      player_id: string
+      penalty: number
+      source: string
+    }) => {
       gameStore.setModal('penalty')
-      console.log(`AI Penalty for ${playerId}: ${amount}`)
+      console.log(`AI Penalty for ${player_id}: ${penalty}`)
     }
   )
 }

--- a/src/services/socket/game.handler.ts
+++ b/src/services/socket/game.handler.ts
@@ -11,7 +11,7 @@ export const setupGameHandlers = () => {
     ({
       game_state,
     }: {
-      game_id: string // Used in type but not in logic, usually fine in TS destruction if needed for shape
+      game_id: string
       game_state: {
         players: Player[]
         tiles: Tile[]
@@ -22,7 +22,7 @@ export const setupGameHandlers = () => {
       gameStore.setGameState({
         players: game_state.players,
         tiles: game_state.tiles,
-        current_turn: game_state.current_turn,
+        currentTurn: game_state.current_turn, // 서버 payload → 프론트 camelCase 매핑
         round: game_state.round,
       })
     }
@@ -40,7 +40,7 @@ export const setupGameHandlers = () => {
       gameStore.setGameState({
         players: state.players,
         tiles: state.tiles,
-        current_turn: state.current_turn,
+        currentTurn: state.current_turn, // 서버 payload → 프론트 camelCase 매핑
         round: state.round,
       })
     }
@@ -58,7 +58,7 @@ export const setupGameHandlers = () => {
       timeout_sec: number
     }) => {
       gameStore.setGameState({
-        current_turn: player_id,
+        currentTurn: player_id,
         round,
       })
     }
@@ -182,7 +182,7 @@ export const setupGameHandlers = () => {
     gameStore.setGameState({
       gameResult: payload,
       isGameOver: true,
-      winnerId: winner?.player_id || null,
+      winnerId: winner?.player_id ?? null,
     })
   })
 

--- a/src/stores/game.store.ts
+++ b/src/stores/game.store.ts
@@ -1,0 +1,77 @@
+import { create } from 'zustand'
+import { immer } from 'zustand/middleware/immer'
+import type {
+  Player,
+  Tile,
+  ActiveModal,
+  GameResult,
+  GameState,
+} from '../types/domain'
+
+interface GameActions {
+  setGameState: (state: Partial<GameState>) => void
+  updatePlayer: (playerId: string, updates: Partial<Player>) => void
+  updateTile: (tileIndex: number, updates: Partial<Tile>) => void
+  setCurrentTurn: (playerId: string) => void
+  setModal: (modal: ActiveModal) => void
+  setGameResult: (result: GameResult) => void
+  resetGame: () => void
+}
+
+const INITIAL_STATE: GameState = {
+  players: [],
+  tiles: [],
+  currentTurnId: null,
+  round: 1,
+  activeModal: null,
+  gameResult: null,
+  isGameOver: false,
+  winnerId: null,
+}
+
+export const useGameStore = create<GameState & GameActions>()(
+  immer((set) => ({
+    ...INITIAL_STATE,
+
+    setGameState: (state) =>
+      set((draft) => {
+        Object.assign(draft, state)
+      }),
+
+    updatePlayer: (playerId, updates) =>
+      set((draft) => {
+        const player = draft.players.find((p) => p.id === playerId)
+        if (player) {
+          Object.assign(player, updates)
+        }
+      }),
+
+    updateTile: (tileIndex, updates) =>
+      set((draft) => {
+        const tile = draft.tiles.find((t) => t.index === tileIndex)
+        if (tile) {
+          Object.assign(tile, updates)
+        }
+      }),
+
+    setCurrentTurn: (playerId) =>
+      set((draft) => {
+        draft.currentTurnId = playerId
+      }),
+
+    setModal: (modal) =>
+      set((draft) => {
+        draft.activeModal = modal
+      }),
+
+    setGameResult: (result) =>
+      set((draft) => {
+        draft.gameResult = result
+      }),
+
+    resetGame: () =>
+      set((draft) => {
+        Object.assign(draft, INITIAL_STATE)
+      }),
+  }))
+)

--- a/src/stores/game.store.ts
+++ b/src/stores/game.store.ts
@@ -21,7 +21,7 @@ interface GameActions {
 const INITIAL_STATE: GameState = {
   players: [],
   tiles: [],
-  current_turn: null, // Changed from currentTurnId
+  currentTurn: null,
   round: 1,
   activeModal: null,
   gameResult: null,
@@ -56,7 +56,7 @@ export const useGameStore = create<GameState & GameActions>()(
 
     setCurrentTurn: (playerId) =>
       set((draft) => {
-        draft.current_turn = playerId
+        draft.currentTurn = playerId
       }),
 
     setModal: (modal) =>

--- a/src/stores/game.store.ts
+++ b/src/stores/game.store.ts
@@ -21,7 +21,7 @@ interface GameActions {
 const INITIAL_STATE: GameState = {
   players: [],
   tiles: [],
-  currentTurnId: null,
+  current_turn: null, // Changed from currentTurnId
   round: 1,
   activeModal: null,
   gameResult: null,
@@ -56,7 +56,7 @@ export const useGameStore = create<GameState & GameActions>()(
 
     setCurrentTurn: (playerId) =>
       set((draft) => {
-        draft.currentTurnId = playerId
+        draft.current_turn = playerId
       }),
 
     setModal: (modal) =>

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -11,48 +11,55 @@ export type TileType =
   | 'airport'
   | 'card'
 
+export interface Card {
+  title: string
+  description: string
+  effect_type: string
+  effect_value: number
+}
+
 export interface Tile {
-  id: number
-  index: number // Added index as store uses t.index
-  name: string
-  type: TileType
-  price?: number
-  toll?: number[]
-  ownerId?: string | null
-  buildingLevel: BuildingLevel
+  index: number
+  owner_id?: string | null
+  building: BuildingLevel
+  name?: string // Optional metadata
+  type?: TileType // Optional metadata
 }
 
 export interface Player {
   id: string
   nickname: string
-  money: number
   position: number
-  isBankrupt: boolean
-  isJailed: boolean
-  jailTurns: number
+  balance: number
+  owned_tiles: number[]
+  is_in_jail: boolean
+  jail_turn_count: number
+  is_bankrupt: boolean
   color: string
 }
 
 export type ActiveModal = 'buy' | 'card' | 'penalty' | 'bankrupt' | null
 
+export type GameRanking = {
+  rank: number
+  player_id: string
+  nickname: string
+  final_assets: number
+  is_winner: boolean
+}
+
 export type GameResult = {
   reason: 'bankrupt' | 'round_limit'
-  rankings: {
-    rank: number
-    playerId: string
-    nickname: string
-    finalAssets: number
-    isWinner: boolean
-  }[]
+  rankings: GameRanking[]
 }
 
 export interface GameState {
   players: Player[]
   tiles: Tile[]
-  currentTurnId: string | null
+  current_turn: string | null
   round: number
   activeModal: ActiveModal
   gameResult: GameResult | null
-  isGameOver: boolean // Added for convenience
-  winnerId: string | null // Added for convenience
+  isGameOver: boolean
+  winnerId: string | null
 }

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -1,0 +1,58 @@
+export type BuildingLevel = 0 | 1 | 2 | 3 | 4 | 5
+
+export type TileType =
+  | 'start'
+  | 'property'
+  | 'chance'
+  | 'jail'
+  | 'tax'
+  | 'park'
+  | 'penalty'
+  | 'airport'
+  | 'card'
+
+export interface Tile {
+  id: number
+  index: number // Added index as store uses t.index
+  name: string
+  type: TileType
+  price?: number
+  toll?: number[]
+  ownerId?: string | null
+  buildingLevel: BuildingLevel
+}
+
+export interface Player {
+  id: string
+  nickname: string
+  money: number
+  position: number
+  isBankrupt: boolean
+  isJailed: boolean
+  jailTurns: number
+  color: string
+}
+
+export type ActiveModal = 'buy' | 'card' | 'penalty' | 'bankrupt' | null
+
+export type GameResult = {
+  reason: 'bankrupt' | 'round_limit'
+  rankings: {
+    rank: number
+    playerId: string
+    nickname: string
+    finalAssets: number
+    isWinner: boolean
+  }[]
+}
+
+export interface GameState {
+  players: Player[]
+  tiles: Tile[]
+  currentTurnId: string | null
+  round: number
+  activeModal: ActiveModal
+  gameResult: GameResult | null
+  isGameOver: boolean // Added for convenience
+  winnerId: string | null // Added for convenience
+}

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -22,8 +22,8 @@ export interface Tile {
   index: number
   owner_id?: string | null
   building: BuildingLevel
-  name?: string // Optional metadata
-  type?: TileType // Optional metadata
+  name?: string
+  type?: TileType
 }
 
 export interface Player {
@@ -56,7 +56,7 @@ export type GameResult = {
 export interface GameState {
   players: Player[]
   tiles: Tile[]
-  current_turn: string | null
+  currentTurn: string | null // 프론트 내부 상태 — camelCase 통일
   round: number
   activeModal: ActiveModal
   gameResult: GameResult | null


### PR DESCRIPTION
## 📌 관련 이슈

> closes #19 

---

## 📝 작업 내용

### 신규 파일 생성

- **[src/types/domain.ts](cci:7://file:///e:/mable/Blue_Marble-frontend/src/types/domain.ts:0:0-0:0)**
  - 게임 도메인 타입 정의 ([Player](cci:2://file:///e:/mable/Blue_Marble-frontend/src/types/domain.ts:28:0-38:1), [Tile](cci:2://file:///e:/mable/Blue_Marble-frontend/src/types/domain.ts:20:0-26:1), [Card](cci:2://file:///e:/mable/Blue_Marble-frontend/src/types/domain.ts:13:0-18:1), [GameResult](cci:2://file:///e:/mable/Blue_Marble-frontend/src/types/domain.ts:50:0-53:1), [GameState](cci:2://file:///e:/mable/Blue_Marble-frontend/src/types/domain.ts:55:0-64:1) 등)
  - 백엔드 소켓 명세 기준 snake_case 필드명 적용 (`player_id`, `is_in_jail`, `owner_id` 등)
  - 프론트 내부 상태는 camelCase 통일 (`currentTurn`, `isGameOver`, `winnerId`)

- **[src/stores/game.store.ts](cci:7://file:///e:/mable/Blue_Marble-frontend/src/stores/game.store.ts:0:0-0:0)**
  - Zustand + Immer 기반 게임 상태 스토어 구현
  - 상태: `players`, `tiles`, `currentTurn`, `round`, `activeModal`, `gameResult`, `isGameOver`, `winnerId`
  - 액션: [setGameState](cci:1://file:///e:/mable/Blue_Marble-frontend/src/stores/game.store.ts:35:4-38:8), [updatePlayer](cci:1://file:///e:/mable/Blue_Marble-frontend/src/stores/game.store.ts:40:4-46:8), [updateTile](cci:1://file:///e:/mable/Blue_Marble-frontend/src/stores/game.store.ts:48:4-54:8), [setCurrentTurn](cci:1://file:///e:/mable/Blue_Marble-frontend/src/stores/game.store.ts:56:4-59:8), [setModal](cci:1://file:///e:/mable/Blue_Marble-frontend/src/stores/game.store.ts:61:4-64:8), [setGameResult](cci:1://file:///e:/mable/Blue_Marble-frontend/src/stores/game.store.ts:66:4-69:8), [resetGame](cci:1://file:///e:/mable/Blue_Marble-frontend/src/stores/game.store.ts:71:4-74:8)

- **[src/services/socket/game.handler.ts](cci:7://file:///e:/mable/Blue_Marble-frontend/src/services/socket/game.handler.ts:0:0-0:0)**
  - 게임 소켓 이벤트 핸들러 구현 (총 12개 이벤트)
  - 커버 이벤트: `game_start`(SOCK-028), `game_state`(SOCK-012), `turn_start`(SOCK-009), `dice_rolled`(SOCK-010), `player_moved`(SOCK-011), `tile_purchased`(SOCK-013), `toll_paid`(SOCK-014), `event_card_drawn`(SOCK-015), `chance_card_drawn`(SOCK-029), `player_sent_to_jail`(SOCK-016), `player_bankrupt`(SOCK-017), `game_over`(SOCK-018), `ai_penalty_loading`(SOCK-019), `ai_penalty`(SOCK-020)
  - 각 핸들러는 store 업데이트만 담당 (UI 로직 없음)
  - 서버 payload(snake_case) → store 상태(camelCase) 명시적 매핑

- **[src/mocks/handlers/game.handler.ts](cci:7://file:///e:/mable/Blue_Marble-frontend/src/mocks/handlers/game.handler.ts:0:0-0:0)** (MSW)
  - `roll-dice` POST 요청 수신 시 `dice_rolled` + `player_moved` 소켓 이벤트 emit 시뮬레이션
  - SOCK-010, SOCK-011 명세 기준 payload 구조 적용

### 기존 파일 수정

- **[src/mocks/handlers.ts](cci:7://file:///e:/mable/Blue_Marble-frontend/src/mocks/handlers.ts:0:0-0:0)**: `gameHandlers` 등록

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거 (명세상 로그만 남김)
- [ ] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

> UI 변경 없음 (store / handler 레이어만 해당)