### PR TITLE
refactor: 하드 코딩 된부분 명세서 대로 리펙토링 하기

### DIFF
--- a/src/components/board/BoardTile.tsx
+++ b/src/components/board/BoardTile.tsx
@@ -7,6 +7,7 @@ import {
   TileOwner,
 } from './board.constants'
 import BuildingBadge from './BuildingBadge'
+import { formatWon } from '../../lib/utils'
 
 // ─── PlayerToken ─────────────────────────────────────────────────
 interface TokenProps {
@@ -98,7 +99,7 @@ const BoardTile: React.FC<BoardTileProps> = ({
   const hasIcon = !!(tile.svgIcon || tile.emoji)
 
   // ── 코너 ─────────────────────────────────────────────────────────
-  if (dir === 'corner') {
+  if (['start', 'island', 'travel', 'go_to_island'].includes(tile.type)) {
     return (
       <div
         style={{
@@ -207,11 +208,20 @@ const BoardTile: React.FC<BoardTileProps> = ({
               />
             )}
             {isCity && (
-              <span
-                style={{ fontSize: 6.5, color: '#9CA3AF', fontWeight: 600 }}
+              <div
+                style={{
+                  backgroundColor: '#F1F5F9',
+                  color: '#64748B',
+                  fontSize: 7,
+                  fontWeight: 800,
+                  padding: '2px 5px',
+                  borderRadius: 8,
+                  marginTop: 'auto',
+                  boxShadow: '0 1px 2px rgba(0,0,0,0.05)',
+                }}
               >
-                60M
-              </span>
+                {formatWon(tile.price ?? 0)}
+              </div>
             )}
           </div>
         </div>
@@ -311,11 +321,20 @@ const BoardTile: React.FC<BoardTileProps> = ({
               />
             )}
             {isCity && (
-              <span
-                style={{ fontSize: 6.5, color: '#9CA3AF', fontWeight: 600 }}
+              <div
+                style={{
+                  backgroundColor: '#F1F5F9',
+                  color: '#64748B',
+                  fontSize: 7,
+                  fontWeight: 800,
+                  padding: '2px 5px',
+                  borderRadius: 8,
+                  marginTop: 'auto',
+                  boxShadow: '0 1px 2px rgba(0,0,0,0.05)',
+                }}
               >
-                60M
-              </span>
+                {formatWon(tile.price ?? 0)}
+              </div>
             )}
           </div>
         </div>

--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -24,10 +24,32 @@ import {
   BuildingLevel,
 } from './board.constants'
 import '../../styles/board.css'
+import { formatWon } from '../../lib/utils'
 
-const PURCHASE_COST = 60
-const UPGRADE_COST = 30
-const TOLL_COST = 30
+// cost helpers are computed per-tile based on price
+
+function getPurchaseCost(tileId: number): number {
+  return TILES[tileId]?.price ?? 0
+}
+
+function getUpgradeCost(price: number, currentLevel: BuildingLevel): number {
+  if (currentLevel === 0) return price * 0.5
+  if (currentLevel === 1) return price * 0.5
+  if (currentLevel === 2) return price * 0.5
+  if (currentLevel === 3) return price * 1.0
+  if (currentLevel === 4) return price * 1.5
+  return 0
+}
+
+function calcToll(price: number, level: BuildingLevel): number {
+  if (level === 0) return price
+  if (level === 1) return price * 2
+  if (level === 2) return price * 3
+  if (level === 3) return price * 5
+  if (level === 4) return price * 7
+  if (level === 5) return price * 10
+  return price
+}
 
 const USE_GAME_SOCKET_MOCK =
   import.meta.env.DEV && import.meta.env.VITE_USE_SOCKET_MOCK !== 'false'
@@ -392,7 +414,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       open: false,
       tileId: null,
       ownerName: '',
-      tollText: `${TOLL_COST}M`,
+      tollText: '',
     })
     const [aiModal, setAiModal] = useState<AIPenaltyModalState>({
       open: false,
@@ -532,10 +554,14 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
 
           const movedPlayers = playersRef.current.map((p, i) => {
             if (i !== activeCurPlayer) return p
-            const newPos = (p.pos + total) % TILES.length
-            setStatus(
-              `${p.name} \u2192 ${TILES[newPos].name} (+${total}\uCE78)`
-            )
+            let newPos = (p.pos + total) % TILES.length
+            // 탈출칸 이동 처리
+            if (TILES[newPos].type === 'go_to_island') {
+              newPos = 8
+              setStatus(`${p.name} 무인도로 이동!`)
+            } else {
+              setStatus(`${p.name} → ${TILES[newPos].name} (+${total}칸)`)
+            }
             return { ...p, pos: newPos }
           })
           playersRef.current = movedPlayers
@@ -549,6 +575,8 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
             if (tile.type === 'city') {
               const owner = tileOwnersRef.current[landedTileId]
               const activePlayer = movedPlayers[activeCurPlayer]
+              const price = tile.price ?? 0
+
               if (!owner) {
                 setBuyModal({
                   open: true,
@@ -569,11 +597,12 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
                 const ownerPlayer = playersRef.current.find(
                   (p) => p.id === owner.ownerId
                 )
+                const tollAmount = calcToll(price, owner.level)
                 setTollModal({
                   open: true,
                   tileId: landedTileId,
                   ownerName: ownerPlayer?.name ?? DEFAULT_OPPONENT_NAME,
-                  tollText: `${TOLL_COST}M`,
+                  tollText: formatWon(tollAmount),
                   onDoneCallback: onDone,
                 })
               }
@@ -611,9 +640,16 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       return '\uC694\uCCAD \uCC98\uB9AC \uC911 \uC624\uB958\uAC00 \uBC1C\uC0DD\uD588\uC2B5\uB2C8\uB2E4.'
     }
 
-    function getSellFallbackRefund(level: BuildingLevel) {
-      if (level <= 0) return 0
-      return PURCHASE_COST + Math.max(0, level - 1) * UPGRADE_COST
+    function getSellFallbackRefund(tileId: number, level: BuildingLevel) {
+      // calculate how much to refund when the server sync fails
+      // start with purchase price plus each upgrade cost up to current level
+      const basePrice = TILES[tileId]?.price ?? 0
+      if (level <= 0 || basePrice === 0) return 0
+      let refund = basePrice
+      for (let l = 1; l < level; l++) {
+        refund += getUpgradeCost(basePrice, l as BuildingLevel)
+      }
+      return refund
     }
 
     async function sellOwnedTileForPlayer(playerIdx: number) {
@@ -645,7 +681,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
           delete next[tileId]
           return next
         })
-        applyMoney(playerIdx, +getSellFallbackRefund(owner.level))
+        applyMoney(playerIdx, +getSellFallbackRefund(tileId, owner.level))
       }
 
       return true
@@ -661,6 +697,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       const active = curPlayerRef.current
       const activePlayerId = getPlayerIdByIndex(active)
       const activePlayerColor = getPlayerColorByIndex(active)
+      const price = getPurchaseCost(tileId)
 
       const actionResult = await gameApi.buyTile(roomId, { tile_index: tileId })
       if (!actionResult.ok) {
@@ -669,7 +706,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       }
 
       setBuyModal({ open: false, tileId: null })
-      const bankrupt = applyMoney(active, -PURCHASE_COST, onDoneCallback)
+      const bankrupt = applyMoney(active, -price, onDoneCallback)
       if (!bankrupt) {
         updateTileOwners((prev) => ({
           ...prev,
@@ -697,6 +734,9 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
         return
       }
       const active = curPlayerRef.current
+      const owner = tileOwnersRef.current[tileId]
+      const price = getPurchaseCost(tileId)
+      const upgradeCost = owner ? getUpgradeCost(price, owner.level) : 0
 
       const actionResult = await gameApi.buildTile(roomId, {
         tile_index: tileId,
@@ -707,7 +747,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       }
 
       setBuildModal({ open: false, tileId: null })
-      const bankrupt = applyMoney(active, -UPGRADE_COST, onDoneCallback)
+      const bankrupt = applyMoney(active, -upgradeCost, onDoneCallback)
       if (!bankrupt) {
         updateTileOwners((prev) => {
           const existing = prev[tileId]
@@ -737,25 +777,27 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
         open: false,
         tileId: null,
         ownerName: '',
-        tollText: `${TOLL_COST}M`,
+        tollText: '',
       })
 
       if (tileId !== null) {
         const owner = tileOwnersRef.current[tileId]
+        const price = TILES[tileId]?.price ?? 0
+        const tollAmount = owner ? calcToll(price, owner.level) : 0
         if (owner) {
-          if (playersRef.current[active].money < TOLL_COST) {
+          if (playersRef.current[active].money < tollAmount) {
             const sold = await sellOwnedTileForPlayer(active)
             if (!sold) {
-              const bankrupt = applyMoney(active, -TOLL_COST, onDoneCallback)
+              const bankrupt = applyMoney(active, -tollAmount, onDoneCallback)
               if (!bankrupt) advanceTurn(onDoneCallback)
               return
             }
           }
           const ownerPlayerIndex = getPlayerIndexById(owner.ownerId)
           if (ownerPlayerIndex >= 0) {
-            applyMoney(ownerPlayerIndex, +TOLL_COST)
+            applyMoney(ownerPlayerIndex, +tollAmount)
           }
-          const bankrupt = applyMoney(active, -TOLL_COST, onDoneCallback)
+          const bankrupt = applyMoney(active, -tollAmount, onDoneCallback)
           if (!bankrupt) advanceTurn(onDoneCallback)
           return
         }
@@ -875,8 +917,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
         <BuyModal
           open={buyModal.open}
           cityName={buyTile?.name ?? ''}
-          purchaseCostText={`${PURCHASE_COST}M`}
-          tollText={`${TOLL_COST}M`}
+          purchaseCostText={formatWon(buyTile?.price ?? 0)}
           isUpgrade={false}
           currentLevel={0}
           onPass={handleBuyPass}
@@ -888,8 +929,12 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
           upgradeStage={getUpgradeStage(currentLevel)}
           currentLevelLabel={LEVEL_LABEL[currentLevel]}
           nextLevelLabel={LEVEL_LABEL[Math.min(currentLevel + 1, 5)]}
-          buildCostText={`${UPGRADE_COST}M`}
-          nextTollText="60M"
+          buildCostText={formatWon(
+            getUpgradeCost(buildTile?.price ?? 0, currentLevel)
+          )}
+          nextTollText={formatWon(
+            calcToll(buildTile?.price ?? 0, (currentLevel + 1) as BuildingLevel)
+          )}
           canBuild={currentLevel < 5}
           onCancel={handleBuildCancel}
           onConfirm={handleBuildConfirm}

--- a/src/components/board/PlayerPiece.tsx
+++ b/src/components/board/PlayerPiece.tsx
@@ -1,6 +1,7 @@
 ﻿// PlayerPanel.tsx — isActive 일 때 파란 테두리 강조
 // 이미 구현되어 있다면 이 파일은 무시하세요.
 import React from 'react'
+import { formatWon } from '../../lib/utils'
 
 interface Player {
   id: string
@@ -62,11 +63,10 @@ const PlayerPanel: React.FC<PlayerPanelProps> = ({ player, isActive }) => {
 
         <div className="flex flex-col items-end">
           <span className="text-[17px] font-black text-[#1F2A44]">
-            {(player.money ?? 0).toLocaleString()}M
+            {formatWon(player.money ?? 0)}
           </span>
           <span className="text-[11px] text-[#8B9AB0]">
-            🏠 총자산{' '}
-            {(player.totalAssets ?? player.money ?? 0).toLocaleString()}M
+            🏠 총자산 {formatWon(player.totalAssets ?? player.money ?? 0)}
           </span>
         </div>
       </div>

--- a/src/components/board/board.constants.ts
+++ b/src/components/board/board.constants.ts
@@ -1,4 +1,12 @@
-﻿export type TileType = 'corner' | 'city' | 'chance' | 'event' | 'ai'
+﻿export type TileType =
+  | 'start'
+  | 'island'
+  | 'travel'
+  | 'go_to_island'
+  | 'city'
+  | 'chance'
+  | 'event'
+  | 'ai'
 export type TileDir = 'top' | 'bottom' | 'left' | 'right' | 'corner'
 
 // 0: 미구매, 1: 집1, 2: 집2, 3: 집3, 4: 호텔, 5: 랜드마크
@@ -17,6 +25,7 @@ export interface TileData {
   color?: string
   emoji?: string
   svgIcon?: string
+  price?: number
 }
 
 export interface PlayerState {
@@ -28,38 +37,38 @@ export interface PlayerState {
 }
 
 export const TILES: TileData[] = [
-  { id: 0, name: 'START', type: 'corner', emoji: '🚩' },
-  { id: 1, name: '수원', type: 'city', color: '#EF5350' },
-  { id: 2, name: '용인', type: 'city', color: '#FFD15B' },
+  { id: 0, name: 'START', type: 'start', emoji: '🚩' },
+  { id: 1, name: '수원', type: 'city', color: '#EF5350', price: 100000000 },
+  { id: 2, name: '용인', type: 'city', color: '#FFD15B', price: 120000000 },
   { id: 3, name: '?', type: 'chance', svgIcon: '/event-question.svg' },
-  { id: 4, name: '군산', type: 'city', color: '#66BB6A' },
-  { id: 5, name: '평택', type: 'city', color: '#42A5F5' },
-  { id: 6, name: '익산', type: 'city', color: '#42A5F5' },
+  { id: 4, name: '군산', type: 'city', color: '#66BB6A', price: 140000000 },
+  { id: 5, name: '평택', type: 'city', color: '#42A5F5', price: 160000000 },
+  { id: 6, name: '익산', type: 'city', color: '#42A5F5', price: 180000000 },
   { id: 7, name: '이벤트', type: 'event', svgIcon: '/chance-box.svg' },
-  { id: 8, name: '무인도', type: 'corner', emoji: '🏝️' },
-  { id: 9, name: '앙양', type: 'city', color: '#FF7043' },
+  { id: 8, name: '무인도', type: 'island', emoji: '🏝️' },
+  { id: 9, name: '경주', type: 'city', color: '#FF7043', price: 200000000 },
   { id: 10, name: '?', type: 'chance', svgIcon: '/event-question.svg' },
-  { id: 11, name: '용포', type: 'city', color: '#26A69A' },
-  { id: 12, name: '나포', type: 'city', color: '#66BB6A' },
-  { id: 13, name: '포포', type: 'city', color: '#7E57C2' },
-  { id: 14, name: '목포', type: 'city', color: '#EF5350' },
-  { id: 15, name: '여수', type: 'city', color: '#EF5350' },
-  { id: 16, name: '국내여행', type: 'corner', emoji: '✈️' },
-  { id: 17, name: '제주', type: 'city', color: '#42A5F5' },
-  { id: 18, name: '여수', type: 'city', color: '#26A69A' },
-  { id: 19, name: '광주', type: 'city', color: '#66BB6A' },
+  { id: 11, name: '포항', type: 'city', color: '#26A69A', price: 240000000 },
+  { id: 12, name: '대구', type: 'city', color: '#66BB6A', price: 280000000 },
+  { id: 13, name: '청원', type: 'city', color: '#7E57C2', price: 320000000 },
+  { id: 14, name: '울산', type: 'city', color: '#EF5350', price: 360000000 },
+  { id: 15, name: '부산', type: 'city', color: '#EF5350', price: 400000000 },
+  { id: 16, name: '국내여행', type: 'travel', emoji: '✈️' },
+  { id: 17, name: '제주', type: 'city', color: '#42A5F5', price: 500000000 },
+  { id: 18, name: '여수', type: 'city', color: '#26A69A', price: 550000000 },
+  { id: 19, name: '광주', type: 'city', color: '#66BB6A', price: 600000000 },
   { id: 20, name: 'AI', type: 'ai', color: '#111111', svgIcon: '/ai-head.png' },
-  { id: 21, name: '춘천', type: 'city', color: '#7E57C2' },
-  { id: 22, name: '강릉', type: 'city', color: '#7E57C2' },
-  { id: 23, name: '원주', type: 'city', color: '#FF7043' },
-  { id: 24, name: '무인도\n이동칸', type: 'corner', emoji: '👮' },
-  { id: 25, name: '춘포', type: 'city', color: '#42A5F5' },
-  { id: 26, name: '원포', type: 'city', color: '#42A5F5' },
+  { id: 21, name: '춘천', type: 'city', color: '#7E57C2', price: 650000000 },
+  { id: 22, name: '강릉', type: 'city', color: '#7E57C2', price: 700000000 },
+  { id: 23, name: '원주', type: 'city', color: '#FF7043', price: 750000000 },
+  { id: 24, name: '무인도\n이동칸', type: 'go_to_island', emoji: '👮' },
+  { id: 25, name: '청주', type: 'city', color: '#42A5F5', price: 800000000 },
+  { id: 26, name: '천안', type: 'city', color: '#42A5F5', price: 900000000 },
   { id: 27, name: '?', type: 'chance', svgIcon: '/event-question.svg' },
-  { id: 28, name: '대전', type: 'city', color: '#66BB6A' },
-  { id: 29, name: '인천', type: 'city', color: '#7E57C2' },
+  { id: 28, name: '대전', type: 'city', color: '#66BB6A', price: 1000000000 },
+  { id: 29, name: '인천', type: 'city', color: '#7E57C2', price: 1100000000 },
   { id: 30, name: '이벤트', type: 'event', svgIcon: '/chance-box.svg' },
-  { id: 31, name: '서울', type: 'city', color: '#FF7043' },
+  { id: 31, name: '서울', type: 'city', color: '#FF7043', price: 1200000000 },
 ]
 
 export const TOP_ROW = [16, 17, 18, 19, 20, 21, 22, 23, 24]
@@ -74,10 +83,34 @@ export const GRID_GAP = 2
 export const PLAYER_COLORS = ['#EF5350', '#42A5F5', '#66BB6A', '#FFD15B']
 
 export const INIT_PLAYERS: PlayerState[] = [
-  { id: 0, name: 'GoormEE', color: PLAYER_COLORS[0], pos: 0, money: 2000 },
-  { id: 1, name: 'MarbleKing', color: PLAYER_COLORS[1], pos: 0, money: 1800 },
-  { id: 2, name: 'Player 3', color: PLAYER_COLORS[2], pos: 0, money: 1500 },
-  { id: 3, name: 'Player 4', color: PLAYER_COLORS[3], pos: 0, money: 1400 },
+  {
+    id: 0,
+    name: 'GoormEE',
+    color: PLAYER_COLORS[0],
+    pos: 0,
+    money: 1000000000,
+  },
+  {
+    id: 1,
+    name: 'MarbleKing',
+    color: PLAYER_COLORS[1],
+    pos: 0,
+    money: 1000000000,
+  },
+  {
+    id: 2,
+    name: 'Player 3',
+    color: PLAYER_COLORS[2],
+    pos: 0,
+    money: 1000000000,
+  },
+  {
+    id: 3,
+    name: 'Player 4',
+    color: PLAYER_COLORS[3],
+    pos: 0,
+    money: 1000000000,
+  },
 ]
 
 export function getStripColor(tile: TileData): string | null {
@@ -86,4 +119,30 @@ export function getStripColor(tile: TileData): string | null {
   if (tile.type === 'chance') return '#FFD15B'
   if (tile.type === 'ai') return tile.color ?? '#111111'
   return null
+}
+
+export function getBuildCost(
+  basePrice: number,
+  currentLevel: BuildingLevel
+): number {
+  if (currentLevel === 0) return basePrice * 0.5 // 집 1채
+  if (currentLevel === 1) return basePrice * 0.5 // 집 2채
+  if (currentLevel === 2) return basePrice * 0.5 // 집 3채
+  if (currentLevel === 3) return basePrice * 1.0 // 호텔
+  if (currentLevel === 4) return basePrice * 1.5 // 랜드마크
+  return 0
+}
+
+export function getTollCost(
+  basePrice: number,
+  currentLevel: BuildingLevel
+): number {
+  // 기본 통행료 = basePrice
+  if (currentLevel === 0) return basePrice
+  if (currentLevel === 1) return basePrice * 2
+  if (currentLevel === 2) return basePrice * 3
+  if (currentLevel === 3) return basePrice * 5
+  if (currentLevel === 4) return basePrice * 7
+  if (currentLevel === 5) return basePrice * 10
+  return basePrice
 }

--- a/src/components/game/modals/BuyModal.tsx
+++ b/src/components/game/modals/BuyModal.tsx
@@ -13,7 +13,6 @@ interface BuyModalProps {
   open: boolean
   cityName?: string
   purchaseCostText?: string
-  tollText?: string
   isUpgrade?: boolean
   currentLevel?: number
   onPass?: () => void
@@ -22,13 +21,11 @@ interface BuyModalProps {
 
 const DEFAULT_CITY_NAME = '대구'
 const DEFAULT_PURCHASE_COST_TEXT = '6칸'
-const DEFAULT_TOLL_TEXT = '6칸'
 
 const BuyModal: React.FC<BuyModalProps> = ({
   open,
   cityName = DEFAULT_CITY_NAME,
   purchaseCostText = DEFAULT_PURCHASE_COST_TEXT,
-  tollText = DEFAULT_TOLL_TEXT,
   isUpgrade = false,
   currentLevel = 0,
   onPass,
@@ -54,7 +51,7 @@ const BuyModal: React.FC<BuyModalProps> = ({
           {isUpgrade ? '도시 업그레이드' : '도시 구매'}
         </h2>
 
-        <p className="text-center text-[36px] font-extrabold leading-[1.3] text-[#5A6D8A]">
+        <p className="text-center text-[36px] font-extrabold leading-[1.3] text-[#5A6D8A] mb-10 mt-4">
           <span className="text-[#245FE5]">{cityName}</span>{' '}
           <span>({purchaseCostText})을(를)</span>
           <br />
@@ -69,10 +66,6 @@ const BuyModal: React.FC<BuyModalProps> = ({
           ) : (
             <span>구매하시겠습니까?</span>
           )}
-        </p>
-
-        <p className="mb-10 mt-4 text-center text-[32px] font-bold leading-[1.35] text-[#5A6D8A]">
-          건설 후 통행료는 {tollText} 입니다
         </p>
 
         <div className="flex items-center justify-center gap-4">

--- a/src/components/game/panels/PlayerPanel.tsx
+++ b/src/components/game/panels/PlayerPanel.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { formatWon } from '../../../lib/utils'
 
 interface Player {
   id: string
@@ -102,7 +103,7 @@ const PlayerPanel: React.FC<PlayerPanelProps> = ({
         <div className="flex items-center justify-between">
           <span className="text-[13px] text-[#8B9AB0]">보유금</span>
           <span className="text-[20px] font-black text-[#1F2A44]">
-            {money.toLocaleString()}M
+            {formatWon(money)}
           </span>
         </div>
 
@@ -113,7 +114,7 @@ const PlayerPanel: React.FC<PlayerPanelProps> = ({
             <span>총자산</span>
           </span>
           <span className="text-[13px] text-[#B0BBC8]">
-            {totalAssets.toLocaleString()}M
+            {formatWon(totalAssets)}
           </span>
         </div>
       </div>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,3 +5,37 @@ import { twMerge } from 'tailwind-merge'
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+// 숫자를 한국 원화 표기법으로 변환합니다.
+// 예: 100000000 -> "1억", 150000000 -> "1억5000만", 105000000 -> "1억500만"
+export function formatWon(value: number): string {
+  if (!value) return '0'
+  const eok = Math.floor(value / 100000000)
+  const man = Math.floor((value % 100000000) / 10000)
+
+  let result = ''
+  if (eok > 0) result += `${eok}억`
+
+  if (man > 0) {
+    if (result.length > 0) result += ' '
+
+    let manStr = ''
+    const cheon = Math.floor(man / 1000)
+    const baek = Math.floor((man % 1000) / 100)
+    const sip = Math.floor((man % 100) / 10)
+    const il = man % 10
+
+    if (cheon > 0) manStr += `${cheon}천`
+    if (baek > 0) manStr += `${baek}백`
+    if (sip > 0) manStr += `${sip}십`
+    if (il > 0) manStr += `${il}`
+
+    if (eok > 0 && il === 0) {
+      result += `${manStr}`
+    } else {
+      result += `${manStr}만`
+    }
+  }
+
+  return result || '0'
+}

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -2,6 +2,9 @@ export type BuildingLevel = 0 | 1 | 2 | 3 | 4 | 5
 
 export type TileType =
   | 'start'
+  | 'island'
+  | 'travel'
+  | 'go_to_island'
   | 'property'
   | 'chance'
   | 'jail'
@@ -10,7 +13,6 @@ export type TileType =
   | 'penalty'
   | 'airport'
   | 'card'
-  | 'corner'
   | 'city'
   | 'event'
   | 'ai'


### PR DESCRIPTION
## 📌 관련 이슈

> closes  #153


---

## 📝 작업 내용

> TileType 수정: 명세서 키워드(start, island, travel 등) 추가.

TILES 배열 업데이트: 명세서 G-028에 정의된 **인덱스(0~31)**와 이름, 가격으로 전면 교체.

PlayerState 수정: money 초기값을 1,000,000,000(10억)으로 변경.

GameBoard.tsx

비용 상수 제거: 상단에 적힌 const PURCHASE_COST = 60 등을 삭제하고, 타일에 정의된 price를 사용하도록 수정.

특수 칸 로직 연결: * if (tile.type === 'ai') → 25번 칸 도달 시 처리.

통행료 계산: 명세서의 통행료 공식(티어별 기본 통행료 등)을 반영.

무인도으로 강제 이동 로직 추가.

BoardTile.tsx

조건부 렌더링 수정: if (dir === 'corner') 대신 명세서 타입인 if (['start', 'island', 'travel', 'go_to_island'].includes(tile.type)) 처럼 변경.

금액 표기 로직: 타일 하단에 60M이라고 고정된 텍스트를 (tile.price / 1000000) + 'M' 처럼 실제 데이터 기반으로 변경.

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

<img width="1585" height="853" alt="스크린샷 2026-03-03 오후 2 20 39" src="https://github.com/user-attachments/assets/94e85210-44e2-4898-9a84-8b6d3ceed121" />

