### PR TITLE
FEAT : 주사위 타이머 팝업 UI 구현

### DIFF
--- a/src/components/game/modals/DiceTimerModal.tsx
+++ b/src/components/game/modals/DiceTimerModal.tsx
@@ -1,0 +1,71 @@
+﻿import React from 'react'
+
+interface DiceTimerModalProps {
+  open: boolean
+  title?: string
+  description?: string
+  confirmLabel?: string
+  onConfirm?: () => void
+}
+
+const DEFAULT_TITLE =
+  '\uC774\uB7F0... \uC2DC\uAC04\uC774 \uB2E4\uB410\uB124\uC694'
+const DEFAULT_DESCRIPTION =
+  '\uC790\uB3D9\uC73C\uB85C \uD134\uC774 \uC885\uB8CC\uB418\uC5C8\uC2B5\uB2C8\uB2E4'
+const DEFAULT_CONFIRM_LABEL = '\uD655\uC778'
+
+const DiceIcon: React.FC = () => (
+  <svg
+    width="75"
+    height="75"
+    viewBox="0 0 75 75"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    aria-hidden="true"
+  >
+    <path
+      d="M16.3826 74.1027L74.1027 57.7201L57.72 -1.4408e-05L-7.87476e-05 16.3826L16.3826 74.1027Z"
+      fill="#0F172B"
+    />
+  </svg>
+)
+
+const DiceTimerModal: React.FC<DiceTimerModalProps> = ({
+  open,
+  title = DEFAULT_TITLE,
+  description = DEFAULT_DESCRIPTION,
+  confirmLabel = DEFAULT_CONFIRM_LABEL,
+  onConfirm,
+}) => {
+  if (!open) {
+    return null
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-[rgba(26,36,56,0.35)] backdrop-blur-sm">
+      <div className="w-full max-w-105 rounded-[44px] bg-white px-10 pb-10 pt-13 shadow-2xl">
+        <div className="mb-7 flex justify-center">
+          <DiceIcon />
+        </div>
+
+        <h2 className="text-center text-[50px] font-black tracking-tight text-[#1F2A44]">
+          {title}
+        </h2>
+
+        <p className="mb-10 mt-5 text-center text-[22px] font-bold leading-[1.35] text-[#5A6D8A]">
+          {description}
+        </p>
+
+        <button
+          type="button"
+          onClick={onConfirm}
+          className="mx-auto flex h-15 w-full max-w-102 items-center justify-center rounded-[22px] bg-[#245FE5] text-[24px] font-black tracking-tight text-white shadow-[0_12px_24px_rgba(36,95,229,0.3)] transition-colors hover:bg-[#1F56D1]"
+        >
+          {confirmLabel}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default DiceTimerModal

--- a/src/components/game/modals/DiceTimerModal.tsx
+++ b/src/components/game/modals/DiceTimerModal.tsx
@@ -14,21 +14,32 @@ const DEFAULT_DESCRIPTION =
   '\uC790\uB3D9\uC73C\uB85C \uD134\uC774 \uC885\uB8CC\uB418\uC5C8\uC2B5\uB2C8\uB2E4'
 const DEFAULT_CONFIRM_LABEL = '\uD655\uC778'
 
-const DiceIcon: React.FC = () => (
-  <svg
-    width="75"
-    height="75"
-    viewBox="0 0 75 75"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-    aria-hidden="true"
-  >
-    <path
-      d="M16.3826 74.1027L74.1027 57.7201L57.72 -1.4408e-05L-7.87476e-05 16.3826L16.3826 74.1027Z"
-      fill="#0F172B"
+const DiceIcon: React.FC = () => {
+  const renderPip = (className: string, color = '#202633') => (
+    <span
+      className={`absolute h-2.5 w-2.5 rounded-full ${className}`}
+      style={{ backgroundColor: color }}
     />
-  </svg>
-)
+  )
+
+  return (
+    <div className="relative h-27 w-33" aria-hidden="true">
+      <div className="absolute left-0 top-5 h-18 w-18 rotate-[-14deg] rounded-[28px] bg-[linear-gradient(145deg,#FCFCFC_0%,#E3E3E3_100%)] shadow-[0_12px_20px_rgba(0,0,0,0.16)]">
+        {renderPip('left-3.5 top-3.5')}
+        {renderPip('right-3.5 bottom-3.5')}
+        {renderPip('left-3.5 bottom-3.5')}
+        {renderPip('right-3.5 top-1/2 -translate-y-1/2', '#EF5350')}
+      </div>
+
+      <div className="absolute right-0 top-1 h-18 w-18 rotate-[18deg] rounded-[28px] bg-[linear-gradient(145deg,#FCFCFC_0%,#DCDCDC_100%)] shadow-[0_12px_20px_rgba(0,0,0,0.16)]">
+        {renderPip('left-3.5 top-3.5', '#EF5350')}
+        {renderPip('left-3.5 bottom-3.5')}
+        {renderPip('right-3.5 top-3.5')}
+        {renderPip('right-3.5 bottom-3.5')}
+      </div>
+    </div>
+  )
+}
 
 const DiceTimerModal: React.FC<DiceTimerModalProps> = ({
   open,
@@ -48,7 +59,7 @@ const DiceTimerModal: React.FC<DiceTimerModalProps> = ({
           <DiceIcon />
         </div>
 
-        <h2 className="text-center text-[50px] font-black tracking-tight text-[#1F2A44]">
+        <h2 className="text-center text-[35px] font-black tracking-tight text-[#1F2A44]">
           {title}
         </h2>
 

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -4,7 +4,6 @@ import { useParams } from 'react-router-dom'
 import PlayerPanel from '../components/game/panels/PlayerPanel'
 import RoomChat from '../features/room-chat/RoomChat'
 import RollButton from '../components/game/controls/RollButton'
-import DiceTimerModal from '../components/game/modals/DiceTimerModal'
 import { useAuthStore } from '../features/auth/store'
 import { useGameStore } from '../stores/game.store'
 import { useGameState } from '../hooks/game/useGameState'
@@ -25,7 +24,6 @@ const DEFAULT_MOCK_PLAYER_ID = 'mock-player-1'
 const DEFAULT_MOCK_NICKNAME = '\uD50C\uB808\uC774\uC5B4 1'
 const DEFAULT_GUEST_ID = 'guest-local'
 const MOCK_LOCAL_PLAYER_INDEX = 0
-const SHOW_DICE_TIMER_MODAL_PREVIEW = import.meta.env.DEV
 
 const toStoreBuildingLevel = (level: number): BuildingLevel =>
   Math.min(Math.max(level, 0), 5) as BuildingLevel
@@ -53,9 +51,6 @@ const GamePage: React.FC = () => {
 
   const [boardPlayers, setBoardPlayers] = useState<PlayerState[]>(INIT_PLAYERS)
   const [boardCurPlayer, setBoardCurPlayer] = useState(0)
-  const [showDiceTimerPreview, setShowDiceTimerPreview] = useState(
-    SHOW_DICE_TIMER_MODAL_PREVIEW
-  )
 
   useGameState(roomId ?? null)
 
@@ -334,11 +329,6 @@ const GamePage: React.FC = () => {
           />
         )}
       </div>
-
-      <DiceTimerModal
-        open={showDiceTimerPreview}
-        onConfirm={() => setShowDiceTimerPreview(false)}
-      />
     </div>
   )
 }

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -4,6 +4,7 @@ import { useParams } from 'react-router-dom'
 import PlayerPanel from '../components/game/panels/PlayerPanel'
 import RoomChat from '../features/room-chat/RoomChat'
 import RollButton from '../components/game/controls/RollButton'
+import DiceTimerModal from '../components/game/modals/DiceTimerModal'
 import { useAuthStore } from '../features/auth/store'
 import { useGameStore } from '../stores/game.store'
 import { useGameState } from '../hooks/game/useGameState'
@@ -24,6 +25,7 @@ const DEFAULT_MOCK_PLAYER_ID = 'mock-player-1'
 const DEFAULT_MOCK_NICKNAME = '\uD50C\uB808\uC774\uC5B4 1'
 const DEFAULT_GUEST_ID = 'guest-local'
 const MOCK_LOCAL_PLAYER_INDEX = 0
+const SHOW_DICE_TIMER_MODAL_PREVIEW = import.meta.env.DEV
 
 const toStoreBuildingLevel = (level: number): BuildingLevel =>
   Math.min(Math.max(level, 0), 5) as BuildingLevel
@@ -51,6 +53,9 @@ const GamePage: React.FC = () => {
 
   const [boardPlayers, setBoardPlayers] = useState<PlayerState[]>(INIT_PLAYERS)
   const [boardCurPlayer, setBoardCurPlayer] = useState(0)
+  const [showDiceTimerPreview, setShowDiceTimerPreview] = useState(
+    SHOW_DICE_TIMER_MODAL_PREVIEW
+  )
 
   useGameState(roomId ?? null)
 
@@ -329,6 +334,11 @@ const GamePage: React.FC = () => {
           />
         )}
       </div>
+
+      <DiceTimerModal
+        open={showDiceTimerPreview}
+        onConfirm={() => setShowDiceTimerPreview(false)}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## 🔗 관련 이슈

> closes #171

---

## 📌 작업 내용

- 주사위 타이머 팝업 UI를 새로 구현했습니다.
- 타이머 만료 상황에 맞는 제목/본문/확인 버튼 레이아웃을 반영했습니다.
- 팝업 상단 주사위 아이콘을 컴포넌트 내부 UI로 구성했습니다.
- 디자인 확인용으로 사용했던 임시 프리뷰 코드를 제거했습니다.

---

## ✅ 체크리스트

- [x] 팝업 UI 구현 완료
- [x] 임시 프리뷰 코드 제거 완료
- [x] `npm run build` 통과
- [x] 워킹트리 clean 상태 확인

---


