### PR TITLE
test: 커버리지 기준선(threshold) 도입

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,13 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'html', 'lcov'],
       reportsDirectory: './coverage',
+      // 현재 테스트 스위트 기준으로 유지 가능한 최소 커버리지 기준선
+      thresholds: {
+        statements: 55,
+        branches: 49,
+        functions: 55,
+        lines: 56,
+      },
     },
   },
 })


### PR DESCRIPTION
## 📌 관련 이슈

> closes #199

---

## 📝 작업 내용

- `vitest.config.ts`에 coverage threshold 추가
  - `statements: 55`
  - `branches: 49`
  - `functions: 55`
  - `lines: 56`
- 현재 커버리지 수치 기준으로 안정적으로 통과 가능한 최소 기준선을 고정
- 향후 테스트 보강 시 기준선을 단계적으로 상향할 수 있는 기반 마련

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료
- [x] `npm run test:coverage` 통과
- [x] 프로덕션 코드 변경 없음 확인

---

## 📸 스크린샷 (선택)

> 테스트 설정 변경 PR이라 스크린샷 없음
