### PR TITLE
feat: 닉네임 설정 플로우와 인증 상태 기반 라우팅추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,11 +2,13 @@ import { Routes, Route } from 'react-router-dom'
 import HomePage from './pages/HomePage'
 import GamePage from './pages/GamePage'
 import LobbyPage from './pages/lobby/LobbyPage'
+import NicknameSetupPage from './pages/NicknameSetupPage'
 
 function App() {
   return (
     <Routes>
       <Route path="/" element={<HomePage />} />
+      <Route path="/nickname-setup" element={<NicknameSetupPage />} />
       <Route path="/game" element={<GamePage />} />
       <Route path="/lobby" element={<LobbyPage />} />
     </Routes>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useRef, useState } from 'react'
-import { Link } from 'react-router-dom'
 import { Dice5 } from 'lucide-react'
 
 interface HeaderMenuItem {
@@ -66,15 +65,12 @@ function Header({
 
   return (
     <header className="flex h-14 items-center justify-between border-b border-ui-border bg-ui-surface px-4 sm:px-6">
-      <Link
-        to="/"
-        className="flex items-center gap-2.5 transition-opacity hover:opacity-90"
-      >
+      <div className="flex items-center gap-2.5">
         <div className="flex size-9 items-center justify-center rounded-lg bg-ui-brand text-white">
           <Dice5 className="size-5" strokeWidth={2} />
         </div>
         <h1 className="text-lg font-bold text-ui-text-strong">MARBLE POP</h1>
-      </Link>
+      </div>
 
       <div className="flex items-center gap-2 text-sm font-medium text-ui-text-muted">
         <span className="max-w-[140px] truncate">{playerLabel}</span>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,15 +1,69 @@
+import { useEffect, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { Dice5 } from 'lucide-react'
 
+interface HeaderMenuItem {
+  id: string
+  label: string
+  onSelect: () => void
+  tone?: 'default' | 'danger'
+}
+
 interface HeaderProps {
+  playerLabel?: string
   avatarText?: string
   avatarBackground?: string
+  menuItems?: HeaderMenuItem[]
 }
 
 function Header({
+  playerLabel = '플레이어',
   avatarText = 'P',
   avatarBackground = '#fde68a',
+  menuItems = [],
 }: HeaderProps) {
+  const [isMenuOpen, setIsMenuOpen] = useState(false)
+  const menuContainerRef = useRef<HTMLDivElement | null>(null)
+
+  const hasMenuItems = menuItems.length > 0
+  const avatar = (
+    <div
+      className="flex size-9 items-center justify-center rounded-full text-xs font-semibold text-ui-text-primary"
+      style={{ backgroundColor: avatarBackground }}
+    >
+      {avatarText}
+    </div>
+  )
+
+  useEffect(() => {
+    if (!hasMenuItems || !isMenuOpen) {
+      return
+    }
+
+    function handlePointerDown(event: PointerEvent) {
+      if (
+        menuContainerRef.current &&
+        !menuContainerRef.current.contains(event.target as Node)
+      ) {
+        setIsMenuOpen(false)
+      }
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        setIsMenuOpen(false)
+      }
+    }
+
+    window.addEventListener('pointerdown', handlePointerDown)
+    window.addEventListener('keydown', handleKeyDown)
+
+    return () => {
+      window.removeEventListener('pointerdown', handlePointerDown)
+      window.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [hasMenuItems, isMenuOpen])
+
   return (
     <header className="flex h-14 items-center justify-between border-b border-ui-border bg-ui-surface px-4 sm:px-6">
       <Link
@@ -23,13 +77,51 @@ function Header({
       </Link>
 
       <div className="flex items-center gap-2 text-sm font-medium text-ui-text-muted">
-        <span>플레이어</span>
-        <div
-          className="flex size-9 items-center justify-center rounded-full text-xs font-semibold text-ui-text-primary"
-          style={{ backgroundColor: avatarBackground }}
-        >
-          {avatarText}
-        </div>
+        <span className="max-w-[140px] truncate">{playerLabel}</span>
+        {hasMenuItems ? (
+          <div ref={menuContainerRef} className="relative group/menu">
+            <button
+              type="button"
+              className="rounded-full outline-none"
+              aria-label="프로필 메뉴 열기"
+              aria-expanded={isMenuOpen}
+              onClick={() => setIsMenuOpen((prev) => !prev)}
+            >
+              {avatar}
+            </button>
+
+            <div
+              className={`absolute right-0 top-full z-20 pt-2 transition-opacity ${
+                isMenuOpen
+                  ? 'pointer-events-auto opacity-100'
+                  : 'pointer-events-none opacity-0'
+              } group-hover/menu:pointer-events-auto group-hover/menu:opacity-100 group-focus-within/menu:pointer-events-auto group-focus-within/menu:opacity-100`}
+            >
+              <ul className="min-w-[140px] rounded-xl border border-ui-border bg-ui-surface p-1 shadow-[0_8px_20px_rgba(15,23,42,0.12)]">
+                {menuItems.map((item) => (
+                  <li key={item.id}>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        item.onSelect()
+                        setIsMenuOpen(false)
+                      }}
+                      className={`flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm font-medium transition hover:bg-ui-surface-muted ${
+                        item.tone === 'danger'
+                          ? 'text-ui-danger'
+                          : 'text-ui-text-primary'
+                      }`}
+                    >
+                      <span>{item.label}</span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        ) : (
+          avatar
+        )}
       </div>
     </header>
   )

--- a/src/features/auth/hooks/useNicknameSetupForm.ts
+++ b/src/features/auth/hooks/useNicknameSetupForm.ts
@@ -1,0 +1,170 @@
+import { FormEvent, useEffect, useMemo, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import {
+  mockCheckNicknameAvailability,
+  mockSetNickname,
+  validateNickname,
+} from '../mockApi'
+import {
+  createNicknameHelperFeedback,
+  NICKNAME_CHECK_DEBOUNCE_MS,
+} from '../nicknameSetupRules'
+import { useAuthStore } from '../store'
+
+export function useNicknameSetupForm() {
+  const navigate = useNavigate()
+  const session = useAuthStore((state) => state.session)
+  const updateNickname = useAuthStore((state) => state.updateNickname)
+
+  const [nickname, setNickname] = useState('')
+  const [submitMessage, setSubmitMessage] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [isNicknameFocused, setIsNicknameFocused] = useState(false)
+  const [isCheckingNickname, setIsCheckingNickname] = useState(false)
+  const [isNicknameAvailable, setIsNicknameAvailable] = useState<
+    boolean | null
+  >(null)
+
+  useEffect(() => {
+    if (!session) {
+      navigate('/', { replace: true })
+      return
+    }
+
+    if (!session.needsNicknameSetup) {
+      navigate('/lobby', { replace: true })
+    }
+  }, [navigate, session])
+
+  const nicknameValidation = useMemo(
+    () => validateNickname(nickname),
+    [nickname]
+  )
+
+  useEffect(() => {
+    setIsCheckingNickname(false)
+    setIsNicknameAvailable(null)
+
+    if (!nicknameValidation.ok) {
+      return
+    }
+
+    let isDisposed = false
+    const normalizedNickname = nicknameValidation.normalizedNickname
+    const debounceTimer = window.setTimeout(async () => {
+      setIsCheckingNickname(true)
+      const result = await mockCheckNicknameAvailability(normalizedNickname)
+      if (isDisposed) {
+        return
+      }
+
+      setIsCheckingNickname(false)
+      if (!result.ok) {
+        setIsNicknameAvailable(null)
+        return
+      }
+
+      setIsNicknameAvailable(result.isAvailable)
+    }, NICKNAME_CHECK_DEBOUNCE_MS)
+
+    return () => {
+      isDisposed = true
+      window.clearTimeout(debounceTimer)
+    }
+  }, [nicknameValidation])
+
+  const helperFeedback = useMemo(
+    () =>
+      createNicknameHelperFeedback({
+        submitMessage,
+        isNicknameFocused,
+        nickname,
+        nicknameValidation,
+        isCheckingNickname,
+        isNicknameAvailable,
+      }),
+    [
+      isCheckingNickname,
+      isNicknameAvailable,
+      isNicknameFocused,
+      nickname,
+      nicknameValidation,
+      submitMessage,
+    ]
+  )
+
+  const isSubmitDisabled =
+    isSubmitting ||
+    !nicknameValidation.ok ||
+    isCheckingNickname ||
+    isNicknameAvailable !== true
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setSubmitMessage(null)
+
+    if (!session) {
+      return
+    }
+
+    if (!nicknameValidation.ok) {
+      setSubmitMessage(`• ${nicknameValidation.message}`)
+      return
+    }
+
+    if (isNicknameAvailable === false) {
+      setSubmitMessage('• 이미 사용 중인 닉네임입니다.')
+      return
+    }
+
+    if (isNicknameAvailable !== true || isCheckingNickname) {
+      setSubmitMessage('• 닉네임 중복 확인이 완료될 때까지 기다려 주세요.')
+      return
+    }
+
+    setIsSubmitting(true)
+    const result = await mockSetNickname({
+      session,
+      nickname: nicknameValidation.normalizedNickname,
+    })
+    setIsSubmitting(false)
+
+    if (!result.ok) {
+      setSubmitMessage(`• ${result.message}`)
+      return
+    }
+
+    updateNickname(result.nickname)
+    navigate('/lobby', { replace: true })
+  }
+
+  function handleNicknameChange(value: string) {
+    setSubmitMessage(null)
+    setNickname(value)
+  }
+
+  function handleNicknameFocus() {
+    setIsNicknameFocused(true)
+  }
+
+  function handleNicknameBlur() {
+    setIsNicknameFocused(false)
+  }
+
+  function handleBackToHome() {
+    navigate('/', { replace: true })
+  }
+
+  return {
+    shouldRender: Boolean(session && session.needsNicknameSetup),
+    nickname,
+    helperFeedback,
+    isSubmitting,
+    isSubmitDisabled,
+    handleSubmit,
+    handleNicknameChange,
+    handleNicknameFocus,
+    handleNicknameBlur,
+    handleBackToHome,
+  }
+}

--- a/src/features/auth/mockApi.ts
+++ b/src/features/auth/mockApi.ts
@@ -1,0 +1,315 @@
+import type {
+  NicknameAvailabilityResult,
+  AuthSession,
+  NicknameSetResult,
+  NicknameValidationResult,
+} from './types'
+
+const MOCK_AUTH_DELAY_MS = 350
+const TAKEN_NICKNAMES_STORAGE_KEY = 'marble-pop-mock-taken-nicknames'
+const KAKAO_USER_STORAGE_KEY = 'marble-pop-mock-kakao-user'
+const DEFAULT_TAKEN_NICKNAMES = [
+  '마블왕',
+  '주사위마스터',
+  '행운의여신',
+  '부동산왕',
+  'GoormEE',
+]
+const NICKNAME_PATTERN = /^[A-Za-z0-9가-힣]{2,10}$/
+const DEFAULT_MOCK_KAKAO_PROFILE_IMAGE =
+  'https://picsum.photos/seed/kakao/96/96'
+const DEFAULT_MOCK_KAKAO_ID = 'mock-kakao-id-001'
+
+interface MockKakaoUser {
+  id: string
+  kakaoId: string
+  nickname: string | null
+  profileImage: string
+}
+
+function delay(ms: number) {
+  return new Promise<void>((resolve) => {
+    setTimeout(() => resolve(), ms)
+  })
+}
+
+function createMockUuid() {
+  if (
+    typeof crypto !== 'undefined' &&
+    typeof crypto.randomUUID === 'function'
+  ) {
+    return crypto.randomUUID()
+  }
+
+  return `${Math.random().toString(16).slice(2)}-${Date.now().toString(16)}`
+}
+
+function saveMockKakaoUser(user: MockKakaoUser) {
+  window.localStorage.setItem(KAKAO_USER_STORAGE_KEY, JSON.stringify(user))
+}
+
+function getStoredMockKakaoUser() {
+  const storedValue = window.localStorage.getItem(KAKAO_USER_STORAGE_KEY)
+  if (!storedValue) {
+    return null
+  }
+
+  try {
+    const parsedValue = JSON.parse(storedValue)
+    if (!parsedValue || typeof parsedValue !== 'object') {
+      return null
+    }
+
+    if (
+      typeof parsedValue.id !== 'string' ||
+      typeof parsedValue.kakaoId !== 'string' ||
+      !(
+        typeof parsedValue.nickname === 'string' ||
+        parsedValue.nickname === null
+      ) ||
+      typeof parsedValue.profileImage !== 'string'
+    ) {
+      return null
+    }
+
+    return parsedValue as MockKakaoUser
+  } catch {
+    return null
+  }
+}
+
+function createMockKakaoUser() {
+  return {
+    id: createMockUuid(),
+    kakaoId: DEFAULT_MOCK_KAKAO_ID,
+    nickname: null,
+    profileImage: DEFAULT_MOCK_KAKAO_PROFILE_IMAGE,
+  } as MockKakaoUser
+}
+
+function getOrCreateMockKakaoUser() {
+  const storedUser = getStoredMockKakaoUser()
+  if (storedUser) {
+    return storedUser
+  }
+
+  const newUser = createMockKakaoUser()
+  saveMockKakaoUser(newUser)
+  return newUser
+}
+
+function updateMockKakaoNickname(nickname: string) {
+  const currentUser = getOrCreateMockKakaoUser()
+  saveMockKakaoUser({
+    ...currentUser,
+    nickname,
+  })
+}
+
+function seedTakenNicknamesIfMissing() {
+  if (window.localStorage.getItem(TAKEN_NICKNAMES_STORAGE_KEY)) {
+    return
+  }
+
+  window.localStorage.setItem(
+    TAKEN_NICKNAMES_STORAGE_KEY,
+    JSON.stringify(DEFAULT_TAKEN_NICKNAMES)
+  )
+}
+
+function getStoredTakenNicknames() {
+  const storedValue = window.localStorage.getItem(TAKEN_NICKNAMES_STORAGE_KEY)
+  if (!storedValue) {
+    return [...DEFAULT_TAKEN_NICKNAMES]
+  }
+
+  try {
+    const parsedValue = JSON.parse(storedValue)
+    if (!Array.isArray(parsedValue)) {
+      return [...DEFAULT_TAKEN_NICKNAMES]
+    }
+
+    const normalizedList = parsedValue.filter(
+      (value): value is string => typeof value === 'string'
+    )
+
+    if (normalizedList.length === 0) {
+      return [...DEFAULT_TAKEN_NICKNAMES]
+    }
+
+    return normalizedList
+  } catch {
+    return [...DEFAULT_TAKEN_NICKNAMES]
+  }
+}
+
+function saveTakenNicknames(nicknames: string[]) {
+  window.localStorage.setItem(
+    TAKEN_NICKNAMES_STORAGE_KEY,
+    JSON.stringify(nicknames)
+  )
+}
+
+function isNicknameDuplicate(nickname: string) {
+  const normalizedNickname = nickname.toLowerCase()
+  return getStoredTakenNicknames().some(
+    (savedNickname) => savedNickname.toLowerCase() === normalizedNickname
+  )
+}
+
+function addTakenNickname(nickname: string) {
+  const currentNicknames = getStoredTakenNicknames()
+  if (currentNicknames.includes(nickname)) {
+    return
+  }
+  saveTakenNicknames([...currentNicknames, nickname])
+}
+
+function createGuestNickname() {
+  const uuid = createMockUuid().replace(/-/g, '')
+  return `Guest_${uuid.slice(0, 4)}`
+}
+
+export function validateNickname(nickname: string): NicknameValidationResult {
+  const normalizedNickname = nickname.trim()
+
+  if (nickname !== normalizedNickname || /\s/.test(nickname)) {
+    return {
+      ok: false,
+      normalizedNickname,
+      message: '공백은 사용할 수 없습니다.',
+    }
+  }
+
+  if (normalizedNickname.length < 2 || normalizedNickname.length > 10) {
+    return {
+      ok: false,
+      normalizedNickname,
+      message: '닉네임은 2~10자여야 합니다.',
+    }
+  }
+
+  if (!NICKNAME_PATTERN.test(normalizedNickname)) {
+    return {
+      ok: false,
+      normalizedNickname,
+      message: '한글/영문/숫자만 입력할 수 있습니다.',
+    }
+  }
+
+  return {
+    ok: true,
+    normalizedNickname,
+  }
+}
+
+export async function mockKakaoLogin() {
+  await delay(MOCK_AUTH_DELAY_MS)
+  seedTakenNicknamesIfMissing()
+
+  const kakaoUser = getOrCreateMockKakaoUser()
+  const existingNickname =
+    typeof kakaoUser.nickname === 'string' ? kakaoUser.nickname : ''
+  const hasNickname = existingNickname.length > 0
+
+  if (hasNickname) {
+    addTakenNickname(existingNickname)
+  }
+
+  const session: AuthSession = {
+    accessToken: `mock-kakao-token-${kakaoUser.id}`,
+    userId: kakaoUser.id,
+    nickname: existingNickname,
+    isGuest: false,
+    needsNicknameSetup: !hasNickname,
+    provider: 'kakao',
+  }
+
+  return session
+}
+
+export async function mockGuestLogin() {
+  await delay(MOCK_AUTH_DELAY_MS)
+  seedTakenNicknamesIfMissing()
+
+  const userId = createMockUuid()
+  const nickname = createGuestNickname()
+  addTakenNickname(nickname)
+
+  const session: AuthSession = {
+    accessToken: `mock-guest-token-${userId}`,
+    userId,
+    nickname,
+    isGuest: true,
+    needsNicknameSetup: false,
+    provider: 'guest',
+  }
+
+  return session
+}
+
+export async function mockCheckNicknameAvailability(
+  nickname: string
+): Promise<NicknameAvailabilityResult> {
+  await delay(MOCK_AUTH_DELAY_MS)
+  seedTakenNicknamesIfMissing()
+
+  const validationResult = validateNickname(nickname)
+  if (!validationResult.ok) {
+    return validationResult
+  }
+
+  return {
+    ok: true,
+    normalizedNickname: validationResult.normalizedNickname,
+    isAvailable: !isNicknameDuplicate(validationResult.normalizedNickname),
+  }
+}
+
+interface MockSetNicknameParams {
+  session: AuthSession
+  nickname: string
+}
+
+export async function mockSetNickname({
+  session,
+  nickname,
+}: MockSetNicknameParams): Promise<NicknameSetResult> {
+  await delay(MOCK_AUTH_DELAY_MS)
+  seedTakenNicknamesIfMissing()
+
+  if (session.isGuest) {
+    return {
+      ok: false,
+      code: 'FORBIDDEN',
+      message: '게스트는 닉네임 설정을 사용할 수 없습니다.',
+    }
+  }
+
+  const validationResult = validateNickname(nickname)
+  if (!validationResult.ok) {
+    return {
+      ok: false,
+      code: 'INVALID_FORMAT',
+      message: validationResult.message,
+    }
+  }
+
+  if (isNicknameDuplicate(validationResult.normalizedNickname)) {
+    return {
+      ok: false,
+      code: 'DUPLICATE',
+      message: '이미 사용 중인 닉네임입니다.',
+    }
+  }
+
+  addTakenNickname(validationResult.normalizedNickname)
+  if (session.provider === 'kakao') {
+    updateMockKakaoNickname(validationResult.normalizedNickname)
+  }
+
+  return {
+    ok: true,
+    nickname: validationResult.normalizedNickname,
+  }
+}

--- a/src/features/auth/nicknameSetupRules.ts
+++ b/src/features/auth/nicknameSetupRules.ts
@@ -1,0 +1,111 @@
+import type { NicknameValidationResult } from './types'
+
+export const NICKNAME_CHECK_DEBOUNCE_MS = 400
+export const NICKNAME_LENGTH_ERROR_MESSAGE = '닉네임은 2~10자여야 합니다.'
+export const NICKNAME_PATTERN_ERROR_MESSAGE =
+  '한글/영문/숫자만 입력할 수 있습니다.'
+export const NICKNAME_WHITESPACE_ERROR_MESSAGE = '공백은 사용할 수 없습니다.'
+
+export type HelperTone = 'default' | 'danger' | 'success'
+
+export interface NicknameHelperFeedback {
+  message: string
+  tone: HelperTone
+}
+
+interface CreateNicknameHelperFeedbackParams {
+  submitMessage: string | null
+  isNicknameFocused: boolean
+  nickname: string
+  nicknameValidation: NicknameValidationResult
+  isCheckingNickname: boolean
+  isNicknameAvailable: boolean | null
+}
+
+function createLengthFeedback(): NicknameHelperFeedback {
+  return {
+    message: `• ${NICKNAME_LENGTH_ERROR_MESSAGE}`,
+    tone: 'default',
+  }
+}
+
+function createPatternFeedback(): NicknameHelperFeedback {
+  return {
+    message: `• ${NICKNAME_PATTERN_ERROR_MESSAGE}`,
+    tone: 'danger',
+  }
+}
+
+function createWhitespaceFeedback(): NicknameHelperFeedback {
+  return {
+    message: `• ${NICKNAME_WHITESPACE_ERROR_MESSAGE}`,
+    tone: 'danger',
+  }
+}
+
+function createValidationFeedback(
+  nicknameValidation: NicknameValidationResult
+): NicknameHelperFeedback {
+  if (
+    !nicknameValidation.ok &&
+    nicknameValidation.message === NICKNAME_WHITESPACE_ERROR_MESSAGE
+  ) {
+    return createWhitespaceFeedback()
+  }
+
+  if (
+    !nicknameValidation.ok &&
+    nicknameValidation.message === NICKNAME_PATTERN_ERROR_MESSAGE
+  ) {
+    return createPatternFeedback()
+  }
+
+  return createLengthFeedback()
+}
+
+export function createNicknameHelperFeedback({
+  submitMessage,
+  isNicknameFocused,
+  nickname,
+  nicknameValidation,
+  isCheckingNickname,
+  isNicknameAvailable,
+}: CreateNicknameHelperFeedbackParams): NicknameHelperFeedback {
+  if (submitMessage) {
+    return {
+      message: submitMessage,
+      tone: 'danger',
+    }
+  }
+
+  if (isNicknameFocused) {
+    return createValidationFeedback(nicknameValidation)
+  }
+
+  if (nickname.length === 0) {
+    return createLengthFeedback()
+  }
+
+  if (!nicknameValidation.ok) {
+    return createValidationFeedback(nicknameValidation)
+  }
+
+  if (isCheckingNickname || isNicknameAvailable === null) {
+    return {
+      message: '• 닉네임 중복 확인 중...',
+      tone: 'default',
+    }
+  }
+
+  if (!isNicknameAvailable) {
+    return {
+      message: '• 이미 사용 중인 닉네임입니다.',
+      tone: 'danger',
+    }
+  }
+
+  return {
+    message: '• 사용 가능한 닉네임입니다.',
+    tone: 'success',
+  }
+}

--- a/src/features/auth/store.ts
+++ b/src/features/auth/store.ts
@@ -1,0 +1,38 @@
+import { create } from 'zustand'
+import { createJSONStorage, persist } from 'zustand/middleware'
+import type { AuthSession } from './types'
+
+interface AuthStoreState {
+  session: AuthSession | null
+  setSession: (session: AuthSession) => void
+  clearSession: () => void
+  updateNickname: (nickname: string) => void
+}
+
+export const useAuthStore = create<AuthStoreState>()(
+  persist(
+    (set) => ({
+      session: null,
+      setSession: (session) => set({ session }),
+      clearSession: () => set({ session: null }),
+      updateNickname: (nickname) =>
+        set((state) => {
+          if (!state.session) {
+            return state
+          }
+
+          return {
+            session: {
+              ...state.session,
+              nickname,
+              needsNicknameSetup: false,
+            },
+          }
+        }),
+    }),
+    {
+      name: 'marble-pop-auth-session',
+      storage: createJSONStorage(() => localStorage),
+    }
+  )
+)

--- a/src/features/auth/types.ts
+++ b/src/features/auth/types.ts
@@ -1,0 +1,44 @@
+export type AuthProvider = 'kakao' | 'guest'
+
+export interface AuthSession {
+  accessToken: string
+  userId: string
+  nickname: string
+  isGuest: boolean
+  needsNicknameSetup: boolean
+  provider: AuthProvider
+}
+
+export type NicknameValidationResult =
+  | {
+      ok: true
+      normalizedNickname: string
+    }
+  | {
+      ok: false
+      normalizedNickname: string
+      message: string
+    }
+
+export type NicknameSetResult =
+  | {
+      ok: true
+      nickname: string
+    }
+  | {
+      ok: false
+      code: 'INVALID_FORMAT' | 'DUPLICATE' | 'FORBIDDEN'
+      message: string
+    }
+
+export type NicknameAvailabilityResult =
+  | {
+      ok: true
+      normalizedNickname: string
+      isAvailable: boolean
+    }
+  | {
+      ok: false
+      normalizedNickname: string
+      message: string
+    }

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -10,6 +10,10 @@ import {
   Zap,
 } from 'lucide-react'
 import { motion } from 'framer-motion'
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { mockGuestLogin, mockKakaoLogin } from '../features/auth/mockApi'
+import { useAuthStore } from '../features/auth/store'
 
 const featureCards = [
   {
@@ -33,6 +37,51 @@ const featureCards = [
 ]
 
 function HomePage() {
+  const navigate = useNavigate()
+  const session = useAuthStore((state) => state.session)
+  const setSession = useAuthStore((state) => state.setSession)
+
+  const [isKakaoLoading, setIsKakaoLoading] = useState(false)
+  const [isGuestLoading, setIsGuestLoading] = useState(false)
+
+  useEffect(() => {
+    if (!session) {
+      return
+    }
+
+    if (session.needsNicknameSetup) {
+      return
+    }
+
+    navigate('/lobby', { replace: true })
+  }, [navigate, session])
+
+  const isAnyLoading = isKakaoLoading || isGuestLoading
+
+  async function handleKakaoLogin() {
+    setIsKakaoLoading(true)
+    try {
+      const kakaoSession = await mockKakaoLogin()
+      setSession(kakaoSession)
+      navigate(kakaoSession.needsNicknameSetup ? '/nickname-setup' : '/lobby', {
+        replace: true,
+      })
+    } finally {
+      setIsKakaoLoading(false)
+    }
+  }
+
+  async function handleGuestLogin() {
+    setIsGuestLoading(true)
+    try {
+      const guestSession = await mockGuestLogin()
+      setSession(guestSession)
+      navigate('/lobby', { replace: true })
+    } finally {
+      setIsGuestLoading(false)
+    }
+  }
+
   return (
     <div className="relative min-h-screen overflow-hidden bg-ui-app-bg px-4 py-8 sm:px-8 sm:py-10">
       {/* 배경 반투명 아이콘 */}
@@ -139,17 +188,21 @@ function HomePage() {
           <div className="mx-auto mt-8 flex w-full max-w-[380px] flex-col gap-3">
             <button
               type="button"
-              className="flex h-14 items-center justify-center gap-2.5 rounded-2xl bg-[#ffe812] py-3 text-[1.125rem] font-bold text-[#191919] shadow-[0_2px_8px_rgba(0,0,0,0.08)] transition-all hover:bg-[#f5dc00] active:scale-[0.98]"
+              onClick={handleKakaoLogin}
+              disabled={isAnyLoading}
+              className="flex h-14 items-center justify-center gap-2.5 rounded-2xl bg-[#ffe812] py-3 text-[1.125rem] font-bold text-[#191919] shadow-[0_2px_8px_rgba(0,0,0,0.08)] transition-all hover:bg-[#f5dc00] active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-70"
             >
               <MessageCircle className="size-6 shrink-0 fill-[#191919]" />
-              카카오 로그인으로 시작
+              {isKakaoLoading ? '로그인 중...' : '카카오 로그인으로 시작'}
             </button>
             <button
               type="button"
-              className="flex h-14 items-center justify-center gap-2.5 rounded-2xl border-2 border-ui-border bg-ui-surface py-3 text-[1.125rem] font-bold text-ui-text-primary transition-colors hover:border-ui-text-subtle hover:bg-ui-surface-muted active:scale-[0.98]"
+              onClick={handleGuestLogin}
+              disabled={isAnyLoading}
+              className="flex h-14 items-center justify-center gap-2.5 rounded-2xl border-2 border-ui-border bg-ui-surface py-3 text-[1.125rem] font-bold text-ui-text-primary transition-colors hover:border-ui-text-subtle hover:bg-ui-surface-muted active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-70"
             >
               <UserRound className="size-6 shrink-0 text-ui-text-muted" />
-              게스트로 시작
+              {isGuestLoading ? '입장 중...' : '게스트로 시작'}
             </button>
           </div>
 

--- a/src/pages/NicknameSetupPage.tsx
+++ b/src/pages/NicknameSetupPage.tsx
@@ -1,0 +1,99 @@
+import { ArrowLeft, UserRound } from 'lucide-react'
+import { useNicknameSetupForm } from '../features/auth/hooks/useNicknameSetupForm'
+
+function NicknameSetupPage() {
+  const {
+    shouldRender,
+    nickname,
+    helperFeedback,
+    isSubmitting,
+    isSubmitDisabled,
+    handleSubmit,
+    handleNicknameChange,
+    handleNicknameFocus,
+    handleNicknameBlur,
+    handleBackToHome,
+  } = useNicknameSetupForm()
+
+  if (!shouldRender) {
+    return null
+  }
+
+  return (
+    <div className="relative min-h-screen bg-ui-app-bg">
+      <button
+        type="button"
+        onClick={handleBackToHome}
+        aria-label="홈으로 이동"
+        className="absolute left-4 top-4 inline-flex items-center gap-1.5 rounded-xl border border-ui-border bg-ui-surface px-3 py-2 text-sm font-semibold text-ui-text-primary transition-colors hover:bg-ui-surface-muted sm:left-6 sm:top-6"
+      >
+        <ArrowLeft className="size-4" />
+        홈으로 이동
+      </button>
+
+      <main className="mx-auto flex min-h-screen max-w-6xl items-center justify-center px-4 py-10 sm:px-6">
+        <section className="w-full max-w-[560px] rounded-3xl border border-ui-border bg-ui-surface px-8 py-10 shadow-[0_12px_32px_rgba(15,23,42,0.08)]">
+          <div className="mb-6 flex justify-center">
+            <div className="flex size-[72px] items-center justify-center rounded-full bg-ui-brand-soft">
+              <UserRound className="size-8 text-ui-brand" />
+            </div>
+          </div>
+
+          <h1 className="text-center text-4xl font-extrabold tracking-tight text-ui-text-strong">
+            닉네임 설정
+          </h1>
+          <p className="mt-2 text-center text-base font-medium text-ui-text-muted">
+            친구들이 당신을 알아볼 수 있도록 닉네임을 정해 주세요.
+          </p>
+
+          <form className="mt-9" onSubmit={handleSubmit}>
+            <label
+              htmlFor="nickname"
+              className="mb-2 block text-base font-semibold text-ui-text-primary"
+            >
+              닉네임
+            </label>
+
+            <div className="relative">
+              <UserRound className="pointer-events-none absolute left-3 top-1/2 size-5 -translate-y-1/2 text-ui-text-subtle" />
+              <input
+                id="nickname"
+                type="text"
+                value={nickname}
+                maxLength={10}
+                onFocus={handleNicknameFocus}
+                onBlur={handleNicknameBlur}
+                onChange={(event) => handleNicknameChange(event.target.value)}
+                placeholder="예) GoormEE"
+                className="h-12 w-full rounded-2xl border border-ui-border bg-ui-surface pl-11 pr-4 text-base text-ui-text-primary outline-none placeholder:text-ui-text-subtle focus:border-ui-brand focus:ring-2 focus:ring-ui-brand/20"
+                autoComplete="off"
+              />
+            </div>
+
+            <p
+              className={`mt-3 text-sm font-medium ${
+                helperFeedback.tone === 'danger'
+                  ? 'text-ui-danger'
+                  : helperFeedback.tone === 'success'
+                    ? 'text-ui-presence-lobby'
+                    : 'text-ui-text-muted'
+              }`}
+            >
+              {helperFeedback.message}
+            </p>
+
+            <button
+              type="submit"
+              disabled={isSubmitDisabled}
+              className="mt-6 flex h-12 w-full items-center justify-center rounded-2xl bg-ui-brand text-lg font-bold text-white transition-colors hover:bg-ui-brand-strong disabled:cursor-not-allowed disabled:bg-ui-disabled-bg disabled:text-ui-disabled-text"
+            >
+              {isSubmitting ? '처리 중...' : '시작하기'}
+            </button>
+          </form>
+        </section>
+      </main>
+    </div>
+  )
+}
+
+export default NicknameSetupPage

--- a/src/pages/lobby/LobbyPage.tsx
+++ b/src/pages/lobby/LobbyPage.tsx
@@ -1,5 +1,7 @@
-import { useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import Header from '../../components/Header'
+import { useAuthStore } from '../../features/auth/store'
 import { UserListPanel } from '../../features/presence/components/UserListPanel'
 import { useOnlineUsersSocket } from '../../features/presence/hooks'
 import type { LobbyRoomFilter } from './api'
@@ -8,10 +10,25 @@ import { LobbyControls } from './LobbyControls'
 import { RoomGrid } from './RoomGrid'
 
 function LobbyPage() {
+  const navigate = useNavigate()
+  const session = useAuthStore((state) => state.session)
+  const clearSession = useAuthStore((state) => state.clearSession)
+
   const [searchRoom, setSearchRoom] = useState('')
   const [roomFilter, setRoomFilter] = useState<LobbyRoomFilter>('ALL')
   const [excludePrivateRoom, setExcludePrivateRoom] = useState(false)
   const [isUserListOpen, setIsUserListOpen] = useState(true)
+
+  useEffect(() => {
+    if (!session) {
+      navigate('/', { replace: true })
+      return
+    }
+
+    if (session.needsNicknameSetup) {
+      navigate('/nickname-setup', { replace: true })
+    }
+  }, [navigate, session])
 
   const {
     data: rooms = [],
@@ -29,9 +46,37 @@ function LobbyPage() {
     isError: isUsersError,
   } = useOnlineUsersSocket()
 
+  const avatarText = useMemo(() => {
+    const trimmedNickname = session?.nickname.trim() ?? ''
+    return trimmedNickname.length > 0 ? trimmedNickname.slice(0, 1) : 'P'
+  }, [session?.nickname])
+
+  const avatarBackground = session?.isGuest ? '#fde68a' : '#bfdbfe'
+
+  function handleLogout() {
+    clearSession()
+    navigate('/', { replace: true })
+  }
+
+  if (!session || session.needsNicknameSetup) {
+    return null
+  }
+
   return (
     <div className="min-h-screen bg-ui-app-bg">
-      <Header />
+      <Header
+        playerLabel={session.nickname}
+        avatarText={avatarText}
+        avatarBackground={avatarBackground}
+        menuItems={[
+          {
+            id: 'logout',
+            label: '로그아웃',
+            onSelect: handleLogout,
+            tone: 'danger',
+          },
+        ]}
+      />
 
       <main className="flex flex-col gap-4 p-4 sm:p-6 xl:flex-row">
         <section className="min-w-0 flex-1">


### PR DESCRIPTION
## 📌 관련 이슈

closes #68

---

## 📝 작업 내용

- **features/auth**: store, types, mockApi, nicknameSetupRules 추가
- **NicknameSetupPage**: `/nickname-setup` 페이지, 닉네임 유효성 검사 및 제출 처리
- **HomePage**: 카카오/게스트 로그인, `needsNicknameSetup` 시 닉네임 설정으로 이동
- **LobbyPage**: 비로그인 시 홈 리다이렉트, 닉네임 미설정 시 닉네임 설정 리다이렉트, 로그아웃 메뉴
- **Header**: 로그인 사용자 닉네임 표시, 프로필 메뉴(로그아웃)

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

<img width="1912" height="1242" alt="스크린샷 2026-02-26 오후 3 53 12" src="https://github.com/user-attachments/assets/d9dca006-36ad-4b5f-86ce-5dfc78237d9f" />
