### PR TITLE
feat: 방 생성 모달과 비밀방 설정/생성 흐름 구현

### DIFF
--- a/src/pages/lobby/CreateRoomModal.tsx
+++ b/src/pages/lobby/CreateRoomModal.tsx
@@ -1,0 +1,206 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Lock, X } from 'lucide-react'
+import { cn } from '../../lib/utils'
+
+const ROOM_PASSWORD_PATTERN = /^\d{4}$/
+const ROOM_TITLE_MAX_LENGTH = 16
+
+export interface CreateRoomFormValues {
+  title: string
+  isPrivate: boolean
+  password?: string
+}
+
+interface CreateRoomModalProps {
+  defaultRoomTitle: string
+  isSubmitting: boolean
+  onClose: () => void
+  onSubmit: (values: CreateRoomFormValues) => void
+}
+
+export function CreateRoomModal({
+  defaultRoomTitle,
+  isSubmitting,
+  onClose,
+  onSubmit,
+}: CreateRoomModalProps) {
+  const [roomTitle, setRoomTitle] = useState('')
+  const [isPrivateRoomEnabled, setIsPrivateRoomEnabled] = useState(false)
+  const [roomPassword, setRoomPassword] = useState('')
+
+  const normalizedRoomTitle = useMemo(() => {
+    const trimmedTitle = roomTitle.trim()
+
+    if (trimmedTitle.length > 0) {
+      return trimmedTitle.slice(0, ROOM_TITLE_MAX_LENGTH)
+    }
+
+    return defaultRoomTitle.slice(0, ROOM_TITLE_MAX_LENGTH)
+  }, [defaultRoomTitle, roomTitle])
+
+  const isPrivatePasswordValid =
+    !isPrivateRoomEnabled || ROOM_PASSWORD_PATTERN.test(roomPassword)
+  const isSubmitDisabled = isSubmitting || !isPrivatePasswordValid
+  const canClose = !isSubmitting
+
+  const handleClose = useCallback(() => {
+    if (!canClose) {
+      return
+    }
+
+    onClose()
+  }, [canClose, onClose])
+
+  useEffect(() => {
+    const handleKeydown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') {
+        return
+      }
+
+      handleClose()
+    }
+
+    window.addEventListener('keydown', handleKeydown)
+    return () => {
+      window.removeEventListener('keydown', handleKeydown)
+    }
+  }, [handleClose])
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-[rgba(15,23,42,0.35)] p-4 backdrop-blur-[2px]">
+      <div className="absolute inset-0" onClick={handleClose} aria-hidden />
+
+      <section
+        role="dialog"
+        aria-modal="true"
+        aria-label="방 만들기"
+        className="relative z-10 w-full max-w-[450px] overflow-hidden rounded-[32px] border border-ui-border bg-ui-surface shadow-[0_24px_60px_rgba(15,23,42,0.2)]"
+      >
+        <button
+          type="button"
+          aria-label="모달 닫기"
+          onClick={handleClose}
+          disabled={!canClose}
+          className={cn(
+            'absolute right-5 top-5 inline-flex size-9 items-center justify-center rounded-full text-white/80 transition-colors',
+            canClose ? 'hover:bg-white/15 hover:text-white' : 'opacity-60'
+          )}
+        >
+          <X className="size-5" />
+        </button>
+
+        <header className="bg-[linear-gradient(104deg,#3f8df7_0%,#334ce9_52%,#5633ea_100%)] px-7 pb-8 pt-7 text-center">
+          <h2 className="text-[2.2rem] font-extrabold tracking-tight text-white">
+            방 만들기
+          </h2>
+          <p className="mt-1 text-base font-semibold text-white/75">
+            친구들을 초대하고 게임을 즐기세요!
+          </p>
+        </header>
+
+        <form
+          className="px-7 pb-8 pt-7"
+          onSubmit={(event) => {
+            event.preventDefault()
+
+            if (isSubmitDisabled) {
+              return
+            }
+
+            onSubmit({
+              title: normalizedRoomTitle,
+              isPrivate: isPrivateRoomEnabled,
+              password: isPrivateRoomEnabled ? roomPassword : undefined,
+            })
+          }}
+        >
+          <label
+            htmlFor="create-room-title"
+            className="text-[1.05rem] font-semibold text-ui-text-primary"
+          >
+            방 제목
+          </label>
+
+          <input
+            id="create-room-title"
+            type="text"
+            value={roomTitle}
+            maxLength={ROOM_TITLE_MAX_LENGTH}
+            onChange={(event) => {
+              setRoomTitle(event.target.value)
+            }}
+            placeholder={defaultRoomTitle}
+            className="mt-2 h-12 w-full rounded-2xl border border-ui-border bg-white px-4 text-[1.2rem] font-semibold text-ui-text-primary outline-none placeholder:text-ui-text-subtle focus:border-ui-brand focus:ring-2 focus:ring-ui-brand/20"
+            autoComplete="off"
+          />
+
+          <div className="mt-8 flex items-center justify-between">
+            <div className="inline-flex items-center gap-2 text-[1.05rem] font-semibold text-ui-text-primary">
+              <Lock className="size-4 text-ui-text-subtle" />
+              비밀방 설정
+            </div>
+
+            <button
+              type="button"
+              role="switch"
+              aria-checked={isPrivateRoomEnabled}
+              onClick={() => {
+                setIsPrivateRoomEnabled((previous) => {
+                  const nextValue = !previous
+
+                  if (!nextValue) {
+                    setRoomPassword('')
+                  }
+
+                  return nextValue
+                })
+              }}
+              className={cn(
+                'relative inline-flex h-7 w-12 shrink-0 rounded-full transition-colors',
+                isPrivateRoomEnabled ? 'bg-ui-brand' : 'bg-ui-text-subtle/35'
+              )}
+            >
+              <span
+                className={cn(
+                  'absolute left-0.5 top-0.5 size-6 rounded-full bg-white shadow transition-transform',
+                  isPrivateRoomEnabled ? 'translate-x-5' : 'translate-x-0'
+                )}
+              />
+            </button>
+          </div>
+
+          {isPrivateRoomEnabled ? (
+            <input
+              type="password"
+              inputMode="numeric"
+              pattern="[0-9]*"
+              maxLength={4}
+              value={roomPassword}
+              onChange={(event) => {
+                const nextValue = event.target.value
+                  .replace(/\D/g, '')
+                  .slice(0, 4)
+                setRoomPassword(nextValue)
+              }}
+              placeholder="비밀번호 (4자리)"
+              className="mt-4 h-12 w-full rounded-2xl border border-ui-border bg-white px-4 text-[1.2rem] font-semibold text-ui-text-primary outline-none placeholder:text-ui-text-subtle focus:border-ui-brand focus:ring-2 focus:ring-ui-brand/20"
+            />
+          ) : null}
+
+          <button
+            type="submit"
+            disabled={isSubmitDisabled}
+            className={cn(
+              'mt-6 h-14 w-full rounded-2xl text-[1.35rem] font-extrabold transition-colors',
+              isSubmitDisabled
+                ? 'cursor-not-allowed bg-ui-disabled-bg text-ui-disabled-text'
+                : 'bg-ui-brand text-white shadow-[0_10px_20px_rgba(37,99,235,0.25)] hover:bg-ui-brand-strong'
+            )}
+          >
+            {isSubmitting ? '생성 중...' : '방 만들기 완료'}
+          </button>
+        </form>
+      </section>
+    </div>
+  )
+}

--- a/src/pages/lobby/LobbyPage.tsx
+++ b/src/pages/lobby/LobbyPage.tsx
@@ -15,7 +15,9 @@ import { useLobbyRoomsQuery } from './hooks'
 import { LobbyControls } from './LobbyControls'
 import { RoomGrid } from './RoomGrid'
 import { PrivateRoomJoinModal } from './PrivateRoomJoinModal'
+import { CreateRoomModal, type CreateRoomFormValues } from './CreateRoomModal'
 import {
+  createWaitingRoom,
   getWaitingRoomErrorMessage,
   isJoinPasswordMismatchError,
   joinWaitingRoom,
@@ -32,6 +34,8 @@ function LobbyPage() {
   const [roomFilter, setRoomFilter] = useState<LobbyRoomFilter>('ALL')
   const [excludePrivateRoom, setExcludePrivateRoom] = useState(false)
   const [isUserListOpen, setIsUserListOpen] = useState(true)
+  const [isCreateRoomModalOpen, setIsCreateRoomModalOpen] = useState(false)
+  const [isCreateRoomPending, setIsCreateRoomPending] = useState(false)
   const [selectedPrivateRoom, setSelectedPrivateRoom] =
     useState<LobbyRoom | null>(null)
   const [privateRoomPassword, setPrivateRoomPassword] = useState('')
@@ -76,6 +80,18 @@ function LobbyPage() {
     navigate('/my-page')
   }
 
+  function handleOpenCreateRoomModal() {
+    setIsCreateRoomModalOpen(true)
+  }
+
+  function handleCloseCreateRoomModal() {
+    if (isCreateRoomPending) {
+      return
+    }
+
+    setIsCreateRoomModalOpen(false)
+  }
+
   function handleJoinRoom(room: LobbyRoom) {
     if (room.isPrivate) {
       setSelectedPrivateRoom(room)
@@ -104,6 +120,37 @@ function LobbyPage() {
         preJoinedSnapshot,
       },
     })
+  }
+
+  async function handleSubmitCreateRoom(values: CreateRoomFormValues) {
+    if (!session) {
+      return
+    }
+
+    setIsCreateRoomPending(true)
+
+    try {
+      const createdRoom = await createWaitingRoom({
+        title: values.title,
+        isPrivate: values.isPrivate,
+        password: values.password,
+        hostUserId: session.userId,
+        hostNickname: session.nickname,
+      })
+
+      setIsCreateRoomModalOpen(false)
+      navigate(`/rooms/${createdRoom.roomId}`, {
+        state: {
+          roomId: createdRoom.roomId,
+          roomTitle: createdRoom.roomTitle,
+          preJoinedSnapshot: createdRoom.preJoinedSnapshot,
+        },
+      })
+    } catch (error) {
+      toast.error(getWaitingRoomErrorMessage(error, '방 생성에 실패했습니다.'))
+    } finally {
+      setIsCreateRoomPending(false)
+    }
   }
 
   async function handleSubmitPrivateRoomJoin() {
@@ -167,6 +214,7 @@ function LobbyPage() {
             onSearchKeywordChange={setSearchRoom}
             onRoomFilterChange={setRoomFilter}
             onExcludePrivateRoomChange={setExcludePrivateRoom}
+            onCreateRoom={handleOpenCreateRoomModal}
           />
 
           <RoomGrid
@@ -202,6 +250,17 @@ function LobbyPage() {
           onClose={handleClosePrivateRoomModal}
           onSubmit={() => {
             void handleSubmitPrivateRoomJoin()
+          }}
+        />
+      ) : null}
+
+      {isCreateRoomModalOpen ? (
+        <CreateRoomModal
+          defaultRoomTitle={`${session.nickname}님의 방`}
+          isSubmitting={isCreateRoomPending}
+          onClose={handleCloseCreateRoomModal}
+          onSubmit={(values) => {
+            void handleSubmitCreateRoom(values)
           }}
         />
       ) : null}

--- a/src/pages/lobby/RoomCard.tsx
+++ b/src/pages/lobby/RoomCard.tsx
@@ -54,7 +54,7 @@ export function RoomCard({ room, onJoinRoom }: RoomCardProps) {
         )}
       </div>
 
-      <h3 className="mt-3 line-clamp-2 text-[1rem] font-bold leading-snug text-ui-text-primary">
+      <h3 className="mt-3 truncate text-[1rem] font-bold leading-snug text-ui-text-primary">
         {room.title}
       </h3>
 

--- a/src/pages/waiting-room/api.ts
+++ b/src/pages/waiting-room/api.ts
@@ -1,6 +1,7 @@
 import { isAxiosError } from 'axios'
 import { apiClient } from '../../lib/axios'
 import {
+  mockCreateWaitingRoom,
   mockJoinWaitingRoom,
   mockLeaveWaitingRoom,
   mockStartWaitingGame,
@@ -8,6 +9,7 @@ import {
   WaitingRoomMockError,
 } from './mockGateway'
 import type {
+  CreateRoomResponsePayload,
   JoinWaitingRoomResponsePayload,
   LeaveWaitingRoomResponsePayload,
   StartWaitingGameResponsePayload,
@@ -28,6 +30,20 @@ interface JoinWaitingRoomParams {
   nickname: string
   fallbackTitle?: string
   password?: string
+}
+
+interface CreateWaitingRoomParams {
+  title: string
+  isPrivate: boolean
+  password?: string
+  hostUserId: string
+  hostNickname: string
+}
+
+export interface CreateWaitingRoomResult {
+  roomId: string
+  roomTitle: string
+  preJoinedSnapshot?: WaitingRoomSnapshot
 }
 
 interface LeaveWaitingRoomParams {
@@ -78,6 +94,59 @@ function mapJoinResponse(
     players: payload.players.map(mapRoomPlayer),
     chatMessages: (payload.chat_messages ?? []).map(mapChatMessage),
   }
+}
+
+function mapCreateRoomResponse(
+  payload: CreateRoomResponsePayload,
+  hostUserId: string,
+  hostNickname: string
+): CreateWaitingRoomResult {
+  return {
+    roomId: payload.id,
+    roomTitle: payload.title,
+    preJoinedSnapshot: {
+      roomId: payload.id,
+      title: payload.title || DEFAULT_WAITING_ROOM_TITLE,
+      status: payload.status ?? 'waiting',
+      maxPlayers: payload.max_players ?? DEFAULT_WAITING_ROOM_MAX_PLAYERS,
+      isPrivate: payload.is_private ?? false,
+      players: [
+        {
+          id: hostUserId,
+          nickname: hostNickname,
+          isReady: false,
+          isHost: true,
+        },
+      ],
+      chatMessages: [],
+    },
+  }
+}
+
+export async function createWaitingRoom({
+  title,
+  isPrivate,
+  password,
+  hostUserId,
+  hostNickname,
+}: CreateWaitingRoomParams): Promise<CreateWaitingRoomResult> {
+  if (USE_WAITING_ROOM_MOCK) {
+    return mockCreateWaitingRoom({
+      title,
+      isPrivate,
+      password,
+      hostUserId,
+      hostNickname,
+    })
+  }
+
+  const { data } = await apiClient.post<CreateRoomResponsePayload>('/rooms', {
+    title,
+    is_private: isPrivate,
+    password: isPrivate ? password : null,
+  })
+
+  return mapCreateRoomResponse(data, hostUserId, hostNickname)
 }
 
 export async function joinWaitingRoom({

--- a/src/pages/waiting-room/hooks.ts
+++ b/src/pages/waiting-room/hooks.ts
@@ -127,6 +127,7 @@ export function useWaitingRoomController({
   const hasEnteredRoomRef = useRef(false)
   const hasLeftRoomRef = useRef(false)
   const hasInitializedPreJoinRef = useRef(false)
+  const shouldSkipNextCleanupLeaveRef = useRef(import.meta.env.DEV)
   const preJoinedRoomId = preJoinedSnapshot?.roomId
 
   useEffect(() => {
@@ -300,6 +301,11 @@ export function useWaitingRoomController({
 
   useEffect(() => {
     return () => {
+      if (shouldSkipNextCleanupLeaveRef.current) {
+        shouldSkipNextCleanupLeaveRef.current = false
+        return
+      }
+
       if (
         !session ||
         !roomId ||

--- a/src/pages/waiting-room/mockGateway.ts
+++ b/src/pages/waiting-room/mockGateway.ts
@@ -259,6 +259,20 @@ interface MockSendChatParams {
   message: string
 }
 
+interface MockCreateRoomParams {
+  title: string
+  isPrivate: boolean
+  password?: string
+  hostUserId: string
+  hostNickname: string
+}
+
+export interface MockCreateRoomResult {
+  roomId: string
+  roomTitle: string
+  preJoinedSnapshot: WaitingRoomSnapshot
+}
+
 export async function mockJoinWaitingRoom({
   roomId,
   userId,
@@ -296,6 +310,64 @@ export async function mockJoinWaitingRoom({
 
   emitLobbyUpdated(room, 'status_changed')
   return toWaitingRoomSnapshot(room)
+}
+
+function getNextRoomId() {
+  const nextRoomNumber =
+    Array.from(roomsStore.keys()).reduce((maxRoomNumber, roomId) => {
+      return Math.max(maxRoomNumber, getRoomIdSortValue(roomId))
+    }, 0) + 1
+
+  return `room-${nextRoomNumber}`
+}
+
+export async function mockCreateWaitingRoom({
+  title,
+  isPrivate,
+  password,
+  hostUserId,
+  hostNickname,
+}: MockCreateRoomParams): Promise<MockCreateRoomResult> {
+  await wait(MOCK_NETWORK_DELAY_MS)
+
+  const normalizedTitle = title.trim()
+
+  if (normalizedTitle.length === 0) {
+    throw new WaitingRoomMockError(400, '방 제목을 입력해주세요.')
+  }
+
+  if (isPrivate && !/^\d{4}$/.test(password ?? '')) {
+    throw new WaitingRoomMockError(400, '비밀번호는 숫자 4자리여야 합니다.')
+  }
+
+  const roomId = getNextRoomId()
+
+  const createdRoom: MockRoom = {
+    id: roomId,
+    title: normalizedTitle,
+    status: 'waiting',
+    max_players: 4,
+    is_private: isPrivate,
+    password: isPrivate ? (password ?? null) : null,
+    players: [
+      {
+        id: hostUserId,
+        nickname: hostNickname,
+        is_ready: false,
+        is_host: true,
+      },
+    ],
+    chat_messages: [],
+  }
+
+  roomsStore.set(createdRoom.id, createdRoom)
+  emitLobbyUpdated(createdRoom, 'created')
+
+  return {
+    roomId: createdRoom.id,
+    roomTitle: createdRoom.title,
+    preJoinedSnapshot: toWaitingRoomSnapshot(createdRoom),
+  }
 }
 
 export async function mockLeaveWaitingRoom({

--- a/src/pages/waiting-room/types.ts
+++ b/src/pages/waiting-room/types.ts
@@ -62,6 +62,15 @@ export interface JoinWaitingRoomResponsePayload {
   chat_messages: WaitingRoomChatPayload[]
 }
 
+export interface CreateRoomResponsePayload {
+  id: string
+  title: string
+  status: LobbyRoomStatus
+  is_private: boolean
+  host_id: string
+  max_players: number
+}
+
 export interface LeaveWaitingRoomResponsePayload {
   success: boolean
   new_host_id?: string


### PR DESCRIPTION
## 📌 관련 이슈

> closes #116 

---

## 📝 작업 내용

> 로비 `방 만들기` 모달과 방 생성 흐름을 구현했습니다.  
> 비밀방 토글 ON 시 비밀번호(숫자 4자리) 입력을 필수로 검증하고, 유효하지 않으면 생성 버튼이 비활성화되도록 처리했습니다.  
> 방 생성 성공 후 생성된 대기방으로 바로 이동하도록 연결했으며, mock 게이트웨이에도 생성 로직과 `lobby_updated(created)` 이벤트를 반영했습니다.  
> 추가로 개발환경 StrictMode에서 초기 unmount cleanup로 방이 즉시 퇴장/삭제되던 문제를 보완해, 생성 직후 채팅이 불가능해지는 이슈를 수정했습니다.  
> UI 측면에서는 방 제목 최대 16자 제한과 로비 카드 제목 말줄임(`...`)을 적용했습니다.

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

<img width="1800" height="1043" alt="스크린샷 2026-02-28 오후 6 43 36" src="https://github.com/user-attachments/assets/09691f34-3ff7-4089-a45c-7045af9eb930" />
