### PR TITLE
test: 대기방 DEV Mock Control 회귀 테스트 추가

### DIFF
--- a/src/pages/waiting-room/mockGateway.test.ts
+++ b/src/pages/waiting-room/mockGateway.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest'
+
+type MockGatewayModule = typeof import('./mockGateway')
+
+// mockGateway의 내부 저장소가 테스트 간 섞이지 않도록 매번 새 모듈로 로드
+async function loadMockGateway(): Promise<MockGatewayModule> {
+  vi.resetModules()
+  return import('./mockGateway')
+}
+
+// 코드 기반 에러 검증 헬퍼
+function expectGatewayErrorCode(error: unknown, expectedCode: string) {
+  expect(error).toBeTruthy()
+  expect(typeof error).toBe('object')
+  expect((error as { code?: string }).code).toBe(expectedCode)
+}
+
+describe('mockGateway DEV control', () => {
+  it('방장 넘기기는 참가자 순서대로 순환 이관된다', async () => {
+    const gateway = await loadMockGateway()
+
+    const firstTransfer = gateway.mockDevTransferWaitingRoomHost('room-5')
+    const firstHost = firstTransfer.players.find((player) => player.isHost)
+
+    expect(firstHost?.id).toBe('room-5-user-2')
+
+    const secondTransfer = gateway.mockDevTransferWaitingRoomHost('room-5')
+    const secondHost = secondTransfer.players.find((player) => player.isHost)
+
+    expect(secondHost?.id).toBe('room-5-user-1')
+  })
+
+  it('방장 넘기기는 1인 방에서 에러를 반환한다', async () => {
+    const gateway = await loadMockGateway()
+
+    try {
+      gateway.mockDevTransferWaitingRoomHost('room-4')
+      throw new Error('expected error')
+    } catch (error) {
+      expectGatewayErrorCode(error, 'PLAYER_NOT_IN_ROOM')
+    }
+  })
+
+  it('방장 넘기기는 게임 중 상태에서 에러를 반환한다', async () => {
+    const gateway = await loadMockGateway()
+
+    try {
+      gateway.mockDevTransferWaitingRoomHost('room-3')
+      throw new Error('expected error')
+    } catch (error) {
+      expectGatewayErrorCode(error, 'ROOM_ALREADY_PLAYING')
+    }
+  })
+
+  it('방 초기화는 현재 사용자만 남기고 채팅/상태를 초기화한다', async () => {
+    const gateway = await loadMockGateway()
+
+    gateway.mockSendWaitingRoomChat({
+      roomId: 'room-5',
+      senderId: 'room-5-user-1',
+      senderNickname: '플레이어1',
+      message: '테스트 메시지',
+    })
+
+    const resetSnapshot = gateway.mockDevResetWaitingRoom(
+      'room-5',
+      'room-5-user-2',
+      '플레이어2'
+    )
+
+    expect(resetSnapshot.status).toBe('waiting')
+    expect(resetSnapshot.chatMessages).toHaveLength(0)
+    expect(resetSnapshot.players).toHaveLength(1)
+    expect(resetSnapshot.players[0]).toEqual({
+      id: 'room-5-user-2',
+      nickname: '플레이어2',
+      isReady: false,
+      isHost: true,
+    })
+  })
+
+  it('방 초기화 결과는 로비 방 목록에도 동일하게 반영된다', async () => {
+    const gateway = await loadMockGateway()
+
+    gateway.mockDevResetWaitingRoom('room-5', 'room-5-user-2', '플레이어2')
+
+    const lobbyRoom = gateway
+      .getMockLobbyRooms()
+      .find((room) => room.id === 'room-5')
+
+    expect(lobbyRoom).toBeTruthy()
+    expect(lobbyRoom?.currentPlayers).toBe(1)
+    expect(lobbyRoom?.status).toBe('waiting')
+  })
+})


### PR DESCRIPTION
## 📌 관련 이슈

> closes #164

---

## 📝 작업 내용

- `src/pages/waiting-room/mockGateway.test.ts` 신규 추가
- DEV Mock Control 회귀 테스트 5개 추가
  - 방장 넘기기 순환 이관 검증
  - 1인 방 방장 넘기기 예외 검증
  - 게임중 방 방장 넘기기 예외 검증
  - 방 초기화 시 플레이어/채팅 상태 초기화 검증
  - 방 초기화 결과의 로비 목록 반영 검증

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료
- [x] `npm run test` 통과 (19 tests)
- [x] `npm run build` 통과

---

## 📸 스크린샷 (선택)

> 테스트 변경 PR이라 스크린샷 없음
