### PR TITLE
feat: 게임중 유저 DM 비활성화 규칙 적용

### DIFF
--- a/src/features/presence/components/UserRow.tsx
+++ b/src/features/presence/components/UserRow.tsx
@@ -1,6 +1,7 @@
 import { MessageCircle } from 'lucide-react'
 import { cn } from '../../../lib/utils'
 import {
+  isDirectMessageAllowed,
   ONLINE_USER_STATUS_DOT_CLASS_MAP,
   ONLINE_USER_STATUS_LABEL_MAP,
 } from '../status'
@@ -23,7 +24,10 @@ export function UserRow({
   onOpenDirectMessage,
 }: UserRowProps) {
   const statusLabel = ONLINE_USER_STATUS_LABEL_MAP[user.status]
-  const isDmDisabled = isCurrentUser || !onOpenDirectMessage
+  const isDmDisabled =
+    isCurrentUser ||
+    !onOpenDirectMessage ||
+    !isDirectMessageAllowed(user.status)
 
   return (
     <div className="group flex items-center gap-3 px-4 py-2.5 hover:bg-ui-surface-muted">
@@ -74,9 +78,11 @@ export function UserRow({
         title={
           isCurrentUser
             ? '본인에게는 DM을 보낼 수 없습니다.'
-            : isDmDisabled
-              ? 'DM 기능을 사용할 수 없습니다.'
-              : 'DM 열기'
+            : !isDirectMessageAllowed(user.status)
+              ? '게임중인 유저에게는 DM을 보낼 수 없습니다.'
+              : isDmDisabled
+                ? 'DM 기능을 사용할 수 없습니다.'
+                : 'DM 열기'
         }
       >
         <MessageCircle className="size-4" />

--- a/src/features/presence/status.ts
+++ b/src/features/presence/status.ts
@@ -16,3 +16,8 @@ export const ONLINE_USER_STATUS_DOT_CLASS_MAP: Record<
   in_room: 'bg-ui-presence-in-room',
   playing: 'bg-ui-presence-playing-status',
 }
+
+// 게임중 상태 유저는 DM 대상에서 제외
+export function isDirectMessageAllowed(status: OnlineUserStatus) {
+  return status !== 'playing'
+}

--- a/src/pages/lobby/LobbyPage.tsx
+++ b/src/pages/lobby/LobbyPage.tsx
@@ -15,6 +15,7 @@ import {
   subscribeDirectMessageSocketEvents,
 } from '../../features/presence/directMessageSocket'
 import { useOnlineUsersSocket } from '../../features/presence/hooks'
+import { isDirectMessageAllowed } from '../../features/presence/status'
 import type {
   DirectMessage,
   DirectMessageReceiveSocketPayload,
@@ -164,6 +165,11 @@ function LobbyPage() {
       return
     }
 
+    if (!isDirectMessageAllowed(matchedUser.status)) {
+      setDmTargetUser(null)
+      return
+    }
+
     if (matchedUser !== dmTargetUser) {
       setDmTargetUser(matchedUser)
     }
@@ -181,6 +187,11 @@ function LobbyPage() {
 
   // DM 창을 열고 해당 사용자 unread 카운트를 초기화
   function handleOpenDirectMessage(user: OnlineUser) {
+    if (!isDirectMessageAllowed(user.status)) {
+      toast.error('게임중인 유저에게는 DM을 보낼 수 없습니다.')
+      return
+    }
+
     setDmTargetUser(user)
     setUnreadDirectMessageCountByUserId((previousCountByUserId) => {
       if (!previousCountByUserId[user.id]) {
@@ -201,6 +212,11 @@ function LobbyPage() {
   function handleSendDirectMessage(message: string) {
     // 대상 사용자 또는 세션이 없으면 전송 중단
     if (!dmTargetUser || !session) {
+      return
+    }
+
+    if (!isDirectMessageAllowed(dmTargetUser.status)) {
+      toast.error('게임중인 유저에게는 DM을 보낼 수 없습니다.')
       return
     }
 

--- a/src/pages/waiting-room/WaitingRoomPage.tsx
+++ b/src/pages/waiting-room/WaitingRoomPage.tsx
@@ -14,6 +14,7 @@ import {
   subscribeDirectMessageSocketEvents,
 } from '../../features/presence/directMessageSocket'
 import { useOnlineUsersSocket } from '../../features/presence/hooks'
+import { isDirectMessageAllowed } from '../../features/presence/status'
 import type {
   DirectMessage,
   DirectMessageReceiveSocketPayload,
@@ -210,6 +211,11 @@ function WaitingRoomPage() {
       return
     }
 
+    if (!isDirectMessageAllowed(matchedUser.status)) {
+      setDmTargetUser(null)
+      return
+    }
+
     if (matchedUser !== dmTargetUser) {
       setDmTargetUser(matchedUser)
     }
@@ -275,6 +281,11 @@ function WaitingRoomPage() {
 
   // DM 창을 열고 해당 사용자 unread 카운트를 제거
   function handleOpenDirectMessage(user: OnlineUser) {
+    if (!isDirectMessageAllowed(user.status)) {
+      toast.error('게임중인 유저에게는 DM을 보낼 수 없습니다.')
+      return
+    }
+
     setDmTargetUser(user)
     setUnreadDirectMessageCountByUserId((previousCountByUserId) => {
       if (!previousCountByUserId[user.id]) {
@@ -295,6 +306,11 @@ function WaitingRoomPage() {
   function handleSendDirectMessage(message: string) {
     // 세션 또는 대상이 없으면 전송 중단
     if (!dmTargetUser || !session) {
+      return
+    }
+
+    if (!isDirectMessageAllowed(dmTargetUser.status)) {
+      toast.error('게임중인 유저에게는 DM을 보낼 수 없습니다.')
       return
     }
 


### PR DESCRIPTION
## 📌 관련 이슈

> closes #126 

---

## 📝 작업 내용

- `playing` 상태 유저 대상 DM 비활성 규칙 추가
- 공통 규칙 함수 추가: `isDirectMessageAllowed(status)`
- 접속자 목록 DM 버튼 비활성 처리 및 안내 문구(tooltip) 반영
- 로비/대기방에서 DM 열기 시 `playing` 대상 차단 + 토스트 안내
- DM 패널이 열린 상태에서 대상 유저가 `playing`으로 바뀌면 자동 닫기 처리
- 전송 시점에도 `playing` 상태 가드 추가(우회 방지)

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

- 접속자 목록에서 `게임중` 유저 DM 버튼 비활성 상태
- `게임중인 유저에게는 DM을 보낼 수 없습니다.` 토스트 노출
