### PR TITLE
chore: 닉네임 설정 UX 개선 + feat: 마이페이지 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,12 +3,14 @@ import HomePage from './pages/HomePage'
 import GamePage from './pages/GamePage'
 import LobbyPage from './pages/lobby/LobbyPage'
 import NicknameSetupPage from './pages/NicknameSetupPage'
+import MyPage from './pages/MyPage'
 
 function App() {
   return (
     <Routes>
       <Route path="/" element={<HomePage />} />
       <Route path="/nickname-setup" element={<NicknameSetupPage />} />
+      <Route path="/my-page" element={<MyPage />} />
       <Route path="/game" element={<GamePage />} />
       <Route path="/lobby" element={<LobbyPage />} />
     </Routes>

--- a/src/features/auth/hooks/useMyPageProfileQuery.ts
+++ b/src/features/auth/hooks/useMyPageProfileQuery.ts
@@ -1,0 +1,27 @@
+import { useQuery } from '@tanstack/react-query'
+import { mockGetMyPageProfile } from '../mockApi'
+import type { AuthSession } from '../types'
+
+const MY_PAGE_PROFILE_STALE_TIME_MS = 30_000
+
+export function useMyPageProfileQuery(session: AuthSession | null) {
+  return useQuery({
+    queryKey: ['my-page', session?.userId],
+    enabled: Boolean(
+      session && !session.isGuest && !session.needsNicknameSetup
+    ),
+    staleTime: MY_PAGE_PROFILE_STALE_TIME_MS,
+    queryFn: async () => {
+      if (!session) {
+        throw new Error('로그인 세션이 없습니다.')
+      }
+
+      const result = await mockGetMyPageProfile(session)
+      if (!result.ok) {
+        throw new Error(result.message)
+      }
+
+      return result.profile
+    },
+  })
+}

--- a/src/features/auth/hooks/useNicknameSetupForm.ts
+++ b/src/features/auth/hooks/useNicknameSetupForm.ts
@@ -8,6 +8,7 @@ import {
 import {
   createNicknameHelperFeedback,
   NICKNAME_CHECK_DEBOUNCE_MS,
+  VALIDATION_MESSAGE_DEBOUNCE_MS,
 } from '../nicknameSetupRules'
 import { useAuthStore } from '../store'
 
@@ -24,6 +25,7 @@ export function useNicknameSetupForm() {
   const [isNicknameAvailable, setIsNicknameAvailable] = useState<
     boolean | null
   >(null)
+  const [showValidationMessage, setShowValidationMessage] = useState(false)
 
   useEffect(() => {
     if (!session) {
@@ -73,6 +75,15 @@ export function useNicknameSetupForm() {
     }
   }, [nicknameValidation])
 
+  useEffect(() => {
+    setShowValidationMessage(false)
+    const timer = window.setTimeout(
+      () => setShowValidationMessage(true),
+      VALIDATION_MESSAGE_DEBOUNCE_MS
+    )
+    return () => window.clearTimeout(timer)
+  }, [nickname])
+
   const helperFeedback = useMemo(
     () =>
       createNicknameHelperFeedback({
@@ -82,6 +93,7 @@ export function useNicknameSetupForm() {
         nicknameValidation,
         isCheckingNickname,
         isNicknameAvailable,
+        showValidationMessage,
       }),
     [
       isCheckingNickname,
@@ -89,6 +101,7 @@ export function useNicknameSetupForm() {
       isNicknameFocused,
       nickname,
       nicknameValidation,
+      showValidationMessage,
       submitMessage,
     ]
   )

--- a/src/features/auth/mockApi.ts
+++ b/src/features/auth/mockApi.ts
@@ -1,11 +1,14 @@
 import type {
   NicknameAvailabilityResult,
   AuthSession,
+  MyPageProfileResult,
+  MyPageStats,
   NicknameSetResult,
   NicknameValidationResult,
 } from './types'
 
 const MOCK_AUTH_DELAY_MS = 350
+const MOCK_NICKNAME_CHECK_DELAY_MS = 0
 const TAKEN_NICKNAMES_STORAGE_KEY = 'marble-pop-mock-taken-nicknames'
 const KAKAO_USER_STORAGE_KEY = 'marble-pop-mock-kakao-user'
 const DEFAULT_TAKEN_NICKNAMES = [
@@ -170,6 +173,23 @@ function createGuestNickname() {
   return `Guest_${uuid.slice(0, 4)}`
 }
 
+function createMockMyPageStats(userId: string): MyPageStats {
+  let hash = 0
+  for (let index = 0; index < userId.length; index += 1) {
+    hash = (hash * 31 + userId.charCodeAt(index)) | 0
+  }
+
+  const normalizedHash = Math.abs(hash)
+  const wins = 100 + (normalizedHash % 700)
+  const losses = 100 + ((normalizedHash >> 4) % 700)
+
+  return {
+    total: wins + losses,
+    wins,
+    losses,
+  }
+}
+
 export function validateNickname(nickname: string): NicknameValidationResult {
   const normalizedNickname = nickname.trim()
 
@@ -220,6 +240,7 @@ export async function mockKakaoLogin() {
     accessToken: `mock-kakao-token-${kakaoUser.id}`,
     userId: kakaoUser.id,
     nickname: existingNickname,
+    profileImage: kakaoUser.profileImage,
     isGuest: false,
     needsNicknameSetup: !hasNickname,
     provider: 'kakao',
@@ -240,6 +261,7 @@ export async function mockGuestLogin() {
     accessToken: `mock-guest-token-${userId}`,
     userId,
     nickname,
+    profileImage: null,
     isGuest: true,
     needsNicknameSetup: false,
     provider: 'guest',
@@ -251,7 +273,9 @@ export async function mockGuestLogin() {
 export async function mockCheckNicknameAvailability(
   nickname: string
 ): Promise<NicknameAvailabilityResult> {
-  await delay(MOCK_AUTH_DELAY_MS)
+  if (MOCK_NICKNAME_CHECK_DELAY_MS > 0) {
+    await delay(MOCK_NICKNAME_CHECK_DELAY_MS)
+  }
   seedTakenNicknamesIfMissing()
 
   const validationResult = validateNickname(nickname)
@@ -311,5 +335,35 @@ export async function mockSetNickname({
   return {
     ok: true,
     nickname: validationResult.normalizedNickname,
+  }
+}
+
+export async function mockGetMyPageProfile(
+  session: AuthSession
+): Promise<MyPageProfileResult> {
+  await delay(MOCK_AUTH_DELAY_MS)
+
+  if (session.isGuest) {
+    return {
+      ok: false,
+      code: 'FORBIDDEN',
+      message: '게스트는 마이페이지를 이용할 수 없습니다.',
+    }
+  }
+
+  const kakaoUser = getOrCreateMockKakaoUser()
+  const profileNickname =
+    session.nickname.trim().length > 0
+      ? session.nickname
+      : (kakaoUser.nickname ?? '플레이어')
+
+  return {
+    ok: true,
+    profile: {
+      id: session.userId,
+      nickname: profileNickname,
+      profileImage: session.profileImage ?? kakaoUser.profileImage,
+      stats: createMockMyPageStats(session.userId),
+    },
   }
 }

--- a/src/features/auth/nicknameSetupRules.ts
+++ b/src/features/auth/nicknameSetupRules.ts
@@ -1,6 +1,7 @@
 import type { NicknameValidationResult } from './types'
 
-export const NICKNAME_CHECK_DEBOUNCE_MS = 400
+export const NICKNAME_CHECK_DEBOUNCE_MS = 0
+export const VALIDATION_MESSAGE_DEBOUNCE_MS = 500
 export const NICKNAME_LENGTH_ERROR_MESSAGE = '닉네임은 2~10자여야 합니다.'
 export const NICKNAME_PATTERN_ERROR_MESSAGE =
   '한글/영문/숫자만 입력할 수 있습니다.'
@@ -20,6 +21,7 @@ interface CreateNicknameHelperFeedbackParams {
   nicknameValidation: NicknameValidationResult
   isCheckingNickname: boolean
   isNicknameAvailable: boolean | null
+  showValidationMessage: boolean
 }
 
 function createLengthFeedback(): NicknameHelperFeedback {
@@ -70,11 +72,35 @@ export function createNicknameHelperFeedback({
   nicknameValidation,
   isCheckingNickname,
   isNicknameAvailable,
+  showValidationMessage,
 }: CreateNicknameHelperFeedbackParams): NicknameHelperFeedback {
   if (submitMessage) {
     return {
       message: submitMessage,
       tone: 'danger',
+    }
+  }
+
+  if (!showValidationMessage) {
+    return createLengthFeedback()
+  }
+
+  if (nicknameValidation.ok) {
+    if (isCheckingNickname || isNicknameAvailable === null) {
+      return {
+        message: '• 닉네임 중복 확인 중...',
+        tone: 'default',
+      }
+    }
+    if (!isNicknameAvailable) {
+      return {
+        message: '• 이미 사용 중인 닉네임입니다.',
+        tone: 'danger',
+      }
+    }
+    return {
+      message: '• 사용 가능한 닉네임입니다.',
+      tone: 'success',
     }
   }
 
@@ -86,26 +112,5 @@ export function createNicknameHelperFeedback({
     return createLengthFeedback()
   }
 
-  if (!nicknameValidation.ok) {
-    return createValidationFeedback(nicknameValidation)
-  }
-
-  if (isCheckingNickname || isNicknameAvailable === null) {
-    return {
-      message: '• 닉네임 중복 확인 중...',
-      tone: 'default',
-    }
-  }
-
-  if (!isNicknameAvailable) {
-    return {
-      message: '• 이미 사용 중인 닉네임입니다.',
-      tone: 'danger',
-    }
-  }
-
-  return {
-    message: '• 사용 가능한 닉네임입니다.',
-    tone: 'success',
-  }
+  return createValidationFeedback(nicknameValidation)
 }

--- a/src/features/auth/types.ts
+++ b/src/features/auth/types.ts
@@ -4,9 +4,23 @@ export interface AuthSession {
   accessToken: string
   userId: string
   nickname: string
+  profileImage: string | null
   isGuest: boolean
   needsNicknameSetup: boolean
   provider: AuthProvider
+}
+
+export interface MyPageStats {
+  total: number
+  wins: number
+  losses: number
+}
+
+export interface MyPageProfile {
+  id: string
+  nickname: string
+  profileImage: string | null
+  stats: MyPageStats
 }
 
 export type NicknameValidationResult =
@@ -40,5 +54,16 @@ export type NicknameAvailabilityResult =
   | {
       ok: false
       normalizedNickname: string
+      message: string
+    }
+
+export type MyPageProfileResult =
+  | {
+      ok: true
+      profile: MyPageProfile
+    }
+  | {
+      ok: false
+      code: 'FORBIDDEN'
       message: string
     }

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -1,0 +1,163 @@
+import { useEffect, useMemo } from 'react'
+import { ArrowLeft, Gamepad2, Shield, Trophy } from 'lucide-react'
+import { useNavigate } from 'react-router-dom'
+import { useAuthStore } from '../features/auth/store'
+import { useMyPageProfileQuery } from '../features/auth/hooks/useMyPageProfileQuery'
+
+const myPageStatsCardMeta = [
+  {
+    key: 'total' as const,
+    label: '총 게임',
+    icon: Gamepad2,
+    iconClassName: 'text-ui-brand',
+    iconBackgroundClassName: 'bg-ui-brand-soft',
+  },
+  {
+    key: 'wins' as const,
+    label: '승리',
+    icon: Trophy,
+    iconClassName: 'text-[#e0a300]',
+    iconBackgroundClassName: 'bg-[#fff5d6]',
+  },
+  {
+    key: 'losses' as const,
+    label: '패배',
+    icon: Shield,
+    iconClassName: 'text-[#ef4444]',
+    iconBackgroundClassName: 'bg-[#fee2e2]',
+  },
+]
+
+function MyPage() {
+  const navigate = useNavigate()
+  const session = useAuthStore((state) => state.session)
+  const { data: profile, isLoading, isError } = useMyPageProfileQuery(session)
+
+  useEffect(() => {
+    if (!session) {
+      navigate('/', { replace: true })
+      return
+    }
+
+    if (session.needsNicknameSetup) {
+      navigate('/nickname-setup', { replace: true })
+    }
+  }, [navigate, session])
+
+  const fallbackAvatarText = useMemo(() => {
+    const trimmedNickname = session?.nickname.trim() ?? ''
+    return trimmedNickname.length > 0 ? trimmedNickname.slice(0, 1) : 'P'
+  }, [session?.nickname])
+
+  if (!session || session.needsNicknameSetup) {
+    return null
+  }
+
+  const isGuest = session.isGuest
+
+  return (
+    <div className="min-h-screen bg-ui-app-bg">
+      <header className="flex h-14 items-center border-b border-ui-border bg-ui-surface px-4 sm:px-6">
+        <button
+          type="button"
+          onClick={() => navigate('/lobby')}
+          className="inline-flex items-center gap-2 rounded-xl px-2 py-1 text-ui-text-primary transition-colors hover:bg-ui-surface-muted"
+        >
+          <span className="flex size-9 items-center justify-center rounded-full border border-ui-border bg-ui-surface-soft">
+            <ArrowLeft className="size-4" />
+          </span>
+          <span className="text-xl font-bold leading-none text-ui-text-strong">
+            내 정보
+          </span>
+        </button>
+      </header>
+
+      <main className="mx-auto max-w-5xl px-4 py-8 sm:px-6">
+        {isGuest ? (
+          <section className="rounded-3xl border border-ui-border bg-ui-surface p-7 shadow-[0_12px_30px_rgba(15,23,42,0.08)]">
+            <h2 className="text-xl font-bold text-ui-text-strong">
+              마이페이지 제한
+            </h2>
+            <p className="mt-2 text-sm font-medium text-ui-text-muted">
+              게스트는 마이페이지 및 전적 조회를 이용할 수 없습니다.
+            </p>
+            <button
+              type="button"
+              onClick={() => navigate('/lobby')}
+              className="mt-5 inline-flex h-11 items-center justify-center rounded-xl bg-ui-brand px-4 text-sm font-semibold text-white transition-colors hover:bg-ui-brand-strong"
+            >
+              로비로 돌아가기
+            </button>
+          </section>
+        ) : null}
+
+        {!isGuest ? (
+          <section className="space-y-5">
+            <article className="rounded-3xl border border-ui-border bg-ui-surface px-8 py-8 shadow-[0_14px_34px_rgba(15,23,42,0.08)]">
+              {isLoading ? (
+                <div className="flex items-center gap-6">
+                  <div className="size-24 animate-pulse rounded-full bg-ui-surface-soft" />
+                  <div className="h-8 w-36 animate-pulse rounded-xl bg-ui-surface-soft" />
+                </div>
+              ) : isError || !profile ? (
+                <p className="text-sm font-medium text-ui-danger">
+                  프로필 정보를 불러오지 못했습니다.
+                </p>
+              ) : (
+                <div className="flex items-center gap-6">
+                  <div className="relative size-24 overflow-hidden rounded-full border border-ui-border bg-ui-brand-soft">
+                    {profile.profileImage ? (
+                      <img
+                        src={profile.profileImage}
+                        alt={`${profile.nickname} 프로필`}
+                        className="size-full object-cover"
+                      />
+                    ) : (
+                      <div className="flex size-full items-center justify-center text-2xl font-bold text-ui-brand">
+                        {fallbackAvatarText}
+                      </div>
+                    )}
+                  </div>
+                  <h1 className="text-3xl font-extrabold tracking-tight text-ui-text-strong">
+                    {profile.nickname}
+                  </h1>
+                </div>
+              )}
+            </article>
+
+            <section className="grid grid-cols-1 gap-4 md:grid-cols-3">
+              {myPageStatsCardMeta.map((statCardMeta) => {
+                const StatIcon = statCardMeta.icon
+                const statValue = profile?.stats[statCardMeta.key] ?? 0
+
+                return (
+                  <article
+                    key={statCardMeta.key}
+                    className="rounded-3xl border border-ui-border bg-ui-surface px-6 py-6 shadow-[0_8px_22px_rgba(15,23,42,0.06)]"
+                  >
+                    <div
+                      className={`mb-3 flex size-12 items-center justify-center rounded-2xl ${statCardMeta.iconBackgroundClassName}`}
+                    >
+                      <StatIcon
+                        className={`size-6 ${statCardMeta.iconClassName}`}
+                      />
+                    </div>
+
+                    <p className="text-3xl font-extrabold tracking-tight text-ui-text-strong">
+                      {isLoading ? '--' : statValue.toLocaleString()}
+                    </p>
+                    <p className="mt-1.5 text-sm font-semibold text-ui-text-muted">
+                      {statCardMeta.label}
+                    </p>
+                  </article>
+                )
+              })}
+            </section>
+          </section>
+        ) : null}
+      </main>
+    </div>
+  )
+}
+
+export default MyPage

--- a/src/pages/NicknameSetupPage.tsx
+++ b/src/pages/NicknameSetupPage.tsx
@@ -25,14 +25,13 @@ function NicknameSetupPage() {
         type="button"
         onClick={handleBackToHome}
         aria-label="홈으로 이동"
-        className="absolute left-4 top-4 inline-flex items-center gap-1.5 rounded-xl border border-ui-border bg-ui-surface px-3 py-2 text-sm font-semibold text-ui-text-primary transition-colors hover:bg-ui-surface-muted sm:left-6 sm:top-6"
+        className="absolute left-4 top-4 flex size-10 items-center justify-center rounded-full border border-ui-border bg-ui-surface text-ui-text-primary transition-colors hover:bg-ui-surface-muted sm:left-6 sm:top-6"
       >
-        <ArrowLeft className="size-4" />
-        홈으로 이동
+        <ArrowLeft className="size-5" />
       </button>
 
       <main className="mx-auto flex min-h-screen max-w-6xl items-center justify-center px-4 py-10 sm:px-6">
-        <section className="w-full max-w-[560px] rounded-3xl border border-ui-border bg-ui-surface px-8 py-10 shadow-[0_12px_32px_rgba(15,23,42,0.08)]">
+        <section className="-mt-24 w-full max-w-[560px] rounded-3xl border border-ui-border bg-ui-surface px-8 py-10 shadow-[0_12px_32px_rgba(15,23,42,0.08)]">
           <div className="mb-6 flex justify-center">
             <div className="flex size-[72px] items-center justify-center rounded-full bg-ui-brand-soft">
               <UserRound className="size-8 text-ui-brand" />

--- a/src/pages/lobby/LobbyPage.tsx
+++ b/src/pages/lobby/LobbyPage.tsx
@@ -58,9 +58,36 @@ function LobbyPage() {
     navigate('/', { replace: true })
   }
 
+  function handleGoMyPage() {
+    navigate('/my-page')
+  }
+
   if (!session || session.needsNicknameSetup) {
     return null
   }
+
+  const headerMenuItems = session.isGuest
+    ? [
+        {
+          id: 'logout',
+          label: '로그아웃',
+          onSelect: handleLogout,
+          tone: 'danger' as const,
+        },
+      ]
+    : [
+        {
+          id: 'my-page',
+          label: '마이페이지',
+          onSelect: handleGoMyPage,
+        },
+        {
+          id: 'logout',
+          label: '로그아웃',
+          onSelect: handleLogout,
+          tone: 'danger' as const,
+        },
+      ]
 
   return (
     <div className="min-h-screen bg-ui-app-bg">
@@ -68,14 +95,7 @@ function LobbyPage() {
         playerLabel={session.nickname}
         avatarText={avatarText}
         avatarBackground={avatarBackground}
-        menuItems={[
-          {
-            id: 'logout',
-            label: '로그아웃',
-            onSelect: handleLogout,
-            tone: 'danger',
-          },
-        ]}
+        menuItems={headerMenuItems}
       />
 
       <main className="flex flex-col gap-4 p-4 sm:p-6 xl:flex-row">


### PR DESCRIPTION
## 📌 관련 이슈

closes #72

---

## 📝 작업 내용

**닉네임 설정 페이지 UX**
- 뒤로가기 버튼 아이콘만 둥글게, 카드 위로 조정
- 유효성 메시지 500ms 디바운스, 기본 안내 상시 표시
- 성공 메시지 포커스 유지 시에도 표시
- 버튼 활성화·닉네임 중복 확인 딜레이 제거

**마이페이지**
- MyPage 추가 (/mypage)
- 프로필 영역: 닉네임, 프로필 이미지
- 전적 카드: 전체 게임, 승리, 패배
- 게스트 접근 시 이용 안내 및 로비 이동 버튼

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

> UI 변경이 있을 경우 첨부해주세요.