### PR TITLE
feat: Board 컴포넌트 제거 및 Phaser 게임 컨테이너로 교체

### DIFF
--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react'
 import { Settings } from 'lucide-react'
-import Board from '../components/game/Board'
 import PlayerCard from '../components/game/PlayerCard'
 import ChatSection from '../components/game/ChatSection'
 import RollControl from '../components/game/RollControl'
@@ -8,7 +7,7 @@ import { useGameStore } from '../stores/game.store'
 import { useGameState } from '../features/game/useGameState'
 
 const GamePage: React.FC = () => {
-  const { players, tiles, messages, currentTurn, addMessage } = useGameStore()
+  const { players, currentTurn, messages, addMessage } = useGameStore()
   const [timeLeft, setTimeLeft] = useState(27)
 
   // Fetch initial state via hook
@@ -56,9 +55,16 @@ const GamePage: React.FC = () => {
           />
         </div>
 
-        {/* Center: Board */}
+        {/* Center: Phaser Game Container */}
         <div className="flex flex-1 items-center justify-center shrink-0">
-          <Board tiles={tiles} />
+          <div
+            id="game-container"
+            className="aspect-square w-full max-w-[800px] rounded-[48px] bg-[#DBEAFE] shadow-[0_50px_100px_-20px_rgba(30,58,138,0.3)] flex items-center justify-center border-[8px] border-white"
+          >
+            <span className="text-[#2B7FFF] font-black opacity-20 text-xl tracking-widest">
+              PHASER ENGINE LOADING...
+            </span>
+          </div>
         </div>
 
         {/* Sidebar Right: Players */}


### PR DESCRIPTION
## 📌 관련 이슈

> closes #35 

---

## 📝 작업 내용

>
GamePage.tsx에서 React 기반 Board 컴포넌트 및 tiles 상태 의존성 제거
Phaser 엔진이 마운트될 id="game-container" div 컨테이너 추가
phaserConfig.ts에 이미 parent: 'game-container'가 설정되어 있으므로, 팀원의 Phaser 코드와 바로 연결 가능한 상태로 준비
기존 UI 레이어(ChatSection, PlayerCard, RollControl)는 그대로 유지.

---
Phaser 엔진을 완성하시면, phaserConfig.ts에 이미 parent: 'game-container'가 설정되어 있기 때문에 그냥 newPhaser.Game(phaserConfig)만 호출하면 
GamePage의 중앙 빈 박스 안에 바로 Phaser 캔버스가 마운트됩니다

## ✅ 체크리스트

- [X] 로컬에서 정상 동작 확인
- [X] 불필요한 console.log 제거
- [X] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

><img width="1910" height="932" alt="image" src="https://github.com/user-attachments/assets/c1186668-08bf-4808-a469-c96b5f7698c6" />
