### PR TITLE
refactor: 특수처리 제거 및 공통 규칙 적용

### DIFF
--- a/src/pages/waiting-room/WaitingRoomPage.tsx
+++ b/src/pages/waiting-room/WaitingRoomPage.tsx
@@ -34,7 +34,8 @@ function formatRoomIdLabel(roomId: string) {
 }
 
 function WaitingRoomPage() {
-  const { roomId = 'room-5' } = useParams<{ roomId: string }>()
+  const { roomId } = useParams<{ roomId: string }>()
+  const currentRoomId = roomId ?? ''
   const location = useLocation()
   const navigate = useNavigate()
   const session = useAuthStore((state) => state.session)
@@ -42,7 +43,7 @@ function WaitingRoomPage() {
   const [isUserListOpen, setIsUserListOpen] = useState(true)
 
   const locationState = location.state as WaitingRoomLocationState | null
-  const isSameRoomState = locationState?.roomId === roomId
+  const isSameRoomState = locationState?.roomId === currentRoomId
   const selectedRoomTitle = isSameRoomState ? locationState?.roomTitle : null
 
   const handleGameStart = useCallback(
@@ -50,11 +51,11 @@ function WaitingRoomPage() {
       navigate('/game', {
         state: {
           gameId: payload.game_id,
-          roomId,
+          roomId: currentRoomId,
         },
       })
     },
-    [navigate, roomId]
+    [currentRoomId, navigate]
   )
 
   const {
@@ -74,7 +75,7 @@ function WaitingRoomPage() {
     handleStartGame,
     leaveRoom,
   } = useWaitingRoomController({
-    roomId,
+    roomId: currentRoomId,
     session,
     fallbackRoomTitle: selectedRoomTitle ?? undefined,
     onGameStart: handleGameStart,
@@ -87,6 +88,11 @@ function WaitingRoomPage() {
   } = useOnlineUsersSocket()
 
   useEffect(() => {
+    if (!currentRoomId) {
+      navigate('/lobby', { replace: true })
+      return
+    }
+
     if (!session) {
       navigate('/', { replace: true })
       return
@@ -95,7 +101,7 @@ function WaitingRoomPage() {
     if (session.needsNicknameSetup) {
       navigate('/nickname-setup', { replace: true })
     }
-  }, [navigate, session])
+  }, [currentRoomId, navigate, session])
 
   useEffect(() => {
     if (!roomErrorMessage) {
@@ -161,10 +167,13 @@ function WaitingRoomPage() {
   if (!session || session.needsNicknameSetup) {
     return null
   }
+  if (!currentRoomId) {
+    return null
+  }
 
   const roomTitle =
     room?.title ?? selectedRoomTitle ?? DEFAULT_WAITING_ROOM_TITLE
-  const roomIdLabel = formatRoomIdLabel(roomId)
+  const roomIdLabel = formatRoomIdLabel(currentRoomId)
   const avatarText = getAvatarText(session.nickname)
   const avatarBackground = getAvatarBackground(session.isGuest)
   const headerMenuItems = createProfileMenuItems({

--- a/src/pages/waiting-room/hooks.ts
+++ b/src/pages/waiting-room/hooks.ts
@@ -126,6 +126,16 @@ export function useWaitingRoomController({
   const hasLeftRoomRef = useRef(false)
 
   useEffect(() => {
+    if (!roomId) {
+      setRoom(null)
+      setChatMessages([])
+      setIsRoomLoading(false)
+      setRoomErrorMessage(null)
+      hasEnteredRoomRef.current = false
+      hasLeftRoomRef.current = false
+      return
+    }
+
     if (!session) {
       setRoom(null)
       setChatMessages([])
@@ -185,7 +195,7 @@ export function useWaitingRoomController({
   const activeRoomId = room?.roomId
 
   useEffect(() => {
-    if (!session || !activeRoomId) {
+    if (!roomId || !session || !activeRoomId) {
       return
     }
 
@@ -255,7 +265,7 @@ export function useWaitingRoomController({
     return () => {
       unsubscribe()
     }
-  }, [activeRoomId, onGameStart, session])
+  }, [activeRoomId, onGameStart, roomId, session])
 
   useEffect(() => {
     return () => {

--- a/src/pages/waiting-room/mockGateway.ts
+++ b/src/pages/waiting-room/mockGateway.ts
@@ -21,22 +21,6 @@ const ROOM_PRIVATE_PASSWORDS: Record<string, string> = {
   'room-7': DEFAULT_ROOM_PASSWORD,
 }
 
-const SEEDED_ROOM_PLAYERS: Record<string, string[]> = {
-  'room-1': ['초보마블', '연습유저'],
-  'room-2': ['고수킹', '주사위마스터', '전략가'],
-  'room-3': ['게임왕1', '게임왕2', '게임왕3', '게임왕4'],
-  'room-4': ['편한방장'],
-  'room-5': ['GoormEE', 'MarbleKing'],
-  'room-6': ['스피드왕', '템포러', '빠른손'],
-  'room-7': ['저녁파티장'],
-  'room-8': ['환영봇', '실력러', '행운의별'],
-  'room-9': ['마지막주자', '도전자', '한자리'],
-}
-
-const SEEDED_READY_INDEXES: Record<string, number[]> = {
-  'room-5': [1],
-}
-
 interface MockRoomPlayer {
   id: string
   nickname: string
@@ -76,44 +60,18 @@ function wait(delayMs: number) {
 }
 
 function createRoomPlayers(roomId: string, count: number): MockRoomPlayer[] {
-  const seededNicknames = SEEDED_ROOM_PLAYERS[roomId] ?? []
-  const seededReadyIndexes = new Set(SEEDED_READY_INDEXES[roomId] ?? [])
-
   return Array.from({ length: count }, (_, index) => {
-    const fallbackNickname = `Player${index + 1}`
-
     return {
       id: `${roomId}-user-${index + 1}`,
-      nickname: seededNicknames[index] ?? fallbackNickname,
-      is_ready: index !== 0 && seededReadyIndexes.has(index),
+      nickname: `플레이어${index + 1}`,
+      is_ready: false,
       is_host: index === 0,
     }
   })
 }
 
-function createSeededRoomChat(roomId: string): WaitingRoomChatPayload[] {
-  if (roomId !== 'room-5') {
-    return []
-  }
-
-  return [
-    {
-      id: 'room-5-chat-1',
-      sender_id: 'room-5-user-1',
-      sender_nickname: 'GoormEE',
-      message: '빨리 시작하죠! 현기증 난단 말이에요🤣',
-      sent_at: '2026-02-26T14:30:00+09:00',
-      type: 'talk',
-    },
-    {
-      id: 'room-5-chat-2',
-      sender_id: 'room-5-user-2',
-      sender_nickname: 'MarbleKing',
-      message: '잠시만요 화장실좀 ㅎㅎ 금방 다녀올게요!',
-      sent_at: '2026-02-26T14:31:00+09:00',
-      type: 'talk',
-    },
-  ]
+function createSeededRoomChat(): WaitingRoomChatPayload[] {
+  return []
 }
 
 function createInitialRooms(): Map<string, MockRoom> {
@@ -128,7 +86,7 @@ function createInitialRooms(): Map<string, MockRoom> {
         ? (ROOM_PRIVATE_PASSWORDS[room.id] ?? DEFAULT_ROOM_PASSWORD)
         : null,
       players: createRoomPlayers(room.id, room.currentPlayers),
-      chat_messages: createSeededRoomChat(room.id),
+      chat_messages: createSeededRoomChat(),
     } as MockRoom
   })
 


### PR DESCRIPTION
## 📌 관련 이슈

> closes #107 

---

## 📝 작업 내용

> 대기방에서 `room-5`만 다르게 동작하던 임시 특수처리를 제거하고, 모든 방을 동일 규칙으로 통일했습니다.

- `mockGateway`에서 room-5 전용 로직 제거
  - 준비 상태 seed 제거
  - 초기 채팅 seed 제거
  - 방별 커스텀 닉네임 seed 제거 후 공통 초기 규칙 적용
- `WaitingRoomPage`에서 `roomId` fallback(`room-5`) 제거
- `roomId` 누락 시 로비로 복귀하도록 가드 추가
- `hooks`에서 `roomId` 없을 때 join 흐름 중단하도록 방어 로직 추가

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

> UI 변경 없음 (동작/구조 리팩터링)
```