### PR TITLE
feat: AI 모달 로딩 상태 UI 분기 구현

### DIFF
--- a/src/components/game/modals/AIPenaltyModal.tsx
+++ b/src/components/game/modals/AIPenaltyModal.tsx
@@ -2,31 +2,68 @@
 
 interface AIPenaltyModalProps {
   open: boolean
+  status?: 'loading' | 'result' | 'error'
   title?: string
   description?: string
+  resultDescription?: string
+  errorDescription?: string
   confirmLabel?: string
+  loadingLabel?: string
+  errorConfirmLabel?: string
   onConfirm?: () => void
 }
 
 const DEFAULT_TITLE = 'AI 칸'
-const DEFAULT_DESCRIPTION = '생각중...'
+const DEFAULT_LOADING_DESCRIPTION = '생각중...'
+const DEFAULT_RESULT_DESCRIPTION = '결과를 확인하세요.'
+const DEFAULT_ERROR_DESCRIPTION = '결과를 불러오지 못했습니다.'
 const DEFAULT_CONFIRM_LABEL = '확인하기'
+const DEFAULT_LOADING_LABEL = '잠시만 기다려주세요'
+const DEFAULT_ERROR_CONFIRM_LABEL = '다시 시도'
 
 const AIPenaltyModal: React.FC<AIPenaltyModalProps> = ({
   open,
+  status = 'loading',
   title = DEFAULT_TITLE,
-  description = DEFAULT_DESCRIPTION,
+  description,
+  resultDescription = DEFAULT_RESULT_DESCRIPTION,
+  errorDescription = DEFAULT_ERROR_DESCRIPTION,
   confirmLabel = DEFAULT_CONFIRM_LABEL,
+  loadingLabel = DEFAULT_LOADING_LABEL,
+  errorConfirmLabel = DEFAULT_ERROR_CONFIRM_LABEL,
   onConfirm,
 }) => {
   if (!open) {
     return null
   }
 
+  const resolvedDescription =
+    status === 'loading'
+      ? (description ?? DEFAULT_LOADING_DESCRIPTION)
+      : status === 'error'
+        ? errorDescription
+        : resultDescription
+
+  const resolvedConfirmLabel =
+    status === 'loading'
+      ? loadingLabel
+      : status === 'error'
+        ? errorConfirmLabel
+        : confirmLabel
+
+  const isLoading = status === 'loading'
+  const isError = status === 'error'
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-[rgba(26,36,56,0.35)] backdrop-blur-sm">
       <div className="w-full max-w-105 rounded-[44px] bg-white px-10 pb-10 pt-11 shadow-2xl">
-        <div className="mx-auto mb-7 flex h-24 w-24 items-center justify-center rounded-[30px] border border-[#CFE1FF] bg-[#EFF5FF]">
+        <div
+          className={`mx-auto mb-7 flex h-24 w-24 items-center justify-center rounded-[30px] border ${
+            isError
+              ? 'border-[#FFE0DF] bg-[#FFF2F1]'
+              : 'border-[#CFE1FF] bg-[#EFF5FF]'
+          }`}
+        >
           <img src="/ai-head.png" alt="AI 아이콘" className="h-16 w-16" />
         </div>
 
@@ -34,16 +71,27 @@ const AIPenaltyModal: React.FC<AIPenaltyModalProps> = ({
           {title}
         </h2>
 
-        <p className="text-center text-[22px] font-bold leading-[1.35] text-[#5A6D8A]">
-          {description}
+        <p
+          className={`text-center text-[22px] font-bold leading-[1.35] ${
+            isError ? 'text-[#EF5350]' : 'text-[#5A6D8A]'
+          }`}
+        >
+          {resolvedDescription}
         </p>
 
         <button
           type="button"
           onClick={onConfirm}
-          className="mx-auto mt-10 flex h-18.5 w-full max-w-102 items-center justify-center rounded-[22px] bg-[#245FE5] text-[24px] font-black tracking-tight text-white shadow-lg transition-colors hover:bg-[#1F56D1]"
+          className={`mx-auto mt-10 flex h-18.5 w-full max-w-102 items-center justify-center rounded-[22px] text-[24px] font-black tracking-tight text-white shadow-lg transition-colors ${
+            isLoading
+              ? 'bg-[#8DA7E9] cursor-not-allowed'
+              : isError
+                ? 'bg-[#EF5350] hover:bg-[#E34A47]'
+                : 'bg-[#245FE5] hover:bg-[#1F56D1]'
+          }`}
+          disabled={isLoading}
         >
-          {confirmLabel}
+          {resolvedConfirmLabel}
         </button>
       </div>
     </div>


### PR DESCRIPTION
## 관련 이슈

> closes #92 

---

## 작업 내용

- `AIPenaltyModal`에 상태 분기(`loading | result | error`)를 추가했습니다.
- 로딩 상태에서 안내 문구를 노출하고 버튼을 비활성화하도록 처리했습니다.
- 결과/에러 상태에 따라 설명 문구, 버튼 라벨, 색상이 분기되도록 구성했습니다.
- 확인용 임시 프리뷰 코드는 제거했습니다.

---

## 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 스크린샷 (선택)

><img width="1873" height="941" alt="image" src="https://github.com/user-attachments/assets/350193de-2a8c-4ef3-bb98-0b137cfd40e3" />