### PR TITLE
test: 공통 테스트 유틸(renderWithProviders/fixtures/socketEmitter) 기반 추가

### DIFF
--- a/src/features/presence/useOnlineUsersSocket.test.tsx
+++ b/src/features/presence/useOnlineUsersSocket.test.tsx
@@ -2,6 +2,11 @@ import { renderHook, waitFor, act } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useOnlineUsersSocket } from './useOnlineUsersSocket'
 import type { OnlineUsersEventPayload } from './types'
+import { createOnlineUserPayloadFixture } from '../../test/fixtures'
+import {
+  emitSocketEvent,
+  getSocketEventHandler,
+} from '../../test/socketEmitter'
 
 const {
   socketOnMock,
@@ -39,19 +44,6 @@ vi.mock('./onlineUsersSocket', () => ({
   ensureOnlineUsersSocketConnection: ensureOnlineUsersSocketConnectionMock,
 }))
 
-// 등록된 online_users 핸들러를 찾아 테스트에서 직접 호출
-function getRegisteredOnlineUsersHandler() {
-  const targetCall = socketOnMock.mock.calls.find(
-    (call) => call[0] === 'online_users'
-  )
-
-  if (!targetCall) {
-    return null
-  }
-
-  return targetCall[1] as (payload: OnlineUsersEventPayload) => void
-}
-
 describe('useOnlineUsersSocket', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -63,7 +55,11 @@ describe('useOnlineUsersSocket', () => {
 
   it('실소켓 모드에서 초기 REST 스냅샷을 반영한다', async () => {
     getOnlineUsersSnapshotMock.mockResolvedValue([
-      { id: 'user-1', nickname: 'Goorm', status: 'lobby' },
+      createOnlineUserPayloadFixture({
+        id: 'user-1',
+        nickname: 'Goorm',
+        status: 'lobby',
+      }),
     ])
 
     const { result } = renderHook(() => useOnlineUsersSocket())
@@ -90,12 +86,21 @@ describe('useOnlineUsersSocket', () => {
       expect(result.current.isLoading).toBe(false)
     })
 
-    const handler = getRegisteredOnlineUsersHandler()
+    const handler = getSocketEventHandler<OnlineUsersEventPayload>(
+      socketOnMock,
+      'online_users'
+    )
     expect(handler).not.toBeNull()
 
     act(() => {
-      handler?.({
-        users: [{ id: 'user-2', nickname: '  alpha ', status: 'in_room' }],
+      emitSocketEvent(socketOnMock, 'online_users', {
+        users: [
+          createOnlineUserPayloadFixture({
+            id: 'user-2',
+            nickname: '  alpha ',
+            status: 'in_room',
+          }),
+        ],
       })
     })
 

--- a/src/pages/lobby/LobbyPage.test.tsx
+++ b/src/pages/lobby/LobbyPage.test.tsx
@@ -1,8 +1,13 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useAuthStore } from '../../features/auth/store'
+import {
+  createAuthSessionFixture,
+  createLobbyRoomFixture,
+  createOnlineUserFixture,
+} from '../../test/fixtures'
+import { renderWithProviders } from '../../test/renderWithProviders'
 import LobbyPage from './LobbyPage'
 import type { GetLobbyRoomsParams } from './api'
 import type { LobbyRoom } from './types'
@@ -30,38 +35,31 @@ vi.mock('../../features/presence/useDirectMessageController', () => ({
 }))
 
 const MOCK_ROOMS: LobbyRoom[] = [
-  {
+  createLobbyRoomFixture({
     id: 'room-1',
     title: '초보 환영 방',
     status: 'waiting',
     currentPlayers: 2,
-    maxPlayers: 4,
-    isPrivate: false,
-  },
-  {
+  }),
+  createLobbyRoomFixture({
     id: 'room-2',
     title: '초보 비밀 방',
     status: 'waiting',
     currentPlayers: 3,
-    maxPlayers: 4,
     isPrivate: true,
-  },
-  {
+  }),
+  createLobbyRoomFixture({
     id: 'room-3',
     title: '친구 게임 중',
     status: 'playing',
     currentPlayers: 4,
-    maxPlayers: 4,
-    isPrivate: false,
-  },
-  {
+  }),
+  createLobbyRoomFixture({
     id: 'room-4',
     title: '고수 대기방',
     status: 'waiting',
     currentPlayers: 1,
-    maxPlayers: 4,
-    isPrivate: false,
-  },
+  }),
 ]
 
 // 테스트에서 로비 필터 조합 결과를 계산
@@ -87,11 +85,9 @@ function filterMockRooms(params: GetLobbyRoomsParams) {
 
 // 공통 렌더링 헬퍼
 function renderLobbyPage() {
-  return render(
-    <MemoryRouter>
-      <LobbyPage />
-    </MemoryRouter>
-  )
+  return renderWithProviders(<LobbyPage />, {
+    initialEntries: ['/lobby'],
+  })
 }
 
 describe('LobbyPage filter and toggle regression', () => {
@@ -100,15 +96,11 @@ describe('LobbyPage filter and toggle regression', () => {
 
     // 각 테스트 시작 시 로그인 세션을 고정
     useAuthStore.setState({
-      session: {
+      session: createAuthSessionFixture({
         accessToken: 'test-token',
         userId: 'user-1',
         nickname: '테스터',
-        profileImage: null,
-        isGuest: false,
-        needsNicknameSetup: false,
-        provider: 'kakao',
-      },
+      }),
     })
 
     useLobbyRoomsQueryMock.mockImplementation((params: GetLobbyRoomsParams) => {
@@ -121,20 +113,20 @@ describe('LobbyPage filter and toggle regression', () => {
 
     useOnlineUsersSocketMock.mockReturnValue({
       data: [
-        {
+        createOnlineUserFixture({
           id: 'user-1',
           nickname: '테스터',
           status: 'lobby',
           avatarText: '테',
           avatarBackground: '#dbeafe',
-        },
-        {
+        }),
+        createOnlineUserFixture({
           id: 'user-2',
           nickname: '상대방',
           status: 'in_room',
           avatarText: '상',
           avatarBackground: '#fde68a',
-        },
+        }),
       ],
       isLoading: false,
       isError: false,

--- a/src/test/fixtures/auth.ts
+++ b/src/test/fixtures/auth.ts
@@ -1,0 +1,17 @@
+import type { AuthSession } from '../../features/auth/types'
+
+// 인증 세션 fixture 생성
+export function createAuthSessionFixture(
+  overrides: Partial<AuthSession> = {}
+): AuthSession {
+  return {
+    accessToken: 'test-access-token',
+    userId: 'user-1',
+    nickname: '테스터',
+    profileImage: null,
+    isGuest: false,
+    needsNicknameSetup: false,
+    provider: 'kakao',
+    ...overrides,
+  }
+}

--- a/src/test/fixtures/index.ts
+++ b/src/test/fixtures/index.ts
@@ -1,0 +1,6 @@
+export { createAuthSessionFixture } from './auth'
+export {
+  createOnlineUserFixture,
+  createOnlineUserPayloadFixture,
+} from './presence'
+export { createLobbyRoomFixture } from './lobby'

--- a/src/test/fixtures/lobby.ts
+++ b/src/test/fixtures/lobby.ts
@@ -1,0 +1,16 @@
+import type { LobbyRoom } from '../../pages/lobby/types'
+
+// 로비 방 fixture 생성
+export function createLobbyRoomFixture(
+  overrides: Partial<LobbyRoom> = {}
+): LobbyRoom {
+  return {
+    id: 'room-1',
+    title: '테스트 방',
+    status: 'waiting',
+    currentPlayers: 2,
+    maxPlayers: 4,
+    isPrivate: false,
+    ...overrides,
+  }
+}

--- a/src/test/fixtures/presence.ts
+++ b/src/test/fixtures/presence.ts
@@ -1,0 +1,30 @@
+import type {
+  OnlineUser,
+  OnlineUserPayload,
+} from '../../features/presence/types'
+
+// 접속자 payload fixture 생성
+export function createOnlineUserPayloadFixture(
+  overrides: Partial<OnlineUserPayload> = {}
+): OnlineUserPayload {
+  return {
+    id: 'user-1',
+    nickname: '플레이어1',
+    status: 'lobby',
+    ...overrides,
+  }
+}
+
+// UI용 접속자 모델 fixture 생성
+export function createOnlineUserFixture(
+  overrides: Partial<OnlineUser> = {}
+): OnlineUser {
+  return {
+    id: 'user-1',
+    nickname: '플레이어1',
+    status: 'lobby',
+    avatarText: '플',
+    avatarBackground: '#dbeafe',
+    ...overrides,
+  }
+}

--- a/src/test/renderWithProviders.tsx
+++ b/src/test/renderWithProviders.tsx
@@ -1,0 +1,55 @@
+import {
+  QueryClient,
+  QueryClientProvider,
+  type QueryClientConfig,
+} from '@tanstack/react-query'
+import { render, type RenderOptions } from '@testing-library/react'
+import { MemoryRouter, type MemoryRouterProps } from 'react-router-dom'
+
+// 테스트용 QueryClient 기본 옵션 생성
+function createTestQueryClient(config?: QueryClientConfig) {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        gcTime: 0,
+      },
+      mutations: {
+        retry: false,
+      },
+    },
+    ...config,
+  })
+}
+
+// 공통 렌더 유틸 입력값 타입
+interface RenderWithProvidersOptions extends Omit<RenderOptions, 'wrapper'> {
+  initialEntries?: MemoryRouterProps['initialEntries']
+  queryClient?: QueryClient
+}
+
+// Router + QueryClient Provider를 묶어 테스트 렌더링 실행
+export function renderWithProviders(
+  ui: React.ReactElement,
+  options?: RenderWithProvidersOptions
+) {
+  const {
+    initialEntries = ['/'],
+    queryClient,
+    ...renderOptions
+  } = options ?? {}
+  const testQueryClient = queryClient ?? createTestQueryClient()
+
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={testQueryClient}>
+        <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
+      </QueryClientProvider>
+    )
+  }
+
+  return {
+    queryClient: testQueryClient,
+    ...render(ui, { wrapper: Wrapper, ...renderOptions }),
+  }
+}

--- a/src/test/socketEmitter.ts
+++ b/src/test/socketEmitter.ts
@@ -1,0 +1,31 @@
+// socket.on mock에서 특정 이벤트 핸들러를 조회
+export function getSocketEventHandler<TPayload>(
+  socketOnMock: { mock: { calls: unknown[][] } },
+  eventName: string
+) {
+  const targetCall = socketOnMock.mock.calls.find((call) => {
+    return call[0] === eventName
+  })
+
+  if (!targetCall) {
+    return null
+  }
+
+  return targetCall[1] as (payload: TPayload) => void
+}
+
+// 등록된 이벤트 핸들러를 직접 실행해 수신 시나리오를 재현
+export function emitSocketEvent<TPayload>(
+  socketOnMock: { mock: { calls: unknown[][] } },
+  eventName: string,
+  payload: TPayload
+) {
+  const eventHandler = getSocketEventHandler<TPayload>(socketOnMock, eventName)
+
+  if (!eventHandler) {
+    return false
+  }
+
+  eventHandler(payload)
+  return true
+}


### PR DESCRIPTION
## 📌 관련 이슈

> closes #175

---

## 📝 작업 내용

- 공통 테스트 유틸 추가
  - `src/test/renderWithProviders.tsx`
    - Router + QueryClient를 묶은 렌더 헬퍼
  - `src/test/socketEmitter.ts`
    - `socket.on` mock 기반 이벤트 핸들러 조회/emit 유틸
  - `src/test/fixtures/*`
    - 세션/접속자/로비 방 fixture 생성 유틸
- 기존 테스트 유틸 기반 전환
  - `src/features/presence/useOnlineUsersSocket.test.tsx`
  - `src/pages/lobby/LobbyPage.test.tsx`
- 목적: 테스트 중복 코드 제거 + 작성 일관성/가독성 향상

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료
- [x] `npm run test` 통과 (33 tests)
- [x] `npm run build` 통과
- [x] 프로덕션 코드 변경 없음 확인

---

## 📸 스크린샷 (선택)

> 테스트 인프라 변경 PR이라 스크린샷 없음
