### PR TITLE
feat: 도시 구매 모달 UI 구현

### DIFF
--- a/src/components/game/modals/BuyModal.tsx
+++ b/src/components/game/modals/BuyModal.tsx
@@ -1,13 +1,74 @@
-﻿import React from 'react'
-import BaseModal from './BaseModal'
+import React from 'react'
 
 interface BuyModalProps {
   open: boolean
+  cityName?: string
+  purchaseCostText?: string
+  tollText?: string
+  onPass?: () => void
+  onBuy?: () => void
 }
 
-const BuyModal: React.FC<BuyModalProps> = ({ open }) => {
-  return <BaseModal open={open} title="Buy" />
+const DEFAULT_CITY_NAME = '대구'
+const DEFAULT_PURCHASE_COST_TEXT = '6칸'
+const DEFAULT_TOLL_TEXT = '6칸'
+
+const BuyModal: React.FC<BuyModalProps> = ({
+  open,
+  cityName = DEFAULT_CITY_NAME,
+  purchaseCostText = DEFAULT_PURCHASE_COST_TEXT,
+  tollText = DEFAULT_TOLL_TEXT,
+  onPass,
+  onBuy,
+}) => {
+  if (!open) {
+    return null
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-[rgba(26,36,56,0.35)] backdrop-blur-sm">
+      <div className="w-full max-w-105 rounded-[44px] bg-white px-10 pb-10 pt-11 shadow-2xl">
+        <div className="mx-auto mb-7 flex h-24 w-24 items-center justify-center rounded-[30px] border border-[#CFE1FF] bg-[#EFF5FF] text-[44px]">
+          <span role="img" aria-label="도시">
+            🏠
+          </span>
+        </div>
+
+        <h2 className="mb-4 text-center text-[54px] font-black tracking-tight text-[#1F2A44]">
+          도시 구매
+        </h2>
+
+        <p className="text-center text-[36px] font-extrabold leading-[1.3] text-[#5A6D8A]">
+          <span className="text-[#245FE5]">{cityName}</span>{' '}
+          <span>({purchaseCostText})을(를)</span>
+          <br />
+          <span>구매하시겠습니까?</span>
+        </p>
+
+        <p className="mb-10 mt-4 text-center text-[32px] font-bold leading-[1.35] text-[#5A6D8A]">
+          건설 후 통행료는 {tollText} 입니다
+        </p>
+
+        <div className="flex items-center justify-center gap-4">
+          <button
+            type="button"
+            onClick={onPass}
+            className="h-18.5 w-39.5 rounded-[22px] bg-[#E6EBF3] text-[34px] font-black tracking-tight text-[#5E708D] transition-colors hover:bg-[#DDE4EE]"
+          >
+            패스
+          </button>
+
+          <button
+            type="button"
+            onClick={onBuy}
+            className="h-18.5 w-46.5 rounded-[22px] bg-[#245FE5] text-[34px] font-black tracking-tight text-white shadow-lg transition-colors hover:bg-[#1F56D1]"
+          >
+            구매하기
+          </button>
+        </div>
+      </div>
+    </div>
+  )
 }
 
 export default BuyModal
-


### PR DESCRIPTION
## 📦 관련 이슈

> closes #53 

---

## 🧩 작업 내용

> 피그마 시안 기준으로 BuyModal UI를 구현했습니다.
> 임시 확인용으로 넣었던 GamePage 내 모달 미리보기 코드는 제거하여 원복했습니다.

- `src/components/game/modals/BuyModal.tsx`
  - 도시 구매 모달 UI 구현
  - props 확장: `cityName`, `purchaseCostText`, `tollText`, `onPass`, `onBuy`
  - tailwind 클래스 규칙 정리
- `src/pages/GamePage.tsx`
  - 임시 미리보기용 `BuyModal open` 코드 제거

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 없음
- [x] 관련 이슈 확인 완료

---

## 🖼 스크린샷 (선택)

> <img width="1878" height="975" alt="image" src="https://github.com/user-attachments/assets/05dd27ae-9971-4638-bcf3-404cc5d768fb" />
