### PR TITLE
refactor: 로비/대기방 공통 DM 컨트롤러 훅으로 중복 로직 통합

### DIFF
--- a/src/features/presence/useDirectMessageController.ts
+++ b/src/features/presence/useDirectMessageController.ts
@@ -1,0 +1,191 @@
+import { useCallback, useEffect, useState } from 'react'
+import type { AuthSession } from '../auth/types'
+import {
+  sendDirectMessage as sendDirectMessageSocket,
+  subscribeDirectMessageSocketEvents,
+} from './directMessageSocket'
+import { isDirectMessageAllowed } from './status'
+import type {
+  DirectMessage,
+  DirectMessageReceiveSocketPayload,
+  OnlineUser,
+} from './types'
+
+// DM 컨트롤러 훅 입력값 타입
+interface UseDirectMessageControllerParams {
+  session: AuthSession | null
+  users: OnlineUser[]
+  onBlockedByPlaying?: () => void
+}
+
+// DM 상태/구독/전송 로직을 공통으로 관리
+export function useDirectMessageController({
+  session,
+  users,
+  onBlockedByPlaying,
+}: UseDirectMessageControllerParams) {
+  const [dmTargetUser, setDmTargetUser] = useState<OnlineUser | null>(null)
+  const [directMessagesByUserId, setDirectMessagesByUserId] = useState<
+    Record<string, DirectMessage[]>
+  >({})
+  const [
+    unreadDirectMessageCountByUserId,
+    setUnreadDirectMessageCountByUserId,
+  ] = useState<Record<string, number>>({})
+
+  const openedDirectMessageUserId = dmTargetUser?.id
+
+  // DM 수신 이벤트를 구독해 대화 목록과 unread 카운트를 갱신
+  useEffect(() => {
+    if (!session) {
+      return
+    }
+
+    const unsubscribe = subscribeDirectMessageSocketEvents({
+      onReceive: (payload: DirectMessageReceiveSocketPayload) => {
+        const receivedMessage: DirectMessage = {
+          id: `${payload.sender_id}-${payload.sent_at}`,
+          senderId: payload.sender_id,
+          senderNickname: payload.sender_nickname,
+          content: payload.message,
+          sentAt: payload.sent_at,
+        }
+
+        setDirectMessagesByUserId((previousMessagesByUserId) => {
+          const previousMessages =
+            previousMessagesByUserId[payload.sender_id] ?? []
+          const hasSameMessage = previousMessages.some(
+            (message) => message.id === receivedMessage.id
+          )
+
+          // 동일 메시지 ID는 중복 삽입을 방지
+          if (hasSameMessage) {
+            return previousMessagesByUserId
+          }
+
+          return {
+            ...previousMessagesByUserId,
+            [payload.sender_id]: [...previousMessages, receivedMessage],
+          }
+        })
+
+        // 현재 열려 있는 사용자 메시지는 unread 카운트에서 제외
+        if (payload.sender_id === openedDirectMessageUserId) {
+          return
+        }
+
+        setUnreadDirectMessageCountByUserId((previousCountByUserId) => {
+          const previousCount = previousCountByUserId[payload.sender_id] ?? 0
+
+          return {
+            ...previousCountByUserId,
+            [payload.sender_id]: previousCount + 1,
+          }
+        })
+      },
+    })
+
+    return () => {
+      unsubscribe()
+    }
+  }, [openedDirectMessageUserId, session])
+
+  // 접속자 목록 갱신 시 DM 대상 사용자 참조를 최신 객체로 동기화
+  useEffect(() => {
+    if (!dmTargetUser) {
+      return
+    }
+
+    const matchedUser = users.find((user) => user.id === dmTargetUser.id)
+
+    if (!matchedUser) {
+      setDmTargetUser(null)
+      return
+    }
+
+    if (!isDirectMessageAllowed(matchedUser.status)) {
+      setDmTargetUser(null)
+      return
+    }
+
+    if (matchedUser !== dmTargetUser) {
+      setDmTargetUser(matchedUser)
+    }
+  }, [dmTargetUser, users])
+
+  // DM 창을 열고 해당 사용자 unread 카운트를 초기화
+  const openDirectMessage = useCallback(
+    (user: OnlineUser) => {
+      if (!isDirectMessageAllowed(user.status)) {
+        onBlockedByPlaying?.()
+        return
+      }
+
+      setDmTargetUser(user)
+      setUnreadDirectMessageCountByUserId((previousCountByUserId) => {
+        if (!previousCountByUserId[user.id]) {
+          return previousCountByUserId
+        }
+
+        const nextCountByUserId = { ...previousCountByUserId }
+        delete nextCountByUserId[user.id]
+        return nextCountByUserId
+      })
+    },
+    [onBlockedByPlaying]
+  )
+
+  // DM 창 닫기
+  const closeDirectMessage = useCallback(() => {
+    setDmTargetUser(null)
+  }, [])
+
+  // 로컬 DM 목록에 메시지를 추가하고 소켓 전송 실행
+  const sendDirectMessage = useCallback(
+    (message: string) => {
+      // 대상 사용자 또는 세션이 없으면 전송 중단
+      if (!dmTargetUser || !session) {
+        return
+      }
+
+      if (!isDirectMessageAllowed(dmTargetUser.status)) {
+        onBlockedByPlaying?.()
+        return
+      }
+
+      const targetUserId = dmTargetUser.id
+      const nextDirectMessage: DirectMessage = {
+        id: `${targetUserId}-${Date.now()}`,
+        senderId: session.userId,
+        senderNickname: session.nickname,
+        content: message,
+        sentAt: new Date().toISOString(),
+      }
+
+      setDirectMessagesByUserId((previousMessagesByUserId) => {
+        const previousMessages = previousMessagesByUserId[targetUserId] ?? []
+
+        return {
+          ...previousMessagesByUserId,
+          [targetUserId]: [...previousMessages, nextDirectMessage],
+        }
+      })
+
+      sendDirectMessageSocket({
+        receiverId: dmTargetUser.id,
+        receiverNickname: dmTargetUser.nickname,
+        message,
+      })
+    },
+    [dmTargetUser, onBlockedByPlaying, session]
+  )
+
+  return {
+    dmTargetUser,
+    directMessagesByUserId,
+    unreadDirectMessageCountByUserId,
+    openDirectMessage,
+    closeDirectMessage,
+    sendDirectMessage,
+  }
+}

--- a/src/pages/lobby/LobbyPage.tsx
+++ b/src/pages/lobby/LobbyPage.tsx
@@ -10,17 +10,8 @@ import {
 } from '../../components/header/profileMenu'
 import { UserListPanel } from '../../features/presence/components/UserListPanel'
 import { DirectMessagePanel } from '../../features/presence/components/DirectMessagePanel'
-import {
-  sendDirectMessage,
-  subscribeDirectMessageSocketEvents,
-} from '../../features/presence/directMessageSocket'
 import { useOnlineUsersSocket } from '../../features/presence/hooks'
-import { isDirectMessageAllowed } from '../../features/presence/status'
-import type {
-  DirectMessage,
-  DirectMessageReceiveSocketPayload,
-  OnlineUser,
-} from '../../features/presence/types'
+import { useDirectMessageController } from '../../features/presence/useDirectMessageController'
 import type { LobbyRoomFilter } from './api'
 import { useLobbyRoomsQuery } from './hooks'
 import { LobbyControls } from './LobbyControls'
@@ -48,14 +39,6 @@ function LobbyPage() {
   const [isUserListOpen, setIsUserListOpen] = useState(true)
   const [isCreateRoomModalOpen, setIsCreateRoomModalOpen] = useState(false)
   const [isCreateRoomPending, setIsCreateRoomPending] = useState(false)
-  const [dmTargetUser, setDmTargetUser] = useState<OnlineUser | null>(null)
-  const [directMessagesByUserId, setDirectMessagesByUserId] = useState<
-    Record<string, DirectMessage[]>
-  >({})
-  const [
-    unreadDirectMessageCountByUserId,
-    setUnreadDirectMessageCountByUserId,
-  ] = useState<Record<string, number>>({})
   const [selectedPrivateRoom, setSelectedPrivateRoom] =
     useState<LobbyRoom | null>(null)
   const [privateRoomPassword, setPrivateRoomPassword] = useState('')
@@ -94,86 +77,20 @@ function LobbyPage() {
     isError: isUsersError,
   } = useOnlineUsersSocket()
 
-  const openedDirectMessageUserId = dmTargetUser?.id
-
-  // DM 수신 이벤트를 구독해 대화 목록과 unread 카운트를 갱신
-  useEffect(() => {
-    // 비로그인 상태에서는 구독을 등록하지 않음
-    if (!session) {
-      return
-    }
-
-    const unsubscribe = subscribeDirectMessageSocketEvents({
-      onReceive: (payload: DirectMessageReceiveSocketPayload) => {
-        const receivedMessage: DirectMessage = {
-          id: `${payload.sender_id}-${payload.sent_at}`,
-          senderId: payload.sender_id,
-          senderNickname: payload.sender_nickname,
-          content: payload.message,
-          sentAt: payload.sent_at,
-        }
-
-        setDirectMessagesByUserId((previousMessagesByUserId) => {
-          const previousMessages =
-            previousMessagesByUserId[payload.sender_id] ?? []
-          const hasSameMessage = previousMessages.some(
-            (message) => message.id === receivedMessage.id
-          )
-
-          // 동일 메시지 ID는 중복 삽입을 방지
-          if (hasSameMessage) {
-            return previousMessagesByUserId
-          }
-
-          return {
-            ...previousMessagesByUserId,
-            [payload.sender_id]: [...previousMessages, receivedMessage],
-          }
-        })
-
-        // 현재 열려 있는 사용자 메시지는 unread 카운트에서 제외
-        if (payload.sender_id === openedDirectMessageUserId) {
-          return
-        }
-
-        setUnreadDirectMessageCountByUserId((previousCountByUserId) => {
-          const previousCount = previousCountByUserId[payload.sender_id] ?? 0
-
-          return {
-            ...previousCountByUserId,
-            [payload.sender_id]: previousCount + 1,
-          }
-        })
-      },
-    })
-
-    return () => {
-      unsubscribe()
-    }
-  }, [openedDirectMessageUserId, session])
-
-  // 접속자 목록 갱신 시 DM 대상 사용자 참조를 최신 객체로 동기화
-  useEffect(() => {
-    if (!dmTargetUser) {
-      return
-    }
-
-    const matchedUser = users.find((user) => user.id === dmTargetUser.id)
-
-    if (!matchedUser) {
-      setDmTargetUser(null)
-      return
-    }
-
-    if (!isDirectMessageAllowed(matchedUser.status)) {
-      setDmTargetUser(null)
-      return
-    }
-
-    if (matchedUser !== dmTargetUser) {
-      setDmTargetUser(matchedUser)
-    }
-  }, [dmTargetUser, users])
+  const {
+    dmTargetUser,
+    directMessagesByUserId,
+    unreadDirectMessageCountByUserId,
+    openDirectMessage,
+    closeDirectMessage,
+    sendDirectMessage,
+  } = useDirectMessageController({
+    session,
+    users,
+    onBlockedByPlaying: () => {
+      toast.error('게임중인 유저에게는 DM을 보낼 수 없습니다.')
+    },
+  })
 
   function handleLogout() {
     clearSession()
@@ -183,66 +100,6 @@ function LobbyPage() {
   // 프로필 드롭다운에서 마이페이지 이동 처리
   function handleGoMyPage() {
     navigate('/my-page')
-  }
-
-  // DM 창을 열고 해당 사용자 unread 카운트를 초기화
-  function handleOpenDirectMessage(user: OnlineUser) {
-    if (!isDirectMessageAllowed(user.status)) {
-      toast.error('게임중인 유저에게는 DM을 보낼 수 없습니다.')
-      return
-    }
-
-    setDmTargetUser(user)
-    setUnreadDirectMessageCountByUserId((previousCountByUserId) => {
-      if (!previousCountByUserId[user.id]) {
-        return previousCountByUserId
-      }
-
-      const nextCountByUserId = { ...previousCountByUserId }
-      delete nextCountByUserId[user.id]
-      return nextCountByUserId
-    })
-  }
-
-  function handleCloseDirectMessage() {
-    setDmTargetUser(null)
-  }
-
-  // 로컬 DM 목록에 메시지를 추가하고 소켓 전송 실행
-  function handleSendDirectMessage(message: string) {
-    // 대상 사용자 또는 세션이 없으면 전송 중단
-    if (!dmTargetUser || !session) {
-      return
-    }
-
-    if (!isDirectMessageAllowed(dmTargetUser.status)) {
-      toast.error('게임중인 유저에게는 DM을 보낼 수 없습니다.')
-      return
-    }
-
-    const targetUserId = dmTargetUser.id
-    const nextDirectMessage: DirectMessage = {
-      id: `${targetUserId}-${Date.now()}`,
-      senderId: session.userId,
-      senderNickname: session.nickname,
-      content: message,
-      sentAt: new Date().toISOString(),
-    }
-
-    setDirectMessagesByUserId((previousMessagesByUserId) => {
-      const previousMessages = previousMessagesByUserId[targetUserId] ?? []
-
-      return {
-        ...previousMessagesByUserId,
-        [targetUserId]: [...previousMessages, nextDirectMessage],
-      }
-    })
-
-    sendDirectMessage({
-      receiverId: dmTargetUser.id,
-      receiverNickname: dmTargetUser.nickname,
-      message,
-    })
   }
 
   function handleOpenCreateRoomModal() {
@@ -406,7 +263,7 @@ function LobbyPage() {
           isOpen={isUserListOpen}
           currentUserId={session.userId}
           unreadDirectMessageCountByUserId={unreadDirectMessageCountByUserId}
-          onOpenDirectMessage={handleOpenDirectMessage}
+          onOpenDirectMessage={openDirectMessage}
           onToggle={() => setIsUserListOpen((prev) => !prev)}
         />
       </main>
@@ -446,8 +303,8 @@ function LobbyPage() {
           user={dmTargetUser}
           currentUserId={session.userId}
           messages={directMessagesByUserId[dmTargetUser.id] ?? []}
-          onClose={handleCloseDirectMessage}
-          onSendMessage={handleSendDirectMessage}
+          onClose={closeDirectMessage}
+          onSendMessage={sendDirectMessage}
         />
       ) : null}
     </div>

--- a/src/pages/waiting-room/WaitingRoomPage.tsx
+++ b/src/pages/waiting-room/WaitingRoomPage.tsx
@@ -9,17 +9,8 @@ import {
 } from '../../components/header/profileMenu'
 import { DirectMessagePanel } from '../../features/presence/components/DirectMessagePanel'
 import { UserListPanel } from '../../features/presence/components/UserListPanel'
-import {
-  sendDirectMessage,
-  subscribeDirectMessageSocketEvents,
-} from '../../features/presence/directMessageSocket'
 import { useOnlineUsersSocket } from '../../features/presence/hooks'
-import { isDirectMessageAllowed } from '../../features/presence/status'
-import type {
-  DirectMessage,
-  DirectMessageReceiveSocketPayload,
-  OnlineUser,
-} from '../../features/presence/types'
+import { useDirectMessageController } from '../../features/presence/useDirectMessageController'
 import { cn } from '../../lib/utils'
 import { WaitingRoomHeader } from './components/WaitingRoomHeader'
 import { WaitingSeatCard } from './components/WaitingSeatCard'
@@ -55,14 +46,6 @@ function WaitingRoomPage() {
   const session = useAuthStore((state) => state.session)
   const clearSession = useAuthStore((state) => state.clearSession)
   const [isUserListOpen, setIsUserListOpen] = useState(true)
-  const [dmTargetUser, setDmTargetUser] = useState<OnlineUser | null>(null)
-  const [directMessagesByUserId, setDirectMessagesByUserId] = useState<
-    Record<string, DirectMessage[]>
-  >({})
-  const [
-    unreadDirectMessageCountByUserId,
-    setUnreadDirectMessageCountByUserId,
-  ] = useState<Record<string, number>>({})
 
   const locationState = location.state as WaitingRoomLocationState | null
   const isSameRoomState = locationState?.roomId === currentRoomId
@@ -114,7 +97,20 @@ function WaitingRoomPage() {
     isError: isUsersError,
   } = useOnlineUsersSocket()
 
-  const openedDirectMessageUserId = dmTargetUser?.id
+  const {
+    dmTargetUser,
+    directMessagesByUserId,
+    unreadDirectMessageCountByUserId,
+    openDirectMessage,
+    closeDirectMessage,
+    sendDirectMessage,
+  } = useDirectMessageController({
+    session,
+    users,
+    onBlockedByPlaying: () => {
+      toast.error('게임중인 유저에게는 DM을 보낼 수 없습니다.')
+    },
+  })
 
   // URL/세션 상태 검증 후 잘못된 진입을 리다이렉트
   useEffect(() => {
@@ -143,83 +139,6 @@ function WaitingRoomPage() {
 
     toast.error(roomErrorMessage)
   }, [roomErrorMessage])
-
-  // DM 수신 이벤트를 구독해 메시지 목록/unread 상태를 갱신
-  useEffect(() => {
-    if (!session) {
-      return
-    }
-
-    const unsubscribe = subscribeDirectMessageSocketEvents({
-      onReceive: (payload: DirectMessageReceiveSocketPayload) => {
-        const receivedMessage: DirectMessage = {
-          id: `${payload.sender_id}-${payload.sent_at}`,
-          senderId: payload.sender_id,
-          senderNickname: payload.sender_nickname,
-          content: payload.message,
-          sentAt: payload.sent_at,
-        }
-
-        setDirectMessagesByUserId((previousMessagesByUserId) => {
-          const previousMessages =
-            previousMessagesByUserId[payload.sender_id] ?? []
-          const hasSameMessage = previousMessages.some(
-            (message) => message.id === receivedMessage.id
-          )
-
-          // 동일 메시지는 중복 저장하지 않음
-          if (hasSameMessage) {
-            return previousMessagesByUserId
-          }
-
-          return {
-            ...previousMessagesByUserId,
-            [payload.sender_id]: [...previousMessages, receivedMessage],
-          }
-        })
-
-        if (payload.sender_id === openedDirectMessageUserId) {
-          return
-        }
-
-        setUnreadDirectMessageCountByUserId((previousCountByUserId) => {
-          const previousCount = previousCountByUserId[payload.sender_id] ?? 0
-
-          return {
-            ...previousCountByUserId,
-            [payload.sender_id]: previousCount + 1,
-          }
-        })
-      },
-    })
-
-    return () => {
-      unsubscribe()
-    }
-  }, [openedDirectMessageUserId, session])
-
-  // 접속자 목록 갱신 시 DM 대상 사용자 참조를 동기화
-  useEffect(() => {
-    if (!dmTargetUser) {
-      return
-    }
-
-    const matchedUser = users.find((user) => user.id === dmTargetUser.id)
-
-    if (!matchedUser) {
-      setDmTargetUser(null)
-      return
-    }
-
-    if (!isDirectMessageAllowed(matchedUser.status)) {
-      setDmTargetUser(null)
-      return
-    }
-
-    if (matchedUser !== dmTargetUser) {
-      setDmTargetUser(matchedUser)
-    }
-  }, [dmTargetUser, users])
 
   // 대기방을 떠나 로비로 복귀
   const handleLeaveToLobby = useCallback(async () => {
@@ -278,66 +197,6 @@ function WaitingRoomPage() {
       toast.error(result.message)
     }
   }, [handleStartGame])
-
-  // DM 창을 열고 해당 사용자 unread 카운트를 제거
-  function handleOpenDirectMessage(user: OnlineUser) {
-    if (!isDirectMessageAllowed(user.status)) {
-      toast.error('게임중인 유저에게는 DM을 보낼 수 없습니다.')
-      return
-    }
-
-    setDmTargetUser(user)
-    setUnreadDirectMessageCountByUserId((previousCountByUserId) => {
-      if (!previousCountByUserId[user.id]) {
-        return previousCountByUserId
-      }
-
-      const nextCountByUserId = { ...previousCountByUserId }
-      delete nextCountByUserId[user.id]
-      return nextCountByUserId
-    })
-  }
-
-  function handleCloseDirectMessage() {
-    setDmTargetUser(null)
-  }
-
-  // DM 메시지를 로컬 목록에 반영한 뒤 소켓으로 전송
-  function handleSendDirectMessage(message: string) {
-    // 세션 또는 대상이 없으면 전송 중단
-    if (!dmTargetUser || !session) {
-      return
-    }
-
-    if (!isDirectMessageAllowed(dmTargetUser.status)) {
-      toast.error('게임중인 유저에게는 DM을 보낼 수 없습니다.')
-      return
-    }
-
-    const targetUserId = dmTargetUser.id
-    const nextDirectMessage: DirectMessage = {
-      id: `${targetUserId}-${Date.now()}`,
-      senderId: session.userId,
-      senderNickname: session.nickname,
-      content: message,
-      sentAt: new Date().toISOString(),
-    }
-
-    setDirectMessagesByUserId((previousMessagesByUserId) => {
-      const previousMessages = previousMessagesByUserId[targetUserId] ?? []
-
-      return {
-        ...previousMessagesByUserId,
-        [targetUserId]: [...previousMessages, nextDirectMessage],
-      }
-    })
-
-    sendDirectMessage({
-      receiverId: dmTargetUser.id,
-      receiverNickname: dmTargetUser.nickname,
-      message,
-    })
-  }
 
   // 리다이렉트 대상 상태에서는 화면 렌더링 생략
   if (!session || session.needsNicknameSetup) {
@@ -445,7 +304,7 @@ function WaitingRoomPage() {
               unreadDirectMessageCountByUserId={
                 unreadDirectMessageCountByUserId
               }
-              onOpenDirectMessage={handleOpenDirectMessage}
+              onOpenDirectMessage={openDirectMessage}
               onToggle={() => setIsUserListOpen((previous) => !previous)}
               heightMode="full"
               disableWidthTransition
@@ -466,8 +325,8 @@ function WaitingRoomPage() {
           user={dmTargetUser}
           currentUserId={session.userId}
           messages={directMessagesByUserId[dmTargetUser.id] ?? []}
-          onClose={handleCloseDirectMessage}
-          onSendMessage={handleSendDirectMessage}
+          onClose={closeDirectMessage}
+          onSendMessage={sendDirectMessage}
         />
       ) : null}
     </div>


### PR DESCRIPTION
## 📌 관련 이슈

> closes #132

---

## 📝 작업 내용

- 로비와 대기방에 중복되어 있던 DM 상태/이벤트 처리 로직을 공통 훅으로 통합했습니다.
- `useDirectMessageController`를 도입해 DM 대상, 메시지 목록, unread 카운트, 전송/열기/닫기 동작을 한 곳에서 관리하도록 정리했습니다.
- 게임중(playing) 유저 DM 차단 규칙을 공통 경로에서 일관되게 적용했습니다.
- 페이지 컴포넌트는 화면 렌더링 중심으로 단순화해 가독성을 개선했습니다.

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

> UI 변경 없음 (N/A)
