### PR TITLE
feat: 접속자 목록 API 엔드포인트 정합화(users/online)

### DIFF
--- a/src/features/presence/api.ts
+++ b/src/features/presence/api.ts
@@ -6,10 +6,10 @@ interface OnlineUsersResponsePayload {
   users: OnlineUserPayload[]
 }
 
-// 로비 접속자 목록 초기 스냅샷 조회
+// 전체 온라인 유저 목록 초기 스냅샷 조회
 export async function getOnlineUsersSnapshot() {
   const { data } =
-    await apiClient.get<OnlineUsersResponsePayload>('/lobby/users')
+    await apiClient.get<OnlineUsersResponsePayload>('/users/online')
 
   return data.users
 }

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -56,8 +56,8 @@ export const handlers = [
       rooms: filteredRooms.map(mapLobbyRoomPayload),
     })
   }),
-  // 접속자 목록 endpoint 모킹
-  http.get('/api/lobby/users', async () => {
+  // 전체 온라인 유저 목록 endpoint 모킹
+  http.get('/api/users/online', async () => {
     await delay(250)
     return HttpResponse.json({ users: mockOnlineUsers })
   }),


### PR DESCRIPTION
## 📌 관련 이슈

> closes #130

---

## 📝 작업 내용

- 접속자 목록 조회 엔드포인트를 `GET /users/online` 기준으로 정합화했습니다.
- 프론트 API 호출 경로와 mock handler 경로를 동일하게 맞췄습니다.
- 로비/대기방 접속자 목록 기능에서 변경 경로를 사용하도록 연결 상태를 점검했습니다.
- 문서/코드 간 엔드포인트 명칭 혼선을 줄이기 위해 관련 참조를 정리했습니다.

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

> UI 변경 없음 (N/A)
