### PR TITLE
feat: DEV 대기방 Mock Control 패널 추가 및 참가자 제거 버그 수정

### DIFF
--- a/src/pages/waiting-room/WaitingRoomPage.tsx
+++ b/src/pages/waiting-room/WaitingRoomPage.tsx
@@ -15,6 +15,7 @@ import { cn } from '../../lib/utils'
 import { WaitingRoomHeader } from './components/WaitingRoomHeader'
 import { WaitingSeatCard } from './components/WaitingSeatCard'
 import { WaitingRoomSidePanel } from './components/WaitingRoomSidePanel'
+import { DevMockControlPanel } from './components/DevMockControlPanel'
 import { useWaitingRoomController } from './hooks'
 import type { GameStartEventPayload, WaitingRoomSnapshot } from './types'
 
@@ -83,6 +84,7 @@ function WaitingRoomPage() {
     handleToggleReady,
     handleStartGame,
     leaveRoom,
+    applyRoomSnapshot,
   } = useWaitingRoomController({
     roomId: currentRoomId,
     session,
@@ -319,6 +321,15 @@ function WaitingRoomPage() {
           aria-hidden
         />
       )}
+
+      <DevMockControlPanel
+        roomId={currentRoomId}
+        currentUserId={session.userId}
+        onApplySnapshot={applyRoomSnapshot}
+        onError={(message) => {
+          toast.error(message)
+        }}
+      />
 
       {dmTargetUser ? (
         <DirectMessagePanel

--- a/src/pages/waiting-room/components/DevMockControlPanel.tsx
+++ b/src/pages/waiting-room/components/DevMockControlPanel.tsx
@@ -1,0 +1,134 @@
+import { useState } from 'react'
+import { getWaitingRoomErrorMessage } from '../api'
+import {
+  mockDevAddWaitingRoomParticipant,
+  mockDevGetWaitingRoomSnapshot,
+  mockDevRemoveWaitingRoomParticipant,
+  mockDevSeedStartCondition,
+  mockDevSetAllNonHostReady,
+} from '../mockGateway'
+import type { WaitingRoomSnapshot } from '../types'
+
+const IS_DEV_MOCK_CONTROL_ENABLED =
+  import.meta.env.DEV && import.meta.env.VITE_USE_SOCKET_MOCK !== 'false'
+
+// DEV 목 제어 패널 입력값 타입
+interface DevMockControlPanelProps {
+  roomId: string
+  currentUserId: string
+  onApplySnapshot: (snapshot: WaitingRoomSnapshot) => void
+  onError: (message: string) => void
+}
+
+// DEV 환경에서만 방 상태를 수동 제어하는 디버그 패널
+export function DevMockControlPanel({
+  roomId,
+  currentUserId,
+  onApplySnapshot,
+  onError,
+}: DevMockControlPanelProps) {
+  const [pendingAction, setPendingAction] = useState<string | null>(null)
+
+  if (!IS_DEV_MOCK_CONTROL_ENABLED || !roomId) {
+    return null
+  }
+
+  // 액션 실행 결과 스냅샷을 화면에 반영하고 에러를 공통 처리
+  function runAction(actionName: string, action: () => WaitingRoomSnapshot) {
+    setPendingAction(actionName)
+
+    try {
+      const snapshot = action()
+      onApplySnapshot(snapshot)
+    } catch (error) {
+      onError(getWaitingRoomErrorMessage(error, 'DEV 목 제어에 실패했습니다.'))
+    } finally {
+      setPendingAction(null)
+    }
+  }
+
+  const isDisabled = pendingAction !== null
+
+  return (
+    <aside className="fixed bottom-4 left-4 z-50 w-[250px] rounded-2xl border border-ui-border bg-white/95 p-3 shadow-xl backdrop-blur">
+      <h3 className="text-xs font-extrabold tracking-wide text-ui-text-main">
+        DEV MOCK CONTROL
+      </h3>
+      <p className="mt-1 text-[11px] text-ui-text-sub">{roomId}</p>
+
+      <div className="mt-3 grid grid-cols-2 gap-2">
+        <button
+          type="button"
+          disabled={isDisabled}
+          onClick={() => {
+            runAction('sync', () => mockDevGetWaitingRoomSnapshot(roomId))
+          }}
+          className="rounded-lg border border-ui-border bg-white px-2 py-1.5 text-xs font-semibold text-ui-text-main disabled:opacity-50"
+        >
+          동기화
+        </button>
+
+        <button
+          type="button"
+          disabled={isDisabled}
+          onClick={() => {
+            runAction('add', () => mockDevAddWaitingRoomParticipant(roomId))
+          }}
+          className="rounded-lg border border-ui-border bg-white px-2 py-1.5 text-xs font-semibold text-ui-text-main disabled:opacity-50"
+        >
+          참가자 +1
+        </button>
+
+        <button
+          type="button"
+          disabled={isDisabled}
+          onClick={() => {
+            runAction('remove', () =>
+              mockDevRemoveWaitingRoomParticipant(roomId, currentUserId)
+            )
+          }}
+          className="rounded-lg border border-ui-border bg-white px-2 py-1.5 text-xs font-semibold text-ui-text-main disabled:opacity-50"
+        >
+          참가자 -1
+        </button>
+
+        <button
+          type="button"
+          disabled={isDisabled}
+          onClick={() => {
+            runAction('seed', () => mockDevSeedStartCondition(roomId))
+          }}
+          className="rounded-lg bg-ui-brand px-2 py-1.5 text-xs font-semibold text-white disabled:opacity-50"
+        >
+          시작조건
+        </button>
+
+        <button
+          type="button"
+          disabled={isDisabled}
+          onClick={() => {
+            runAction('ready-all', () =>
+              mockDevSetAllNonHostReady(roomId, true)
+            )
+          }}
+          className="col-span-2 rounded-lg border border-ui-border bg-white px-2 py-1.5 text-xs font-semibold text-ui-text-main disabled:opacity-50"
+        >
+          non-host 전원 준비
+        </button>
+
+        <button
+          type="button"
+          disabled={isDisabled}
+          onClick={() => {
+            runAction('ready-none', () =>
+              mockDevSetAllNonHostReady(roomId, false)
+            )
+          }}
+          className="col-span-2 rounded-lg border border-ui-border bg-white px-2 py-1.5 text-xs font-semibold text-ui-text-main disabled:opacity-50"
+        >
+          non-host 준비 해제
+        </button>
+      </div>
+    </aside>
+  )
+}

--- a/src/pages/waiting-room/hooks.ts
+++ b/src/pages/waiting-room/hooks.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { AuthSession } from '../../features/auth/types'
 import type {
   GameStartEventPayload,
@@ -128,6 +128,14 @@ export function useWaitingRoomController({
     return buildWaitingRoomSeats(room, session?.userId ?? '')
   }, [room, session])
 
+  // DEV 목 제어 패널에서 받은 스냅샷을 화면 상태에 반영
+  const applyRoomSnapshot = useCallback((snapshot: WaitingRoomSnapshot) => {
+    setRoom(snapshot)
+    setChatMessages(snapshot.chatMessages)
+    setRoomErrorMessage(null)
+    setIsRoomLoading(false)
+  }, [])
+
   return {
     room,
     seats,
@@ -145,5 +153,6 @@ export function useWaitingRoomController({
     handleToggleReady,
     handleStartGame,
     leaveRoom,
+    applyRoomSnapshot,
   }
 }

--- a/src/pages/waiting-room/mockGateway.ts
+++ b/src/pages/waiting-room/mockGateway.ts
@@ -17,10 +17,12 @@ const MOCK_NETWORK_DELAY_MS = 220
 const DEFAULT_ROOM_PASSWORD = '1234'
 const GAME_START_BALANCE = 1_000_000_000
 const GAME_PLAYER_COLORS = ['#FF6B6B', '#4F86F7', '#F8B500', '#2CCF9A']
+const DEV_BOT_NICKNAME_PREFIX = '테스터봇'
 const ROOM_PRIVATE_PASSWORDS: Record<string, string> = {
   'room-2': DEFAULT_ROOM_PASSWORD,
   'room-7': DEFAULT_ROOM_PASSWORD,
 }
+let devBotSequence = 1
 
 // 목 저장소 내부 플레이어 타입
 interface MockRoomPlayer {
@@ -88,6 +90,19 @@ function createRoomPlayers(roomId: string, count: number): MockRoomPlayer[] {
       is_host: index === 0,
     }
   })
+}
+
+// 대기방 제어 패널에서 사용할 가짜 참가자 정보를 생성
+function createDevBotPlayer(roomId: string): MockRoomPlayer {
+  const botNumber = devBotSequence
+  devBotSequence += 1
+
+  return {
+    id: `${roomId}-bot-${botNumber}`,
+    nickname: `${DEV_BOT_NICKNAME_PREFIX}${botNumber}`,
+    is_ready: false,
+    is_host: false,
+  }
 }
 
 // 초기 채팅은 빈 배열로 시작
@@ -654,4 +669,128 @@ export function getMockLobbyRooms(): LobbyRoom[] {
       maxPlayers: room.max_players,
       isPrivate: room.is_private,
     }))
+}
+
+// DEV 목 제어: 방 현재 스냅샷을 그대로 반환
+export function mockDevGetWaitingRoomSnapshot(roomId: string) {
+  const room = findRoomOrThrow(roomId)
+  return toWaitingRoomSnapshot(room)
+}
+
+// DEV 목 제어: non-host 가짜 참가자 1명을 추가
+export function mockDevAddWaitingRoomParticipant(roomId: string) {
+  const room = findRoomOrThrow(roomId)
+
+  // 게임 중인 방에는 DEV 참가자 추가를 막음
+  if (room.status === 'playing') {
+    throw new WaitingRoomMockError(
+      409,
+      '게임 중에는 참가자를 추가할 수 없습니다.',
+      {
+        code: 'ROOM_ALREADY_PLAYING',
+        detail: '게임 중에는 참가자를 추가할 수 없습니다.',
+      }
+    )
+  }
+
+  // 정원 초과를 방지
+  if (room.players.length >= room.max_players) {
+    throw new WaitingRoomMockError(409, '방 인원이 가득 찼습니다.', {
+      code: 'ROOM_FULL',
+      detail: '방 인원이 가득 찼습니다.',
+    })
+  }
+
+  room.players.push(createDevBotPlayer(room.id))
+  emitLobbyUpdated(room, 'status_changed')
+
+  return toWaitingRoomSnapshot(room)
+}
+
+// DEV 목 제어: 마지막 non-host 참가자 1명을 제거
+export function mockDevRemoveWaitingRoomParticipant(
+  roomId: string,
+  excludeUserId?: string
+) {
+  const room = findRoomOrThrow(roomId)
+  const indexedPlayers = room.players.map((player, index) => ({
+    player,
+    index,
+  }))
+
+  // 현재 사용자 제외, non-host 봇을 우선 제거
+  const removableBots = indexedPlayers.filter(({ player }) => {
+    return (
+      !player.is_host &&
+      player.id !== excludeUserId &&
+      player.id.startsWith(`${room.id}-bot-`)
+    )
+  })
+  const removableBotIndex =
+    removableBots.length > 0
+      ? removableBots[removableBots.length - 1].index
+      : undefined
+
+  // 봇이 없으면 현재 사용자 제외 non-host를 제거
+  const removablePlayers =
+    removableBotIndex === undefined
+      ? indexedPlayers.filter(({ player }) => {
+          return !player.is_host && player.id !== excludeUserId
+        })
+      : []
+  const removablePlayerIndex =
+    removableBotIndex ??
+    (removablePlayers.length > 0
+      ? removablePlayers[removablePlayers.length - 1].index
+      : undefined)
+
+  // 제거 가능한 참가자가 없으면 종료
+  if (removablePlayerIndex === undefined) {
+    throw new WaitingRoomMockError(400, '제거할 참가자가 없습니다.', {
+      code: 'PLAYER_NOT_IN_ROOM',
+      detail: '제거할 참가자가 없습니다.',
+    })
+  }
+
+  room.players.splice(removablePlayerIndex, 1)
+  emitLobbyUpdated(room, 'status_changed')
+
+  return toWaitingRoomSnapshot(room)
+}
+
+// DEV 목 제어: 방장 제외 전원의 준비 상태를 일괄로 변경
+export function mockDevSetAllNonHostReady(roomId: string, isReady: boolean) {
+  const room = findRoomOrThrow(roomId)
+  const nonHostPlayers = room.players.filter((player) => !player.is_host)
+
+  nonHostPlayers.forEach((player) => {
+    const hasChanged = player.is_ready !== isReady
+    player.is_ready = isReady
+
+    // 바뀐 사용자만 준비 상태 이벤트를 발행
+    if (hasChanged) {
+      const payload: PlayerReadyEventPayload = {
+        player_id: player.id,
+        is_ready: player.is_ready,
+        all_ready: isAllReady(room),
+      }
+      emitSocketEvent<PlayerReadyEventPayload>('player_ready', payload)
+    }
+  })
+
+  return toWaitingRoomSnapshot(room)
+}
+
+// DEV 목 제어: 게임 시작 조건(최소 2명 + non-host 전원 준비)을 즉시 만족
+export function mockDevSeedStartCondition(roomId: string) {
+  const room = findRoomOrThrow(roomId)
+
+  // 플레이어가 1명뿐이면 bot을 1명 추가해 시작 최소 인원을 만족
+  while (room.players.length < 2 && room.players.length < room.max_players) {
+    room.players.push(createDevBotPlayer(room.id))
+  }
+
+  const snapshot = mockDevSetAllNonHostReady(roomId, true)
+  emitLobbyUpdated(room, 'status_changed')
+  return snapshot
 }


### PR DESCRIPTION
## 📌 관련 이슈

> closes #158 

---

## 📝 작업 내용

- DEV + mock 모드에서만 노출되는 대기방 Mock Control 패널을 추가했습니다.
- 기존 레이아웃은 유지하고, 좌하단 고정 오버레이 패널로 제어 UI를 제공했습니다.
- 제공 액션:
  - 동기화
  - 참가자 +1
  - 참가자 -1
  - 시작조건(최소 2명 + non-host 전원 준비)
  - non-host 전원 준비 / 준비 해제
- 대기방 훅에 DEV 스냅샷 반영 함수(`applyRoomSnapshot`)를 추가해 패널 조작 결과를 즉시 UI에 반영했습니다.
- 버그 수정:
  - `참가자 -1` 조작 시 현재 사용자가 제거되어 퇴장 플로우가 깨지던 문제를 수정했습니다.
  - 현재 사용자 제외 + non-host bot 우선 제거 규칙으로 변경했습니다.

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

<img width="1800" height="1043" alt="스크린샷 2026-03-03 오후 2 42 20" src="https://github.com/user-attachments/assets/2dccc430-6949-416e-a214-0ea5d8a32c8a" />

---

## 🔍 검증 결과

- `npx eslint` (관련 파일) 통과
- `npm run test` 통과 (3 files, 14 tests)
- `npm run build` 통과
