### PR TITLE
feat: Header 추가

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,38 @@
+import { Link } from 'react-router-dom'
+import { Dice5 } from 'lucide-react'
+
+interface HeaderProps {
+  avatarText?: string
+  avatarBackground?: string
+}
+
+function Header({
+  avatarText = 'P',
+  avatarBackground = '#fde68a',
+}: HeaderProps) {
+  return (
+    <header className="flex h-14 items-center justify-between border-b border-[#e2e8f0] bg-white px-4 sm:px-6">
+      <Link
+        to="/"
+        className="flex items-center gap-2.5 transition-opacity hover:opacity-90"
+      >
+        <div className="flex size-9 items-center justify-center rounded-lg bg-[#3b82f6] text-white">
+          <Dice5 className="size-5" strokeWidth={2} />
+        </div>
+        <h1 className="text-lg font-bold text-[#1e293b]">MARBLE POP</h1>
+      </Link>
+
+      <div className="flex items-center gap-2 text-sm font-medium text-[#64748b]">
+        <span>플레이어</span>
+        <div
+          className="flex size-9 items-center justify-center rounded-full text-xs font-semibold text-[#92400e]"
+          style={{ backgroundColor: avatarBackground }}
+        >
+          {avatarText}
+        </div>
+      </div>
+    </header>
+  )
+}
+
+export default Header


### PR DESCRIPTION
## 📌 관련 이슈
> closes #21

---

## 📝 작업 내용
> 어떤 작업을 했는지 간단하게 설명해주세요.

### Header 컴포넌트 분리

- `src/components/Header.tsx` 신규 추가
- 로고 + MARBLE POP 제목 (`react-router-dom` Link로 홈 `/` 연결)
- 플레이어 영역: `avatarText`, `avatarBackground` props 지원
- `LobbyPage`에서 인라인 헤더 제거 후 `<Header />` 사용
- 다른 페이지에서도 `<Header />`로 재사용 가능

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

<img width="1796" height="58" alt="스크린샷 2026-02-25 오후 1 49 43" src="https://github.com/user-attachments/assets/d477226b-66da-465e-a6b3-4e7f30b35de4" />
