### PR TITLE
feat: 건설 모달 업그레이드 UI구현 

### DIFF
--- a/src/components/game/modals/BuildModal.tsx
+++ b/src/components/game/modals/BuildModal.tsx
@@ -3,6 +3,7 @@
 interface BuildModalProps {
   open: boolean
   cityName?: string
+  upgradeStage?: 'building-to-hotel' | 'hotel-to-landmark'
   currentLevelLabel?: string
   nextLevelLabel?: string
   buildCostText?: string
@@ -15,8 +16,13 @@ interface BuildModalProps {
 }
 
 const DEFAULT_CITY_NAME = '대구'
-const DEFAULT_CURRENT_LEVEL_LABEL = '별장'
-const DEFAULT_NEXT_LEVEL_LABEL = '빌딩'
+const UPGRADE_STAGE_LABEL: Record<
+  NonNullable<BuildModalProps['upgradeStage']>,
+  { current: string; next: string }
+> = {
+  'building-to-hotel': { current: '건물', next: '호텔' },
+  'hotel-to-landmark': { current: '호텔', next: '랜드마크' },
+}
 const DEFAULT_BUILD_COST_TEXT = '30M'
 const DEFAULT_NEXT_TOLL_TEXT = '60M'
 const DEFAULT_CANCEL_LABEL = '취소'
@@ -25,8 +31,9 @@ const DEFAULT_CONFIRM_LABEL = '건설하기'
 const BuildModal: React.FC<BuildModalProps> = ({
   open,
   cityName = DEFAULT_CITY_NAME,
-  currentLevelLabel = DEFAULT_CURRENT_LEVEL_LABEL,
-  nextLevelLabel = DEFAULT_NEXT_LEVEL_LABEL,
+  upgradeStage = 'building-to-hotel',
+  currentLevelLabel,
+  nextLevelLabel,
   buildCostText = DEFAULT_BUILD_COST_TEXT,
   nextTollText = DEFAULT_NEXT_TOLL_TEXT,
   cancelLabel = DEFAULT_CANCEL_LABEL,
@@ -38,6 +45,11 @@ const BuildModal: React.FC<BuildModalProps> = ({
   if (!open) {
     return null
   }
+
+  const resolvedCurrentLevelLabel =
+    currentLevelLabel ?? UPGRADE_STAGE_LABEL[upgradeStage].current
+  const resolvedNextLevelLabel =
+    nextLevelLabel ?? UPGRADE_STAGE_LABEL[upgradeStage].next
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-[rgba(26,36,56,0.35)] backdrop-blur-sm">
@@ -59,9 +71,9 @@ const BuildModal: React.FC<BuildModalProps> = ({
         </p>
 
         <p className="mb-8 mt-4 text-center text-[20px] font-bold leading-[1.35] text-[#5A6D8A]">
-          <span>{currentLevelLabel}</span>
+          <span>{resolvedCurrentLevelLabel}</span>
           <span> → </span>
-          <span className="text-[#245FE5]">{nextLevelLabel}</span>
+          <span className="text-[#245FE5]">{resolvedNextLevelLabel}</span>
           <br />
           건설 비용 <span className="text-[#EF5350]">{buildCostText}</span> · 다음 통행료{' '}
           <span className="text-[#245FE5]">{nextTollText}</span>

--- a/src/components/game/modals/BuildModal.tsx
+++ b/src/components/game/modals/BuildModal.tsx
@@ -1,13 +1,99 @@
 ﻿import React from 'react'
-import BaseModal from './BaseModal'
 
 interface BuildModalProps {
   open: boolean
+  cityName?: string
+  currentLevelLabel?: string
+  nextLevelLabel?: string
+  buildCostText?: string
+  nextTollText?: string
+  cancelLabel?: string
+  confirmLabel?: string
+  canBuild?: boolean
+  onCancel?: () => void
+  onConfirm?: () => void
 }
 
-const BuildModal: React.FC<BuildModalProps> = ({ open }) => {
-  return <BaseModal open={open} title="Build" />
+const DEFAULT_CITY_NAME = '대구'
+const DEFAULT_CURRENT_LEVEL_LABEL = '별장'
+const DEFAULT_NEXT_LEVEL_LABEL = '빌딩'
+const DEFAULT_BUILD_COST_TEXT = '30M'
+const DEFAULT_NEXT_TOLL_TEXT = '60M'
+const DEFAULT_CANCEL_LABEL = '취소'
+const DEFAULT_CONFIRM_LABEL = '건설하기'
+
+const BuildModal: React.FC<BuildModalProps> = ({
+  open,
+  cityName = DEFAULT_CITY_NAME,
+  currentLevelLabel = DEFAULT_CURRENT_LEVEL_LABEL,
+  nextLevelLabel = DEFAULT_NEXT_LEVEL_LABEL,
+  buildCostText = DEFAULT_BUILD_COST_TEXT,
+  nextTollText = DEFAULT_NEXT_TOLL_TEXT,
+  cancelLabel = DEFAULT_CANCEL_LABEL,
+  confirmLabel = DEFAULT_CONFIRM_LABEL,
+  canBuild = true,
+  onCancel,
+  onConfirm,
+}) => {
+  if (!open) {
+    return null
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-[rgba(26,36,56,0.35)] backdrop-blur-sm">
+      <div className="w-full max-w-105 rounded-[44px] bg-white px-10 pb-10 pt-11 shadow-2xl">
+        <div className="mx-auto mb-7 flex h-24 w-24 items-center justify-center rounded-[30px] border border-[#CFE1FF] bg-[#EFF5FF] text-[52px]">
+          <span role="img" aria-label="건설">
+            🏗️
+          </span>
+        </div>
+
+        <h2 className="mb-4 text-center text-[48px] font-black tracking-tight text-[#1F2A44]">
+          건설 업그레이드
+        </h2>
+
+        <p className="text-center text-[24px] font-extrabold leading-[1.3] text-[#5A6D8A]">
+          <span className="text-[#245FE5]">{cityName}</span> 도시를
+          <br />
+          업그레이드하시겠습니까?
+        </p>
+
+        <p className="mb-8 mt-4 text-center text-[20px] font-bold leading-[1.35] text-[#5A6D8A]">
+          <span>{currentLevelLabel}</span>
+          <span> → </span>
+          <span className="text-[#245FE5]">{nextLevelLabel}</span>
+          <br />
+          건설 비용 <span className="text-[#EF5350]">{buildCostText}</span> · 다음 통행료{' '}
+          <span className="text-[#245FE5]">{nextTollText}</span>
+        </p>
+
+        {!canBuild ? (
+          <p className="mb-6 text-center text-[20px] font-bold text-[#EF5350]">
+            더 이상 건설할 수 없습니다.
+          </p>
+        ) : null}
+
+        <div className="flex items-center justify-center gap-4">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="h-15 w-full max-w-42 rounded-[22px] bg-[#E6EBF3] text-[24px] font-black tracking-tight text-[#5E708D] transition-colors hover:bg-[#DDE4EE]"
+          >
+            {cancelLabel}
+          </button>
+
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={!canBuild}
+            className="h-15 w-full max-w-56 rounded-[22px] bg-[#245FE5] text-[24px] font-black tracking-tight text-white shadow-lg transition-colors hover:bg-[#1F56D1] disabled:opacity-40"
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
 }
 
 export default BuildModal
-


### PR DESCRIPTION
## 관련 이슈

> closes #59

---

## 작업 내용

- BuildModal 업그레이드 ui 구현
- 기본 단계를 `건물 -> 호텔`로 변경
- `upgradeStage` 옵션 추가로 `호텔 -> 랜드마크` 단계도 동일 모달에서 지원
- 확인용 임시 프리뷰 코드는 제거하여 실제 코드만 유지

---

## 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 스크린샷 (선택)

> <img width="1906" height="937" alt="image" src="https://github.com/user-attachments/assets/4a99fefe-406f-47b5-b0c1-cf558dc1bdda" />