### PR TITLE
feat: 로비페이지 API Mock 데이터 연동

### DIFF
--- a/src/features/lobby/api.ts
+++ b/src/features/lobby/api.ts
@@ -1,0 +1,20 @@
+import { apiClient } from '../../lib/axios'
+import type { LobbyRoom, LobbyUser } from './types'
+
+interface LobbyRoomsResponse {
+  rooms: LobbyRoom[]
+}
+
+interface LobbyUsersResponse {
+  users: LobbyUser[]
+}
+
+export async function getLobbyRooms() {
+  const { data } = await apiClient.get<LobbyRoomsResponse>('/lobby/rooms')
+  return data.rooms
+}
+
+export async function getLobbyUsers() {
+  const { data } = await apiClient.get<LobbyUsersResponse>('/lobby/users')
+  return data.users
+}

--- a/src/features/lobby/hooks.ts
+++ b/src/features/lobby/hooks.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query'
+import { getLobbyRooms, getLobbyUsers } from './api'
+
+export function useLobbyRoomsQuery() {
+  return useQuery({
+    queryKey: ['lobby', 'rooms'],
+    queryFn: getLobbyRooms,
+    staleTime: 20_000,
+  })
+}
+
+export function useLobbyUsersQuery() {
+  return useQuery({
+    queryKey: ['lobby', 'users'],
+    queryFn: getLobbyUsers,
+    staleTime: 20_000,
+  })
+}

--- a/src/features/lobby/mockData.ts
+++ b/src/features/lobby/mockData.ts
@@ -1,0 +1,107 @@
+import type { LobbyRoom, LobbyUser } from './types'
+
+export const mockLobbyRooms: LobbyRoom[] = [
+  {
+    id: 'room-1',
+    title: '초보자 환영! 같이 즐겨요',
+    status: 'WAITING',
+    currentPlayers: 2,
+    maxPlayers: 4,
+    isPrivate: false,
+  },
+  {
+    id: 'room-2',
+    title: '고수들만 오세요',
+    status: 'WAITING',
+    currentPlayers: 3,
+    maxPlayers: 4,
+    isPrivate: true,
+  },
+  {
+    id: 'room-3',
+    title: '친구끼리 재미있게',
+    status: 'PLAYING',
+    currentPlayers: 4,
+    maxPlayers: 4,
+    isPrivate: false,
+  },
+  {
+    id: 'room-4',
+    title: '편하게 하실 분',
+    status: 'WAITING',
+    currentPlayers: 1,
+    maxPlayers: 4,
+    isPrivate: false,
+  },
+  {
+    id: 'room-5',
+    title: '느긋하게 즐기는 방',
+    status: 'WAITING',
+    currentPlayers: 2,
+    maxPlayers: 4,
+    isPrivate: false,
+  },
+  {
+    id: 'room-6',
+    title: '빠른 게임 원하시는 분',
+    status: 'PLAYING',
+    currentPlayers: 3,
+    maxPlayers: 4,
+    isPrivate: false,
+  },
+  {
+    id: 'room-7',
+    title: '저녁 파티룸',
+    status: 'WAITING',
+    currentPlayers: 1,
+    maxPlayers: 4,
+    isPrivate: true,
+  },
+  {
+    id: 'room-8',
+    title: '실력 상관없이 환영',
+    status: 'WAITING',
+    currentPlayers: 3,
+    maxPlayers: 4,
+    isPrivate: false,
+  },
+  {
+    id: 'room-9',
+    title: '마지막 한 자리!',
+    status: 'WAITING',
+    currentPlayers: 3,
+    maxPlayers: 4,
+    isPrivate: false,
+  },
+]
+
+export const mockLobbyUsers: LobbyUser[] = [
+  {
+    id: 'user-1',
+    nickname: '마블왕',
+    status: 'WAITING',
+    avatarText: 'M',
+    avatarBackground: '#f6c8a9',
+  },
+  {
+    id: 'user-2',
+    nickname: '주사위마스터',
+    status: 'PLAYING',
+    avatarText: 'D',
+    avatarBackground: '#7f8ea3',
+  },
+  {
+    id: 'user-3',
+    nickname: '행운의여신',
+    status: 'WAITING',
+    avatarText: 'L',
+    avatarBackground: '#dbc4f8',
+  },
+  {
+    id: 'user-4',
+    nickname: '부동산왕',
+    status: 'PLAYING',
+    avatarText: 'R',
+    avatarBackground: '#8f7f77',
+  },
+]

--- a/src/features/lobby/types.ts
+++ b/src/features/lobby/types.ts
@@ -1,0 +1,20 @@
+export type LobbyRoomStatus = 'WAITING' | 'PLAYING'
+
+export type LobbyUserStatus = 'WAITING' | 'PLAYING'
+
+export interface LobbyRoom {
+  id: string
+  title: string
+  status: LobbyRoomStatus
+  currentPlayers: number
+  maxPlayers: number
+  isPrivate: boolean
+}
+
+export interface LobbyUser {
+  id: string
+  nickname: string
+  status: LobbyUserStatus
+  avatarText: string
+  avatarBackground: string
+}

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,9 +1,18 @@
-import { http, HttpResponse } from 'msw'
+import { delay, http, HttpResponse } from 'msw'
+import { mockLobbyRooms, mockLobbyUsers } from '../features/lobby/mockData'
 import { gameHandlers } from './handlers/game.handler'
 
 export const handlers = [
   ...gameHandlers,
   http.get('/api/health', () => {
     return HttpResponse.json({ status: 'ok' })
+  }),
+  http.get('/api/lobby/rooms', async () => {
+    await delay(250)
+    return HttpResponse.json({ rooms: mockLobbyRooms })
+  }),
+  http.get('/api/lobby/users', async () => {
+    await delay(250)
+    return HttpResponse.json({ users: mockLobbyUsers })
   }),
 ]


### PR DESCRIPTION
## 📌 관련 이슈

> closes #25 

---

## 📝 작업 내용

- 로비 페이지 API Mock 데이터 연동
- `src/features/lobby/` 모듈 추가 (types, mockData, api, hooks, constants)
- MSW 핸들러로 `GET /api/lobby/rooms`, `GET /api/lobby/users` 목업 응답 처리
- `LobbyPage`, `RoomCard`, `UserRow` 컴포넌트 분리
- `UserRow`를 공통 컴포넌트로 분리 (`src/components/UserRow.tsx`)
- 매직 넘버·문자열 상수화 (`constants.ts`)
- `joinButtonLabel` 중첩 삼항 → `getJoinButtonLabel()` 함수로 분리

---

## ✅ 체크리스트

- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

> UI 변경이 있을 경우 첨부해주세요.