### PR TITLE
refactor: 방장/일반 유저 버튼을 권한별 단일 액션으로 분리

### DIFF
--- a/src/pages/waiting-room/WaitingRoomPage.tsx
+++ b/src/pages/waiting-room/WaitingRoomPage.tsx
@@ -67,6 +67,7 @@ function WaitingRoomPage() {
     isReadyPending,
     isStartPending,
     isLeavePending,
+    isHost,
     isReady,
     canToggleReady,
     canStartGame,
@@ -243,6 +244,7 @@ function WaitingRoomPage() {
             <WaitingRoomChatPanel
               messages={chatMessages}
               currentUserId={session.userId}
+              isHost={isHost}
               canStartGame={canStartGame}
               canToggleReady={canToggleReady}
               isReady={isReady}

--- a/src/pages/waiting-room/components/WaitingRoomChatPanel.tsx
+++ b/src/pages/waiting-room/components/WaitingRoomChatPanel.tsx
@@ -7,6 +7,7 @@ import type { WaitingRoomChatMessage } from '../types'
 interface WaitingRoomChatPanelProps {
   messages: WaitingRoomChatMessage[]
   currentUserId: string
+  isHost: boolean
   canStartGame: boolean
   canToggleReady: boolean
   isReady: boolean
@@ -20,6 +21,7 @@ interface WaitingRoomChatPanelProps {
 export function WaitingRoomChatPanel({
   messages,
   currentUserId,
+  isHost,
   canStartGame,
   canToggleReady,
   isReady,
@@ -42,11 +44,7 @@ export function WaitingRoomChatPanel({
 
   const isStartButtonDisabled = !canStartGame || isStartPending
   const isReadyButtonDisabled = !canToggleReady || isReadyPending
-  const readyButtonLabel = canToggleReady
-    ? isReady
-      ? '준비 완료!'
-      : '준비하기'
-    : '방장'
+  const readyButtonLabel = isReady ? '준비 취소' : '준비하기'
 
   return (
     <aside className="flex h-full min-h-[320px] flex-col rounded-3xl border border-ui-border bg-ui-surface p-3">
@@ -59,35 +57,38 @@ export function WaitingRoomChatPanel({
         onSendMessage={onSendMessage}
       />
 
-      <div className="mt-4 grid grid-cols-2 gap-2">
-        <button
-          type="button"
-          disabled={isStartButtonDisabled}
-          onClick={onStartGame}
-          className={cn(
-            'h-16 rounded-2xl text-[2.1rem] font-bold transition-colors',
-            !isStartButtonDisabled
-              ? 'bg-ui-brand text-white hover:bg-ui-brand-strong'
-              : 'cursor-not-allowed bg-ui-disabled-bg text-ui-disabled-text'
-          )}
-        >
-          시작
-        </button>
-        <button
-          type="button"
-          disabled={isReadyButtonDisabled}
-          onClick={onToggleReady}
-          className={cn(
-            'h-16 rounded-2xl text-[2.1rem] font-bold transition-colors',
-            isReadyButtonDisabled
-              ? 'cursor-not-allowed border border-ui-border bg-ui-surface-soft text-ui-text-subtle'
-              : isReady
-                ? 'border border-ui-border bg-ui-surface-soft text-ui-text-muted hover:bg-ui-surface-muted'
-                : 'bg-[#00c853] text-white hover:bg-[#00b84d]'
-          )}
-        >
-          {readyButtonLabel}
-        </button>
+      <div className="mt-4">
+        {isHost ? (
+          <button
+            type="button"
+            disabled={isStartButtonDisabled}
+            onClick={onStartGame}
+            className={cn(
+              'h-16 w-full rounded-2xl text-[2.1rem] font-bold transition-colors',
+              !isStartButtonDisabled
+                ? 'bg-ui-brand text-white hover:bg-ui-brand-strong'
+                : 'cursor-not-allowed bg-ui-disabled-bg text-ui-disabled-text'
+            )}
+          >
+            시작
+          </button>
+        ) : (
+          <button
+            type="button"
+            disabled={isReadyButtonDisabled}
+            onClick={onToggleReady}
+            className={cn(
+              'h-16 w-full rounded-2xl text-[2.1rem] font-bold transition-colors',
+              isReadyButtonDisabled
+                ? 'cursor-not-allowed border border-ui-border bg-ui-surface-soft text-ui-text-subtle'
+                : isReady
+                  ? 'border border-ui-border bg-ui-surface-soft text-ui-text-muted hover:bg-ui-surface-muted'
+                  : 'bg-[#00c853] text-white hover:bg-[#00b84d]'
+            )}
+          >
+            {readyButtonLabel}
+          </button>
+        )}
       </div>
     </aside>
   )


### PR DESCRIPTION
## 📌 관련 이슈

> closes #109 

---

## 📝 작업 내용

> 대기방 액션 버튼을 권한 기준으로 분리해 혼동을 줄이고 명세와 일치하도록 정리했습니다.

- `WaitingRoomChatPanel`
  - `isHost` prop 추가
  - 방장인 경우 `시작` 버튼만 노출
  - 일반 유저인 경우 `준비하기/준비 완료!` 버튼만 노출
  - 버튼은 각각 전체 너비 단일 액션 UI로 변경
- `WaitingRoomPage`
  - `useWaitingRoomController` 결과에서 `isHost` 구조분해 추가
  - `WaitingRoomChatPanel`에 `isHost` 전달

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

<img width="1800" height="1043" alt="스크린샷 2026-02-27 오후 5 22 17" src="https://github.com/user-attachments/assets/6ff507ba-3dfb-46fa-a55a-e407aeb8766e" />
