### PR TITLE
feat: 비밀방 입장 모달 및 비밀번호 검증/입장 흐름 구현

### DIFF
--- a/src/pages/lobby/LobbyPage.tsx
+++ b/src/pages/lobby/LobbyPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import toast from 'react-hot-toast'
 import { useNavigate } from 'react-router-dom'
 import Header from '../../components/header/Header'
 import { useAuthStore } from '../../features/auth/store'
@@ -13,7 +14,14 @@ import type { LobbyRoomFilter } from './api'
 import { useLobbyRoomsQuery } from './hooks'
 import { LobbyControls } from './LobbyControls'
 import { RoomGrid } from './RoomGrid'
+import { PrivateRoomJoinModal } from './PrivateRoomJoinModal'
+import {
+  getWaitingRoomErrorMessage,
+  isJoinPasswordMismatchError,
+  joinWaitingRoom,
+} from '../waiting-room/api'
 import type { LobbyRoom } from './types'
+import type { WaitingRoomSnapshot } from '../waiting-room/types'
 
 function LobbyPage() {
   const navigate = useNavigate()
@@ -24,6 +32,13 @@ function LobbyPage() {
   const [roomFilter, setRoomFilter] = useState<LobbyRoomFilter>('ALL')
   const [excludePrivateRoom, setExcludePrivateRoom] = useState(false)
   const [isUserListOpen, setIsUserListOpen] = useState(true)
+  const [selectedPrivateRoom, setSelectedPrivateRoom] =
+    useState<LobbyRoom | null>(null)
+  const [privateRoomPassword, setPrivateRoomPassword] = useState('')
+  const [isPrivateRoomJoinPending, setIsPrivateRoomJoinPending] =
+    useState(false)
+  const [isPrivateRoomPasswordInvalid, setIsPrivateRoomPasswordInvalid] =
+    useState(false)
 
   useEffect(() => {
     if (!session) {
@@ -62,12 +77,64 @@ function LobbyPage() {
   }
 
   function handleJoinRoom(room: LobbyRoom) {
+    if (room.isPrivate) {
+      setSelectedPrivateRoom(room)
+      setPrivateRoomPassword('')
+      setIsPrivateRoomPasswordInvalid(false)
+      return
+    }
+
+    handleEnterWaitingRoom(room)
+  }
+
+  function handleClosePrivateRoomModal() {
+    setSelectedPrivateRoom(null)
+    setPrivateRoomPassword('')
+    setIsPrivateRoomPasswordInvalid(false)
+  }
+
+  function handleEnterWaitingRoom(
+    room: LobbyRoom,
+    preJoinedSnapshot?: WaitingRoomSnapshot
+  ) {
     navigate(`/rooms/${room.id}`, {
       state: {
         roomId: room.id,
         roomTitle: room.title,
+        preJoinedSnapshot,
       },
     })
+  }
+
+  async function handleSubmitPrivateRoomJoin() {
+    if (!selectedPrivateRoom || !session) {
+      return
+    }
+
+    setIsPrivateRoomJoinPending(true)
+
+    try {
+      const joinedRoomSnapshot = await joinWaitingRoom({
+        roomId: selectedPrivateRoom.id,
+        userId: session.userId,
+        nickname: session.nickname,
+        fallbackTitle: selectedPrivateRoom.title,
+        password: privateRoomPassword,
+      })
+
+      handleEnterWaitingRoom(selectedPrivateRoom, joinedRoomSnapshot)
+      handleClosePrivateRoomModal()
+    } catch (error) {
+      if (isJoinPasswordMismatchError(error)) {
+        setIsPrivateRoomPasswordInvalid(true)
+      }
+
+      toast.error(
+        getWaitingRoomErrorMessage(error, '비밀방 입장에 실패했습니다.')
+      )
+    } finally {
+      setIsPrivateRoomJoinPending(false)
+    }
   }
 
   if (!session || session.needsNicknameSetup) {
@@ -119,6 +186,25 @@ function LobbyPage() {
           onToggle={() => setIsUserListOpen((prev) => !prev)}
         />
       </main>
+
+      {selectedPrivateRoom ? (
+        <PrivateRoomJoinModal
+          roomTitle={selectedPrivateRoom.title}
+          password={privateRoomPassword}
+          isSubmitting={isPrivateRoomJoinPending}
+          isPasswordInvalid={isPrivateRoomPasswordInvalid}
+          onPasswordChange={(password) => {
+            setPrivateRoomPassword(password)
+            if (isPrivateRoomPasswordInvalid) {
+              setIsPrivateRoomPasswordInvalid(false)
+            }
+          }}
+          onClose={handleClosePrivateRoomModal}
+          onSubmit={() => {
+            void handleSubmitPrivateRoomJoin()
+          }}
+        />
+      ) : null}
     </div>
   )
 }

--- a/src/pages/lobby/PrivateRoomJoinModal.tsx
+++ b/src/pages/lobby/PrivateRoomJoinModal.tsx
@@ -1,0 +1,161 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Lock, X } from 'lucide-react'
+import { cn } from '../../lib/utils'
+
+const PASSWORD_PATTERN = /^\d{4}$/
+
+interface PrivateRoomJoinModalProps {
+  roomTitle: string
+  password: string
+  isSubmitting: boolean
+  isPasswordInvalid: boolean
+  onPasswordChange: (password: string) => void
+  onClose: () => void
+  onSubmit: () => void
+}
+
+export function PrivateRoomJoinModal({
+  roomTitle,
+  password,
+  isSubmitting,
+  isPasswordInvalid,
+  onPasswordChange,
+  onClose,
+  onSubmit,
+}: PrivateRoomJoinModalProps) {
+  const [isPasswordInputFocused, setIsPasswordInputFocused] = useState(false)
+  const isJoinDisabled = !PASSWORD_PATTERN.test(password) || isSubmitting
+  const shouldShowHelperMessage = isPasswordInputFocused || isPasswordInvalid
+  const helperMessage = isPasswordInvalid
+    ? '비밀번호가 올바르지 않습니다.'
+    : '비밀번호 4자리를 입력해주세요'
+  const canClose = !isSubmitting
+  const handleClose = useCallback(() => {
+    if (!canClose) {
+      return
+    }
+    onClose()
+  }, [canClose, onClose])
+
+  useEffect(() => {
+    const handleKeydown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') {
+        return
+      }
+      handleClose()
+    }
+
+    window.addEventListener('keydown', handleKeydown)
+    return () => {
+      window.removeEventListener('keydown', handleKeydown)
+    }
+  }, [handleClose])
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-[rgba(15,23,42,0.35)] p-4 backdrop-blur-[2px]">
+      <div className="absolute inset-0" onClick={handleClose} aria-hidden />
+
+      <section
+        role="dialog"
+        aria-modal="true"
+        aria-label="비밀방 입장"
+        className="relative z-1 w-full max-w-[430px] rounded-[32px] border border-ui-border bg-ui-surface px-7 pb-7 pt-8 shadow-[0_24px_60px_rgba(15,23,42,0.2)]"
+      >
+        <button
+          type="button"
+          aria-label="모달 닫기"
+          onClick={handleClose}
+          disabled={!canClose}
+          className={cn(
+            'absolute right-5 top-5 inline-flex size-9 items-center justify-center rounded-full border border-ui-border bg-white text-ui-text-muted transition-colors',
+            canClose
+              ? 'hover:bg-ui-surface-soft hover:text-ui-text-strong'
+              : 'cursor-not-allowed opacity-60'
+          )}
+        >
+          <X className="size-5" />
+        </button>
+
+        <div className="mx-auto mb-4 flex size-[62px] items-center justify-center rounded-full bg-ui-surface-soft text-ui-text-subtle">
+          <Lock className="size-8" />
+        </div>
+
+        <h2 className="text-center text-[2.1rem] font-extrabold tracking-tight text-ui-text-strong">
+          비밀방 입장
+        </h2>
+
+        <p className="mt-1 text-center text-lg font-semibold text-ui-text-muted">
+          {roomTitle}
+        </p>
+
+        <form
+          className="mt-6"
+          onSubmit={(event) => {
+            event.preventDefault()
+            if (isJoinDisabled) {
+              return
+            }
+            onSubmit()
+          }}
+        >
+          <input
+            type="password"
+            inputMode="numeric"
+            pattern="[0-9]*"
+            maxLength={4}
+            value={password}
+            onFocus={() => setIsPasswordInputFocused(true)}
+            onBlur={() => setIsPasswordInputFocused(false)}
+            onChange={(event) => {
+              const nextValue = event.target.value
+                .replace(/\D/g, '')
+                .slice(0, 4)
+              onPasswordChange(nextValue)
+            }}
+            placeholder="비밀번호 입력"
+            className={cn(
+              'h-12 w-full rounded-2xl border bg-white px-4 text-[1.2rem] font-semibold text-ui-text-strong placeholder:text-ui-text-subtle focus:outline-none focus:ring-0 transition-colors',
+              isPasswordInvalid
+                ? 'border-2 border-ui-danger bg-ui-danger-bg/30 focus:border-ui-danger'
+                : 'border-ui-border focus:border-ui-border'
+            )}
+          />
+
+          {shouldShowHelperMessage ? (
+            <p
+              className={cn(
+                'mt-2 text-sm font-semibold',
+                isPasswordInvalid ? 'text-ui-danger' : 'text-ui-text-muted'
+              )}
+            >
+              {helperMessage}
+            </p>
+          ) : null}
+
+          <div className="mt-5 grid grid-cols-2 gap-3">
+            <button
+              type="button"
+              onClick={handleClose}
+              disabled={isSubmitting}
+              className="h-12 rounded-2xl bg-ui-disabled-bg text-lg font-bold text-ui-text-muted transition-colors hover:bg-ui-surface-soft"
+            >
+              취소
+            </button>
+            <button
+              type="submit"
+              disabled={isJoinDisabled}
+              className={cn(
+                'h-12 rounded-2xl text-lg font-bold transition-colors',
+                isJoinDisabled
+                  ? 'cursor-not-allowed bg-ui-disabled-bg text-ui-disabled-text'
+                  : 'bg-ui-brand text-white hover:bg-ui-brand-strong'
+              )}
+            >
+              {isSubmitting ? '입장 중...' : '입장'}
+            </button>
+          </div>
+        </form>
+      </section>
+    </div>
+  )
+}

--- a/src/pages/lobby/hooks.ts
+++ b/src/pages/lobby/hooks.ts
@@ -39,5 +39,6 @@ export function useLobbyRoomsQuery(params: GetLobbyRoomsParams) {
     ],
     queryFn: () => getLobbyRooms(params),
     staleTime: LOBBY_QUERY_STALE_TIME_MS,
+    refetchOnMount: 'always',
   })
 }

--- a/src/pages/waiting-room/WaitingRoomPage.tsx
+++ b/src/pages/waiting-room/WaitingRoomPage.tsx
@@ -14,11 +14,12 @@ import { WaitingRoomHeader } from './components/WaitingRoomHeader'
 import { WaitingSeatCard } from './components/WaitingSeatCard'
 import { WaitingRoomSidePanel } from './components/WaitingRoomSidePanel'
 import { useWaitingRoomController } from './hooks'
-import type { GameStartEventPayload } from './types'
+import type { GameStartEventPayload, WaitingRoomSnapshot } from './types'
 
 interface WaitingRoomLocationState {
   roomId?: string
   roomTitle?: string
+  preJoinedSnapshot?: WaitingRoomSnapshot
 }
 
 const DEFAULT_WAITING_ROOM_TITLE = '즐거운 게임 한판!'
@@ -45,6 +46,9 @@ function WaitingRoomPage() {
   const locationState = location.state as WaitingRoomLocationState | null
   const isSameRoomState = locationState?.roomId === currentRoomId
   const selectedRoomTitle = isSameRoomState ? locationState?.roomTitle : null
+  const preJoinedSnapshot = isSameRoomState
+    ? (locationState?.preJoinedSnapshot ?? null)
+    : null
 
   const handleGameStart = useCallback(
     (payload: GameStartEventPayload) => {
@@ -79,6 +83,7 @@ function WaitingRoomPage() {
     roomId: currentRoomId,
     session,
     fallbackRoomTitle: selectedRoomTitle ?? undefined,
+    preJoinedSnapshot,
     onGameStart: handleGameStart,
   })
 

--- a/src/pages/waiting-room/api.ts
+++ b/src/pages/waiting-room/api.ts
@@ -191,3 +191,15 @@ export function getWaitingRoomErrorMessage(
 
   return fallbackMessage
 }
+
+export function isJoinPasswordMismatchError(error: unknown) {
+  if (error instanceof WaitingRoomMockError) {
+    return error.status === 403
+  }
+
+  if (isAxiosError(error)) {
+    return error.response?.status === 403
+  }
+
+  return false
+}

--- a/src/pages/waiting-room/hooks.ts
+++ b/src/pages/waiting-room/hooks.ts
@@ -35,6 +35,7 @@ interface UseWaitingRoomControllerParams {
   roomId: string
   session: AuthSession | null
   fallbackRoomTitle?: string
+  preJoinedSnapshot?: WaitingRoomSnapshot | null
   onGameStart: (payload: GameStartEventPayload) => void
 }
 
@@ -112,6 +113,7 @@ export function useWaitingRoomController({
   roomId,
   session,
   fallbackRoomTitle,
+  preJoinedSnapshot,
   onGameStart,
 }: UseWaitingRoomControllerParams) {
   const [room, setRoom] = useState<WaitingRoomSnapshot | null>(null)
@@ -124,6 +126,8 @@ export function useWaitingRoomController({
 
   const hasEnteredRoomRef = useRef(false)
   const hasLeftRoomRef = useRef(false)
+  const hasInitializedPreJoinRef = useRef(false)
+  const preJoinedRoomId = preJoinedSnapshot?.roomId
 
   useEffect(() => {
     if (!roomId) {
@@ -133,6 +137,7 @@ export function useWaitingRoomController({
       setRoomErrorMessage(null)
       hasEnteredRoomRef.current = false
       hasLeftRoomRef.current = false
+      hasInitializedPreJoinRef.current = false
       return
     }
 
@@ -143,6 +148,32 @@ export function useWaitingRoomController({
       setRoomErrorMessage(null)
       hasEnteredRoomRef.current = false
       hasLeftRoomRef.current = false
+      hasInitializedPreJoinRef.current = false
+      return
+    }
+
+    if (
+      hasInitializedPreJoinRef.current &&
+      hasEnteredRoomRef.current &&
+      preJoinedRoomId === roomId
+    ) {
+      setIsRoomLoading(false)
+      return
+    }
+
+    if (
+      preJoinedSnapshot &&
+      preJoinedRoomId === roomId &&
+      !hasInitializedPreJoinRef.current
+    ) {
+      setRoom(preJoinedSnapshot)
+      setChatMessages(preJoinedSnapshot.chatMessages)
+      setRoomErrorMessage(null)
+      setIsRoomLoading(false)
+      enterWaitingRoomSocket({ roomId })
+      hasEnteredRoomRef.current = true
+      hasLeftRoomRef.current = false
+      hasInitializedPreJoinRef.current = true
       return
     }
 
@@ -190,7 +221,7 @@ export function useWaitingRoomController({
     return () => {
       isMounted = false
     }
-  }, [fallbackRoomTitle, roomId, session])
+  }, [fallbackRoomTitle, preJoinedRoomId, preJoinedSnapshot, roomId, session])
 
   const activeRoomId = room?.roomId
 
@@ -269,13 +300,23 @@ export function useWaitingRoomController({
 
   useEffect(() => {
     return () => {
-      if (!hasEnteredRoomRef.current || hasLeftRoomRef.current) {
+      if (
+        !session ||
+        !roomId ||
+        !hasEnteredRoomRef.current ||
+        hasLeftRoomRef.current
+      ) {
         return
       }
 
+      hasLeftRoomRef.current = true
+      void leaveWaitingRoom({
+        roomId,
+        userId: session.userId,
+      })
       leaveWaitingRoomSocket({ roomId })
     }
-  }, [roomId])
+  }, [roomId, session])
 
   const me = useMemo(() => {
     if (!room || !session) {
@@ -395,7 +436,7 @@ export function useWaitingRoomController({
     }, [canStartGame, isStartPending, room, session])
 
   const leaveRoom = useCallback(async (): Promise<WaitingRoomActionResult> => {
-    if (!room || !session || hasLeftRoomRef.current) {
+    if (!session || hasLeftRoomRef.current) {
       return {
         ok: true,
       }
@@ -408,21 +449,32 @@ export function useWaitingRoomController({
     }
 
     setIsLeavePending(true)
+    const targetRoomId = room?.roomId ?? roomId
+
+    if (!targetRoomId) {
+      setIsLeavePending(false)
+      return {
+        ok: false,
+        message: '대기방 퇴장에 실패했습니다.',
+      }
+    }
+
+    hasLeftRoomRef.current = true
 
     try {
       await leaveWaitingRoom({
-        roomId: room.roomId,
+        roomId: targetRoomId,
         userId: session.userId,
       })
       leaveWaitingRoomSocket({
-        roomId: room.roomId,
+        roomId: targetRoomId,
       })
-      hasLeftRoomRef.current = true
 
       return {
         ok: true,
       }
     } catch (error) {
+      hasLeftRoomRef.current = false
       return {
         ok: false,
         message: getWaitingRoomErrorMessage(
@@ -433,7 +485,7 @@ export function useWaitingRoomController({
     } finally {
       setIsLeavePending(false)
     }
-  }, [isLeavePending, room, session])
+  }, [isLeavePending, room, roomId, session])
 
   return {
     room,

--- a/src/providers/AppProviders.tsx
+++ b/src/providers/AppProviders.tsx
@@ -16,7 +16,12 @@ export function AppProviders({ children }: { children: React.ReactNode }) {
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
         {children}
-        <Toaster position="top-center" />
+        <Toaster
+          position="top-center"
+          containerStyle={{
+            top: 72,
+          }}
+        />
       </BrowserRouter>
     </QueryClientProvider>
   )


### PR DESCRIPTION
## 📌 관련 이슈

> closes #114 

---

## 📝 작업 내용

> 로비 비밀방 입장 흐름을 구현했습니다.  
> 비밀방 카드 클릭 시 비밀번호 모달이 열리고, 4자리 숫자 비밀번호 검증 후 입장하도록 처리했습니다.  
> 비밀번호 불일치 시 입장 차단 + 에러 토스트 + 인라인 에러 메시지 + 입력창 에러 보더를 적용했습니다.  
> 모달은 `취소`, 오버레이 클릭, 우측 상단 `X`, `Esc`로 닫히며, 제출 중에는 닫기 동작을 막아 상태 경쟁을 방지했습니다.  
> 추가로 대기방 진입/퇴장 동기화와 로비 복귀 시 방 목록 재조회 동작을 보강했습니다.

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

<img width="1800" height="1043" alt="스크린샷 2026-02-28 오후 5 44 01" src="https://github.com/user-attachments/assets/c52a3182-1481-4a5b-bfec-8872b608cd8f" />
