### PR TITLE
feat: presence 초기 부트스트랩 REST+Socket 정합화

### DIFF
--- a/src/features/presence/api.ts
+++ b/src/features/presence/api.ts
@@ -1,0 +1,15 @@
+import { apiClient } from '../../lib/axios'
+import type { OnlineUserPayload } from './types'
+
+// 접속자 목록 초기 스냅샷 응답 타입
+interface OnlineUsersResponsePayload {
+  users: OnlineUserPayload[]
+}
+
+// 로비 접속자 목록 초기 스냅샷 조회
+export async function getOnlineUsersSnapshot() {
+  const { data } =
+    await apiClient.get<OnlineUsersResponsePayload>('/lobby/users')
+
+  return data.users
+}

--- a/src/features/presence/hooks.ts
+++ b/src/features/presence/hooks.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { connectSocketWithAuthIfNeeded, socket } from '../../lib/socket'
+import { getOnlineUsersSnapshot } from './api'
 import { mockOnlineUsers } from './mockData'
 import type {
   OnlineUser,
@@ -73,10 +74,16 @@ export function useOnlineUsersSocket() {
   const [isError, setIsError] = useState(false)
 
   useEffect(() => {
+    let isActive = true
+
     // 접속자 이벤트 수신 시 목록과 상태를 갱신
     const handleOnlineUsers = ({
       users: payloadUsers,
     }: OnlineUsersEventPayload) => {
+      if (!isActive) {
+        return
+      }
+
       setUsers(mapOnlineUsers(payloadUsers))
       setIsLoading(false)
       setIsError(false)
@@ -90,6 +97,10 @@ export function useOnlineUsersSocket() {
 
     // 연결 종료 상태를 에러로 표시
     const handleDisconnect = () => {
+      if (!isActive) {
+        return
+      }
+
       setIsError(true)
     }
 
@@ -104,6 +115,26 @@ export function useOnlineUsersSocket() {
         emitOnlineUsersMock(mockOnlineUsers)
       }, SOCKET_MOCK_INTERVAL_MS)
     } else {
+      // 초기 진입 시 REST 스냅샷으로 첫 목록을 확보
+      void getOnlineUsersSnapshot()
+        .then((payloadUsers) => {
+          if (!isActive) {
+            return
+          }
+
+          setUsers(mapOnlineUsers(payloadUsers))
+          setIsLoading(false)
+          setIsError(false)
+        })
+        .catch(() => {
+          // REST 초기화 실패 시 소켓 실시간 수신으로 복구를 시도
+          if (!isActive) {
+            return
+          }
+
+          setIsLoading(false)
+        })
+
       // 실제 소켓 모드에서는 연결 오류/끊김 이벤트를 구독
       socket.on('connect_error', handleConnectError)
       socket.on('disconnect', handleDisconnect)
@@ -115,6 +146,7 @@ export function useOnlineUsersSocket() {
     }
 
     return () => {
+      isActive = false
       socket.off(ONLINE_USERS_EVENT, handleOnlineUsers)
       socket.off('connect_error', handleConnectError)
       socket.off('disconnect', handleDisconnect)


### PR DESCRIPTION
## 📌 관련 이슈

> closes #129

---

## 📝 작업 내용

- 접속자 목록 초기화 흐름을 `REST 초기 스냅샷 + Socket 실시간 갱신` 구조로 정리했습니다.
- 소켓 연결/구독/해제(cleanup) 시퀀스를 명확히 분리해 상태 꼬임 가능성을 줄였습니다.
- mock 모드와 실소켓 모드 분기를 정리해 개발/연동 환경 모두에서 동작 일관성을 맞췄습니다.
- payload -> UI 모델 매핑 책임을 분리해 유지보수성을 개선했습니다.

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

> UI 변경 없음 (N/A)
