### PR TITLE
feat: 대기방 DEV Mock Control에 방장 넘기기/방 초기화 기능 추가

### DIFF
--- a/src/pages/waiting-room/WaitingRoomPage.tsx
+++ b/src/pages/waiting-room/WaitingRoomPage.tsx
@@ -325,6 +325,7 @@ function WaitingRoomPage() {
       <DevMockControlPanel
         roomId={currentRoomId}
         currentUserId={session.userId}
+        currentNickname={session.nickname}
         onApplySnapshot={applyRoomSnapshot}
         onError={(message) => {
           toast.error(message)

--- a/src/pages/waiting-room/components/DevMockControlPanel.tsx
+++ b/src/pages/waiting-room/components/DevMockControlPanel.tsx
@@ -4,8 +4,10 @@ import {
   mockDevAddWaitingRoomParticipant,
   mockDevGetWaitingRoomSnapshot,
   mockDevRemoveWaitingRoomParticipant,
+  mockDevResetWaitingRoom,
   mockDevSeedStartCondition,
   mockDevSetAllNonHostReady,
+  mockDevTransferWaitingRoomHost,
 } from '../mockGateway'
 import type { WaitingRoomSnapshot } from '../types'
 
@@ -16,6 +18,7 @@ const IS_DEV_MOCK_CONTROL_ENABLED =
 interface DevMockControlPanelProps {
   roomId: string
   currentUserId: string
+  currentNickname: string
   onApplySnapshot: (snapshot: WaitingRoomSnapshot) => void
   onError: (message: string) => void
 }
@@ -24,6 +27,7 @@ interface DevMockControlPanelProps {
 export function DevMockControlPanel({
   roomId,
   currentUserId,
+  currentNickname,
   onApplySnapshot,
   onError,
 }: DevMockControlPanelProps) {
@@ -127,6 +131,32 @@ export function DevMockControlPanel({
           className="col-span-2 rounded-lg border border-ui-border bg-white px-2 py-1.5 text-xs font-semibold text-ui-text-main disabled:opacity-50"
         >
           non-host 준비 해제
+        </button>
+
+        <button
+          type="button"
+          disabled={isDisabled}
+          onClick={() => {
+            runAction('transfer-host', () =>
+              mockDevTransferWaitingRoomHost(roomId)
+            )
+          }}
+          className="col-span-2 rounded-lg border border-ui-border bg-white px-2 py-1.5 text-xs font-semibold text-ui-text-main disabled:opacity-50"
+        >
+          방장 넘기기
+        </button>
+
+        <button
+          type="button"
+          disabled={isDisabled}
+          onClick={() => {
+            runAction('reset-room', () =>
+              mockDevResetWaitingRoom(roomId, currentUserId, currentNickname)
+            )
+          }}
+          className="col-span-2 rounded-lg border border-ui-danger-border bg-ui-danger-bg px-2 py-1.5 text-xs font-semibold text-ui-danger disabled:opacity-50"
+        >
+          방 초기화
         </button>
       </div>
     </aside>

--- a/src/pages/waiting-room/mockGateway.ts
+++ b/src/pages/waiting-room/mockGateway.ts
@@ -105,6 +105,35 @@ function createDevBotPlayer(roomId: string): MockRoomPlayer {
   }
 }
 
+// 방장 승계를 단일 규칙으로 적용
+function applyHostTransfer(room: MockRoom, nextHostId: string) {
+  let nextHostNickname = ''
+
+  room.players = room.players.map((player) => {
+    if (player.id !== nextHostId) {
+      return {
+        ...player,
+        is_host: false,
+      }
+    }
+
+    nextHostNickname = player.nickname
+    return {
+      ...player,
+      is_host: true,
+      is_ready: false,
+    }
+  })
+
+  const hostChangedPayload: HostChangedEventPayload = {
+    new_host_id: nextHostId,
+    new_host_nickname: nextHostNickname,
+  }
+  emitSocketEvent<HostChangedEventPayload>('host_changed', hostChangedPayload)
+
+  return hostChangedPayload
+}
+
 // 초기 채팅은 빈 배열로 시작
 function createSeededRoomChat(): WaitingRoomChatPayload[] {
   return []
@@ -482,32 +511,8 @@ export async function mockLeaveWaitingRoom({
     const [nextHost] = room.players
 
     if (nextHost) {
-      room.players = room.players.map((player) => {
-        // 새 방장 외 플레이어는 방장 플래그 false로 유지
-        if (player.id !== nextHost.id) {
-          return {
-            ...player,
-            is_host: false,
-          }
-        }
-
-        return {
-          ...player,
-          is_host: true,
-          is_ready: false,
-        }
-      })
-
       newHostId = nextHost.id
-
-      const hostChangedPayload: HostChangedEventPayload = {
-        new_host_id: nextHost.id,
-        new_host_nickname: nextHost.nickname,
-      }
-      emitSocketEvent<HostChangedEventPayload>(
-        'host_changed',
-        hostChangedPayload
-      )
+      applyHostTransfer(room, nextHost.id)
     }
   }
 
@@ -793,4 +798,79 @@ export function mockDevSeedStartCondition(roomId: string) {
   const snapshot = mockDevSetAllNonHostReady(roomId, true)
   emitLobbyUpdated(room, 'status_changed')
   return snapshot
+}
+
+// DEV 목 제어: non-host 중 첫 번째 참가자에게 방장을 넘김
+export function mockDevTransferWaitingRoomHost(roomId: string) {
+  const room = findRoomOrThrow(roomId)
+
+  // 게임 중에는 방장 이관 테스트를 막음
+  if (room.status === 'playing') {
+    throw new WaitingRoomMockError(
+      409,
+      '게임 중에는 방장을 넘길 수 없습니다.',
+      {
+        code: 'ROOM_ALREADY_PLAYING',
+        detail: '게임 중에는 방장을 넘길 수 없습니다.',
+      }
+    )
+  }
+
+  // 플레이어가 2명 미만이면 방장 이관 대상이 없음
+  if (room.players.length < 2) {
+    throw new WaitingRoomMockError(400, '방장을 넘길 참가자가 없습니다.', {
+      code: 'PLAYER_NOT_IN_ROOM',
+      detail: '방장을 넘길 참가자가 없습니다.',
+    })
+  }
+
+  const currentHostIndex = room.players.findIndex((player) => player.is_host)
+
+  if (currentHostIndex === -1) {
+    throw new WaitingRoomMockError(400, '방장을 넘길 참가자가 없습니다.', {
+      code: 'PLAYER_NOT_IN_ROOM',
+      detail: '방장을 넘길 참가자가 없습니다.',
+    })
+  }
+
+  const nextHostIndex = (currentHostIndex + 1) % room.players.length
+  const nextHost = room.players[nextHostIndex]
+
+  applyHostTransfer(room, nextHost.id)
+  emitLobbyUpdated(room, 'status_changed')
+
+  return toWaitingRoomSnapshot(room)
+}
+
+// DEV 목 제어: 현재 사용자만 남기고 대기방 상태를 초기화
+export function mockDevResetWaitingRoom(
+  roomId: string,
+  currentUserId: string,
+  currentNickname: string
+) {
+  const room = findRoomOrThrow(roomId)
+  const currentPlayer = room.players.find(
+    (player) => player.id === currentUserId
+  )
+  const trimmedNickname = currentNickname.trim()
+  const normalizedNickname =
+    currentPlayer?.nickname ??
+    (trimmedNickname.length > 0 ? trimmedNickname : '플레이어')
+
+  room.status = 'waiting'
+  room.players = [
+    {
+      id: currentUserId,
+      nickname: normalizedNickname,
+      is_ready: false,
+      is_host: true,
+    },
+  ]
+  room.chat_messages = []
+
+  // 멀티 클라이언트에서도 방장 표시가 즉시 맞도록 host_changed를 함께 발행
+  applyHostTransfer(room, currentUserId)
+  emitLobbyUpdated(room, 'status_changed')
+
+  return toWaitingRoomSnapshot(room)
 }


### PR DESCRIPTION
## 📌 관련 이슈

> closes #162 

---

## 📝 작업 내용

- DEV Mock Control 패널에 `방장 넘기기`, `방 초기화` 액션 추가
- `방 초기화` 시 현재 사용자 1인 방장 상태로 리셋하고 채팅 메시지 초기화
- `방 초기화` 시 `host_changed` 이벤트도 함께 emit 하도록 보강해 멀티 클라이언트 동기화 일관성 확보
- 기존 퇴장 시 방장 승계 로직을 `applyHostTransfer`로 공통화하여 중복 제거
- `WaitingRoomPage`에서 DEV 패널로 `currentNickname` 전달

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료
- [x] `npm run test` 통과
- [x] `npm run build` 통과

---

## 📸 스크린샷 (선택)

<img width="1793" height="1043" alt="스크린샷 2026-03-03 오후 3 11 55" src="https://github.com/user-attachments/assets/d19d2692-6be2-43b5-83d5-add52e7ed4ba" />

