### PR TITLE
feat: 로비/대기방 1:1 DM 소켓 연동 및 unread 숫자 뱃지(99+) 구현

### DIFF
--- a/src/features/presence/components/DirectMessagePanel.tsx
+++ b/src/features/presence/components/DirectMessagePanel.tsx
@@ -1,0 +1,141 @@
+import { useMemo, useState } from 'react'
+import { SendHorizontal, X } from 'lucide-react'
+import { cn } from '../../../lib/utils'
+import type { DirectMessage, OnlineUser } from '../types'
+
+interface DirectMessagePanelProps {
+  user: OnlineUser
+  currentUserId: string
+  messages: DirectMessage[]
+  onClose: () => void
+  onSendMessage: (message: string) => void
+}
+
+function formatMessageTime(sentAt: string) {
+  return new Date(sentAt).toLocaleTimeString('ko-KR', {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  })
+}
+
+export function DirectMessagePanel({
+  user,
+  currentUserId,
+  messages,
+  onClose,
+  onSendMessage,
+}: DirectMessagePanelProps) {
+  const [inputMessage, setInputMessage] = useState('')
+
+  const sortedMessages = useMemo(() => {
+    return [...messages].sort((firstMessage, secondMessage) => {
+      return firstMessage.sentAt.localeCompare(secondMessage.sentAt)
+    })
+  }, [messages])
+
+  const canSend = inputMessage.trim().length > 0
+
+  return (
+    <section className="fixed bottom-6 right-4 z-40 w-[340px] max-w-[calc(100vw-1rem)] overflow-hidden rounded-2xl border border-ui-border bg-ui-surface shadow-[0_18px_40px_rgba(15,23,42,0.2)] sm:right-6">
+      <header className="flex h-14 items-center justify-between border-b border-ui-border px-4">
+        <div className="flex min-w-0 items-center gap-3">
+          <div
+            className="flex size-8 shrink-0 items-center justify-center rounded-full text-xs font-semibold text-ui-text-strong"
+            style={{ backgroundColor: user.avatarBackground }}
+          >
+            {user.avatarText}
+          </div>
+          <p className="truncate text-base font-semibold text-ui-text-primary">
+            {user.nickname}
+          </p>
+        </div>
+
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded-lg p-1.5 text-ui-text-muted transition-colors hover:bg-ui-surface-soft hover:text-ui-text-primary"
+          aria-label="DM 닫기"
+        >
+          <X className="size-4" />
+        </button>
+      </header>
+
+      <div className="h-[320px] overflow-y-auto bg-ui-surface px-4 py-3">
+        {sortedMessages.length === 0 ? (
+          <p className="flex h-full items-center justify-center text-sm font-medium text-ui-text-subtle">
+            메시지를 보내 대화를 시작하세요
+          </p>
+        ) : (
+          <div className="space-y-2">
+            {sortedMessages.map((message) => {
+              const isMine = message.senderId === currentUserId
+
+              return (
+                <div
+                  key={message.id}
+                  className={cn(
+                    'flex flex-col',
+                    isMine ? 'items-end' : 'items-start'
+                  )}
+                >
+                  <div
+                    className={cn(
+                      'max-w-[75%] rounded-2xl px-3 py-2 text-sm font-medium',
+                      isMine
+                        ? 'rounded-br-md bg-ui-brand text-white'
+                        : 'rounded-bl-md bg-ui-surface-soft text-ui-text-primary'
+                    )}
+                  >
+                    {message.content}
+                  </div>
+                  <span className="mt-1 text-[11px] text-ui-text-subtle">
+                    {formatMessageTime(message.sentAt)}
+                  </span>
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </div>
+
+      <form
+        className="flex items-center gap-2 border-t border-ui-border bg-ui-surface p-3"
+        onSubmit={(event) => {
+          event.preventDefault()
+
+          const normalizedMessage = inputMessage.trim()
+
+          if (!normalizedMessage) {
+            return
+          }
+
+          onSendMessage(normalizedMessage)
+          setInputMessage('')
+        }}
+      >
+        <input
+          type="text"
+          value={inputMessage}
+          onChange={(event) => setInputMessage(event.target.value)}
+          placeholder="메시지를 입력하세요..."
+          className="h-9 flex-1 rounded-xl border border-ui-border bg-ui-surface-muted px-3 text-sm text-ui-text-primary outline-none placeholder:text-ui-text-subtle focus:border-ui-brand focus:ring-2 focus:ring-ui-brand/20"
+          autoComplete="off"
+        />
+        <button
+          type="submit"
+          disabled={!canSend}
+          className={cn(
+            'inline-flex size-9 items-center justify-center rounded-xl transition-colors',
+            canSend
+              ? 'bg-ui-brand text-white hover:bg-ui-brand-strong'
+              : 'cursor-not-allowed bg-ui-disabled-bg text-ui-disabled-text'
+          )}
+          aria-label="DM 전송"
+        >
+          <SendHorizontal className="size-4" />
+        </button>
+      </form>
+    </section>
+  )
+}

--- a/src/features/presence/components/UserListPanel.tsx
+++ b/src/features/presence/components/UserListPanel.tsx
@@ -2,6 +2,7 @@ import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { cn } from '../../../lib/utils'
 import { ONLINE_USER_STATUS_DOT_CLASS_MAP } from '../status'
 import type { OnlineUser } from '../types'
+import { formatUnreadBadgeCount } from '../unreadBadge'
 import { UserRow } from './UserRow'
 
 interface UserListPanelProps {
@@ -10,6 +11,9 @@ interface UserListPanelProps {
   isError: boolean
   isOpen: boolean
   onToggle: () => void
+  currentUserId?: string
+  unreadDirectMessageCountByUserId?: Record<string, number>
+  onOpenDirectMessage?: (user: OnlineUser) => void
   heightMode?: 'screen' | 'full'
   disableWidthTransition?: boolean
 }
@@ -20,6 +24,9 @@ export function UserListPanel({
   isError,
   isOpen,
   onToggle,
+  currentUserId,
+  unreadDirectMessageCountByUserId = {},
+  onOpenDirectMessage,
   heightMode = 'screen',
   disableWidthTransition = false,
 }: UserListPanelProps) {
@@ -85,7 +92,17 @@ export function UserListPanel({
 
             {!isLoading &&
               !isError &&
-              users.map((user) => <UserRow key={user.id} user={user} />)}
+              users.map((user) => (
+                <UserRow
+                  key={user.id}
+                  user={user}
+                  isCurrentUser={currentUserId === user.id}
+                  unreadDirectMessageCount={
+                    unreadDirectMessageCountByUserId[user.id] ?? 0
+                  }
+                  onOpenDirectMessage={onOpenDirectMessage}
+                />
+              ))}
           </div>
         </div>
       ) : (
@@ -125,6 +142,13 @@ export function UserListPanel({
                       ONLINE_USER_STATUS_DOT_CLASS_MAP[user.status]
                     )}
                   />
+                  {(unreadDirectMessageCountByUserId[user.id] ?? 0) > 0 ? (
+                    <span className="absolute -left-1 -top-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full border-2 border-white bg-ui-danger px-1 text-[10px] font-bold leading-none text-white">
+                      {formatUnreadBadgeCount(
+                        unreadDirectMessageCountByUserId[user.id] ?? 0
+                      )}
+                    </span>
+                  ) : null}
                 </div>
               ))}
           </div>

--- a/src/features/presence/components/UserRow.tsx
+++ b/src/features/presence/components/UserRow.tsx
@@ -5,11 +5,23 @@ import {
   ONLINE_USER_STATUS_LABEL_MAP,
 } from '../status'
 import type { OnlineUser } from '../types'
+import { formatUnreadBadgeCount } from '../unreadBadge'
 
-export function UserRow({ user }: { user: OnlineUser }) {
-  const isPlaying = user.status === 'playing'
+interface UserRowProps {
+  user: OnlineUser
+  isCurrentUser?: boolean
+  unreadDirectMessageCount?: number
+  onOpenDirectMessage?: (user: OnlineUser) => void
+}
+
+export function UserRow({
+  user,
+  isCurrentUser = false,
+  unreadDirectMessageCount = 0,
+  onOpenDirectMessage,
+}: UserRowProps) {
   const statusLabel = ONLINE_USER_STATUS_LABEL_MAP[user.status]
-  const isDmDisabled = isPlaying
+  const isDmDisabled = isCurrentUser || !onOpenDirectMessage
 
   return (
     <div className="group flex items-center gap-3 px-4 py-2.5 hover:bg-ui-surface-muted">
@@ -26,6 +38,11 @@ export function UserRow({ user }: { user: OnlineUser }) {
             ONLINE_USER_STATUS_DOT_CLASS_MAP[user.status]
           )}
         />
+        {unreadDirectMessageCount > 0 ? (
+          <span className="absolute -left-1 -top-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full border-2 border-white bg-ui-danger px-1 text-[10px] font-bold leading-none text-white">
+            {formatUnreadBadgeCount(unreadDirectMessageCount)}
+          </span>
+        ) : null}
       </div>
 
       <div className="min-w-0 flex-1">
@@ -38,14 +55,26 @@ export function UserRow({ user }: { user: OnlineUser }) {
       <button
         type="button"
         disabled={isDmDisabled}
+        onClick={() => {
+          if (isDmDisabled) {
+            return
+          }
+          onOpenDirectMessage?.(user)
+        }}
         className={cn(
-          'rounded-lg p-2 text-ui-text-subtle transition sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100',
+          'rounded-lg p-2 text-ui-text-subtle transition',
           isDmDisabled
             ? 'cursor-not-allowed opacity-45'
             : 'hover:bg-ui-surface-soft hover:text-ui-text-muted'
         )}
         aria-label={`${user.nickname} 채팅`}
-        title={isDmDisabled ? '게임 중에는 DM을 보낼 수 없습니다.' : 'DM 열기'}
+        title={
+          isCurrentUser
+            ? '본인에게는 DM을 보낼 수 없습니다.'
+            : isDmDisabled
+              ? 'DM 기능을 사용할 수 없습니다.'
+              : 'DM 열기'
+        }
       >
         <MessageCircle className="size-4" />
       </button>

--- a/src/features/presence/directMessageSocket.ts
+++ b/src/features/presence/directMessageSocket.ts
@@ -1,0 +1,107 @@
+import { socket } from '../../lib/socket'
+import type {
+  DirectMessageReceiveSocketPayload,
+  DirectMessageSendSocketPayload,
+} from './types'
+
+const DIRECT_MESSAGE_EVENT_NAMES = {
+  send: 'dm_send',
+  receive: 'dm_receive',
+} as const
+
+const USE_SOCKET_MOCK =
+  import.meta.env.DEV && import.meta.env.VITE_USE_SOCKET_MOCK !== 'false'
+const MOCK_REPLY_DELAY_MS = 700
+
+interface SendDirectMessageParams {
+  receiverId: string
+  receiverNickname: string
+  message: string
+}
+
+interface SubscribeDirectMessageSocketParams {
+  onReceive: (payload: DirectMessageReceiveSocketPayload) => void
+}
+
+interface SocketWithListeners {
+  listeners: (
+    eventName: string
+  ) => Array<(payload: DirectMessageReceiveSocketPayload) => void>
+}
+
+function connectSocketIfNeeded() {
+  if (USE_SOCKET_MOCK) {
+    return
+  }
+
+  if (!socket.connected) {
+    socket.connect()
+  }
+}
+
+function emitDirectMessageReceiveMock(
+  payload: DirectMessageReceiveSocketPayload
+) {
+  const socketWithListeners = socket as unknown as SocketWithListeners
+  const listeners = socketWithListeners.listeners(
+    DIRECT_MESSAGE_EVENT_NAMES.receive
+  )
+
+  listeners.forEach((listener) => {
+    listener(payload)
+  })
+}
+
+function buildMockReplyMessage(originalMessage: string) {
+  const shortMessage =
+    originalMessage.length > 18
+      ? `${originalMessage.slice(0, 18)}...`
+      : originalMessage
+
+  return `확인했어요: ${shortMessage}`
+}
+
+export function subscribeDirectMessageSocketEvents({
+  onReceive,
+}: SubscribeDirectMessageSocketParams) {
+  socket.on(DIRECT_MESSAGE_EVENT_NAMES.receive, onReceive)
+  connectSocketIfNeeded()
+
+  return () => {
+    socket.off(DIRECT_MESSAGE_EVENT_NAMES.receive, onReceive)
+  }
+}
+
+export function sendDirectMessage({
+  receiverId,
+  receiverNickname,
+  message,
+}: SendDirectMessageParams) {
+  const normalizedMessage = message.trim()
+
+  if (normalizedMessage.length === 0) {
+    return
+  }
+
+  if (USE_SOCKET_MOCK) {
+    window.setTimeout(() => {
+      emitDirectMessageReceiveMock({
+        sender_id: receiverId,
+        sender_nickname: receiverNickname,
+        message: buildMockReplyMessage(normalizedMessage),
+        sent_at: new Date().toISOString(),
+      })
+    }, MOCK_REPLY_DELAY_MS)
+
+    return
+  }
+
+  connectSocketIfNeeded()
+
+  const payload: DirectMessageSendSocketPayload = {
+    receiver_id: receiverId,
+    message: normalizedMessage,
+  }
+
+  socket.emit(DIRECT_MESSAGE_EVENT_NAMES.send, payload)
+}

--- a/src/features/presence/types.ts
+++ b/src/features/presence/types.ts
@@ -14,3 +14,23 @@ export interface OnlineUser extends OnlineUserPayload {
   avatarText: string
   avatarBackground: string
 }
+
+export interface DirectMessage {
+  id: string
+  senderId: string
+  senderNickname: string
+  content: string
+  sentAt: string
+}
+
+export interface DirectMessageSendSocketPayload {
+  receiver_id: string
+  message: string
+}
+
+export interface DirectMessageReceiveSocketPayload {
+  sender_id: string
+  sender_nickname: string
+  message: string
+  sent_at: string
+}

--- a/src/features/presence/unreadBadge.ts
+++ b/src/features/presence/unreadBadge.ts
@@ -1,0 +1,13 @@
+const UNREAD_BADGE_MAX_COUNT = 99
+
+export function formatUnreadBadgeCount(count: number) {
+  if (count <= 0) {
+    return '0'
+  }
+
+  if (count > UNREAD_BADGE_MAX_COUNT) {
+    return `${UNREAD_BADGE_MAX_COUNT}+`
+  }
+
+  return `${count}`
+}

--- a/src/pages/lobby/LobbyPage.tsx
+++ b/src/pages/lobby/LobbyPage.tsx
@@ -9,7 +9,17 @@ import {
   getAvatarText,
 } from '../../components/header/profileMenu'
 import { UserListPanel } from '../../features/presence/components/UserListPanel'
+import { DirectMessagePanel } from '../../features/presence/components/DirectMessagePanel'
+import {
+  sendDirectMessage,
+  subscribeDirectMessageSocketEvents,
+} from '../../features/presence/directMessageSocket'
 import { useOnlineUsersSocket } from '../../features/presence/hooks'
+import type {
+  DirectMessage,
+  DirectMessageReceiveSocketPayload,
+  OnlineUser,
+} from '../../features/presence/types'
 import type { LobbyRoomFilter } from './api'
 import { useLobbyRoomsQuery } from './hooks'
 import { LobbyControls } from './LobbyControls'
@@ -36,6 +46,14 @@ function LobbyPage() {
   const [isUserListOpen, setIsUserListOpen] = useState(true)
   const [isCreateRoomModalOpen, setIsCreateRoomModalOpen] = useState(false)
   const [isCreateRoomPending, setIsCreateRoomPending] = useState(false)
+  const [dmTargetUser, setDmTargetUser] = useState<OnlineUser | null>(null)
+  const [directMessagesByUserId, setDirectMessagesByUserId] = useState<
+    Record<string, DirectMessage[]>
+  >({})
+  const [
+    unreadDirectMessageCountByUserId,
+    setUnreadDirectMessageCountByUserId,
+  ] = useState<Record<string, number>>({})
   const [selectedPrivateRoom, setSelectedPrivateRoom] =
     useState<LobbyRoom | null>(null)
   const [privateRoomPassword, setPrivateRoomPassword] = useState('')
@@ -71,6 +89,77 @@ function LobbyPage() {
     isError: isUsersError,
   } = useOnlineUsersSocket()
 
+  const openedDirectMessageUserId = dmTargetUser?.id
+
+  useEffect(() => {
+    if (!session) {
+      return
+    }
+
+    const unsubscribe = subscribeDirectMessageSocketEvents({
+      onReceive: (payload: DirectMessageReceiveSocketPayload) => {
+        const receivedMessage: DirectMessage = {
+          id: `${payload.sender_id}-${payload.sent_at}`,
+          senderId: payload.sender_id,
+          senderNickname: payload.sender_nickname,
+          content: payload.message,
+          sentAt: payload.sent_at,
+        }
+
+        setDirectMessagesByUserId((previousMessagesByUserId) => {
+          const previousMessages =
+            previousMessagesByUserId[payload.sender_id] ?? []
+          const hasSameMessage = previousMessages.some(
+            (message) => message.id === receivedMessage.id
+          )
+
+          if (hasSameMessage) {
+            return previousMessagesByUserId
+          }
+
+          return {
+            ...previousMessagesByUserId,
+            [payload.sender_id]: [...previousMessages, receivedMessage],
+          }
+        })
+
+        if (payload.sender_id === openedDirectMessageUserId) {
+          return
+        }
+
+        setUnreadDirectMessageCountByUserId((previousCountByUserId) => {
+          const previousCount = previousCountByUserId[payload.sender_id] ?? 0
+
+          return {
+            ...previousCountByUserId,
+            [payload.sender_id]: previousCount + 1,
+          }
+        })
+      },
+    })
+
+    return () => {
+      unsubscribe()
+    }
+  }, [openedDirectMessageUserId, session])
+
+  useEffect(() => {
+    if (!dmTargetUser) {
+      return
+    }
+
+    const matchedUser = users.find((user) => user.id === dmTargetUser.id)
+
+    if (!matchedUser) {
+      setDmTargetUser(null)
+      return
+    }
+
+    if (matchedUser !== dmTargetUser) {
+      setDmTargetUser(matchedUser)
+    }
+  }, [dmTargetUser, users])
+
   function handleLogout() {
     clearSession()
     navigate('/', { replace: true })
@@ -78,6 +167,53 @@ function LobbyPage() {
 
   function handleGoMyPage() {
     navigate('/my-page')
+  }
+
+  function handleOpenDirectMessage(user: OnlineUser) {
+    setDmTargetUser(user)
+    setUnreadDirectMessageCountByUserId((previousCountByUserId) => {
+      if (!previousCountByUserId[user.id]) {
+        return previousCountByUserId
+      }
+
+      const nextCountByUserId = { ...previousCountByUserId }
+      delete nextCountByUserId[user.id]
+      return nextCountByUserId
+    })
+  }
+
+  function handleCloseDirectMessage() {
+    setDmTargetUser(null)
+  }
+
+  function handleSendDirectMessage(message: string) {
+    if (!dmTargetUser || !session) {
+      return
+    }
+
+    const targetUserId = dmTargetUser.id
+    const nextDirectMessage: DirectMessage = {
+      id: `${targetUserId}-${Date.now()}`,
+      senderId: session.userId,
+      senderNickname: session.nickname,
+      content: message,
+      sentAt: new Date().toISOString(),
+    }
+
+    setDirectMessagesByUserId((previousMessagesByUserId) => {
+      const previousMessages = previousMessagesByUserId[targetUserId] ?? []
+
+      return {
+        ...previousMessagesByUserId,
+        [targetUserId]: [...previousMessages, nextDirectMessage],
+      }
+    })
+
+    sendDirectMessage({
+      receiverId: dmTargetUser.id,
+      receiverNickname: dmTargetUser.nickname,
+      message,
+    })
   }
 
   function handleOpenCreateRoomModal() {
@@ -231,6 +367,9 @@ function LobbyPage() {
           isLoading={isUsersLoading}
           isError={isUsersError}
           isOpen={isUserListOpen}
+          currentUserId={session.userId}
+          unreadDirectMessageCountByUserId={unreadDirectMessageCountByUserId}
+          onOpenDirectMessage={handleOpenDirectMessage}
           onToggle={() => setIsUserListOpen((prev) => !prev)}
         />
       </main>
@@ -262,6 +401,16 @@ function LobbyPage() {
           onSubmit={(values) => {
             void handleSubmitCreateRoom(values)
           }}
+        />
+      ) : null}
+
+      {dmTargetUser ? (
+        <DirectMessagePanel
+          user={dmTargetUser}
+          currentUserId={session.userId}
+          messages={directMessagesByUserId[dmTargetUser.id] ?? []}
+          onClose={handleCloseDirectMessage}
+          onSendMessage={handleSendDirectMessage}
         />
       ) : null}
     </div>

--- a/src/pages/waiting-room/WaitingRoomPage.tsx
+++ b/src/pages/waiting-room/WaitingRoomPage.tsx
@@ -7,8 +7,18 @@ import {
   getAvatarBackground,
   getAvatarText,
 } from '../../components/header/profileMenu'
+import { DirectMessagePanel } from '../../features/presence/components/DirectMessagePanel'
 import { UserListPanel } from '../../features/presence/components/UserListPanel'
+import {
+  sendDirectMessage,
+  subscribeDirectMessageSocketEvents,
+} from '../../features/presence/directMessageSocket'
 import { useOnlineUsersSocket } from '../../features/presence/hooks'
+import type {
+  DirectMessage,
+  DirectMessageReceiveSocketPayload,
+  OnlineUser,
+} from '../../features/presence/types'
 import { cn } from '../../lib/utils'
 import { WaitingRoomHeader } from './components/WaitingRoomHeader'
 import { WaitingSeatCard } from './components/WaitingSeatCard'
@@ -42,6 +52,14 @@ function WaitingRoomPage() {
   const session = useAuthStore((state) => state.session)
   const clearSession = useAuthStore((state) => state.clearSession)
   const [isUserListOpen, setIsUserListOpen] = useState(true)
+  const [dmTargetUser, setDmTargetUser] = useState<OnlineUser | null>(null)
+  const [directMessagesByUserId, setDirectMessagesByUserId] = useState<
+    Record<string, DirectMessage[]>
+  >({})
+  const [
+    unreadDirectMessageCountByUserId,
+    setUnreadDirectMessageCountByUserId,
+  ] = useState<Record<string, number>>({})
 
   const locationState = location.state as WaitingRoomLocationState | null
   const isSameRoomState = locationState?.roomId === currentRoomId
@@ -93,6 +111,8 @@ function WaitingRoomPage() {
     isError: isUsersError,
   } = useOnlineUsersSocket()
 
+  const openedDirectMessageUserId = dmTargetUser?.id
+
   useEffect(() => {
     if (!currentRoomId) {
       navigate('/lobby', { replace: true })
@@ -116,6 +136,75 @@ function WaitingRoomPage() {
 
     toast.error(roomErrorMessage)
   }, [roomErrorMessage])
+
+  useEffect(() => {
+    if (!session) {
+      return
+    }
+
+    const unsubscribe = subscribeDirectMessageSocketEvents({
+      onReceive: (payload: DirectMessageReceiveSocketPayload) => {
+        const receivedMessage: DirectMessage = {
+          id: `${payload.sender_id}-${payload.sent_at}`,
+          senderId: payload.sender_id,
+          senderNickname: payload.sender_nickname,
+          content: payload.message,
+          sentAt: payload.sent_at,
+        }
+
+        setDirectMessagesByUserId((previousMessagesByUserId) => {
+          const previousMessages =
+            previousMessagesByUserId[payload.sender_id] ?? []
+          const hasSameMessage = previousMessages.some(
+            (message) => message.id === receivedMessage.id
+          )
+
+          if (hasSameMessage) {
+            return previousMessagesByUserId
+          }
+
+          return {
+            ...previousMessagesByUserId,
+            [payload.sender_id]: [...previousMessages, receivedMessage],
+          }
+        })
+
+        if (payload.sender_id === openedDirectMessageUserId) {
+          return
+        }
+
+        setUnreadDirectMessageCountByUserId((previousCountByUserId) => {
+          const previousCount = previousCountByUserId[payload.sender_id] ?? 0
+
+          return {
+            ...previousCountByUserId,
+            [payload.sender_id]: previousCount + 1,
+          }
+        })
+      },
+    })
+
+    return () => {
+      unsubscribe()
+    }
+  }, [openedDirectMessageUserId, session])
+
+  useEffect(() => {
+    if (!dmTargetUser) {
+      return
+    }
+
+    const matchedUser = users.find((user) => user.id === dmTargetUser.id)
+
+    if (!matchedUser) {
+      setDmTargetUser(null)
+      return
+    }
+
+    if (matchedUser !== dmTargetUser) {
+      setDmTargetUser(matchedUser)
+    }
+  }, [dmTargetUser, users])
 
   const handleLeaveToLobby = useCallback(async () => {
     const result = await leaveRoom()
@@ -169,6 +258,53 @@ function WaitingRoomPage() {
       toast.error(result.message)
     }
   }, [handleStartGame])
+
+  function handleOpenDirectMessage(user: OnlineUser) {
+    setDmTargetUser(user)
+    setUnreadDirectMessageCountByUserId((previousCountByUserId) => {
+      if (!previousCountByUserId[user.id]) {
+        return previousCountByUserId
+      }
+
+      const nextCountByUserId = { ...previousCountByUserId }
+      delete nextCountByUserId[user.id]
+      return nextCountByUserId
+    })
+  }
+
+  function handleCloseDirectMessage() {
+    setDmTargetUser(null)
+  }
+
+  function handleSendDirectMessage(message: string) {
+    if (!dmTargetUser || !session) {
+      return
+    }
+
+    const targetUserId = dmTargetUser.id
+    const nextDirectMessage: DirectMessage = {
+      id: `${targetUserId}-${Date.now()}`,
+      senderId: session.userId,
+      senderNickname: session.nickname,
+      content: message,
+      sentAt: new Date().toISOString(),
+    }
+
+    setDirectMessagesByUserId((previousMessagesByUserId) => {
+      const previousMessages = previousMessagesByUserId[targetUserId] ?? []
+
+      return {
+        ...previousMessagesByUserId,
+        [targetUserId]: [...previousMessages, nextDirectMessage],
+      }
+    })
+
+    sendDirectMessage({
+      receiverId: dmTargetUser.id,
+      receiverNickname: dmTargetUser.nickname,
+      message,
+    })
+  }
 
   if (!session || session.needsNicknameSetup) {
     return null
@@ -271,6 +407,11 @@ function WaitingRoomPage() {
               isLoading={isUsersLoading}
               isError={isUsersError}
               isOpen={isUserListOpen}
+              currentUserId={session.userId}
+              unreadDirectMessageCountByUserId={
+                unreadDirectMessageCountByUserId
+              }
+              onOpenDirectMessage={handleOpenDirectMessage}
               onToggle={() => setIsUserListOpen((previous) => !previous)}
               heightMode="full"
               disableWidthTransition
@@ -285,6 +426,16 @@ function WaitingRoomPage() {
           aria-hidden
         />
       )}
+
+      {dmTargetUser ? (
+        <DirectMessagePanel
+          user={dmTargetUser}
+          currentUserId={session.userId}
+          messages={directMessagesByUserId[dmTargetUser.id] ?? []}
+          onClose={handleCloseDirectMessage}
+          onSendMessage={handleSendDirectMessage}
+        />
+      ) : null}
     </div>
   )
 }


### PR DESCRIPTION
## 📌 관련 이슈

> closes #118 

---

## 📝 작업 내용

> 로비/대기방 접속자 목록에서 1:1 DM 기능을 구현했습니다.  
> 메시지 아이콘 클릭 시 우하단 DM 패널이 열리며, 소켓 이벤트(`dm_send`, `dm_receive`) 기반으로 송수신되도록 연결했습니다.  
> DM 패널이 닫혀 있거나 다른 사용자와 대화 중일 때 수신 메시지는 해당 사용자 아바타에 unread 숫자 뱃지로 표시됩니다.  
> 뱃지 표시는 `1~99` 숫자, `100 이상`은 `99+` 규칙으로 처리했습니다.  
> 동일 동작을 로비와 대기방 양쪽 접속자 목록에 공통 적용했습니다.

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

<img width="1800" height="1044" alt="스크린샷 2026-03-01 오전 12 33 31" src="https://github.com/user-attachments/assets/c6879baf-9091-40c3-bfdd-4af899e70d59" />
