### PR TITLE
test: 대기방 액션 시퀀스 및 detail/code 에러 파싱 회귀 테스트 추가

### DIFF
--- a/src/pages/waiting-room/api.test.ts
+++ b/src/pages/waiting-room/api.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import { getWaitingRoomErrorMessage, isJoinPasswordMismatchError } from './api'
+import { WaitingRoomMockError } from './mockGateway'
+
+// axios 에러 형태를 테스트에서 간단히 재현
+function createAxiosLikeError(options: {
+  status?: number
+  code?: string
+  detail?: string
+  message?: string
+}) {
+  return {
+    isAxiosError: true,
+    message: options.message ?? 'Request failed',
+    response: {
+      status: options.status,
+      data: {
+        code: options.code,
+        detail: options.detail,
+      },
+    },
+  }
+}
+
+describe('waiting-room api error mapping', () => {
+  it('getWaitingRoomErrorMessage는 mock 에러에서 detail을 우선 반환한다', () => {
+    const error = new WaitingRoomMockError(403, 'fallback', {
+      code: 'ROOM_PASSWORD_MISMATCH',
+      detail: '비밀번호가 올바르지 않습니다.',
+    })
+
+    expect(getWaitingRoomErrorMessage(error, '기본 메시지')).toBe(
+      '비밀번호가 올바르지 않습니다.'
+    )
+  })
+
+  it('getWaitingRoomErrorMessage는 axios 에러의 detail/code를 파싱해 detail을 반환한다', () => {
+    const error = createAxiosLikeError({
+      status: 409,
+      code: 'ROOM_FULL',
+      detail: '방 인원이 가득 찼습니다.',
+      message: 'request failed',
+    })
+
+    expect(getWaitingRoomErrorMessage(error, '기본 메시지')).toBe(
+      '방 인원이 가득 찼습니다.'
+    )
+  })
+
+  it('isJoinPasswordMismatchError는 code 기반으로 비밀번호 불일치를 판별한다', () => {
+    const error = createAxiosLikeError({
+      status: 400,
+      code: 'ROOM_PASSWORD_MISMATCH',
+      detail: '비밀번호가 올바르지 않습니다.',
+    })
+
+    expect(isJoinPasswordMismatchError(error)).toBe(true)
+  })
+
+  it('isJoinPasswordMismatchError는 code가 없으면 403 status로 판별한다', () => {
+    const error = createAxiosLikeError({
+      status: 403,
+      detail: '권한이 없습니다.',
+    })
+
+    expect(isJoinPasswordMismatchError(error)).toBe(true)
+  })
+
+  it('detail/message가 없으면 fallback 메시지를 반환한다', () => {
+    const error = { random: 'value' }
+
+    expect(
+      getWaitingRoomErrorMessage(error, '대기방 정보를 불러오지 못했습니다.')
+    ).toBe('대기방 정보를 불러오지 못했습니다.')
+  })
+})

--- a/src/pages/waiting-room/mockGateway.test.ts
+++ b/src/pages/waiting-room/mockGateway.test.ts
@@ -93,3 +93,97 @@ describe('mockGateway DEV control', () => {
     expect(lobbyRoom?.status).toBe('waiting')
   })
 })
+
+describe('mockGateway waiting-room action sequence', () => {
+  it('non-host 준비 토글은 상태를 반전한다', async () => {
+    const gateway = await loadMockGateway()
+
+    const firstToggle = await gateway.mockToggleWaitingReady({
+      roomId: 'room-5',
+      userId: 'room-5-user-2',
+    })
+    expect(firstToggle.isReady).toBe(true)
+
+    const secondToggle = await gateway.mockToggleWaitingReady({
+      roomId: 'room-5',
+      userId: 'room-5-user-2',
+    })
+    expect(secondToggle.isReady).toBe(false)
+  })
+
+  it('host 준비 토글은 HOST_CANNOT_TOGGLE_READY 에러를 반환한다', async () => {
+    const gateway = await loadMockGateway()
+
+    try {
+      await gateway.mockToggleWaitingReady({
+        roomId: 'room-5',
+        userId: 'room-5-user-1',
+      })
+      throw new Error('expected error')
+    } catch (error) {
+      expectGatewayErrorCode(error, 'HOST_CANNOT_TOGGLE_READY')
+    }
+  })
+
+  it('시작 조건 미충족 상태에서 host 시작 요청은 READY_CONDITION_NOT_MET 에러를 반환한다', async () => {
+    const gateway = await loadMockGateway()
+
+    try {
+      await gateway.mockStartWaitingGame({
+        roomId: 'room-5',
+        userId: 'room-5-user-1',
+      })
+      throw new Error('expected error')
+    } catch (error) {
+      expectGatewayErrorCode(error, 'READY_CONDITION_NOT_MET')
+    }
+  })
+
+  it('host가 아닌 사용자의 시작 요청은 ONLY_HOST_CAN_START 에러를 반환한다', async () => {
+    const gateway = await loadMockGateway()
+
+    try {
+      await gateway.mockStartWaitingGame({
+        roomId: 'room-5',
+        userId: 'room-5-user-2',
+      })
+      throw new Error('expected error')
+    } catch (error) {
+      expectGatewayErrorCode(error, 'ONLY_HOST_CAN_START')
+    }
+  })
+
+  it('퇴장 후 같은 사용자가 다시 퇴장하면 ALREADY_LEFT_ROOM 에러를 반환한다', async () => {
+    const gateway = await loadMockGateway()
+
+    await gateway.mockLeaveWaitingRoom({
+      roomId: 'room-5',
+      userId: 'room-5-user-2',
+    })
+
+    try {
+      await gateway.mockLeaveWaitingRoom({
+        roomId: 'room-5',
+        userId: 'room-5-user-2',
+      })
+      throw new Error('expected error')
+    } catch (error) {
+      expectGatewayErrorCode(error, 'ALREADY_LEFT_ROOM')
+    }
+  })
+
+  it('마지막 인원이 퇴장하면 방이 삭제되어 로비 목록에서 제거된다', async () => {
+    const gateway = await loadMockGateway()
+
+    await gateway.mockLeaveWaitingRoom({
+      roomId: 'room-4',
+      userId: 'room-4-user-1',
+    })
+
+    const removedRoom = gateway
+      .getMockLobbyRooms()
+      .find((room) => room.id === 'room-4')
+
+    expect(removedRoom).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## 📌 관련 이슈

> closes #169

---

## 📝 작업 내용

- `src/pages/waiting-room/mockGateway.test.ts` 확장
  - non-host 준비 토글 성공 시 상태 반전 검증
  - host 준비 토글 차단(`HOST_CANNOT_TOGGLE_READY`) 검증
  - 시작 조건 미충족 차단(`READY_CONDITION_NOT_MET`) 검증
  - non-host 시작 요청 차단(`ONLY_HOST_CAN_START`) 검증
  - 재퇴장 차단(`ALREADY_LEFT_ROOM`) 검증
  - 마지막 인원 퇴장 시 방 삭제/로비 제거 검증
- `src/pages/waiting-room/api.test.ts` 신규 추가
  - `getWaitingRoomErrorMessage`의 `detail` 우선 메시지 반환 검증
  - axios 형태 `detail/code` 파싱 검증
  - `isJoinPasswordMismatchError`의 code/status 분기 검증
  - fallback 메시지 반환 검증

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료
- [x] `npm run test` 통과 (33 tests)
- [x] `npm run build` 통과

---

## 📸 스크린샷 (선택)

> 테스트 코드 변경 PR이라 스크린샷 없음
