### PR TITLE
FEAT :게임 소켓/API 런타임 연동 및 타이머/매각 로직

### DIFF
--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -31,12 +31,12 @@ const UPGRADE_COST = 30
 const TOLL_COST = 30
 
 const LEVEL_LABEL: Record<number, string> = {
-  0: '誘멸뎄留?,
-  1: '吏?1梨?,
-  2: '吏?2梨?,
-  3: '吏?3梨?,
-  4: '?명뀛',
-  5: '?쒕뱶留덊겕',
+  0: '미구매',
+  1: '집 1채',
+  2: '집 2채',
+  3: '집 3채',
+  4: '호텔',
+  5: '랜드마크',
 }
 
 function getUpgradeStage(
@@ -394,7 +394,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
                 setTollModal({
                   open: true,
                   tileId: landedTileId,
-                  ownerName: ownerPlayer?.name ?? '?곷?諛?,
+                  ownerName: ownerPlayer?.name ?? '상대방',
                   tollText: `${TOLL_COST}M`,
                   onDoneCallback: onDone,
                 })
@@ -617,8 +617,8 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
 
           {/* ?? 以묒븰: ?뚮젅?댁뼱 ???쒓굅, 二쇱궗?꾨쭔 ?? */}
           <div className="board-center">
-            <span style={{ fontSize: 52 }}>?눖?눟</span>
-            <span className="board-center__title">遺猷⑤쭏釉?/span>
+            <span style={{ fontSize: 52 }}>🎲</span>
+            <span className="board-center__title">부루마블</span>
             <div className="board-dice-pair">
               <DiceFace value={dice1} rolling={rolling} />
               <DiceFace value={dice2} rolling={rolling} />

--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -170,6 +170,29 @@ interface BankruptModalState {
   onDoneCallback?: () => void
 }
 
+type SyncStatePayload = {
+  players?: Array<{
+    id: string | number
+    nickname?: string
+    name?: string
+    position?: number
+    pos?: number
+    balance?: number
+    money?: number
+    color?: string
+  }>
+  tiles?: Array<{
+    index?: number
+    id?: number
+    owner_id?: string | number | null
+    ownerId?: string | number | null
+    building?: number
+    level?: number
+  }>
+  current_turn?: string | number | null
+  currentTurn?: string | number | null
+}
+
 // ??? GameBoard ???????????????????????????????????????????????????
 const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
   (
@@ -194,6 +217,77 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
 
     const [tileOwners, setTileOwners] = useState<Record<number, TileOwner>>({})
     const tileOwnersRef = useRef<Record<number, TileOwner>>({})
+
+    async function syncBoardStateFromServer() {
+      const syncResult = await gameApi.syncState()
+      if (!syncResult.ok) return false
+
+      const payload = syncResult.data as SyncStatePayload
+      const nextPlayers = (payload.players ?? []).map((player, idx) => {
+        const prevPlayer = playersRef.current[idx]
+        return {
+          id: Number(player.id),
+          name:
+            player.nickname ??
+            player.name ??
+            prevPlayer?.name ??
+            `Player ${idx + 1}`,
+          color:
+            player.color ??
+            prevPlayer?.color ??
+            PLAYER_COLORS[idx % PLAYER_COLORS.length],
+          pos: player.position ?? player.pos ?? prevPlayer?.pos ?? 0,
+          money: player.balance ?? player.money ?? prevPlayer?.money ?? 0,
+        }
+      })
+
+      if (nextPlayers.length > 0) {
+        playersRef.current = nextPlayers
+        onPlayersChange(nextPlayers)
+      }
+
+      if (payload.tiles) {
+        const nextOwners: Record<number, TileOwner> = {}
+        payload.tiles.forEach((tile) => {
+          const tileIndex = tile.index ?? tile.id
+          const ownerRaw = tile.owner_id ?? tile.ownerId
+          if (tileIndex === undefined || ownerRaw === null || ownerRaw === undefined) {
+            return
+          }
+
+          const ownerId =
+            typeof ownerRaw === 'number'
+              ? ownerRaw
+              : Number.parseInt(String(ownerRaw), 10)
+          if (Number.isNaN(ownerId)) return
+
+          const ownerPlayer = playersRef.current.find((player) => player.id === ownerId)
+          nextOwners[tileIndex] = {
+            ownerId,
+            ownerColor: ownerPlayer?.color ?? PLAYER_COLORS[ownerId % PLAYER_COLORS.length],
+            level: Math.min(
+              Math.max(tile.building ?? tile.level ?? 1, 0),
+              5
+            ) as BuildingLevel,
+          }
+        })
+        tileOwnersRef.current = nextOwners
+        setTileOwners(nextOwners)
+      }
+
+      const nextTurnRaw = payload.current_turn ?? payload.currentTurn
+      if (nextTurnRaw !== undefined && nextTurnRaw !== null) {
+        const nextTurnIndex = playersRef.current.findIndex(
+          (player) => String(player.id) === String(nextTurnRaw)
+        )
+        if (nextTurnIndex >= 0) {
+          curPlayerRef.current = nextTurnIndex
+          onCurPlayerChange(nextTurnIndex)
+        }
+      }
+
+      return true
+    }
 
     const [buyModal, setBuyModal] = useState<BuyModalState>({
       open: false,
@@ -429,6 +523,38 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       return '요청 처리 중 오류가 발생했습니다.'
     }
 
+    async function sellOwnedTileForPlayer(playerIdx: number) {
+      const ownedTileEntries = Object.entries(tileOwnersRef.current)
+        .filter(([, owner]) => owner.ownerId === playerIdx)
+        .sort(([, a], [, b]) => b.level - a.level)
+
+      if (ownedTileEntries.length === 0) return false
+
+      const [tileIdText, owner] = ownedTileEntries[0]
+      const tileId = Number(tileIdText)
+      const sellResult = await gameApi.sellTile({
+        tile_index: tileId,
+        level: owner.level,
+      })
+
+      if (!sellResult.ok) {
+        setStatus(toActionErrorMessage(sellResult.status))
+        return false
+      }
+
+      const synced = await syncBoardStateFromServer()
+      if (!synced) {
+        updateTileOwners((prev) => {
+          const next = { ...prev }
+          delete next[tileId]
+          return next
+        })
+        applyMoney(playerIdx, +PURCHASE_COST)
+      }
+
+      return true
+    }
+
     // ?? 援щℓ (-60M) ???????????????????????????????????????????????
     async function handleBuy() {
       const { tileId, onDoneCallback } = buyModal
@@ -452,6 +578,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
             level: 1,
           },
         }))
+        void syncBoardStateFromServer()
         advanceTurn(onDoneCallback)
       }
     }
@@ -488,6 +615,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
             },
           }
         })
+        void syncBoardStateFromServer()
         advanceTurn(onDoneCallback)
       }
     }
@@ -499,7 +627,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
     }
 
     // ?? ?듯뻾猷?(-30M / +30M) ??????????????????????????????????????
-    function handleTollConfirm() {
+    async function handleTollConfirm() {
       const { tileId, onDoneCallback } = tollModal
       const active = curPlayerRef.current
       setTollModal({
@@ -512,6 +640,14 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       if (tileId !== null) {
         const owner = tileOwnersRef.current[tileId]
         if (owner) {
+          if (playersRef.current[active].money < TOLL_COST) {
+            const sold = await sellOwnedTileForPlayer(active)
+            if (!sold) {
+              const bankrupt = applyMoney(active, -TOLL_COST, onDoneCallback)
+              if (!bankrupt) advanceTurn(onDoneCallback)
+              return
+            }
+          }
           applyMoney(owner.ownerId, +TOLL_COST)
           const bankrupt = applyMoney(active, -TOLL_COST, onDoneCallback)
           if (!bankrupt) advanceTurn(onDoneCallback)

--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -1,4 +1,4 @@
-﻿import { useState, useRef, forwardRef, useImperativeHandle } from 'react'
+import { useRef, useState, forwardRef, useImperativeHandle } from 'react'
 import BoardTile from './BoardTile'
 import BuyModal from '../game/modals/BuyModal'
 import BuildModal from '../game/modals/BuildModal'
@@ -25,7 +25,6 @@ import {
 } from './board.constants'
 import '../../styles/board.css'
 
-// ??? 鍮꾩슜 ?곸닔 ????????????????????????????????????????????????????
 const PURCHASE_COST = 60
 const UPGRADE_COST = 30
 const TOLL_COST = 30
@@ -116,22 +115,15 @@ function DiceFace({ value, rolling }: { value: number; rolling: boolean }) {
   )
 }
 
-// ??? 怨듦컻 ?몃뱾 ???????????????????????????????????????????????????
 export interface BoardGameHandle {
   rollDice: (onDone?: () => void) => void
 }
 
-// ??? Props ???????????????????????????????????????????????????????
 interface GameBoardProps {
-  /** ?뚮젅?댁뼱 ?곹깭 (GamePage?먯꽌 愿由? */
   players: PlayerState[]
-  /** ?꾩옱 ???몃뜳??(GamePage?먯꽌 愿由? */
   curPlayer: number
-  /** ???꾩튂 蹂??肄쒕갚 ??GamePage媛 state ?낅뜲?댄듃 */
   onPlayersChange: (players: PlayerState[]) => void
-  /** ??蹂寃?肄쒕갚 */
   onCurPlayerChange: (idx: number) => void
-  /** ?뚯궛 肄쒕갚 */
   onBankrupt?: (playerIdx: number) => void
 }
 
@@ -193,7 +185,6 @@ type SyncStatePayload = {
   currentTurn?: string | number | null
 }
 
-// ??? GameBoard ???????????????????????????????????????????????????
 const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
   (
     { players, curPlayer, onPlayersChange, onCurPlayerChange, onBankrupt },
@@ -202,19 +193,15 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
     const [dice1, setDice1] = useState(1)
     const [dice2, setDice2] = useState(1)
     const [rolling, setRolling] = useState(false)
-    const [status, setStatus] = useState('?렜 寃뚯엫 ?쒖옉!')
+    const [status, setStatus] = useState('게임 시작!')
     const lock = useRef(false)
 
-    // ref 濡?理쒖떊媛??좎? (setInterval ?대줈? stale 諛⑹?)
     const curPlayerRef = useRef(curPlayer)
     const playersRef = useRef<PlayerState[]>(players)
-
-    // props 蹂寃???ref ?숆린??
     curPlayerRef.current = curPlayer
     playersRef.current = players
 
     const bankruptSetRef = useRef<Set<number>>(new Set())
-
     const [tileOwners, setTileOwners] = useState<Record<number, TileOwner>>({})
     const tileOwnersRef = useRef<Record<number, TileOwner>>({})
 
@@ -223,35 +210,61 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       if (!syncResult.ok) return false
 
       const payload = syncResult.data as SyncStatePayload
-      const nextPlayers = (payload.players ?? []).map((player, idx) => {
-        const prevPlayer = playersRef.current[idx]
-        return {
-          id: Number(player.id),
-          name:
-            player.nickname ??
-            player.name ??
-            prevPlayer?.name ??
-            `Player ${idx + 1}`,
-          color:
-            player.color ??
-            prevPlayer?.color ??
-            PLAYER_COLORS[idx % PLAYER_COLORS.length],
-          pos: player.position ?? player.pos ?? prevPlayer?.pos ?? 0,
-          money: player.balance ?? player.money ?? prevPlayer?.money ?? 0,
-        }
-      })
+      const payloadPlayers = payload.players ?? []
+      const prevById = new Map(
+        playersRef.current.map((player) => [String(player.id), player])
+      )
 
-      if (nextPlayers.length > 0) {
+      if (payloadPlayers.length > 0) {
+        const nextById = new Map<string, PlayerState>()
+
+        payloadPlayers.forEach((player, idx) => {
+          const playerId = Number(player.id)
+          if (Number.isNaN(playerId)) return
+
+          const prevPlayer = prevById.get(String(player.id))
+          nextById.set(String(player.id), {
+            id: playerId,
+            name:
+              player.nickname ??
+              player.name ??
+              prevPlayer?.name ??
+              `Player ${idx + 1}`,
+            color:
+              player.color ??
+              prevPlayer?.color ??
+              PLAYER_COLORS[idx % PLAYER_COLORS.length],
+            pos: player.position ?? player.pos ?? prevPlayer?.pos ?? 0,
+            money: player.balance ?? player.money ?? prevPlayer?.money ?? 0,
+          })
+        })
+
+        const orderedPlayers = playersRef.current.map((prevPlayer) => {
+          return nextById.get(String(prevPlayer.id)) ?? prevPlayer
+        })
+        const additionalPlayers = Array.from(nextById.values()).filter(
+          (nextPlayer) =>
+            !orderedPlayers.some(
+              (orderedPlayer) => orderedPlayer.id === nextPlayer.id
+            )
+        )
+
+        const nextPlayers = [...orderedPlayers, ...additionalPlayers]
         playersRef.current = nextPlayers
         onPlayersChange(nextPlayers)
       }
 
       if (payload.tiles) {
         const nextOwners: Record<number, TileOwner> = {}
+
         payload.tiles.forEach((tile) => {
           const tileIndex = tile.index ?? tile.id
           const ownerRaw = tile.owner_id ?? tile.ownerId
-          if (tileIndex === undefined || ownerRaw === null || ownerRaw === undefined) {
+          if (
+            tileIndex === undefined ||
+            ownerRaw === null ||
+            ownerRaw === undefined
+          ) {
             return
           }
 
@@ -261,16 +274,17 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
               : Number.parseInt(String(ownerRaw), 10)
           if (Number.isNaN(ownerId)) return
 
-          const ownerPlayer = playersRef.current.find((player) => player.id === ownerId)
+          const ownerPlayer = playersRef.current.find(
+            (player) => player.id === ownerId
+          )
           nextOwners[tileIndex] = {
             ownerId,
-            ownerColor: ownerPlayer?.color ?? PLAYER_COLORS[ownerId % PLAYER_COLORS.length],
-            level: Math.min(
-              Math.max(tile.building ?? tile.level ?? 1, 0),
-              5
-            ) as BuildingLevel,
+            ownerColor:
+              ownerPlayer?.color ?? PLAYER_COLORS[ownerId % PLAYER_COLORS.length],
+            level: Math.min(Math.max(tile.building ?? tile.level ?? 1, 0), 5) as BuildingLevel,
           }
         })
+
         tileOwnersRef.current = nextOwners
         setTileOwners(nextOwners)
       }
@@ -327,7 +341,6 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       })
     }
 
-    // ?? ??蹂寃???遺紐⑥뿉寃??꾨떖 ??????????????????????????????????
     function applyMoney(
       playerIdx: number,
       delta: number,
@@ -358,7 +371,6 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       return false
     }
 
-    // ?? ?뚯궛 ?뺤젙 ?????????????????????????????????????????????????
     function handleBankruptConfirm() {
       const { playerIdx, onDoneCallback } = bankruptModal
       setBankruptModal({ open: false, playerIdx: -1, playerName: '' })
@@ -377,7 +389,6 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       advanceTurn(onDoneCallback)
     }
 
-    // ?? ???섍린湲?(?뚯궛??嫄대꼫?) ????????????????????????????????
     function advanceTurn(onDone?: () => void) {
       let next = (curPlayerRef.current + 1) % INIT_PLAYERS.length
       let tries = 0
@@ -390,9 +401,9 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       onDone?.()
     }
 
-    // ?? AI 移??????????????????????????????????????????????????????
     async function handleAITile(onDone?: () => void) {
       setAiModal({ open: true, status: 'loading', onDoneCallback: onDone })
+
       try {
         const res = await fetch('https://api.anthropic.com/v1/messages', {
           method: 'POST',
@@ -404,18 +415,20 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
               {
                 role: 'user',
                 content:
-                  '遺猷⑤쭏釉?蹂대뱶寃뚯엫??AI 移몄뿉 ?꾩갑?덉뒿?덈떎. ?뚮젅?댁뼱?먭쾶 ?щ??덈뒗 ?⑤꼸?곕굹 蹂대꼫?ㅻ? ??臾몄옣?쇰줈 ?뚮젮二쇱꽭?? ?? "?ㅼ쓬 ???대룞 移?+2 蹂대꼫??" ?먮뒗 "?듯뻾猷?1??硫댁젣 移대뱶 ?띾뱷!"',
+                  '부루마블 보드게임의 AI 칸에 도착했습니다. 플레이어에게 재미있는 패널티나 보너스를 한 문장으로 알려주세요. 예: "다음 턴 이동 칸 +2 보너스!" 또는 "통행료 1회 면제 카드 획득!"',
               },
             ],
           }),
         })
+
         if (!res.ok) throw new Error()
         const data = await res.json()
         const text =
           data.content
             ?.filter((b: { type: string }) => b.type === 'text')
             .map((b: { text: string }) => b.text)
-            .join('') ?? '寃곌낵瑜??뺤씤?섏꽭??'
+            .join('') ?? '결과를 확인하세요.'
+
         setAiModal((prev) => ({
           ...prev,
           status: 'result',
@@ -426,21 +439,22 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       }
     }
 
-    // ?? 二쇱궗??????????????????????????????????????????????????????
     function rollDice(onDone?: () => void) {
       if (lock.current) return
       lock.current = true
       setRolling(true)
 
-      let count = 0,
-        f1 = 1,
-        f2 = 1
+      let count = 0
+      let f1 = 1
+      let f2 = 1
+
       const iv = setInterval(() => {
         f1 = Math.ceil(Math.random() * 6)
         f2 = Math.ceil(Math.random() * 6)
         setDice1(f1)
         setDice2(f2)
         count++
+
         if (count >= 12) {
           clearInterval(iv)
           setRolling(false)
@@ -449,11 +463,10 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
           const total = f1 + f2
           const activeCurPlayer = curPlayerRef.current
 
-          // ?꾩튂 ?대룞
           const movedPlayers = playersRef.current.map((p, i) => {
             if (i !== activeCurPlayer) return p
             const newPos = (p.pos + total) % TILES.length
-            setStatus(`${p.name} ??${TILES[newPos].name} (+${total}移?`)
+            setStatus(`${p.name} → ${TILES[newPos].name} (+${total}칸)`)
             return { ...p, pos: newPos }
           })
           playersRef.current = movedPlayers
@@ -463,6 +476,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
 
           setTimeout(() => {
             const tile = TILES[landedTileId]
+
             if (tile.type === 'city') {
               const owner = tileOwnersRef.current[landedTileId]
               if (!owner) {
@@ -523,6 +537,11 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       return '요청 처리 중 오류가 발생했습니다.'
     }
 
+    function getSellFallbackRefund(level: BuildingLevel) {
+      if (level <= 0) return 0
+      return PURCHASE_COST + Math.max(0, level - 1) * UPGRADE_COST
+    }
+
     async function sellOwnedTileForPlayer(playerIdx: number) {
       const ownedTileEntries = Object.entries(tileOwnersRef.current)
         .filter(([, owner]) => owner.ownerId === playerIdx)
@@ -532,6 +551,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
 
       const [tileIdText, owner] = ownedTileEntries[0]
       const tileId = Number(tileIdText)
+
       const sellResult = await gameApi.sellTile({
         tile_index: tileId,
         level: owner.level,
@@ -549,13 +569,12 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
           delete next[tileId]
           return next
         })
-        applyMoney(playerIdx, +PURCHASE_COST)
+        applyMoney(playerIdx, +getSellFallbackRefund(owner.level))
       }
 
       return true
     }
 
-    // ?? 援щℓ (-60M) ???????????????????????????????????????????????
     async function handleBuy() {
       const { tileId, onDoneCallback } = buyModal
       if (tileId === null) return
@@ -589,7 +608,6 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       advanceTurn(onDoneCallback)
     }
 
-    // ?? ?낃렇?덉씠??(-30M) ?????????????????????????????????????????
     async function handleBuildConfirm() {
       const { tileId, onDoneCallback } = buildModal
       if (tileId === null) return
@@ -626,7 +644,6 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       advanceTurn(onDoneCallback)
     }
 
-    // ?? ?듯뻾猷?(-30M / +30M) ??????????????????????????????????????
     async function handleTollConfirm() {
       const { tileId, onDoneCallback } = tollModal
       const active = curPlayerRef.current
@@ -670,11 +687,13 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
         handleAITile(onDoneCallback)
         return
       }
+
       const active = curPlayerRef.current
       const activePlayer = playersRef.current[active]
       if (activePlayer) {
         emitConfirmPenalty({ player_id: String(activePlayer.id) })
       }
+
       setAiModal({ open: false, status: 'loading' })
       advanceTurn(onDoneCallback)
     }
@@ -687,9 +706,9 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       byTile[p.pos].push(p)
     })
 
-    const CS = CORNER_SIZE,
-      SS = STRAIGHT_SIZE,
-      GAP = GRID_GAP
+    const CS = CORNER_SIZE
+    const SS = STRAIGHT_SIZE
+    const GAP = GRID_GAP
     const buyTile = buyModal.tileId !== null ? TILES[buyModal.tileId] : null
     const buildTile =
       buildModal.tileId !== null ? TILES[buildModal.tileId] : null
@@ -751,7 +770,6 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
             </div>
           ))}
 
-          {/* ?? 以묒븰: ?뚮젅?댁뼱 ???쒓굅, 二쇱궗?꾨쭔 ?? */}
           <div className="board-center">
             <span style={{ fontSize: 52 }}>🎲</span>
             <span className="board-center__title">부루마블</span>
@@ -805,7 +823,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
         <BankruptModal
           open={bankruptModal.open}
           playerName={bankruptModal.playerName}
-          description="寃뚯엫?먯꽌 ?덈씫?⑸땲??"
+          description="게임에서 탈락합니다."
           onConfirm={handleBankruptConfirm}
         />
       </div>
@@ -815,4 +833,3 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
 
 GameBoard.displayName = 'GameBoard'
 export default GameBoard
-

--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, forwardRef, useImperativeHandle } from 'react'
+﻿import { useState, useRef, forwardRef, useImperativeHandle } from 'react'
 import BoardTile from './BoardTile'
 import BuyModal from '../game/modals/BuyModal'
 import BuildModal from '../game/modals/BuildModal'
@@ -6,6 +6,7 @@ import CardModal from '../game/modals/CardModal'
 import TollModal from '../game/modals/TollModal'
 import AIPenaltyModal from '../game/modals/AIPenaltyModal'
 import BankruptModal from '../game/modals/BankruptModal'
+import { emitConfirmPenalty } from '../../services/socket/game.handler'
 import {
   TILES,
   TOP_ROW,
@@ -23,18 +24,18 @@ import {
 } from './board.constants'
 import '../../styles/board.css'
 
-// ─── 비용 상수 ────────────────────────────────────────────────────
+// ??? 鍮꾩슜 ?곸닔 ????????????????????????????????????????????????????
 const PURCHASE_COST = 60
 const UPGRADE_COST = 30
 const TOLL_COST = 30
 
 const LEVEL_LABEL: Record<number, string> = {
-  0: '미구매',
-  1: '집 1채',
-  2: '집 2채',
-  3: '집 3채',
-  4: '호텔',
-  5: '랜드마크',
+  0: '誘멸뎄留?,
+  1: '吏?1梨?,
+  2: '吏?2梨?,
+  3: '吏?3梨?,
+  4: '?명뀛',
+  5: '?쒕뱶留덊겕',
 }
 
 function getUpgradeStage(
@@ -114,22 +115,22 @@ function DiceFace({ value, rolling }: { value: number; rolling: boolean }) {
   )
 }
 
-// ─── 공개 핸들 ───────────────────────────────────────────────────
+// ??? 怨듦컻 ?몃뱾 ???????????????????????????????????????????????????
 export interface BoardGameHandle {
   rollDice: (onDone?: () => void) => void
 }
 
-// ─── Props ───────────────────────────────────────────────────────
+// ??? Props ???????????????????????????????????????????????????????
 interface GameBoardProps {
-  /** 플레이어 상태 (GamePage에서 관리) */
+  /** ?뚮젅?댁뼱 ?곹깭 (GamePage?먯꽌 愿由? */
   players: PlayerState[]
-  /** 현재 턴 인덱스 (GamePage에서 관리) */
+  /** ?꾩옱 ???몃뜳??(GamePage?먯꽌 愿由? */
   curPlayer: number
-  /** 돈/위치 변화 콜백 → GamePage가 state 업데이트 */
+  /** ???꾩튂 蹂??肄쒕갚 ??GamePage媛 state ?낅뜲?댄듃 */
   onPlayersChange: (players: PlayerState[]) => void
-  /** 턴 변경 콜백 */
+  /** ??蹂寃?肄쒕갚 */
   onCurPlayerChange: (idx: number) => void
-  /** 파산 콜백 */
+  /** ?뚯궛 肄쒕갚 */
   onBankrupt?: (playerIdx: number) => void
 }
 
@@ -168,7 +169,7 @@ interface BankruptModalState {
   onDoneCallback?: () => void
 }
 
-// ─── GameBoard ───────────────────────────────────────────────────
+// ??? GameBoard ???????????????????????????????????????????????????
 const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
   (
     { players, curPlayer, onPlayersChange, onCurPlayerChange, onBankrupt },
@@ -177,14 +178,14 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
     const [dice1, setDice1] = useState(1)
     const [dice2, setDice2] = useState(1)
     const [rolling, setRolling] = useState(false)
-    const [status, setStatus] = useState('🎮 게임 시작!')
+    const [status, setStatus] = useState('?렜 寃뚯엫 ?쒖옉!')
     const lock = useRef(false)
 
-    // ref 로 최신값 유지 (setInterval 클로저 stale 방지)
+    // ref 濡?理쒖떊媛??좎? (setInterval ?대줈? stale 諛⑹?)
     const curPlayerRef = useRef(curPlayer)
     const playersRef = useRef<PlayerState[]>(players)
 
-    // props 변경 시 ref 동기화
+    // props 蹂寃???ref ?숆린??
     curPlayerRef.current = curPlayer
     playersRef.current = players
 
@@ -231,7 +232,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       })
     }
 
-    // ── 돈 변경 → 부모에게 전달 ──────────────────────────────────
+    // ?? ??蹂寃???遺紐⑥뿉寃??꾨떖 ??????????????????????????????????
     function applyMoney(
       playerIdx: number,
       delta: number,
@@ -262,7 +263,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       return false
     }
 
-    // ── 파산 확정 ─────────────────────────────────────────────────
+    // ?? ?뚯궛 ?뺤젙 ?????????????????????????????????????????????????
     function handleBankruptConfirm() {
       const { playerIdx, onDoneCallback } = bankruptModal
       setBankruptModal({ open: false, playerIdx: -1, playerName: '' })
@@ -281,7 +282,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       advanceTurn(onDoneCallback)
     }
 
-    // ── 턴 넘기기 (파산자 건너뜀) ────────────────────────────────
+    // ?? ???섍린湲?(?뚯궛??嫄대꼫?) ????????????????????????????????
     function advanceTurn(onDone?: () => void) {
       let next = (curPlayerRef.current + 1) % INIT_PLAYERS.length
       let tries = 0
@@ -294,7 +295,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       onDone?.()
     }
 
-    // ── AI 칸 ─────────────────────────────────────────────────────
+    // ?? AI 移??????????????????????????????????????????????????????
     async function handleAITile(onDone?: () => void) {
       setAiModal({ open: true, status: 'loading', onDoneCallback: onDone })
       try {
@@ -308,7 +309,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
               {
                 role: 'user',
                 content:
-                  '부루마블 보드게임의 AI 칸에 도착했습니다. 플레이어에게 재미있는 패널티나 보너스를 한 문장으로 알려주세요. 예: "다음 턴 이동 칸 +2 보너스!" 또는 "통행료 1회 면제 카드 획득!"',
+                  '遺猷⑤쭏釉?蹂대뱶寃뚯엫??AI 移몄뿉 ?꾩갑?덉뒿?덈떎. ?뚮젅?댁뼱?먭쾶 ?щ??덈뒗 ?⑤꼸?곕굹 蹂대꼫?ㅻ? ??臾몄옣?쇰줈 ?뚮젮二쇱꽭?? ?? "?ㅼ쓬 ???대룞 移?+2 蹂대꼫??" ?먮뒗 "?듯뻾猷?1??硫댁젣 移대뱶 ?띾뱷!"',
               },
             ],
           }),
@@ -319,7 +320,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
           data.content
             ?.filter((b: { type: string }) => b.type === 'text')
             .map((b: { text: string }) => b.text)
-            .join('') ?? '결과를 확인하세요.'
+            .join('') ?? '寃곌낵瑜??뺤씤?섏꽭??'
         setAiModal((prev) => ({
           ...prev,
           status: 'result',
@@ -330,7 +331,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       }
     }
 
-    // ── 주사위 ────────────────────────────────────────────────────
+    // ?? 二쇱궗??????????????????????????????????????????????????????
     function rollDice(onDone?: () => void) {
       if (lock.current) return
       lock.current = true
@@ -353,11 +354,11 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
           const total = f1 + f2
           const activeCurPlayer = curPlayerRef.current
 
-          // 위치 이동
+          // ?꾩튂 ?대룞
           const movedPlayers = playersRef.current.map((p, i) => {
             if (i !== activeCurPlayer) return p
             const newPos = (p.pos + total) % TILES.length
-            setStatus(`${p.name} → ${TILES[newPos].name} (+${total}칸)`)
+            setStatus(`${p.name} ??${TILES[newPos].name} (+${total}移?`)
             return { ...p, pos: newPos }
           })
           playersRef.current = movedPlayers
@@ -392,7 +393,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
                 setTollModal({
                   open: true,
                   tileId: landedTileId,
-                  ownerName: ownerPlayer?.name ?? '상대방',
+                  ownerName: ownerPlayer?.name ?? '?곷?諛?,
                   tollText: `${TOLL_COST}M`,
                   onDoneCallback: onDone,
                 })
@@ -419,7 +420,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       }, 70)
     }
 
-    // ── 구매 (-60M) ───────────────────────────────────────────────
+    // ?? 援щℓ (-60M) ???????????????????????????????????????????????
     function handleBuy() {
       const { tileId, onDoneCallback } = buyModal
       if (tileId === null) return
@@ -445,7 +446,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       advanceTurn(onDoneCallback)
     }
 
-    // ── 업그레이드 (-30M) ─────────────────────────────────────────
+    // ?? ?낃렇?덉씠??(-30M) ?????????????????????????????????????????
     function handleBuildConfirm() {
       const { tileId, onDoneCallback } = buildModal
       if (tileId === null) return
@@ -474,7 +475,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       advanceTurn(onDoneCallback)
     }
 
-    // ── 통행료 (-30M / +30M) ──────────────────────────────────────
+    // ?? ?듯뻾猷?(-30M / +30M) ??????????????????????????????????????
     function handleTollConfirm() {
       const { tileId, onDoneCallback } = tollModal
       const active = curPlayerRef.current
@@ -509,6 +510,11 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       if (aiModal.status === 'error') {
         handleAITile(onDoneCallback)
         return
+      }
+      const active = curPlayerRef.current
+      const activePlayer = playersRef.current[active]
+      if (activePlayer) {
+        emitConfirmPenalty({ player_id: String(activePlayer.id) })
       }
       setAiModal({ open: false, status: 'loading' })
       advanceTurn(onDoneCallback)
@@ -586,10 +592,10 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
             </div>
           ))}
 
-          {/* ── 중앙: 플레이어 점 제거, 주사위만 ── */}
+          {/* ?? 以묒븰: ?뚮젅?댁뼱 ???쒓굅, 二쇱궗?꾨쭔 ?? */}
           <div className="board-center">
-            <span style={{ fontSize: 52 }}>🇰🇷</span>
-            <span className="board-center__title">부루마블</span>
+            <span style={{ fontSize: 52 }}>?눖?눟</span>
+            <span className="board-center__title">遺猷⑤쭏釉?/span>
             <div className="board-dice-pair">
               <DiceFace value={dice1} rolling={rolling} />
               <DiceFace value={dice2} rolling={rolling} />
@@ -640,7 +646,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
         <BankruptModal
           open={bankruptModal.open}
           playerName={bankruptModal.playerName}
-          description="게임에서 탈락합니다."
+          description="寃뚯엫?먯꽌 ?덈씫?⑸땲??"
           onConfirm={handleBankruptConfirm}
         />
       </div>
@@ -650,3 +656,4 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
 
 GameBoard.displayName = 'GameBoard'
 export default GameBoard
+

--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -7,6 +7,7 @@ import TollModal from '../game/modals/TollModal'
 import AIPenaltyModal from '../game/modals/AIPenaltyModal'
 import BankruptModal from '../game/modals/BankruptModal'
 import { emitConfirmPenalty } from '../../services/socket/game.handler'
+import { gameApi } from '../../services/game/game.api'
 import {
   TILES,
   TOP_ROW,
@@ -420,11 +421,26 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       }, 70)
     }
 
+    function toActionErrorMessage(status: number) {
+      if (status === 401) return '로그인이 필요합니다.'
+      if (status === 403) return '현재 턴이 아닙니다.'
+      if (status === 404) return '대상을 찾을 수 없습니다.'
+      if (status === 409) return '조건이 맞지 않아 처리할 수 없습니다.'
+      return '요청 처리 중 오류가 발생했습니다.'
+    }
+
     // ?? 援щℓ (-60M) ???????????????????????????????????????????????
-    function handleBuy() {
+    async function handleBuy() {
       const { tileId, onDoneCallback } = buyModal
       if (tileId === null) return
       const active = curPlayerRef.current
+
+      const actionResult = await gameApi.buyTile({ tile_index: tileId })
+      if (!actionResult.ok) {
+        setStatus(toActionErrorMessage(actionResult.status))
+        return
+      }
+
       setBuyModal({ open: false, tileId: null })
       const bankrupt = applyMoney(active, -PURCHASE_COST, onDoneCallback)
       if (!bankrupt) {
@@ -447,10 +463,17 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
     }
 
     // ?? ?낃렇?덉씠??(-30M) ?????????????????????????????????????????
-    function handleBuildConfirm() {
+    async function handleBuildConfirm() {
       const { tileId, onDoneCallback } = buildModal
       if (tileId === null) return
       const active = curPlayerRef.current
+
+      const actionResult = await gameApi.buildTile({ tile_index: tileId })
+      if (!actionResult.ok) {
+        setStatus(toActionErrorMessage(actionResult.status))
+        return
+      }
+
       setBuildModal({ open: false, tileId: null })
       const bankrupt = applyMoney(active, -UPGRADE_COST, onDoneCallback)
       if (!bankrupt) {

--- a/src/hooks/game/useDiceRoll.ts
+++ b/src/hooks/game/useDiceRoll.ts
@@ -1,4 +1,4 @@
-﻿import { RefObject, useCallback } from 'react'
+import { RefObject, useCallback } from 'react'
 import type { BoardGameHandle } from '../../components/board/LegacyBoardGame'
 import { socket } from '../../lib/socket'
 import { emitRollDice } from '../../services/socket/game.handler'

--- a/src/hooks/game/useDiceRoll.ts
+++ b/src/hooks/game/useDiceRoll.ts
@@ -1,9 +1,20 @@
 ﻿import { RefObject, useCallback } from 'react'
 import type { BoardGameHandle } from '../../components/board/LegacyBoardGame'
+import { socket } from '../../lib/socket'
+import { emitRollDice } from '../../services/socket/game.handler'
+import { useGameStore } from '../../stores/game.store'
 
 export const useDiceRoll = (boardRef: RefObject<BoardGameHandle | null>) => {
-  return useCallback(() => {
-    boardRef.current?.rollDice()
-  }, [boardRef])
-}
+  const currentTurn = useGameStore((state) => state.currentTurn)
 
+  return useCallback(() => {
+    // Prefer server-authoritative roll via socket.
+    if (socket.connected && currentTurn) {
+      emitRollDice({ player_id: currentTurn })
+      return
+    }
+
+    // Fallback for local/mock flow.
+    boardRef.current?.rollDice()
+  }, [boardRef, currentTurn])
+}

--- a/src/hooks/game/useGameState.ts
+++ b/src/hooks/game/useGameState.ts
@@ -1,24 +1,48 @@
 import { useEffect } from 'react'
+import { socket } from '../../lib/socket'
+import { gameApi } from '../../services/game/game.api'
+import { setupGameHandlers } from '../../services/socket/game.handler'
 import { useGameStore } from '../../stores/game.store'
 
 export const useGameState = () => {
   const { setGameState, players } = useGameStore()
 
   useEffect(() => {
+    const teardownHandlers = setupGameHandlers()
+    if (!socket.connected) {
+      socket.connect()
+    }
+
     const fetchGameState = async () => {
-      // Only mock if storage is empty
+      // Initial hydrate only when store is empty.
       if (players.length > 0) return
 
-      try {
-        const response = await fetch('/api/game/state')
-        const data = await response.json()
-        setGameState(data)
-      } catch (error) {
-        console.error('Failed to fetch game state:', error)
+      const result = await gameApi.getState()
+      if (result.ok) {
+        const payload = result.data as {
+          players?: unknown[]
+          tiles?: unknown[]
+          messages?: unknown[]
+          current_turn?: string | null
+          currentTurn?: string | null
+          round?: number
+        }
+
+        setGameState({
+          players: (payload.players as never[]) ?? [],
+          tiles: (payload.tiles as never[]) ?? [],
+          messages: (payload.messages as never[]) ?? [],
+          currentTurn: payload.current_turn ?? payload.currentTurn ?? null,
+          round: payload.round ?? 1,
+        })
       }
     }
 
     fetchGameState()
+
+    return () => {
+      teardownHandlers()
+    }
   }, [setGameState, players.length])
 
   return {}

--- a/src/hooks/game/useGameState.ts
+++ b/src/hooks/game/useGameState.ts
@@ -26,6 +26,8 @@ export const useGameState = () => {
           current_turn?: string | null
           currentTurn?: string | null
           round?: number
+          timeout_sec?: number
+          timeoutSec?: number
         }
 
         setGameState({
@@ -34,6 +36,7 @@ export const useGameState = () => {
           messages: (payload.messages as never[]) ?? [],
           currentTurn: payload.current_turn ?? payload.currentTurn ?? null,
           round: payload.round ?? 1,
+          turnTimeoutSec: payload.timeout_sec ?? payload.timeoutSec ?? 30,
         })
       }
     }

--- a/src/hooks/game/useGameTimer.ts
+++ b/src/hooks/game/useGameTimer.ts
@@ -2,22 +2,26 @@
 
 interface UseGameTimerOptions {
   initialTime?: number
-  resetTime?: number
+  resetSignal?: number
 }
 
 export const useGameTimer = ({
   initialTime = 30,
-  resetTime = 30,
+  resetSignal = 0,
 }: UseGameTimerOptions = {}) => {
   const [timeLeft, setTimeLeft] = useState(initialTime)
 
   useEffect(() => {
+    setTimeLeft(initialTime)
+  }, [initialTime, resetSignal])
+
+  useEffect(() => {
     const timer = window.setInterval(() => {
-      setTimeLeft((prev) => (prev > 0 ? prev - 1 : resetTime))
+      setTimeLeft((prev) => (prev > 0 ? prev - 1 : 0))
     }, 1000)
 
     return () => window.clearInterval(timer)
-  }, [resetTime])
+  }, [])
 
   return [timeLeft, setTimeLeft] as const
 }

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -12,8 +12,12 @@ import BoardGame, { BoardGameHandle } from '../components/board/LegacyBoardGame'
 import { INIT_PLAYERS, PlayerState } from '../components/board/board.constants'
 
 const GamePage: React.FC = () => {
-  const { currentTurn, messages, addMessage } = useGameStore()
-  const [timeLeft] = useGameTimer({ initialTime: 27, resetTime: 30 })
+  const { currentTurn, messages, addMessage, turnTimeoutSec, turnTimerKey } =
+    useGameStore()
+  const [timeLeft] = useGameTimer({
+    initialTime: turnTimeoutSec,
+    resetSignal: turnTimerKey,
+  })
   const boardRef = useRef<BoardGameHandle>(null)
   const isMyTurn = useTurn(currentTurn)
 

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -10,6 +10,7 @@ import { useDiceRoll } from '../hooks/game/useDiceRoll'
 import { useTurn } from '../hooks/game/useTurn'
 import BoardGame, { BoardGameHandle } from '../components/board/LegacyBoardGame'
 import { INIT_PLAYERS, PlayerState } from '../components/board/board.constants'
+import { emitSendChat } from '../services/socket/game.handler'
 
 const GamePage: React.FC = () => {
   const { currentTurn, messages, addMessage } = useGameStore()
@@ -24,6 +25,7 @@ const GamePage: React.FC = () => {
   useGameState()
 
   const handleSendMessage = (content: string) => {
+    emitSendChat({ message: content })
     addMessage({
       id: Date.now().toString(),
       sender_id: 'me',

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -10,7 +10,6 @@ import { useDiceRoll } from '../hooks/game/useDiceRoll'
 import { useTurn } from '../hooks/game/useTurn'
 import BoardGame, { BoardGameHandle } from '../components/board/LegacyBoardGame'
 import { INIT_PLAYERS, PlayerState } from '../components/board/board.constants'
-import { emitSendChat } from '../services/socket/game.handler'
 
 const GamePage: React.FC = () => {
   const { currentTurn, messages, addMessage } = useGameStore()
@@ -25,7 +24,6 @@ const GamePage: React.FC = () => {
   useGameState()
 
   const handleSendMessage = (content: string) => {
-    emitSendChat({ message: content })
     addMessage({
       id: Date.now().toString(),
       sender_id: 'me',

--- a/src/services/game/game.api.ts
+++ b/src/services/game/game.api.ts
@@ -1,0 +1,71 @@
+import { apiClient } from '../../lib/axios'
+
+export type GameActionErrorCode = 401 | 403 | 404 | 409 | 500
+
+type GameActionResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; status: GameActionErrorCode | number; message: string }
+
+const toErrorResult = (error: unknown): GameActionResult<never> => {
+  const status =
+    typeof error === 'object' &&
+    error !== null &&
+    'response' in error &&
+    typeof (error as { response?: { status?: number } }).response?.status ===
+      'number'
+      ? (error as { response: { status: number } }).response.status
+      : 500
+
+  return {
+    ok: false,
+    status,
+    message: '요청 처리 중 오류가 발생했습니다.',
+  }
+}
+
+export const gameApi = {
+  async getState() {
+    try {
+      const { data } = await apiClient.get('/game/state')
+      return { ok: true, data } as const
+    } catch (error) {
+      return toErrorResult(error)
+    }
+  },
+
+  // GAME-001
+  async buyTile(payload: { tile_index: number }) {
+    try {
+      const { data } = await apiClient.post('/game/buy', payload)
+      return { ok: true, data } as const
+    } catch (error) {
+      return toErrorResult(error)
+    }
+  },
+
+  // GAME-002
+  async buildTile(payload: { tile_index: number }) {
+    try {
+      const { data } = await apiClient.post('/game/build', payload)
+      return { ok: true, data } as const
+    } catch (error) {
+      return toErrorResult(error)
+    }
+  },
+
+  // GAME-003
+  async sellTile(payload: { tile_index: number; level?: number }) {
+    try {
+      const { data } = await apiClient.post('/game/sell', payload)
+      return { ok: true, data } as const
+    } catch (error) {
+      return toErrorResult(error)
+    }
+  },
+
+  // GAME-004
+  async syncState() {
+    return this.getState()
+  },
+}
+

--- a/src/services/socket/game.handler.ts
+++ b/src/services/socket/game.handler.ts
@@ -99,6 +99,7 @@ export const setupGameHandlers = (): Teardown => {
 
   const handleTollPaid = ({
     payer_id,
+    owner_id,
     amount,
   }: {
     payer_id: string
@@ -109,8 +110,13 @@ export const setupGameHandlers = (): Teardown => {
     // If this player exists in store, pessimistically reflect balance.
     const state = useGameStore.getState()
     const payer = state.players.find((p) => p.id === payer_id)
-    if (!payer) return
-    state.updatePlayer(payer_id, { balance: Math.max(0, payer.balance - amount) })
+    const owner = state.players.find((p) => p.id === owner_id)
+    if (payer) {
+      state.updatePlayer(payer_id, { balance: Math.max(0, payer.balance - amount) })
+    }
+    if (owner) {
+      state.updatePlayer(owner_id, { balance: owner.balance + amount })
+    }
   }
 
   const handleCardDrawn = ({ card }: { player_id: string; card: Card }) => {

--- a/src/services/socket/game.handler.ts
+++ b/src/services/socket/game.handler.ts
@@ -182,8 +182,3 @@ export const emitRollDice = (payload: { player_id: string }) => {
 export const emitConfirmPenalty = (payload: { player_id: string }) => {
   socket.emit('confirm_penalty', payload)
 }
-
-export const emitSendChat = (payload: { game_id?: string; message: string }) => {
-  socket.emit('send_chat', payload)
-}
-

--- a/src/services/socket/game.handler.ts
+++ b/src/services/socket/game.handler.ts
@@ -1,209 +1,189 @@
 import { socket } from '../../lib/socket'
 import { useGameStore } from '../../stores/game.store'
-import { Player, Tile, Card, GameResult } from '../../types/domain'
+import type { Card, GameResult, Player, Tile } from '../../types/domain'
 
-export const setupGameHandlers = () => {
+type Teardown = () => void
+
+type GameStatePayload = {
+  players: Player[]
+  tiles: Tile[]
+  current_turn: string | null
+  round: number
+}
+
+let teardownGameHandlersRef: Teardown | null = null
+
+const applyGameState = (payload: GameStatePayload) => {
+  const gameStore = useGameStore.getState()
+  gameStore.setGameState({
+    players: payload.players,
+    tiles: payload.tiles,
+    currentTurn: payload.current_turn,
+    round: payload.round,
+  })
+}
+
+export const setupGameHandlers = (): Teardown => {
+  // Prevent duplicated listeners on remount.
+  teardownGameHandlersRef?.()
+
   const gameStore = useGameStore.getState()
 
-  // SOCK-028: game_start
-  socket.on(
-    'game_start',
-    ({
-      game_state,
-    }: {
-      game_id: string
-      game_state: {
-        players: Player[]
-        tiles: Tile[]
-        current_turn: string | null
-        round: number
-      }
-    }) => {
-      gameStore.setGameState({
-        players: game_state.players,
-        tiles: game_state.tiles,
-        currentTurn: game_state.current_turn, // 서버 payload → 프론트 camelCase 매핑
-        round: game_state.round,
-      })
-    }
-  )
+  const handleGameStart = ({ game_state }: { game_state: GameStatePayload }) => {
+    applyGameState(game_state)
+  }
 
-  // SOCK-012: game_state
-  socket.on(
-    'game_state',
-    (state: {
-      players: Player[]
-      tiles: Tile[]
-      current_turn: string | null
-      round: number
-    }) => {
-      gameStore.setGameState({
-        players: state.players,
-        tiles: state.tiles,
-        currentTurn: state.current_turn, // 서버 payload → 프론트 camelCase 매핑
-        round: state.round,
-      })
-    }
-  )
+  const handleGameState = (state: GameStatePayload) => {
+    applyGameState(state)
+  }
 
-  // SOCK-009: turn_start
-  socket.on(
-    'turn_start',
-    ({
-      player_id,
-      round,
-    }: {
-      player_id: string
-      round: number
-      timeout_sec: number
-    }) => {
-      gameStore.setGameState({
-        currentTurn: player_id,
-        round,
-      })
-    }
-  )
-
-  // SOCK-010: dice_rolled
-  socket.on(
-    'dice_rolled',
-    ({
-      player_id,
-      dice,
-    }: {
-      player_id: string
-      dice: number[]
-      is_double: boolean
-      double_count: number
-    }) => {
-      console.log(`Player ${player_id} rolled: ${dice[0]}, ${dice[1]}`)
-    }
-  )
-
-  // SOCK-011: player_moved
-  socket.on(
-    'player_moved',
-    ({
-      player_id,
-      to_index,
-      pass_go,
-      pass_go_salary,
-    }: {
-      player_id: string
-      from_index: number
-      to_index: number
-      trigger: string
-      pass_go: boolean
-      pass_go_salary: number
-    }) => {
-      gameStore.updatePlayer(player_id, { position: to_index })
-      if (pass_go) {
-        console.log(
-          `Player ${player_id} passed GO and earned ${pass_go_salary}`
-        )
-      }
-    }
-  )
-
-  // SOCK-013: tile_purchased
-  socket.on(
-    'tile_purchased',
-    ({
-      player_id,
-      tile_index,
-    }: {
-      player_id: string
-      tile_index: number
-      tile_name: string
-      price: number
-    }) => {
-      gameStore.updateTile(tile_index, { owner_id: player_id })
-      gameStore.setModal(null)
-    }
-  )
-
-  // SOCK-014: toll_paid
-  socket.on(
-    'toll_paid',
-    ({
-      payer_id,
-      owner_id,
-      amount,
-    }: {
-      payer_id: string
-      owner_id: string
-      tile_index: number
-      amount: number
-    }) => {
-      console.log(`Player ${payer_id} paid ${amount} to ${owner_id}`)
-    }
-  )
-
-  // SOCK-015, SOCK-029: event_card_drawn, chance_card_drawn
-  const handleCardDrawn = ({
+  const handleTurnStart = ({
     player_id,
-    card,
+    round,
   }: {
     player_id: string
-    card: Card
+    round: number
+    timeout_sec: number
   }) => {
-    gameStore.setModal('card')
-    console.log(`Player ${player_id} drew: ${card.title} - ${card.description}`)
+    gameStore.setGameState({
+      currentTurn: player_id,
+      round,
+    })
   }
-  socket.on('event_card_drawn', handleCardDrawn)
-  socket.on('chance_card_drawn', handleCardDrawn)
 
-  // SOCK-016: player_sent_to_jail
-  socket.on(
-    'player_sent_to_jail',
-    ({ player_id }: { player_id: string; source: string }) => {
-      gameStore.updatePlayer(player_id, { is_in_jail: true })
-    }
-  )
+  const handleDiceRolled = ({
+    player_id,
+    dice,
+  }: {
+    player_id: string
+    dice: number[]
+    is_double: boolean
+    double_count: number
+  }) => {
+    // UI animation sync hook point. Keeping no-op to avoid console noise.
+    void player_id
+    void dice
+  }
 
-  // SOCK-017: player_bankrupt
-  socket.on(
-    'player_bankrupt',
-    ({
-      player_id,
-    }: {
-      player_id: string
-      reason: string
-      released_tiles: number[]
-    }) => {
-      gameStore.updatePlayer(player_id, { is_bankrupt: true })
-      gameStore.setModal('bankrupt')
-    }
-  )
+  const handlePlayerMoved = ({
+    player_id,
+    to_index,
+  }: {
+    player_id: string
+    from_index: number
+    to_index: number
+    trigger: string
+    pass_go: boolean
+    pass_go_salary: number
+  }) => {
+    gameStore.updatePlayer(player_id, { position: to_index })
+  }
 
-  // SOCK-018: game_over
-  socket.on('game_over', (payload: GameResult) => {
+  const handleTilePurchased = ({
+    player_id,
+    tile_index,
+  }: {
+    player_id: string
+    tile_index: number
+    tile_name: string
+    price: number
+  }) => {
+    gameStore.updateTile(tile_index, { owner_id: player_id })
+    gameStore.setModal(null)
+  }
+
+  const handleTollPaid = ({
+    payer_id,
+    amount,
+  }: {
+    payer_id: string
+    owner_id: string
+    tile_index: number
+    amount: number
+  }) => {
+    // If this player exists in store, pessimistically reflect balance.
+    const state = useGameStore.getState()
+    const payer = state.players.find((p) => p.id === payer_id)
+    if (!payer) return
+    state.updatePlayer(payer_id, { balance: Math.max(0, payer.balance - amount) })
+  }
+
+  const handleCardDrawn = ({ card }: { player_id: string; card: Card }) => {
+    void card
+    gameStore.setModal('card')
+  }
+
+  const handlePlayerSentToJail = ({ player_id }: { player_id: string }) => {
+    gameStore.updatePlayer(player_id, { is_in_jail: true })
+  }
+
+  const handlePlayerBankrupt = ({ player_id }: { player_id: string }) => {
+    gameStore.updatePlayer(player_id, { is_bankrupt: true })
+    gameStore.setModal('bankrupt')
+  }
+
+  const handleGameOver = (payload: GameResult) => {
     const winner = payload.rankings.find((r) => r.is_winner)
     gameStore.setGameState({
       gameResult: payload,
       isGameOver: true,
       winnerId: winner?.player_id ?? null,
     })
-  })
+  }
 
-  // SOCK-019: ai_penalty_loading
-  socket.on('ai_penalty_loading', ({ player_id }: { player_id: string }) => {
-    console.log(`AI Penalty loading for ${player_id}...`)
-  })
+  const handleAIPenaltyLoading = () => {
+    gameStore.setModal('penalty')
+  }
 
-  // SOCK-020: ai_penalty
-  socket.on(
-    'ai_penalty',
-    ({
-      player_id,
-      penalty,
-    }: {
-      player_id: string
-      penalty: number
-      source: string
-    }) => {
-      gameStore.setModal('penalty')
-      console.log(`AI Penalty for ${player_id}: ${penalty}`)
-    }
-  )
+  const handleAIPenalty = () => {
+    gameStore.setModal('penalty')
+  }
+
+  socket.on('game_start', handleGameStart)
+  socket.on('game_state', handleGameState)
+  socket.on('turn_start', handleTurnStart)
+  socket.on('dice_rolled', handleDiceRolled)
+  socket.on('player_moved', handlePlayerMoved)
+  socket.on('tile_purchased', handleTilePurchased)
+  socket.on('toll_paid', handleTollPaid)
+  socket.on('event_card_drawn', handleCardDrawn)
+  socket.on('chance_card_drawn', handleCardDrawn)
+  socket.on('player_sent_to_jail', handlePlayerSentToJail)
+  socket.on('player_bankrupt', handlePlayerBankrupt)
+  socket.on('game_over', handleGameOver)
+  socket.on('ai_penalty_loading', handleAIPenaltyLoading)
+  socket.on('ai_penalty', handleAIPenalty)
+
+  const teardown = () => {
+    socket.off('game_start', handleGameStart)
+    socket.off('game_state', handleGameState)
+    socket.off('turn_start', handleTurnStart)
+    socket.off('dice_rolled', handleDiceRolled)
+    socket.off('player_moved', handlePlayerMoved)
+    socket.off('tile_purchased', handleTilePurchased)
+    socket.off('toll_paid', handleTollPaid)
+    socket.off('event_card_drawn', handleCardDrawn)
+    socket.off('chance_card_drawn', handleCardDrawn)
+    socket.off('player_sent_to_jail', handlePlayerSentToJail)
+    socket.off('player_bankrupt', handlePlayerBankrupt)
+    socket.off('game_over', handleGameOver)
+    socket.off('ai_penalty_loading', handleAIPenaltyLoading)
+    socket.off('ai_penalty', handleAIPenalty)
+  }
+
+  teardownGameHandlersRef = teardown
+  return teardown
 }
+
+export const emitRollDice = (payload: { player_id: string }) => {
+  socket.emit('roll_dice', payload)
+}
+
+export const emitConfirmPenalty = (payload: { player_id: string }) => {
+  socket.emit('confirm_penalty', payload)
+}
+
+export const emitSendChat = (payload: { game_id?: string; message: string }) => {
+  socket.emit('send_chat', payload)
+}
+

--- a/src/services/socket/game.handler.ts
+++ b/src/services/socket/game.handler.ts
@@ -9,6 +9,7 @@ type GameStatePayload = {
   tiles: Tile[]
   current_turn: string | null
   round: number
+  timeout_sec?: number
 }
 
 let teardownGameHandlersRef: Teardown | null = null
@@ -20,6 +21,7 @@ const applyGameState = (payload: GameStatePayload) => {
     tiles: payload.tiles,
     currentTurn: payload.current_turn,
     round: payload.round,
+    turnTimeoutSec: payload.timeout_sec ?? gameStore.turnTimeoutSec,
   })
 }
 
@@ -40,6 +42,7 @@ export const setupGameHandlers = (): Teardown => {
   const handleTurnStart = ({
     player_id,
     round,
+    timeout_sec,
   }: {
     player_id: string
     round: number
@@ -48,6 +51,8 @@ export const setupGameHandlers = (): Teardown => {
     gameStore.setGameState({
       currentTurn: player_id,
       round,
+      turnTimeoutSec: timeout_sec,
+      turnTimerKey: Date.now(),
     })
   }
 

--- a/src/stores/game.store.ts
+++ b/src/stores/game.store.ts
@@ -26,6 +26,8 @@ const INITIAL_STATE: GameState = {
   messages: [],
   currentTurn: null,
   round: 1,
+  turnTimeoutSec: 30,
+  turnTimerKey: 0,
   activeModal: null,
   gameResult: null,
   isGameOver: false,

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -71,6 +71,8 @@ export interface GameState {
   messages: ChatMessage[]
   currentTurn: string | null // 프론트 내부 상태 — camelCase 통일
   round: number
+  turnTimeoutSec: number
+  turnTimerKey: number
   activeModal: ActiveModal
   gameResult: GameResult | null
   isGameOver: boolean


### PR DESCRIPTION
## 🔗 관련 이슈

> closes #106 

---

## 📌 작업 내용

- 게임 소켓 핸들러 lifecycle 정리 (`setup/teardown`)
- 소켓 emit 추가
  - `roll_dice`
  - `confirm_penalty`
- 게임 액션 API 유틸 추가/연결
  - `GAME-001 buy`
  - `GAME-002 build`
  - `GAME-003 sell`
  - `GAME-004 sync`
- `turn_start.timeout_sec` 기반 턴 타이머 리셋 연동
  - store 필드 추가: `turnTimeoutSec`, `turnTimerKey`
  - `GamePage`/`useGameTimer` 연동
- 통행료 부족 시 매각 API 호출 경로 추가
- 액션 후 `syncState()`로 보드 상태 동기화 보강
- `toll_paid` 수신 시 payer/owner 잔액 동시 반영
- 인코딩 깨짐 문구/문자(BOM) 정리

---

커밋 묶음 요약

1.소켓/런타임 연결
게임 소켓 핸들러 등록/해제 lifecycle 정리
roll_dice, confirm_penalty emit 경로 추가
중복 리스너 방지(teardown 선행) 적용

2.API 계층 정리
gameApi 유틸 신설 (buy/build/sell/sync/getState)
액션 실패 코드(401/403/404/409/500) 공통 처리 기반 마련

3.타이머 동기화
store에 turnTimeoutSec, turnTimerKey 추가
turn_start.timeout_sec 수신 시 타이머 리셋 신호 반영
GamePage + useGameTimer를 서버 턴 기준으로 동기화

4.보드 액션 보강
구매/건설에서 API 우선 호출 후 상태 반영
통행료 부족 시 매각 API(GAME-003) 호출 경로 추가
액션 이후 syncState()로 서버 상태 재동기화
5. 안정화/품질 보정
-syncState 플레이어 매핑을 index 의존에서 id 기준으로 개선
-toll_paid 수신 시 payer/owner 잔액 모두 반영
-인코딩 깨짐 문자열 및 BOM 정리, 타입체크 통과 (npx tsc -b)

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 🖼 스크린샷 (선택)

> UI 변경이 큰 PR은 아니므로 생략
