### PR TITLE
FIX :게임 mock 흐름 안정화 및 건물 SVG 렌더링 보정

### DIFF
--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -213,6 +213,36 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
     const [tileOwners, setTileOwners] = useState<Record<number, TileOwner>>({})
     const tileOwnersRef = useRef<Record<number, TileOwner>>({})
 
+    function getPlayerIdByIndex(playerIdx: number) {
+      return playersRef.current[playerIdx]?.id ?? playerIdx
+    }
+
+    function getPlayerColorByIndex(playerIdx: number) {
+      return (
+        playersRef.current[playerIdx]?.color ??
+        PLAYER_COLORS[playerIdx % PLAYER_COLORS.length]
+      )
+    }
+
+    function getPlayerIndexById(playerId: number) {
+      return playersRef.current.findIndex((player) => player.id === playerId)
+    }
+
+    function toBoardBuildingLevel(
+      tile: { building?: number; level?: number },
+      hasOwner: boolean
+    ) {
+      if (!hasOwner) return 0 as BuildingLevel
+
+      if (typeof tile.level === 'number') {
+        return Math.min(Math.max(tile.level, 1), 5) as BuildingLevel
+      }
+
+      const buildingLevel =
+        typeof tile.building === 'number' ? tile.building : 0
+      return Math.min(Math.max(buildingLevel + 1, 1), 5) as BuildingLevel
+    }
+
     async function syncBoardStateFromServer() {
       if (!roomId) return false
 
@@ -224,17 +254,25 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       const prevById = new Map(
         playersRef.current.map((player) => [String(player.id), player])
       )
+      const serverToBoardId = new Map<string, number>()
 
       if (payloadPlayers.length > 0) {
         const nextById = new Map<string, PlayerState>()
 
         payloadPlayers.forEach((player, idx) => {
-          const playerId = Number(player.id)
-          if (Number.isNaN(playerId)) return
-
           const prevPlayer = prevById.get(String(player.id))
+          const parsedPlayerId =
+            typeof player.id === 'number'
+              ? player.id
+              : Number.parseInt(String(player.id), 10)
+          const boardPlayerId = Number.isNaN(parsedPlayerId)
+            ? (prevPlayer?.id ?? idx)
+            : parsedPlayerId
+
+          serverToBoardId.set(String(player.id), boardPlayerId)
+
           nextById.set(String(player.id), {
-            id: playerId,
+            id: boardPlayerId,
             name:
               player.nickname ??
               player.name ??
@@ -278,11 +316,15 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
             return
           }
 
-          const ownerId =
+          const mappedOwnerId = serverToBoardId.get(String(ownerRaw))
+          const parsedOwnerId =
             typeof ownerRaw === 'number'
               ? ownerRaw
               : Number.parseInt(String(ownerRaw), 10)
-          if (Number.isNaN(ownerId)) return
+          const ownerId =
+            mappedOwnerId ??
+            (Number.isNaN(parsedOwnerId) ? null : parsedOwnerId)
+          if (ownerId === null) return
 
           const ownerPlayer = playersRef.current.find(
             (player) => player.id === ownerId
@@ -292,10 +334,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
             ownerColor:
               ownerPlayer?.color ??
               PLAYER_COLORS[ownerId % PLAYER_COLORS.length],
-            level: Math.min(
-              Math.max(tile.building ?? tile.level ?? 1, 0),
-              5
-            ) as BuildingLevel,
+            level: toBoardBuildingLevel(tile, true),
           }
         })
 
@@ -305,8 +344,11 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
 
       const nextTurnRaw = payload.current_turn ?? payload.currentTurn
       if (nextTurnRaw !== undefined && nextTurnRaw !== null) {
+        const mappedTurnId = serverToBoardId.get(String(nextTurnRaw))
         const nextTurnIndex = playersRef.current.findIndex(
-          (player) => String(player.id) === String(nextTurnRaw)
+          (player) =>
+            player.id === mappedTurnId ||
+            String(player.id) === String(nextTurnRaw)
         )
         if (nextTurnIndex >= 0) {
           curPlayerRef.current = nextTurnIndex
@@ -390,11 +432,13 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       setBankruptModal({ open: false, playerIdx: -1, playerName: '' })
 
       bankruptSetRef.current.add(playerIdx)
+      const bankruptPlayerId = getPlayerIdByIndex(playerIdx)
 
       updateTileOwners((prev) => {
         const next = { ...prev }
         Object.keys(next).forEach((k) => {
-          if (next[Number(k)].ownerId === playerIdx) delete next[Number(k)]
+          if (next[Number(k)].ownerId === bankruptPlayerId)
+            delete next[Number(k)]
         })
         return next
       })
@@ -493,13 +537,14 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
 
             if (tile.type === 'city') {
               const owner = tileOwnersRef.current[landedTileId]
+              const activePlayer = movedPlayers[activeCurPlayer]
               if (!owner) {
                 setBuyModal({
                   open: true,
                   tileId: landedTileId,
                   onDoneCallback: onDone,
                 })
-              } else if (owner.ownerId === activeCurPlayer) {
+              } else if (owner.ownerId === activePlayer.id) {
                 if (owner.level < 5) {
                   setBuildModal({
                     open: true,
@@ -557,8 +602,9 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
     }
 
     async function sellOwnedTileForPlayer(playerIdx: number) {
+      const playerId = getPlayerIdByIndex(playerIdx)
       const ownedTileEntries = Object.entries(tileOwnersRef.current)
-        .filter(([, owner]) => owner.ownerId === playerIdx)
+        .filter(([, owner]) => owner.ownerId === playerId)
         .sort(([, a], [, b]) => b.level - a.level)
 
       if (ownedTileEntries.length === 0) return false
@@ -598,6 +644,8 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
         return
       }
       const active = curPlayerRef.current
+      const activePlayerId = getPlayerIdByIndex(active)
+      const activePlayerColor = getPlayerColorByIndex(active)
 
       const actionResult = await gameApi.buyTile(roomId, { tile_index: tileId })
       if (!actionResult.ok) {
@@ -611,8 +659,8 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
         updateTileOwners((prev) => ({
           ...prev,
           [tileId]: {
-            ownerId: active,
-            ownerColor: PLAYER_COLORS[active],
+            ownerId: activePlayerId,
+            ownerColor: activePlayerColor,
             level: 1,
           },
         }))
@@ -690,7 +738,10 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
               return
             }
           }
-          applyMoney(owner.ownerId, +TOLL_COST)
+          const ownerPlayerIndex = getPlayerIndexById(owner.ownerId)
+          if (ownerPlayerIndex >= 0) {
+            applyMoney(ownerPlayerIndex, +TOLL_COST)
+          }
           const bankrupt = applyMoney(active, -TOLL_COST, onDoneCallback)
           if (!bankrupt) advanceTurn(onDoneCallback)
           return

--- a/src/hooks/game/useDiceRoll.ts
+++ b/src/hooks/game/useDiceRoll.ts
@@ -4,6 +4,9 @@ import { socket } from '../../lib/socket'
 import { emitRollDice } from '../../services/socket/game.handler'
 import { useGameStore } from '../../stores/game.store'
 
+const USE_GAME_SOCKET_MOCK =
+  import.meta.env.DEV && import.meta.env.VITE_USE_SOCKET_MOCK !== 'false'
+
 export const useDiceRoll = (boardRef: RefObject<BoardGameHandle | null>) => {
   const currentTurn = useGameStore((state) => state.currentTurn)
 
@@ -14,7 +17,7 @@ export const useDiceRoll = (boardRef: RefObject<BoardGameHandle | null>) => {
       }
 
       // Prefer server-authoritative roll via socket.
-      if (socket.connected && currentTurn) {
+      if (!USE_GAME_SOCKET_MOCK && socket.connected && currentTurn) {
         emitRollDice({ room_id: roomId })
         return
       }

--- a/src/hooks/game/useGameState.ts
+++ b/src/hooks/game/useGameState.ts
@@ -17,7 +17,11 @@ export const useGameState = (roomId: string | null) => {
 
     const teardownHandlers = setupGameHandlers()
 
-    if (!USE_GAME_SOCKET_MOCK && !socket.connected) {
+    // In mock mode, explicitly stop the shared socket so reconnect loops
+    // from previous pages do not keep hitting the real backend endpoint.
+    if (USE_GAME_SOCKET_MOCK) {
+      socket.disconnect()
+    } else if (!socket.connected) {
       connectSocketWithAuthIfNeeded()
     }
 

--- a/src/mocks/handlers/game.handler.ts
+++ b/src/mocks/handlers/game.handler.ts
@@ -114,7 +114,7 @@ const getSellRefund = (tile: Tile, requestedLevel?: number) => {
 }
 
 export const gameHandlers = [
-  http.post('/api/game/roll-dice', async ({ request }) => {
+  http.post('/api/game/:roomId/roll-dice', async ({ request }) => {
     const { player_id } = (await request.json()) as DiceRequestBody
 
     const dice1 = Math.floor(Math.random() * 6) + 1
@@ -162,7 +162,7 @@ export const gameHandlers = [
     })
   }),
 
-  http.get('/api/game/state', async ({ request }) => {
+  http.get('/api/game/:roomId/state', async ({ request }) => {
     const url = new URL(request.url)
     if (url.searchParams.get('reset') === 'true') {
       resetMockGameState()
@@ -172,7 +172,7 @@ export const gameHandlers = [
     return HttpResponse.json(buildStateResponse())
   }),
 
-  http.post('/api/game/buy', async ({ request }) => {
+  http.post('/api/game/:roomId/buy', async ({ request }) => {
     const { tile_index } = (await request.json()) as TileActionRequestBody
     const player = getCurrentPlayer()
     const tile = getTileByIndex(tile_index)
@@ -222,7 +222,7 @@ export const gameHandlers = [
     })
   }),
 
-  http.post('/api/game/build', async ({ request }) => {
+  http.post('/api/game/:roomId/build', async ({ request }) => {
     const { tile_index } = (await request.json()) as TileActionRequestBody
     const player = getCurrentPlayer()
     const tile = getTileByIndex(tile_index)
@@ -271,7 +271,7 @@ export const gameHandlers = [
     })
   }),
 
-  http.post('/api/game/sell', async ({ request }) => {
+  http.post('/api/game/:roomId/sell', async ({ request }) => {
     const { tile_index, level } =
       (await request.json()) as TileActionRequestBody
     const player = getCurrentPlayer()


### PR DESCRIPTION
## 🔗 관련 이슈

> closes #143 
> closes #144 

---

## 📌 작업 내용

- mock 환경에서 게임 페이지 진입 시 공유 소켓이 재연결되지 않도록 정리했습니다.
- mock 모드에서는 주사위 굴리기 소켓 emit 대신 보드 fallback 흐름을 사용하도록 수정했습니다.
- 게임 MSW 핸들러 경로를 `roomId` 기반 API 계약에 맞게 수정했습니다.
  - `GET /api/game/:roomId/state`
  - `POST /api/game/:roomId/buy`
  - `POST /api/game/:roomId/build`
  - `POST /api/game/:roomId/sell`
- 건물 구매 직후 보드에서 건물 SVG가 표시되지 않던 문제를 수정했습니다.
- 서버 응답의 플레이어 id와 보드 내부 플레이어 index가 혼용되던 부분을 정리했습니다.
- 구매/통행료/파산 처리에서 타일 소유자 판정을 `player id` 기준으로 맞췄습니다.
- mock 상태 동기화 시 `building=0`인 구매 직후 타일도 1단계 건물로 올바르게 표시되도록 보정했습니다.

---

## ✅ 체크리스트

- [x] mock 환경에서 게임 페이지 진입 시 소켓 재연결 루프 완화
- [x] mock 환경에서 주사위 -> 구매 흐름 확인 가능
- [x] 건물 구매 후 건물 SVG 렌더링 로직 보정
- [x] `npm run build` 통과
- [x] 워킹트리 clean 확인

---

## 🖼 스크린샷 (선택)

> <img width="900" height="851" alt="image" src="https://github.com/user-attachments/assets/131bdc2e-0f3a-41ae-9dfe-1278b6602b8b" />
