### PR TITLE
test: 게임중 유저 DM 차단 규칙 회귀 테스트 추가

### DIFF
--- a/src/features/presence/status.test.ts
+++ b/src/features/presence/status.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { isDirectMessageAllowed } from './status'
+
+describe('isDirectMessageAllowed', () => {
+  it('로비 상태는 DM 허용', () => {
+    expect(isDirectMessageAllowed('lobby')).toBe(true)
+  })
+
+  it('대기방 상태는 DM 허용', () => {
+    expect(isDirectMessageAllowed('in_room')).toBe(true)
+  })
+
+  it('게임중 상태는 DM 차단', () => {
+    expect(isDirectMessageAllowed('playing')).toBe(false)
+  })
+})

--- a/src/features/presence/useDirectMessageController.test.tsx
+++ b/src/features/presence/useDirectMessageController.test.tsx
@@ -1,0 +1,185 @@
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  createAuthSessionFixture,
+  createOnlineUserFixture,
+} from '../../test/fixtures'
+import { useDirectMessageController } from './useDirectMessageController'
+import type { OnlineUser } from './types'
+
+const {
+  sendDirectMessageSocketMock,
+  subscribeDirectMessageSocketEventsMock,
+  unsubscribeDirectMessageSocketMock,
+} = vi.hoisted(() => ({
+  sendDirectMessageSocketMock: vi.fn(),
+  subscribeDirectMessageSocketEventsMock: vi.fn(),
+  unsubscribeDirectMessageSocketMock: vi.fn(),
+}))
+
+vi.mock('./directMessageSocket', () => ({
+  sendDirectMessage: sendDirectMessageSocketMock,
+  subscribeDirectMessageSocketEvents: subscribeDirectMessageSocketEventsMock,
+}))
+
+interface RenderDirectMessageControllerHookParams {
+  users: OnlineUser[]
+  onBlockedByPlaying?: () => void
+}
+
+// useDirectMessageController 렌더 헬퍼
+function renderDirectMessageControllerHook({
+  users,
+  onBlockedByPlaying,
+}: RenderDirectMessageControllerHookParams) {
+  const session = createAuthSessionFixture({
+    userId: 'user-me',
+    nickname: '나',
+  })
+
+  return renderHook(
+    ({ nextUsers }) =>
+      useDirectMessageController({
+        session,
+        users: nextUsers,
+        onBlockedByPlaying,
+      }),
+    {
+      initialProps: {
+        nextUsers: users,
+      },
+    }
+  )
+}
+
+describe('useDirectMessageController', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    subscribeDirectMessageSocketEventsMock.mockReturnValue(
+      unsubscribeDirectMessageSocketMock
+    )
+  })
+
+  it('playing 상태 유저로 DM 창 열기 시 차단 콜백 호출 후 대상 설정을 막는다', () => {
+    const onBlockedByPlaying = vi.fn()
+    const playingUser = createOnlineUserFixture({
+      id: 'user-2',
+      nickname: '게임중 유저',
+      status: 'playing',
+    })
+
+    const { result } = renderDirectMessageControllerHook({
+      users: [playingUser],
+      onBlockedByPlaying,
+    })
+
+    act(() => {
+      result.current.openDirectMessage(playingUser)
+    })
+
+    expect(onBlockedByPlaying).toHaveBeenCalledTimes(1)
+    expect(result.current.dmTargetUser).toBeNull()
+  })
+
+  it('lobby/in_room 상태 유저는 DM 열기 및 전송이 허용된다', () => {
+    const lobbyUser = createOnlineUserFixture({
+      id: 'user-2',
+      nickname: '로비 유저',
+      status: 'lobby',
+    })
+
+    const { result } = renderDirectMessageControllerHook({
+      users: [lobbyUser],
+    })
+
+    act(() => {
+      result.current.openDirectMessage(lobbyUser)
+    })
+
+    expect(result.current.dmTargetUser?.id).toBe('user-2')
+
+    act(() => {
+      result.current.sendDirectMessage('안녕하세요')
+    })
+
+    expect(sendDirectMessageSocketMock).toHaveBeenCalledWith({
+      receiverId: 'user-2',
+      receiverNickname: '로비 유저',
+      message: '안녕하세요',
+    })
+    expect(result.current.directMessagesByUserId['user-2']).toHaveLength(1)
+  })
+
+  it('대상 유저가 playing 상태가 되면 DM 창을 닫는다', () => {
+    const lobbyUser = createOnlineUserFixture({
+      id: 'user-2',
+      nickname: '상대',
+      status: 'lobby',
+    })
+
+    const { result, rerender } = renderHook(
+      ({ nextUsers }) =>
+        useDirectMessageController({
+          session: createAuthSessionFixture({
+            userId: 'user-me',
+            nickname: '나',
+          }),
+          users: nextUsers,
+          onBlockedByPlaying: vi.fn(),
+        }),
+      {
+        initialProps: {
+          nextUsers: [lobbyUser],
+        },
+      }
+    )
+
+    act(() => {
+      result.current.openDirectMessage(lobbyUser)
+    })
+
+    expect(result.current.dmTargetUser?.id).toBe('user-2')
+
+    rerender({
+      nextUsers: [
+        createOnlineUserFixture({
+          id: 'user-2',
+          nickname: '상대',
+          status: 'playing',
+        }),
+      ],
+    })
+
+    expect(result.current.dmTargetUser).toBeNull()
+  })
+
+  it('DM 대상이 playing 상태일 때 전송하면 차단되고 로컬 메시지가 추가되지 않는다', () => {
+    const onBlockedByPlaying = vi.fn()
+    const mutableUser = createOnlineUserFixture({
+      id: 'user-2',
+      nickname: '상대',
+      status: 'lobby',
+    })
+
+    const { result } = renderDirectMessageControllerHook({
+      users: [mutableUser],
+      onBlockedByPlaying,
+    })
+
+    act(() => {
+      result.current.openDirectMessage(mutableUser)
+    })
+
+    // DM 창이 열린 뒤 상대 상태가 게임중으로 변한 상황을 재현
+    mutableUser.status = 'playing'
+
+    act(() => {
+      result.current.sendDirectMessage('보내기 시도')
+    })
+
+    expect(onBlockedByPlaying).toHaveBeenCalledTimes(1)
+    expect(sendDirectMessageSocketMock).not.toHaveBeenCalled()
+    expect(result.current.directMessagesByUserId['user-2']).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## 📌 관련 이슈

> closes #184

---

## 📝 작업 내용

- `src/features/presence/status.test.ts` 신규 추가
  - `isDirectMessageAllowed` 상태 분기 검증
  - `lobby`, `in_room` 허용 / `playing` 차단
- `src/features/presence/useDirectMessageController.test.tsx` 신규 추가
  - `playing` 유저 DM 열기 차단 + `onBlockedByPlaying` 호출 검증
  - 허용 상태 유저(`lobby/in_room`) DM 열기/전송 검증
  - 대상 유저 상태가 `playing`으로 변경되면 DM 창 자동 닫힘 검증
  - `playing` 대상 전송 시 소켓 전송/로컬 메시지 추가 차단 검증

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료
- [x] `npm run test` 통과 (47 tests)
- [x] `npm run build` 통과
- [x] 프로덕션 코드 변경 없음 확인

---

## 📸 스크린샷 (선택)

> 테스트 코드 변경 PR이라 스크린샷 없음
