### PR TITLE
feat: axios/socket JWT 토큰 연결 적용

### DIFF
--- a/src/features/presence/directMessageSocket.ts
+++ b/src/features/presence/directMessageSocket.ts
@@ -1,4 +1,4 @@
-import { socket } from '../../lib/socket'
+import { connectSocketWithAuthIfNeeded, socket } from '../../lib/socket'
 import type {
   DirectMessageReceiveSocketPayload,
   DirectMessageSendSocketPayload,
@@ -41,7 +41,7 @@ function connectSocketIfNeeded() {
 
   // 연결이 닫혀 있으면 재연결 시도
   if (!socket.connected) {
-    socket.connect()
+    connectSocketWithAuthIfNeeded()
   }
 }
 

--- a/src/features/presence/hooks.ts
+++ b/src/features/presence/hooks.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { socket } from '../../lib/socket'
+import { connectSocketWithAuthIfNeeded, socket } from '../../lib/socket'
 import { mockOnlineUsers } from './mockData'
 import type {
   OnlineUser,
@@ -110,7 +110,7 @@ export function useOnlineUsersSocket() {
 
       // 아직 연결되지 않았다면 명시적으로 연결 시작
       if (!socket.connected) {
-        socket.connect()
+        connectSocketWithAuthIfNeeded()
       }
     }
 

--- a/src/hooks/game/useGameState.ts
+++ b/src/hooks/game/useGameState.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { socket } from '../../lib/socket'
+import { connectSocketWithAuthIfNeeded, socket } from '../../lib/socket'
 import { gameApi } from '../../services/game/game.api'
 import { setupGameHandlers } from '../../services/socket/game.handler'
 import { useGameStore } from '../../stores/game.store'
@@ -14,11 +14,11 @@ export const useGameState = () => {
     const teardownHandlers = setupGameHandlers()
 
     if (!USE_GAME_SOCKET_MOCK && !socket.connected) {
-      socket.connect()
+      connectSocketWithAuthIfNeeded()
     }
 
     const fetchGameState = async () => {
-      // Initial hydrate only when store is empty.
+      // 스토어가 비어 있을 때만 초기 상태를 1회 동기화
       if (players.length > 0) return
 
       const result = await gameApi.getState({ reset: USE_GAME_SOCKET_MOCK })

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -1,4 +1,5 @@
-import axios from 'axios'
+import axios, { AxiosHeaders } from 'axios'
+import { useAuthStore } from '../features/auth/store'
 
 // 공통 API 요청에 사용할 axios 인스턴스 생성
 export const apiClient = axios.create({
@@ -7,4 +8,18 @@ export const apiClient = axios.create({
   headers: {
     'Content-Type': 'application/json',
   },
+})
+
+// 요청 직전에 최신 세션 토큰을 Authorization 헤더로 동기화
+apiClient.interceptors.request.use((config) => {
+  const accessToken = useAuthStore.getState().session?.accessToken
+  const nextHeaders = AxiosHeaders.from(config.headers)
+  if (accessToken) {
+    nextHeaders.set('Authorization', `Bearer ${accessToken}`)
+  } else {
+    nextHeaders.delete('Authorization')
+  }
+
+  config.headers = nextHeaders
+  return config
 })

--- a/src/lib/socket.ts
+++ b/src/lib/socket.ts
@@ -1,4 +1,5 @@
 import { io } from 'socket.io-client'
+import { useAuthStore } from '../features/auth/store'
 
 // 소켓 서버 기본 URL을 환경변수 또는 로컬 값으로 결정
 const SOCKET_URL = import.meta.env.VITE_SOCKET_URL ?? 'http://localhost:3000'
@@ -7,3 +8,37 @@ const SOCKET_URL = import.meta.env.VITE_SOCKET_URL ?? 'http://localhost:3000'
 export const socket = io(SOCKET_URL, {
   autoConnect: false,
 })
+
+// 소켓 auth 객체에서 현재 토큰 값을 안전하게 조회
+function getSocketAuthToken() {
+  if (typeof socket.auth !== 'object' || !socket.auth) {
+    return null
+  }
+
+  const token = (socket.auth as { token?: unknown }).token
+  return typeof token === 'string' ? token : null
+}
+
+// 현재 세션 토큰을 소켓 auth payload로 반영
+export function syncSocketAuthToken() {
+  const accessToken = useAuthStore.getState().session?.accessToken
+  socket.auth = accessToken ? { token: accessToken } : {}
+}
+
+// 토큰 동기화 후 필요할 때만 소켓 연결
+export function connectSocketWithAuthIfNeeded() {
+  const previousToken = getSocketAuthToken()
+  syncSocketAuthToken()
+  const nextToken = getSocketAuthToken()
+
+  // 연결된 상태에서 토큰이 바뀌면 재연결로 인증 컨텍스트를 갱신
+  if (socket.connected) {
+    if (previousToken !== nextToken) {
+      socket.disconnect()
+      socket.connect()
+    }
+    return
+  }
+
+  socket.connect()
+}

--- a/src/pages/lobby/hooks.ts
+++ b/src/pages/lobby/hooks.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { socket } from '../../lib/socket'
+import { connectSocketWithAuthIfNeeded, socket } from '../../lib/socket'
 import { getLobbyRooms, type GetLobbyRoomsParams } from './api'
 
 const LOBBY_QUERY_STALE_TIME_MS = 20_000
@@ -24,7 +24,7 @@ export function useLobbyRoomsQuery(params: GetLobbyRoomsParams) {
 
     // 실제 소켓 모드에서만 연결 상태를 확인해 connect 실행
     if (!USE_SOCKET_MOCK && !socket.connected) {
-      socket.connect()
+      connectSocketWithAuthIfNeeded()
     }
 
     return () => {

--- a/src/pages/waiting-room/socket.ts
+++ b/src/pages/waiting-room/socket.ts
@@ -1,4 +1,4 @@
-import { socket } from '../../lib/socket'
+import { connectSocketWithAuthIfNeeded, socket } from '../../lib/socket'
 import {
   mockEnterWaitingRoomSocket,
   mockLeaveWaitingRoomSocket,
@@ -60,7 +60,7 @@ function connectSocketIfNeeded() {
 
   // 연결이 닫혀 있으면 명시적으로 연결
   if (!socket.connected) {
-    socket.connect()
+    connectSocketWithAuthIfNeeded()
   }
 }
 


### PR DESCRIPTION
## 📌 관련 이슈

> closes #124 

---

## 📝 작업 내용

- `apiClient` 요청 인터셉터에서 `Authorization: Bearer <accessToken>` 자동 주입
- 소켓 연결 전 `socket.auth.token` 동기화 로직 추가
- 소켓 연결 상태에서 토큰 변경 시 재연결 처리 추가
- 로비/프레즌스/대기방/게임 훅의 `socket.connect()` 호출을 인증 헬퍼로 통일
- 주석 톤 한국어 요약 스타일로 정리 (`useGameState`)

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

> UI 변경 없음
