### PR TITLE
refactor: 헤더 프로필 드롭다운과 아바타 메뉴 로직 공통화

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,18 +1,12 @@
-import { useEffect, useRef, useState } from 'react'
 import { Dice5 } from 'lucide-react'
-
-interface HeaderMenuItem {
-  id: string
-  label: string
-  onSelect: () => void
-  tone?: 'default' | 'danger'
-}
+import { ProfileDropdown } from './layout/ProfileDropdown'
+import type { ProfileMenuItem } from '../types/layout'
 
 interface HeaderProps {
   playerLabel?: string
   avatarText?: string
   avatarBackground?: string
-  menuItems?: HeaderMenuItem[]
+  menuItems?: ProfileMenuItem[]
 }
 
 function Header({
@@ -21,48 +15,6 @@ function Header({
   avatarBackground = '#fde68a',
   menuItems = [],
 }: HeaderProps) {
-  const [isMenuOpen, setIsMenuOpen] = useState(false)
-  const menuContainerRef = useRef<HTMLDivElement | null>(null)
-
-  const hasMenuItems = menuItems.length > 0
-  const avatar = (
-    <div
-      className="flex size-9 items-center justify-center rounded-full text-xs font-semibold text-ui-text-primary"
-      style={{ backgroundColor: avatarBackground }}
-    >
-      {avatarText}
-    </div>
-  )
-
-  useEffect(() => {
-    if (!hasMenuItems || !isMenuOpen) {
-      return
-    }
-
-    function handlePointerDown(event: PointerEvent) {
-      if (
-        menuContainerRef.current &&
-        !menuContainerRef.current.contains(event.target as Node)
-      ) {
-        setIsMenuOpen(false)
-      }
-    }
-
-    function handleKeyDown(event: KeyboardEvent) {
-      if (event.key === 'Escape') {
-        setIsMenuOpen(false)
-      }
-    }
-
-    window.addEventListener('pointerdown', handlePointerDown)
-    window.addEventListener('keydown', handleKeyDown)
-
-    return () => {
-      window.removeEventListener('pointerdown', handlePointerDown)
-      window.removeEventListener('keydown', handleKeyDown)
-    }
-  }, [hasMenuItems, isMenuOpen])
-
   return (
     <header className="flex h-14 items-center justify-between border-b border-ui-border bg-ui-surface px-4 sm:px-6">
       <div className="flex items-center gap-2.5">
@@ -72,53 +24,12 @@ function Header({
         <h1 className="text-lg font-bold text-ui-text-strong">MARBLE POP</h1>
       </div>
 
-      <div className="flex items-center gap-2 text-sm font-medium text-ui-text-muted">
-        <span className="max-w-[140px] truncate">{playerLabel}</span>
-        {hasMenuItems ? (
-          <div ref={menuContainerRef} className="relative group/menu">
-            <button
-              type="button"
-              className="rounded-full outline-none"
-              aria-label="프로필 메뉴 열기"
-              aria-expanded={isMenuOpen}
-              onClick={() => setIsMenuOpen((prev) => !prev)}
-            >
-              {avatar}
-            </button>
-
-            <div
-              className={`absolute right-0 top-full z-20 pt-2 transition-opacity ${
-                isMenuOpen
-                  ? 'pointer-events-auto opacity-100'
-                  : 'pointer-events-none opacity-0'
-              } group-hover/menu:pointer-events-auto group-hover/menu:opacity-100 group-focus-within/menu:pointer-events-auto group-focus-within/menu:opacity-100`}
-            >
-              <ul className="min-w-[140px] rounded-xl border border-ui-border bg-ui-surface p-1 shadow-[0_8px_20px_rgba(15,23,42,0.12)]">
-                {menuItems.map((item) => (
-                  <li key={item.id}>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        item.onSelect()
-                        setIsMenuOpen(false)
-                      }}
-                      className={`flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm font-medium transition hover:bg-ui-surface-muted ${
-                        item.tone === 'danger'
-                          ? 'text-ui-danger'
-                          : 'text-ui-text-primary'
-                      }`}
-                    >
-                      <span>{item.label}</span>
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          </div>
-        ) : (
-          avatar
-        )}
-      </div>
+      <ProfileDropdown
+        playerLabel={playerLabel}
+        avatarText={avatarText}
+        avatarBackground={avatarBackground}
+        menuItems={menuItems}
+      />
     </header>
   )
 }

--- a/src/components/layout/ProfileDropdown.tsx
+++ b/src/components/layout/ProfileDropdown.tsx
@@ -1,0 +1,108 @@
+import { useEffect, useRef, useState } from 'react'
+import type { ProfileMenuItem } from '../../types/layout'
+
+interface ProfileDropdownProps {
+  playerLabel?: string
+  avatarText?: string
+  avatarBackground?: string
+  menuItems?: ProfileMenuItem[]
+}
+
+export function ProfileDropdown({
+  playerLabel = '플레이어',
+  avatarText = 'P',
+  avatarBackground = '#fde68a',
+  menuItems = [],
+}: ProfileDropdownProps) {
+  const [isMenuOpen, setIsMenuOpen] = useState(false)
+  const menuContainerRef = useRef<HTMLDivElement | null>(null)
+
+  const hasMenuItems = menuItems.length > 0
+  const avatar = (
+    <div
+      className="flex size-9 items-center justify-center rounded-full text-xs font-semibold text-ui-text-primary"
+      style={{ backgroundColor: avatarBackground }}
+    >
+      {avatarText}
+    </div>
+  )
+
+  useEffect(() => {
+    if (!hasMenuItems || !isMenuOpen) {
+      return
+    }
+
+    function handlePointerDown(event: PointerEvent) {
+      if (
+        menuContainerRef.current &&
+        !menuContainerRef.current.contains(event.target as Node)
+      ) {
+        setIsMenuOpen(false)
+      }
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        setIsMenuOpen(false)
+      }
+    }
+
+    window.addEventListener('pointerdown', handlePointerDown)
+    window.addEventListener('keydown', handleKeyDown)
+
+    return () => {
+      window.removeEventListener('pointerdown', handlePointerDown)
+      window.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [hasMenuItems, isMenuOpen])
+
+  return (
+    <div className="flex items-center gap-2 text-sm font-medium text-ui-text-muted">
+      <span className="max-w-[140px] truncate">{playerLabel}</span>
+      {hasMenuItems ? (
+        <div ref={menuContainerRef} className="relative group/menu">
+          <button
+            type="button"
+            className="rounded-full outline-none"
+            aria-label="프로필 메뉴 열기"
+            aria-expanded={isMenuOpen}
+            onClick={() => setIsMenuOpen((previous) => !previous)}
+          >
+            {avatar}
+          </button>
+
+          <div
+            className={`absolute right-0 top-full z-20 pt-2 transition-opacity ${
+              isMenuOpen
+                ? 'pointer-events-auto opacity-100'
+                : 'pointer-events-none opacity-0'
+            } group-hover/menu:pointer-events-auto group-hover/menu:opacity-100 group-focus-within/menu:pointer-events-auto group-focus-within/menu:opacity-100`}
+          >
+            <ul className="min-w-[140px] rounded-xl border border-ui-border bg-ui-surface p-1 shadow-[0_8px_20px_rgba(15,23,42,0.12)]">
+              {menuItems.map((item) => (
+                <li key={item.id}>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      item.onSelect()
+                      setIsMenuOpen(false)
+                    }}
+                    className={`flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm font-medium transition hover:bg-ui-surface-muted ${
+                      item.tone === 'danger'
+                        ? 'text-ui-danger'
+                        : 'text-ui-text-primary'
+                    }`}
+                  >
+                    <span>{item.label}</span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      ) : (
+        avatar
+      )}
+    </div>
+  )
+}

--- a/src/features/auth/ui.ts
+++ b/src/features/auth/ui.ts
@@ -1,0 +1,47 @@
+import type { ProfileMenuItem } from '../../types/layout'
+
+interface CreateProfileMenuItemsParams {
+  isGuest: boolean
+  onGoMyPage: () => void
+  onLogout: () => void
+}
+
+export function getAvatarText(nickname?: string): string {
+  const trimmedNickname = nickname?.trim() ?? ''
+  return trimmedNickname.length > 0 ? trimmedNickname.slice(0, 1) : 'P'
+}
+
+export function getAvatarBackground(isGuest?: boolean): string {
+  return isGuest ? '#fde68a' : '#bfdbfe'
+}
+
+export function createProfileMenuItems({
+  isGuest,
+  onGoMyPage,
+  onLogout,
+}: CreateProfileMenuItemsParams): ProfileMenuItem[] {
+  if (isGuest) {
+    return [
+      {
+        id: 'logout',
+        label: '로그아웃',
+        onSelect: onLogout,
+        tone: 'danger',
+      },
+    ]
+  }
+
+  return [
+    {
+      id: 'my-page',
+      label: '마이페이지',
+      onSelect: onGoMyPage,
+    },
+    {
+      id: 'logout',
+      label: '로그아웃',
+      onSelect: onLogout,
+      tone: 'danger',
+    },
+  ]
+}

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -3,6 +3,7 @@ import { ArrowLeft, Gamepad2, Shield, Trophy } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import { useAuthStore } from '../features/auth/store'
 import { useMyPageProfileQuery } from '../features/auth/hooks/useMyPageProfileQuery'
+import { getAvatarText } from '../features/auth/ui'
 
 const myPageStatsCardMeta = [
   {
@@ -45,8 +46,7 @@ function MyPage() {
   }, [navigate, session])
 
   const fallbackAvatarText = useMemo(() => {
-    const trimmedNickname = session?.nickname.trim() ?? ''
-    return trimmedNickname.length > 0 ? trimmedNickname.slice(0, 1) : 'P'
+    return getAvatarText(session?.nickname)
   }, [session?.nickname])
 
   if (!session || session.needsNicknameSetup) {

--- a/src/types/layout.ts
+++ b/src/types/layout.ts
@@ -1,0 +1,6 @@
+export interface ProfileMenuItem {
+  id: string
+  label: string
+  onSelect: () => void
+  tone?: 'default' | 'danger'
+}


### PR DESCRIPTION
## 📌 관련 이슈

> closes #80 

---

## 📝 작업 내용

- 프로필 드롭다운 로직을 공통 컴포넌트로 분리했습니다.  
  (`src/components/layout/ProfileDropdown.tsx`)
- `Header`에서 프로필 메뉴 상태/이벤트 중복 코드를 제거하고 공통 컴포넌트를 사용하도록 변경했습니다.
- 아바타 텍스트/배경, 메뉴 아이템 생성 로직을 유틸로 통합했습니다.  
  (`src/features/auth/ui.ts`)
- `ProfileMenuItem` 타입을 공용 타입으로 분리해 참조 구조를 정리했습니다.  
  (`src/types/layout.ts`)
- `MyPage`의 아바타 fallback 계산을 공용 유틸로 통일했습니다.

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인 (`npm run lint`, `npm run build`)
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

- UI 구조/동작은 기존과 동일하며 내부 리팩토링 중심 변경입니다.
