### PR TITLE
feat: detail/code 기반 에러 응답 파서 적용 및 로비/대기방 에러 처리 정합화

### DIFF
--- a/src/lib/apiError.ts
+++ b/src/lib/apiError.ts
@@ -1,0 +1,93 @@
+import { isAxiosError } from 'axios'
+
+// API 에러에서 화면 분기에 사용할 공통 필드
+export interface ParsedApiError {
+  status?: number
+  code?: string
+  detail?: string
+  message?: string
+}
+
+type UnknownRecord = Record<string, unknown>
+
+// object 형태인지 확인해 안전하게 Record로 변환
+function toRecord(value: unknown): UnknownRecord | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null
+  }
+
+  return value as UnknownRecord
+}
+
+// 비어있지 않은 문자열만 반환
+function toNonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined
+  }
+
+  const trimmedValue = value.trim()
+  if (!trimmedValue) {
+    return undefined
+  }
+
+  return trimmedValue
+}
+
+// detail 필드를 문자열/배열/객체 형태 모두에서 추출
+function readDetail(detail: unknown): string | undefined {
+  const detailText = toNonEmptyString(detail)
+  if (detailText) {
+    return detailText
+  }
+
+  if (Array.isArray(detail)) {
+    for (const item of detail) {
+      const itemText = readDetail(item)
+      if (itemText) {
+        return itemText
+      }
+    }
+
+    return undefined
+  }
+
+  const detailRecord = toRecord(detail)
+  if (!detailRecord) {
+    return undefined
+  }
+
+  return (
+    toNonEmptyString(detailRecord.detail) ??
+    toNonEmptyString(detailRecord.message) ??
+    toNonEmptyString(detailRecord.msg) ??
+    toNonEmptyString(detailRecord.error)
+  )
+}
+
+// Axios/일반 Error를 공통 에러 모델로 정규화
+export function parseApiError(error: unknown): ParsedApiError {
+  if (isAxiosError(error)) {
+    const responseData = error.response?.data
+    const responseRecord = toRecord(responseData)
+
+    return {
+      status: error.response?.status,
+      code: toNonEmptyString(responseRecord?.code),
+      detail:
+        readDetail(responseRecord?.detail) ??
+        readDetail(responseRecord?.error) ??
+        readDetail(responseData),
+      message:
+        toNonEmptyString(responseRecord?.message) ??
+        toNonEmptyString(error.message),
+    }
+  }
+
+  if (error instanceof Error) {
+    return {
+      message: toNonEmptyString(error.message),
+    }
+  }
+
+  return {}
+}

--- a/src/pages/waiting-room/api.ts
+++ b/src/pages/waiting-room/api.ts
@@ -1,5 +1,5 @@
-import { isAxiosError } from 'axios'
 import { apiClient } from '../../lib/axios'
+import { parseApiError } from '../../lib/apiError'
 import {
   mockCreateWaitingRoom,
   mockJoinWaitingRoom,
@@ -24,6 +24,12 @@ const DEFAULT_WAITING_ROOM_TITLE = '즐거운 게임 한판!'
 const DEFAULT_WAITING_ROOM_MAX_PLAYERS = 4
 const USE_WAITING_ROOM_MOCK =
   import.meta.env.DEV && import.meta.env.VITE_USE_SOCKET_MOCK !== 'false'
+// 비밀번호 불일치로 간주할 서버 에러 코드 집합
+const JOIN_PASSWORD_MISMATCH_ERROR_CODES = new Set([
+  'ROOM_PASSWORD_MISMATCH',
+  'INVALID_ROOM_PASSWORD',
+  'PASSWORD_MISMATCH',
+])
 
 // 대기방 입장 요청 파라미터 타입
 interface JoinWaitingRoomParams {
@@ -257,39 +263,40 @@ export function getWaitingRoomErrorMessage(
   error: unknown,
   fallbackMessage: string
 ) {
-  // 목 게이트웨이 에러는 message를 그대로 사용
+  // 목 게이트웨이 에러는 detail > message 순으로 사용
   if (error instanceof WaitingRoomMockError) {
-    return error.message
+    return error.detail ?? error.message
   }
 
-  // Axios 에러는 서버 message가 있으면 우선 사용
-  if (isAxiosError(error)) {
-    const serverMessage = (
-      error.response?.data as { message?: string } | undefined
-    )?.message
+  // 실서버 에러는 detail 우선으로 사용자 메시지 선택
+  const parsedError = parseApiError(error)
+  const normalizedMessage = parsedError.detail ?? parsedError.message
 
-    if (serverMessage) {
-      return serverMessage
-    }
-  }
-
-  // 일반 Error message가 있으면 fallback 대신 사용
-  if (error instanceof Error && error.message.length > 0) {
-    return error.message
+  if (normalizedMessage) {
+    return normalizedMessage
   }
 
   return fallbackMessage
 }
 
+// code 값이 비밀번호 불일치 케이스인지 판별
+function isJoinPasswordMismatchCode(code?: string) {
+  if (!code) {
+    return false
+  }
+
+  return JOIN_PASSWORD_MISMATCH_ERROR_CODES.has(code.toUpperCase())
+}
+
 // 입장 실패 원인이 비밀번호 불일치인지 판별
 export function isJoinPasswordMismatchError(error: unknown) {
   if (error instanceof WaitingRoomMockError) {
-    return error.status === 403
+    return isJoinPasswordMismatchCode(error.code) || error.status === 403
   }
 
-  if (isAxiosError(error)) {
-    return error.response?.status === 403
-  }
+  const parsedError = parseApiError(error)
 
-  return false
+  return (
+    isJoinPasswordMismatchCode(parsedError.code) || parsedError.status === 403
+  )
 }

--- a/src/pages/waiting-room/mockGateway.ts
+++ b/src/pages/waiting-room/mockGateway.ts
@@ -50,11 +50,24 @@ interface SocketWithListeners {
 // 목 게이트웨이 에러 상태코드와 메시지를 함께 전달
 export class WaitingRoomMockError extends Error {
   status: number
+  // 명세 기반 분기를 위한 에러 코드
+  code?: string
+  // 사용자 안내에 사용할 상세 메시지
+  detail?: string
 
-  constructor(status: number, message: string) {
-    super(message)
+  constructor(
+    status: number,
+    message: string,
+    options?: {
+      code?: string
+      detail?: string
+    }
+  ) {
+    super(options?.detail ?? message)
     this.name = 'WaitingRoomMockError'
     this.status = status
+    this.code = options?.code
+    this.detail = options?.detail ?? message
   }
 }
 
@@ -192,7 +205,10 @@ function findRoomOrThrow(roomId: string) {
   const room = roomsStore.get(roomId)
 
   if (!room) {
-    throw new WaitingRoomMockError(404, '존재하지 않는 방입니다.')
+    throw new WaitingRoomMockError(404, '존재하지 않는 방입니다.', {
+      code: 'ROOM_NOT_FOUND',
+      detail: '존재하지 않는 방입니다.',
+    })
   }
 
   return room
@@ -305,12 +321,18 @@ export async function mockJoinWaitingRoom({
 
   // 비밀방 비밀번호가 다르면 403 반환
   if (room.is_private && room.password !== (password ?? '')) {
-    throw new WaitingRoomMockError(403, '비밀번호가 올바르지 않습니다.')
+    throw new WaitingRoomMockError(403, '비밀번호가 올바르지 않습니다.', {
+      code: 'ROOM_PASSWORD_MISMATCH',
+      detail: '비밀번호가 올바르지 않습니다.',
+    })
   }
 
   // 이미 게임 중인 방은 입장 차단
   if (room.status === 'playing') {
-    throw new WaitingRoomMockError(409, '이미 게임이 시작된 방입니다.')
+    throw new WaitingRoomMockError(409, '이미 게임이 시작된 방입니다.', {
+      code: 'ROOM_ALREADY_PLAYING',
+      detail: '이미 게임이 시작된 방입니다.',
+    })
   }
 
   const existingPlayer = room.players.find((player) => player.id === userId)
@@ -322,7 +344,10 @@ export async function mockJoinWaitingRoom({
 
   // 정원이 가득 찬 방은 입장 차단
   if (room.players.length >= room.max_players) {
-    throw new WaitingRoomMockError(409, '방 인원이 가득 찼습니다.')
+    throw new WaitingRoomMockError(409, '방 인원이 가득 찼습니다.', {
+      code: 'ROOM_FULL',
+      detail: '방 인원이 가득 찼습니다.',
+    })
   }
 
   room.players.push({
@@ -360,12 +385,18 @@ export async function mockCreateWaitingRoom({
 
   // 빈 방 제목은 생성 차단
   if (normalizedTitle.length === 0) {
-    throw new WaitingRoomMockError(400, '방 제목을 입력해주세요.')
+    throw new WaitingRoomMockError(400, '방 제목을 입력해주세요.', {
+      code: 'ROOM_TITLE_REQUIRED',
+      detail: '방 제목을 입력해주세요.',
+    })
   }
 
   // 비밀방이면 숫자 4자리 비밀번호를 강제
   if (isPrivate && !/^\d{4}$/.test(password ?? '')) {
-    throw new WaitingRoomMockError(400, '비밀번호는 숫자 4자리여야 합니다.')
+    throw new WaitingRoomMockError(400, '비밀번호는 숫자 4자리여야 합니다.', {
+      code: 'INVALID_ROOM_PASSWORD',
+      detail: '비밀번호는 숫자 4자리여야 합니다.',
+    })
   }
 
   const roomId = getNextRoomId()
@@ -412,7 +443,10 @@ export async function mockLeaveWaitingRoom({
 
   // 이미 나간 사용자면 중복 퇴장 요청 차단
   if (targetPlayerIndex === -1) {
-    throw new WaitingRoomMockError(409, '이미 방에서 나간 상태입니다.')
+    throw new WaitingRoomMockError(409, '이미 방에서 나간 상태입니다.', {
+      code: 'ALREADY_LEFT_ROOM',
+      detail: '이미 방에서 나간 상태입니다.',
+    })
   }
 
   const [leftPlayer] = room.players.splice(targetPlayerIndex, 1)
@@ -482,14 +516,21 @@ export async function mockToggleWaitingReady({
 
   // 참가자가 아니면 404 반환
   if (!player) {
-    throw new WaitingRoomMockError(404, '방 참가자를 찾을 수 없습니다.')
+    throw new WaitingRoomMockError(404, '방 참가자를 찾을 수 없습니다.', {
+      code: 'PLAYER_NOT_IN_ROOM',
+      detail: '방 참가자를 찾을 수 없습니다.',
+    })
   }
 
   // 방장은 준비 토글이 아닌 시작 버튼만 사용
   if (player.is_host) {
     throw new WaitingRoomMockError(
       403,
-      '방장은 준비 상태를 변경할 수 없습니다.'
+      '방장은 준비 상태를 변경할 수 없습니다.',
+      {
+        code: 'HOST_CANNOT_TOGGLE_READY',
+        detail: '방장은 준비 상태를 변경할 수 없습니다.',
+      }
     )
   }
 
@@ -520,14 +561,21 @@ export async function mockStartWaitingGame({
 
   // 방장이 아니면 시작 요청 차단
   if (!hostPlayer || hostPlayer.id !== userId) {
-    throw new WaitingRoomMockError(403, '방장만 게임을 시작할 수 있습니다.')
+    throw new WaitingRoomMockError(403, '방장만 게임을 시작할 수 있습니다.', {
+      code: 'ONLY_HOST_CAN_START',
+      detail: '방장만 게임을 시작할 수 있습니다.',
+    })
   }
 
   // 시작 조건 미충족 시 409 반환
   if (!isAllReady(room)) {
     throw new WaitingRoomMockError(
       409,
-      '최소 2명 + 전원 준비 완료 조건이 필요합니다.'
+      '최소 2명 + 전원 준비 완료 조건이 필요합니다.',
+      {
+        code: 'READY_CONDITION_NOT_MET',
+        detail: '최소 2명 + 전원 준비 완료 조건이 필요합니다.',
+      }
     )
   }
 


### PR DESCRIPTION
## 📌 관련 이슈

> closes #127

---

## 📝 작업 내용

- 서버 에러 응답 파싱을 `detail`, `code` 우선으로 통일했습니다.
- 기존 `message` 기반 응답도 깨지지 않도록 fallback 호환을 유지했습니다.
- 로비/대기방 에러 처리 분기에서 코드 기반 처리(예: 비밀번호 불일치 등)를 반영했습니다.
- 사용자 노출 에러 메시지 선택 규칙을 일관되게 정리했습니다.

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

> UI 변경 없음 (N/A)
