### PR TITLE
FIX: mock 게임 자금 표시 및 전체 턴 테스트 모드 개선

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,40 +1,25 @@
 import { type ClassValue, clsx } from 'clsx'
 import { twMerge } from 'tailwind-merge'
 
-// 조건부 className을 합치고 Tailwind 충돌 클래스를 정리
+// Merge conditional class names and resolve Tailwind conflicts.
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
-// 숫자를 한국 원화 표기법으로 변환합니다.
-// 예: 100000000 -> "1억", 150000000 -> "1억5000만", 105000000 -> "1억500만"
+// Format a number using Korean won-style large units.
+// Example: 100000000 -> "1억", 150000000 -> "1억 5000만"
 export function formatWon(value: number): string {
   if (!value) return '0'
+
   const eok = Math.floor(value / 100000000)
   const man = Math.floor((value % 100000000) / 10000)
 
   let result = ''
-  if (eok > 0) result += `${eok}억`
+  if (eok > 0) result += `${eok}\uC5B5`
 
   if (man > 0) {
     if (result.length > 0) result += ' '
-
-    let manStr = ''
-    const cheon = Math.floor(man / 1000)
-    const baek = Math.floor((man % 1000) / 100)
-    const sip = Math.floor((man % 100) / 10)
-    const il = man % 10
-
-    if (cheon > 0) manStr += `${cheon}천`
-    if (baek > 0) manStr += `${baek}백`
-    if (sip > 0) manStr += `${sip}십`
-    if (il > 0) manStr += `${il}`
-
-    if (eok > 0 && il === 0) {
-      result += `${manStr}`
-    } else {
-      result += `${manStr}만`
-    }
+    result += `${man}\uB9CC`
   }
 
   return result || '0'

--- a/src/mocks/gameMockData.ts
+++ b/src/mocks/gameMockData.ts
@@ -198,7 +198,7 @@ export const mockPlayers: Player[] = [
   {
     id: 'mock-player-1',
     nickname: '\uD50C\uB808\uC774\uC5B4 1',
-    balance: 2000000000,
+    balance: 1000000000,
     position: 0,
     owned_tiles: [],
     is_in_jail: false,
@@ -210,7 +210,7 @@ export const mockPlayers: Player[] = [
   {
     id: 'player2',
     nickname: '\uD50C\uB808\uC774\uC5B4 2',
-    balance: 1800000000,
+    balance: 1000000000,
     position: 0,
     owned_tiles: [],
     is_in_jail: false,
@@ -222,7 +222,7 @@ export const mockPlayers: Player[] = [
   {
     id: 'player3',
     nickname: '\uD50C\uB808\uC774\uC5B4 3',
-    balance: 1500000000,
+    balance: 1000000000,
     position: 0,
     owned_tiles: [],
     is_in_jail: false,
@@ -234,7 +234,7 @@ export const mockPlayers: Player[] = [
   {
     id: 'player4',
     nickname: '\uD50C\uB808\uC774\uC5B4 4',
-    balance: 1400000000,
+    balance: 1000000000,
     position: 0,
     owned_tiles: [],
     is_in_jail: false,

--- a/src/mocks/gameMockData.ts
+++ b/src/mocks/gameMockData.ts
@@ -198,7 +198,7 @@ export const mockPlayers: Player[] = [
   {
     id: 'mock-player-1',
     nickname: '\uD50C\uB808\uC774\uC5B4 1',
-    balance: 2000,
+    balance: 2000000000,
     position: 0,
     owned_tiles: [],
     is_in_jail: false,
@@ -210,7 +210,7 @@ export const mockPlayers: Player[] = [
   {
     id: 'player2',
     nickname: '\uD50C\uB808\uC774\uC5B4 2',
-    balance: 1800,
+    balance: 1800000000,
     position: 0,
     owned_tiles: [],
     is_in_jail: false,
@@ -222,7 +222,7 @@ export const mockPlayers: Player[] = [
   {
     id: 'player3',
     nickname: '\uD50C\uB808\uC774\uC5B4 3',
-    balance: 1500,
+    balance: 1500000000,
     position: 0,
     owned_tiles: [],
     is_in_jail: false,
@@ -234,7 +234,7 @@ export const mockPlayers: Player[] = [
   {
     id: 'player4',
     nickname: '\uD50C\uB808\uC774\uC5B4 4',
-    balance: 1400,
+    balance: 1400000000,
     position: 0,
     owned_tiles: [],
     is_in_jail: false,

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -16,6 +16,8 @@ import type { BuildingLevel } from '../types/domain'
 
 const USE_GAME_SOCKET_MOCK =
   import.meta.env.DEV && import.meta.env.VITE_USE_SOCKET_MOCK !== 'false'
+const ALLOW_ALL_MOCK_TURNS =
+  import.meta.env.DEV && import.meta.env.VITE_ALLOW_ALL_MOCK_TURNS === 'true'
 
 const GAME_CHAT_TITLE = '\uC2E4\uC2DC\uAC04 \uCC44\uD305'
 const GAME_START_NOTICE =
@@ -68,7 +70,7 @@ const GamePage: React.FC = () => {
 
   const isMyTurnFromStore = useTurn(normalizedCurrentTurn, currentUserId)
   const isMyTurn = USE_GAME_SOCKET_MOCK
-    ? boardCurPlayer === MOCK_LOCAL_PLAYER_INDEX
+    ? ALLOW_ALL_MOCK_TURNS || boardCurPlayer === MOCK_LOCAL_PLAYER_INDEX
     : normalizedCurrentTurn === null
       ? true
       : isMyTurnFromStore


### PR DESCRIPTION
## 🔗 관련 이슈

> closes #187 
> closes #186  


---

## 📌 작업 내용

- mock 플레이어 시작 자금을 모두 10억으로 통일했습니다.
- 게임 보유금 표시가 정상적으로 보이도록 `formatWon()` 포맷 함수를 정리했습니다.
- dev/mock 환경에서 전체 플레이어 턴을 직접 테스트할 수 있는 옵션을 추가했습니다.
- `VITE_ALLOW_ALL_MOCK_TURNS=true` 설정 시 1/2/3/4 턴 모두 주사위를 굴릴 수 있도록 분기 처리했습니다.
- 실서버/실운영 흐름에는 영향이 없도록 mock/dev 환경에서만 동작하게 제한했습니다.

---

## ✅ 체크리스트

- [x] mock 시작 자금 10억 통일
- [x] 보유금 표시 정상화
- [x] dev/mock 전체 턴 테스트 모드 추가
- [x] `npm run build` 통과
- [x] 원격 브랜치 push 완료

---

스크린샷 

<img width="1863" height="934" alt="image" src="https://github.com/user-attachments/assets/cfc2ea6a-9234-4919-804a-b44a15682819" />

## 🧪 테스트 방법

1. 기본 보유금 표시 확인
- 게임 페이지 진입
- 우측 플레이어 패널의 보유금이 `0`이 아니라 정상 금액으로 표시되는지 확인

2. 기본 mock 턴 동작 확인
- 별도 환경변수 없이 실행
- 플레이어 1 턴에서만 주사위 버튼이 활성화되는지 확인

(테스트 모드 시 npm run dev 재시작 ) 
3. 전체 턴 테스트 모드 확인
- `.env.local`에 아래 값 추가
```env
VITE_ALLOW_ALL_MOCK_TURNS=true

