### PR TITLE
refactor: 폴더 구조 정리

### DIFF
--- a/src/components/game/controls/RollButton.tsx
+++ b/src/components/game/controls/RollButton.tsx
@@ -54,7 +54,7 @@ const RollControl: React.FC<RollControlProps> = ({
       <button
         onClick={onRoll}
         disabled={!isMyTurn}
-        className="group relative flex h-24 w-24 flex-col items-center justify-center gap-0.5 rounded-3xl bg-gradient-to-br from-[#2B7FFF] to-[#4F39F6] border-4 border-[#BEDBFF] text-white shadow-[0_0_0_4px_rgba(255,255,255,0.5),0_20px_25px_-5px_rgba(142,197,255,0.5)] transition-all hover:translate-y-[-2px] hover:shadow-2xl active:translate-y-[2px] active:scale-95 disabled:grayscale disabled:opacity-50"
+        className="group relative flex h-24 w-24 flex-col items-center justify-center gap-0.5 rounded-3xl bg-linear-to-br from-[#2B7FFF] to-[#4F39F6] border-4 border-[#BEDBFF] text-white shadow-[0_0_0_4px_rgba(255,255,255,0.5),0_20px_25px_-5px_rgba(142,197,255,0.5)] transition-all hover:translate-y-[-2px] hover:shadow-2xl active:translate-y-[2px] active:scale-95 disabled:grayscale disabled:opacity-50"
       >
         <span className="text-3xl leading-none drop-shadow-md">🎲</span>
         <span className="text-[10px] font-black tracking-widest opacity-90 uppercase">

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -1,6 +1,6 @@
 import { Dice5 } from 'lucide-react'
-import { ProfileDropdown } from './layout/ProfileDropdown'
-import type { ProfileMenuItem } from '../types/layout'
+import { ProfileDropdown } from './ProfileDropdown'
+import type { ProfileMenuItem } from './profileMenu'
 
 interface HeaderProps {
   playerLabel?: string

--- a/src/components/header/ProfileDropdown.tsx
+++ b/src/components/header/ProfileDropdown.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import type { ProfileMenuItem } from '../../types/layout'
+import type { ProfileMenuItem } from './profileMenu'
 
 interface ProfileDropdownProps {
   playerLabel?: string

--- a/src/components/header/profileMenu.ts
+++ b/src/components/header/profileMenu.ts
@@ -1,4 +1,9 @@
-import type { ProfileMenuItem } from '../../types/layout'
+export interface ProfileMenuItem {
+  id: string
+  label: string
+  onSelect: () => void
+  tone?: 'default' | 'danger'
+}
 
 interface CreateProfileMenuItemsParams {
   isGuest: boolean

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -3,7 +3,7 @@ import { ArrowLeft, Gamepad2, Shield, Trophy } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import { useAuthStore } from '../features/auth/store'
 import { useMyPageProfileQuery } from '../features/auth/hooks/useMyPageProfileQuery'
-import { getAvatarText } from '../features/auth/ui'
+import { getAvatarText } from '../components/header/profileMenu'
 
 const myPageStatsCardMeta = [
   {

--- a/src/pages/lobby/LobbyPage.tsx
+++ b/src/pages/lobby/LobbyPage.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import Header from '../../components/Header'
+import Header from '../../components/header/Header'
 import { useAuthStore } from '../../features/auth/store'
 import {
   createProfileMenuItems,
   getAvatarBackground,
   getAvatarText,
-} from '../../features/auth/ui'
+} from '../../components/header/profileMenu'
 import { UserListPanel } from '../../features/presence/components/UserListPanel'
 import { useOnlineUsersSocket } from '../../features/presence/hooks'
 import type { LobbyRoomFilter } from './api'

--- a/src/pages/waiting-room/WaitingRoomPage.tsx
+++ b/src/pages/waiting-room/WaitingRoomPage.tsx
@@ -5,7 +5,7 @@ import {
   createProfileMenuItems,
   getAvatarBackground,
   getAvatarText,
-} from '../../features/auth/ui'
+} from '../../components/header/profileMenu'
 import { UserListPanel } from '../../features/presence/components/UserListPanel'
 import { useOnlineUsersSocket } from '../../features/presence/hooks'
 import { cn } from '../../lib/utils'

--- a/src/pages/waiting-room/components/WaitingRoomHeader.tsx
+++ b/src/pages/waiting-room/components/WaitingRoomHeader.tsx
@@ -1,6 +1,6 @@
 import { ArrowLeft } from 'lucide-react'
-import { ProfileDropdown } from '../../../components/layout/ProfileDropdown'
-import type { ProfileMenuItem } from '../../../types/layout'
+import { ProfileDropdown } from '../../../components/header/ProfileDropdown'
+import type { ProfileMenuItem } from '../../../components/header/profileMenu'
 
 interface WaitingRoomHeaderProps {
   roomIdLabel: string

--- a/src/types/layout.ts
+++ b/src/types/layout.ts
@@ -1,6 +1,0 @@
-export interface ProfileMenuItem {
-  id: string
-  label: string
-  onSelect: () => void
-  tone?: 'default' | 'danger'
-}


### PR DESCRIPTION
## 📌 관련 이슈

> closes #94 

---

## 📝 작업 내용

- `header` 관련 공통 UI/유틸 파일을 `src/components/header`로 재배치해 폴더 구조를 명확히 정리했습니다.
  - `Header.tsx`
  - `ProfileDropdown.tsx`
  - `profileMenu.ts`
- 기존 분산되어 있던 타입/유틸 참조를 `header` 경계 기준으로 통합했습니다.
- 불필요해진 경로/파일(`components/layout`, `features/auth/ui.ts`, `types/layout.ts`)을 제거/정리했습니다.
- `LobbyPage`, `WaitingRoomPage`, `WaitingRoomHeader`, `MyPage`에서 새 경로를 사용하도록 import를 갱신했습니다.

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인 (`npm run lint`, `npm run build`)
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

> UI 변경 없음 (폴더/구조 리팩터링)
