### PR TITLE
test: DM unread 배지 증가/초기화 회귀 테스트 추가

### DIFF
--- a/src/features/presence/unreadBadge.test.ts
+++ b/src/features/presence/unreadBadge.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { formatUnreadBadgeCount } from './unreadBadge'
+
+describe('formatUnreadBadgeCount', () => {
+  it('0 이하는 0으로 반환한다', () => {
+    expect(formatUnreadBadgeCount(0)).toBe('0')
+    expect(formatUnreadBadgeCount(-3)).toBe('0')
+  })
+
+  it('1~99 범위는 숫자 문자열 그대로 반환한다', () => {
+    expect(formatUnreadBadgeCount(1)).toBe('1')
+    expect(formatUnreadBadgeCount(57)).toBe('57')
+    expect(formatUnreadBadgeCount(99)).toBe('99')
+  })
+
+  it('100 이상은 99+로 압축 표기한다', () => {
+    expect(formatUnreadBadgeCount(100)).toBe('99+')
+    expect(formatUnreadBadgeCount(999)).toBe('99+')
+  })
+})

--- a/src/features/presence/useDirectMessageController.test.tsx
+++ b/src/features/presence/useDirectMessageController.test.tsx
@@ -11,10 +11,21 @@ const {
   sendDirectMessageSocketMock,
   subscribeDirectMessageSocketEventsMock,
   unsubscribeDirectMessageSocketMock,
+  directMessageReceiveHandlerRef,
 } = vi.hoisted(() => ({
   sendDirectMessageSocketMock: vi.fn(),
   subscribeDirectMessageSocketEventsMock: vi.fn(),
   unsubscribeDirectMessageSocketMock: vi.fn(),
+  directMessageReceiveHandlerRef: {
+    current: null as
+      | ((payload: {
+          sender_id: string
+          sender_nickname: string
+          message: string
+          sent_at: string
+        }) => void)
+      | null,
+  },
 }))
 
 vi.mock('./directMessageSocket', () => ({
@@ -56,8 +67,12 @@ describe('useDirectMessageController', () => {
   beforeEach(() => {
     vi.clearAllMocks()
 
-    subscribeDirectMessageSocketEventsMock.mockReturnValue(
-      unsubscribeDirectMessageSocketMock
+    directMessageReceiveHandlerRef.current = null
+    subscribeDirectMessageSocketEventsMock.mockImplementation(
+      ({ onReceive }) => {
+        directMessageReceiveHandlerRef.current = onReceive
+        return unsubscribeDirectMessageSocketMock
+      }
     )
   })
 
@@ -181,5 +196,100 @@ describe('useDirectMessageController', () => {
     expect(onBlockedByPlaying).toHaveBeenCalledTimes(1)
     expect(sendDirectMessageSocketMock).not.toHaveBeenCalled()
     expect(result.current.directMessagesByUserId['user-2']).toBeUndefined()
+  })
+
+  it('DM 창이 닫힌 상태에서 수신하면 unread 카운트가 증가하고 창을 열면 초기화된다', () => {
+    const user = createOnlineUserFixture({
+      id: 'user-2',
+      nickname: '상대',
+      status: 'lobby',
+    })
+
+    const { result } = renderDirectMessageControllerHook({
+      users: [user],
+    })
+
+    act(() => {
+      directMessageReceiveHandlerRef.current?.({
+        sender_id: 'user-2',
+        sender_nickname: '상대',
+        message: '첫 메시지',
+        sent_at: '2026-03-03T10:00:00.000Z',
+      })
+    })
+
+    expect(result.current.unreadDirectMessageCountByUserId['user-2']).toBe(1)
+
+    act(() => {
+      result.current.openDirectMessage(user)
+    })
+
+    expect(
+      result.current.unreadDirectMessageCountByUserId['user-2']
+    ).toBeUndefined()
+  })
+
+  it('현재 열려 있는 대상의 수신 메시지는 unread가 증가하지 않는다', () => {
+    const user = createOnlineUserFixture({
+      id: 'user-2',
+      nickname: '상대',
+      status: 'lobby',
+    })
+
+    const { result } = renderDirectMessageControllerHook({
+      users: [user],
+    })
+
+    act(() => {
+      result.current.openDirectMessage(user)
+    })
+
+    act(() => {
+      directMessageReceiveHandlerRef.current?.({
+        sender_id: 'user-2',
+        sender_nickname: '상대',
+        message: '열린 창 메시지',
+        sent_at: '2026-03-03T10:01:00.000Z',
+      })
+    })
+
+    expect(
+      result.current.unreadDirectMessageCountByUserId['user-2']
+    ).toBeUndefined()
+  })
+
+  it('다른 사용자의 수신 메시지는 unread가 독립적으로 누적된다', () => {
+    const user2 = createOnlineUserFixture({
+      id: 'user-2',
+      nickname: '상대A',
+      status: 'lobby',
+    })
+    const user3 = createOnlineUserFixture({
+      id: 'user-3',
+      nickname: '상대B',
+      status: 'in_room',
+    })
+
+    const { result } = renderDirectMessageControllerHook({
+      users: [user2, user3],
+    })
+
+    act(() => {
+      result.current.openDirectMessage(user2)
+    })
+
+    act(() => {
+      directMessageReceiveHandlerRef.current?.({
+        sender_id: 'user-3',
+        sender_nickname: '상대B',
+        message: '다른 사용자 메시지',
+        sent_at: '2026-03-03T10:02:00.000Z',
+      })
+    })
+
+    expect(
+      result.current.unreadDirectMessageCountByUserId['user-2']
+    ).toBeUndefined()
+    expect(result.current.unreadDirectMessageCountByUserId['user-3']).toBe(1)
   })
 })


### PR DESCRIPTION
## 📌 관련 이슈

> closes #189

---

## 📝 작업 내용

- `src/features/presence/useDirectMessageController.test.tsx` 테스트 확장
  - DM 창 닫힘 상태 수신 시 unread 증가 검증
  - DM 창 열기 시 unread 초기화 검증
  - 현재 열려 있는 대상 메시지 수신 시 unread 미증가 검증
  - 다른 사용자 메시지 수신 시 unread 독립 누적 검증
- `src/features/presence/unreadBadge.test.ts` 신규 추가
  - unread 배지 포맷 규칙 검증 (`0`, `1~99`, `99+`)

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료
- [x] `npm run test` 통과 (53 tests)
- [x] `npm run build` 통과
- [x] 프로덕션 코드 변경 없음 확인

---

## 📸 스크린샷 (선택)

> 테스트 코드 변경 PR이라 스크린샷 없음
