### PR TITLE
test: 로비/접속자/대기방 핵심 회귀 테스트 추가

### DIFF
--- a/src/features/presence/onlineUsersModel.test.ts
+++ b/src/features/presence/onlineUsersModel.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getOnlineUserAvatarBackground,
+  getOnlineUserAvatarText,
+  mapOnlineUsersToViewModel,
+} from './onlineUsersModel'
+
+describe('getOnlineUserAvatarText', () => {
+  it('앞뒤 공백을 제거한 닉네임 첫 글자를 대문자로 반환한다', () => {
+    expect(getOnlineUserAvatarText('  goorm  ')).toBe('G')
+  })
+
+  it('닉네임이 공백이면 기본 문자 ? 를 반환한다', () => {
+    expect(getOnlineUserAvatarText('   ')).toBe('?')
+  })
+})
+
+describe('getOnlineUserAvatarBackground', () => {
+  it('동일 userId에 대해 항상 동일한 배경색을 반환한다', () => {
+    const first = getOnlineUserAvatarBackground('user-100')
+    const second = getOnlineUserAvatarBackground('user-100')
+
+    expect(first).toBe(second)
+  })
+})
+
+describe('mapOnlineUsersToViewModel', () => {
+  it('payload를 렌더링 모델로 매핑하고 avatar 필드를 채운다', () => {
+    const mapped = mapOnlineUsersToViewModel([
+      { id: 'u-1', nickname: 'Alpha', status: 'lobby' },
+      { id: 'u-2', nickname: '   ', status: 'in_room' },
+    ])
+
+    expect(mapped).toHaveLength(2)
+    expect(mapped[0]).toMatchObject({
+      id: 'u-1',
+      nickname: 'Alpha',
+      status: 'lobby',
+      avatarText: 'A',
+    })
+    expect(mapped[1]).toMatchObject({
+      id: 'u-2',
+      nickname: '   ',
+      status: 'in_room',
+      avatarText: '?',
+    })
+    expect(mapped[0].avatarBackground).toBeTruthy()
+    expect(mapped[1].avatarBackground).toBeTruthy()
+  })
+})

--- a/src/features/presence/useOnlineUsersSocket.test.tsx
+++ b/src/features/presence/useOnlineUsersSocket.test.tsx
@@ -1,0 +1,125 @@
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useOnlineUsersSocket } from './useOnlineUsersSocket'
+import type { OnlineUsersEventPayload } from './types'
+
+const {
+  socketOnMock,
+  socketOffMock,
+  getOnlineUsersSnapshotMock,
+  isOnlineUsersSocketMockModeMock,
+  startOnlineUsersMockBroadcastMock,
+  stopMockBroadcastMock,
+  ensureOnlineUsersSocketConnectionMock,
+} = vi.hoisted(() => ({
+  socketOnMock: vi.fn(),
+  socketOffMock: vi.fn(),
+  getOnlineUsersSnapshotMock: vi.fn(),
+  isOnlineUsersSocketMockModeMock: vi.fn(),
+  startOnlineUsersMockBroadcastMock: vi.fn(),
+  stopMockBroadcastMock: vi.fn(),
+  ensureOnlineUsersSocketConnectionMock: vi.fn(),
+}))
+
+vi.mock('../../lib/socket', () => ({
+  socket: {
+    on: socketOnMock,
+    off: socketOffMock,
+  },
+}))
+
+vi.mock('./api', () => ({
+  getOnlineUsersSnapshot: getOnlineUsersSnapshotMock,
+}))
+
+vi.mock('./onlineUsersSocket', () => ({
+  ONLINE_USERS_EVENT_NAME: 'online_users',
+  isOnlineUsersSocketMockMode: isOnlineUsersSocketMockModeMock,
+  startOnlineUsersMockBroadcast: startOnlineUsersMockBroadcastMock,
+  ensureOnlineUsersSocketConnection: ensureOnlineUsersSocketConnectionMock,
+}))
+
+// 등록된 online_users 핸들러를 찾아 테스트에서 직접 호출
+function getRegisteredOnlineUsersHandler() {
+  const targetCall = socketOnMock.mock.calls.find(
+    (call) => call[0] === 'online_users'
+  )
+
+  if (!targetCall) {
+    return null
+  }
+
+  return targetCall[1] as (payload: OnlineUsersEventPayload) => void
+}
+
+describe('useOnlineUsersSocket', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    isOnlineUsersSocketMockModeMock.mockReturnValue(false)
+    getOnlineUsersSnapshotMock.mockResolvedValue([])
+    startOnlineUsersMockBroadcastMock.mockReturnValue(stopMockBroadcastMock)
+  })
+
+  it('실소켓 모드에서 초기 REST 스냅샷을 반영한다', async () => {
+    getOnlineUsersSnapshotMock.mockResolvedValue([
+      { id: 'user-1', nickname: 'Goorm', status: 'lobby' },
+    ])
+
+    const { result } = renderHook(() => useOnlineUsersSocket())
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    expect(result.current.isError).toBe(false)
+    expect(result.current.data).toHaveLength(1)
+    expect(result.current.data[0]).toMatchObject({
+      id: 'user-1',
+      nickname: 'Goorm',
+      status: 'lobby',
+      avatarText: 'G',
+    })
+    expect(ensureOnlineUsersSocketConnectionMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('online_users 이벤트 수신 시 접속자 목록을 갱신한다', async () => {
+    const { result } = renderHook(() => useOnlineUsersSocket())
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    const handler = getRegisteredOnlineUsersHandler()
+    expect(handler).not.toBeNull()
+
+    act(() => {
+      handler?.({
+        users: [{ id: 'user-2', nickname: '  alpha ', status: 'in_room' }],
+      })
+    })
+
+    expect(result.current.data).toHaveLength(1)
+    expect(result.current.data[0]).toMatchObject({
+      id: 'user-2',
+      status: 'in_room',
+      avatarText: 'A',
+    })
+  })
+
+  it('cleanup 시 구독 해제와 mock 브로드캐스트 정리를 수행한다', () => {
+    isOnlineUsersSocketMockModeMock.mockReturnValue(true)
+
+    const { unmount } = renderHook(() => useOnlineUsersSocket())
+
+    expect(startOnlineUsersMockBroadcastMock).toHaveBeenCalledTimes(1)
+
+    unmount()
+
+    expect(stopMockBroadcastMock).toHaveBeenCalledTimes(1)
+    expect(socketOffMock).toHaveBeenCalledWith(
+      'online_users',
+      expect.any(Function)
+    )
+  })
+})

--- a/src/pages/waiting-room/controller/state.test.ts
+++ b/src/pages/waiting-room/controller/state.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+import { buildWaitingRoomSeats, getStartConditionMet } from './state'
+import type { WaitingRoomSnapshot } from '../types'
+
+// 테스트 기본 대기방 스냅샷 생성
+function createWaitingRoomSnapshot(
+  overrides?: Partial<WaitingRoomSnapshot>
+): WaitingRoomSnapshot {
+  return {
+    roomId: 'room-1',
+    title: '테스트 방',
+    status: 'waiting',
+    maxPlayers: 4,
+    isPrivate: false,
+    players: [
+      { id: 'host-1', nickname: 'Host', isReady: false, isHost: true },
+      { id: 'user-1', nickname: 'User1', isReady: true, isHost: false },
+    ],
+    chatMessages: [],
+    ...overrides,
+  }
+}
+
+describe('getStartConditionMet', () => {
+  it('방이 없으면 false를 반환한다', () => {
+    expect(getStartConditionMet(null)).toBe(false)
+  })
+
+  it('인원이 2명 미만이면 false를 반환한다', () => {
+    const room = createWaitingRoomSnapshot({
+      players: [
+        { id: 'host-1', nickname: 'Host', isReady: false, isHost: true },
+      ],
+    })
+
+    expect(getStartConditionMet(room)).toBe(false)
+  })
+
+  it('방장 제외 전원이 준비 완료면 true를 반환한다', () => {
+    const room = createWaitingRoomSnapshot({
+      players: [
+        { id: 'host-1', nickname: 'Host', isReady: false, isHost: true },
+        { id: 'user-1', nickname: 'User1', isReady: true, isHost: false },
+        { id: 'user-2', nickname: 'User2', isReady: true, isHost: false },
+      ],
+    })
+
+    expect(getStartConditionMet(room)).toBe(true)
+  })
+
+  it('방장 제외 인원 중 미준비자가 있으면 false를 반환한다', () => {
+    const room = createWaitingRoomSnapshot({
+      players: [
+        { id: 'host-1', nickname: 'Host', isReady: false, isHost: true },
+        { id: 'user-1', nickname: 'User1', isReady: true, isHost: false },
+        { id: 'user-2', nickname: 'User2', isReady: false, isHost: false },
+      ],
+    })
+
+    expect(getStartConditionMet(room)).toBe(false)
+  })
+})
+
+describe('buildWaitingRoomSeats', () => {
+  it('방이 없으면 기본 정원 크기의 빈 좌석 배열을 반환한다', () => {
+    const seats = buildWaitingRoomSeats(null, 'user-1')
+
+    expect(seats).toHaveLength(4)
+    expect(seats.every((seat) => seat === null)).toBe(true)
+  })
+
+  it('플레이어 좌석을 채우고 내 좌석을 isMe=true로 표시한다', () => {
+    const room = createWaitingRoomSnapshot()
+
+    const seats = buildWaitingRoomSeats(room, 'user-1')
+
+    expect(seats).toHaveLength(4)
+    expect(seats[0]?.id).toBe('host-1')
+    expect(seats[1]?.id).toBe('user-1')
+    expect(seats[1]?.isMe).toBe(true)
+    expect(seats[2]).toBeNull()
+    expect(seats[0]?.avatarColor).toBeTruthy()
+  })
+
+  it('maxPlayers를 초과한 플레이어는 좌석에 배치하지 않는다', () => {
+    const room = createWaitingRoomSnapshot({
+      maxPlayers: 2,
+      players: [
+        { id: 'host-1', nickname: 'Host', isReady: false, isHost: true },
+        { id: 'user-1', nickname: 'User1', isReady: true, isHost: false },
+        { id: 'user-2', nickname: 'User2', isReady: true, isHost: false },
+      ],
+    })
+
+    const seats = buildWaitingRoomSeats(room, 'user-2')
+
+    expect(seats).toHaveLength(2)
+    expect(seats[0]?.id).toBe('host-1')
+    expect(seats[1]?.id).toBe('user-1')
+  })
+})


### PR DESCRIPTION
## 📌 관련 이슈

> closes #156 

---

## 📝 작업 내용

- 핵심 상태 전환 로직에 대한 회귀 테스트를 추가했습니다.
- 대기방 순수 로직 테스트 추가
  - `getStartConditionMet`
  - `buildWaitingRoomSeats`
- 접속자 모델 매핑 테스트 추가
  - 닉네임/아바타 텍스트/배경색 매핑
- 접속자 훅 테스트 추가
  - 초기 REST 스냅샷 반영
  - `online_users` 이벤트 수신 반영
  - cleanup 시 구독 해제 및 mock 브로드캐스트 정리

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

> UI 변경 없음 (N/A)

---

## 🔍 검증 결과

- `npm run test` 통과  
  - Test Files: 3 passed  
  - Tests: 14 passed
- `npm run lint` 통과
- `npm run build` 통과
