### PR TITLE
test: WaitingRoomPage/CreateRoomModal/RoomChat 커버리지 보강

### DIFF
--- a/src/features/room-chat/RoomChat.test.tsx
+++ b/src/features/room-chat/RoomChat.test.tsx
@@ -1,0 +1,95 @@
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { renderWithProviders } from '../../test/renderWithProviders'
+import RoomChat from './RoomChat'
+
+describe('RoomChat', () => {
+  it('제목/공지/메시지를 렌더링한다', () => {
+    renderWithProviders(
+      <RoomChat
+        title="실시간 채팅"
+        notice="공지 메시지"
+        currentUserId="me"
+        inputPlaceholder="메시지 입력..."
+        onSendMessage={vi.fn()}
+        messages={[
+          {
+            id: 'm1',
+            sender_id: 'me',
+            sender_nickname: '나',
+            content: '안녕하세요',
+            timestamp: '2026-03-03T10:00:00.000Z',
+            type: 'talk',
+          },
+          {
+            id: 'm2',
+            sender_id: 'user-2',
+            sender_nickname: '상대',
+            content: '반가워요',
+            timestamp: '2026-03-03T10:01:00.000Z',
+            type: 'talk',
+          },
+        ]}
+      />
+    )
+
+    expect(screen.getByText('실시간 채팅')).toBeInTheDocument()
+    expect(screen.getByText('공지 메시지')).toBeInTheDocument()
+    expect(screen.getByText('안녕하세요')).toBeInTheDocument()
+    expect(screen.getByText('반가워요')).toBeInTheDocument()
+  })
+
+  it('메시지 전송 시 trim 처리 후 콜백 호출하고 입력을 비운다', async () => {
+    const user = userEvent.setup()
+    const onSendMessage = vi.fn()
+
+    renderWithProviders(
+      <RoomChat
+        currentUserId="me"
+        onSendMessage={onSendMessage}
+        messages={[]}
+      />
+    )
+
+    const input = screen.getByPlaceholderText('메시지...') as HTMLInputElement
+    await user.type(input, '   테스트 전송   ')
+    await user.click(screen.getByRole('button', { name: '➤' }))
+
+    expect(onSendMessage).toHaveBeenCalledWith('테스트 전송')
+    expect(input.value).toBe('')
+  })
+
+  it('공백 입력은 전송하지 않는다', async () => {
+    const user = userEvent.setup()
+    const onSendMessage = vi.fn()
+
+    renderWithProviders(
+      <RoomChat
+        currentUserId="me"
+        onSendMessage={onSendMessage}
+        messages={[]}
+      />
+    )
+
+    await user.type(screen.getByPlaceholderText('메시지...'), '   ')
+    await user.click(screen.getByRole('button', { name: '➤' }))
+
+    expect(onSendMessage).not.toHaveBeenCalled()
+  })
+
+  it('커스텀 placeholder를 표시한다', () => {
+    renderWithProviders(
+      <RoomChat
+        currentUserId="me"
+        onSendMessage={vi.fn()}
+        inputPlaceholder="메시지를 입력하세요..."
+        messages={[]}
+      />
+    )
+
+    expect(
+      screen.getByPlaceholderText('메시지를 입력하세요...')
+    ).toBeInTheDocument()
+  })
+})

--- a/src/pages/lobby/CreateRoomModal.test.tsx
+++ b/src/pages/lobby/CreateRoomModal.test.tsx
@@ -1,0 +1,134 @@
+import { fireEvent, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { renderWithProviders } from '../../test/renderWithProviders'
+import { CreateRoomModal } from './CreateRoomModal'
+
+describe('CreateRoomModal', () => {
+  it('입력 제목이 비어 있으면 기본 제목을 사용해 제출한다', async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn()
+
+    renderWithProviders(
+      <CreateRoomModal
+        defaultRoomTitle="아주아주긴기본제목12345"
+        isSubmitting={false}
+        onClose={vi.fn()}
+        onSubmit={onSubmit}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: '방 만들기 완료' }))
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      title: '아주아주긴기본제목12345'.slice(0, 16),
+      isPrivate: false,
+      password: undefined,
+    })
+  })
+
+  it('입력 제목은 16자 제한 후 제출한다', async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn()
+
+    renderWithProviders(
+      <CreateRoomModal
+        defaultRoomTitle="기본 방"
+        isSubmitting={false}
+        onClose={vi.fn()}
+        onSubmit={onSubmit}
+      />
+    )
+
+    await user.type(screen.getByLabelText('방 제목'), '커스텀방제목1234567890')
+    await user.click(screen.getByRole('button', { name: '방 만들기 완료' }))
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      title: '커스텀방제목1234567890'.slice(0, 16),
+      isPrivate: false,
+      password: undefined,
+    })
+  })
+
+  it('비밀방 설정 시 4자리 비밀번호가 아니면 제출이 비활성화된다', async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn()
+
+    renderWithProviders(
+      <CreateRoomModal
+        defaultRoomTitle="기본 방"
+        isSubmitting={false}
+        onClose={vi.fn()}
+        onSubmit={onSubmit}
+      />
+    )
+
+    await user.click(screen.getByRole('switch'))
+    const passwordInput = screen.getByPlaceholderText(
+      '비밀번호 (4자리)'
+    ) as HTMLInputElement
+
+    await user.type(passwordInput, '12')
+    expect(
+      screen.getByRole('button', { name: '방 만들기 완료' })
+    ).toBeDisabled()
+
+    await user.clear(passwordInput)
+    await user.type(passwordInput, '1234')
+    expect(screen.getByRole('button', { name: '방 만들기 완료' })).toBeEnabled()
+
+    await user.click(screen.getByRole('button', { name: '방 만들기 완료' }))
+    expect(onSubmit).toHaveBeenCalledWith({
+      title: '기본 방',
+      isPrivate: true,
+      password: '1234',
+    })
+  })
+
+  it('비밀방 토글을 끄면 비밀번호 입력값이 초기화된다', async () => {
+    const user = userEvent.setup()
+
+    renderWithProviders(
+      <CreateRoomModal
+        defaultRoomTitle="기본 방"
+        isSubmitting={false}
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+      />
+    )
+
+    await user.click(screen.getByRole('switch'))
+    const passwordInput = screen.getByPlaceholderText(
+      '비밀번호 (4자리)'
+    ) as HTMLInputElement
+    await user.type(passwordInput, '1234')
+    expect(passwordInput.value).toBe('1234')
+
+    await user.click(screen.getByRole('switch'))
+    await user.click(screen.getByRole('switch'))
+
+    const reopenedInput = screen.getByPlaceholderText(
+      '비밀번호 (4자리)'
+    ) as HTMLInputElement
+    expect(reopenedInput.value).toBe('')
+  })
+
+  it('제출 중에는 모달 닫기 동작이 차단된다', async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+
+    renderWithProviders(
+      <CreateRoomModal
+        defaultRoomTitle="기본 방"
+        isSubmitting
+        onClose={onClose}
+        onSubmit={vi.fn()}
+      />
+    )
+
+    await user.click(screen.getByLabelText('모달 닫기'))
+    fireEvent.keyDown(window, { key: 'Escape' })
+
+    expect(onClose).not.toHaveBeenCalled()
+  })
+})

--- a/src/pages/waiting-room/WaitingRoomPage.test.tsx
+++ b/src/pages/waiting-room/WaitingRoomPage.test.tsx
@@ -1,4 +1,5 @@
-import { act, screen } from '@testing-library/react'
+import { act, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { Route, Routes } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useAuthStore } from '../../features/auth/store'
@@ -37,6 +38,7 @@ const {
   useOnlineUsersSocketMock,
   useDirectMessageControllerMock,
   navigateMock,
+  toastErrorMock,
   waitingRoomControllerStateRef,
   gameStartHandlerRef,
 } = vi.hoisted(() => ({
@@ -44,11 +46,18 @@ const {
   useOnlineUsersSocketMock: vi.fn(),
   useDirectMessageControllerMock: vi.fn(),
   navigateMock: vi.fn(),
+  toastErrorMock: vi.fn(),
   waitingRoomControllerStateRef: {
     current: null as WaitingRoomControllerResult | null,
   },
   gameStartHandlerRef: {
     current: null as ((payload: GameStartEventPayload) => void) | null,
+  },
+}))
+
+vi.mock('react-hot-toast', () => ({
+  default: {
+    error: toastErrorMock,
   },
 }))
 
@@ -133,13 +142,19 @@ function createWaitingRoomControllerState(
 }
 
 // 라우트 파라미터가 포함된 대기방 페이지 렌더링 헬퍼
-function renderWaitingRoomPage() {
+function renderWaitingRoomPage({
+  routePath = '/rooms/:roomId',
+  initialEntries = ['/rooms/room-5'],
+}: {
+  routePath?: string
+  initialEntries?: string[]
+} = {}) {
   return renderWithProviders(
     <Routes>
-      <Route path="/rooms/:roomId" element={<WaitingRoomPage />} />
+      <Route path={routePath} element={<WaitingRoomPage />} />
     </Routes>,
     {
-      initialEntries: ['/rooms/room-5'],
+      initialEntries,
     }
   )
 }
@@ -236,6 +251,136 @@ describe('WaitingRoomPage interaction', () => {
         gameId: 'game-123',
         roomId: 'room-5',
       },
+    })
+  })
+
+  it('roomId가 없으면 로비로 리다이렉트한다', async () => {
+    renderWaitingRoomPage({
+      routePath: '/rooms',
+      initialEntries: ['/rooms'],
+    })
+
+    await waitFor(() => {
+      expect(navigateMock).toHaveBeenCalledWith('/lobby', { replace: true })
+    })
+  })
+
+  it('세션이 없으면 홈으로 리다이렉트한다', async () => {
+    useAuthStore.setState({ session: null })
+
+    renderWaitingRoomPage()
+
+    await waitFor(() => {
+      expect(navigateMock).toHaveBeenCalledWith('/', { replace: true })
+    })
+  })
+
+  it('닉네임 미설정 세션이면 닉네임 설정 페이지로 리다이렉트한다', async () => {
+    useAuthStore.setState({
+      session: createAuthSessionFixture({
+        userId: 'user-1',
+        nickname: '테스터',
+        needsNicknameSetup: true,
+      }),
+    })
+
+    renderWaitingRoomPage()
+
+    await waitFor(() => {
+      expect(navigateMock).toHaveBeenCalledWith('/nickname-setup', {
+        replace: true,
+      })
+    })
+  })
+
+  it('대기방 오류 메시지가 있으면 토스트를 표시한다', async () => {
+    waitingRoomControllerStateRef.current = createWaitingRoomControllerState({
+      roomErrorMessage: '대기방 정보를 불러오지 못했습니다.',
+    })
+
+    renderWaitingRoomPage()
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        '대기방 정보를 불러오지 못했습니다.'
+      )
+    })
+  })
+
+  it('헤더 뒤로가기 클릭 시 퇴장 성공이면 로비로 이동한다', async () => {
+    const user = userEvent.setup()
+    const leaveRoomMock = vi.fn(async () => ({ ok: true }))
+    waitingRoomControllerStateRef.current = createWaitingRoomControllerState({
+      leaveRoom: leaveRoomMock,
+    })
+
+    renderWaitingRoomPage()
+    await user.click(screen.getByRole('button', { name: '로비로 이동' }))
+
+    await waitFor(() => {
+      expect(leaveRoomMock).toHaveBeenCalledTimes(1)
+      expect(navigateMock).toHaveBeenCalledWith('/lobby', { replace: true })
+    })
+  })
+
+  it('헤더 뒤로가기 클릭 시 퇴장 실패면 토스트를 표시한다', async () => {
+    const user = userEvent.setup()
+    const leaveRoomMock = vi.fn(async () => ({
+      ok: false,
+      message: '퇴장 실패',
+    }))
+    waitingRoomControllerStateRef.current = createWaitingRoomControllerState({
+      leaveRoom: leaveRoomMock,
+    })
+
+    renderWaitingRoomPage()
+    await user.click(screen.getByRole('button', { name: '로비로 이동' }))
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith('퇴장 실패')
+    })
+  })
+
+  it('non-host 준비 토글 실패 시 토스트를 표시한다', async () => {
+    const user = userEvent.setup()
+    const handleToggleReadyMock = vi.fn(async () => ({
+      ok: false,
+      message: '준비 실패',
+    }))
+    waitingRoomControllerStateRef.current = createWaitingRoomControllerState({
+      isHost: false,
+      canToggleReady: true,
+      isReady: false,
+      handleToggleReady: handleToggleReadyMock,
+    })
+
+    renderWaitingRoomPage()
+    await user.click(screen.getByRole('button', { name: '준비하기' }))
+
+    await waitFor(() => {
+      expect(handleToggleReadyMock).toHaveBeenCalledTimes(1)
+      expect(toastErrorMock).toHaveBeenCalledWith('준비 실패')
+    })
+  })
+
+  it('host 시작 실패 시 토스트를 표시한다', async () => {
+    const user = userEvent.setup()
+    const handleStartGameMock = vi.fn(async () => ({
+      ok: false,
+      message: '시작 실패',
+    }))
+    waitingRoomControllerStateRef.current = createWaitingRoomControllerState({
+      isHost: true,
+      canStartGame: true,
+      handleStartGame: handleStartGameMock,
+    })
+
+    renderWaitingRoomPage()
+    await user.click(screen.getByRole('button', { name: '시작' }))
+
+    await waitFor(() => {
+      expect(handleStartGameMock).toHaveBeenCalledTimes(1)
+      expect(toastErrorMock).toHaveBeenCalledWith('시작 실패')
     })
   })
 })


### PR DESCRIPTION
## 📌 관련 이슈

> closes #201 

---

## 📝 작업 내용

- `src/pages/waiting-room/WaitingRoomPage.test.tsx` 확장
  - 리다이렉트 분기(`roomId 없음`, `세션 없음`, `닉네임 미설정`)
  - 에러 토스트 표시
  - 뒤로가기 퇴장 성공/실패 분기
  - 준비/시작 실패 토스트 분기
  - 시작 버튼 조건 및 `game_start` 화면 전환 검증 유지
- `src/pages/lobby/CreateRoomModal.test.tsx` 신규 추가
  - 기본 제목 fallback 제출
  - 제목 길이 제한 제출
  - 비밀방 비밀번호 유효성/제출
  - 비밀방 토글 해제 시 비밀번호 초기화
  - 제출 중 모달 닫기 차단
- `src/features/room-chat/RoomChat.test.tsx` 신규 추가
  - title/notice/messages 렌더
  - trim 전송 + 입력 초기화
  - 공백 전송 차단
  - custom placeholder 렌더

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료
- [x] `npm run test` 통과 (70 tests)
- [x] `npm run test:coverage` 통과
- [x] `npm run build` 통과
- [x] 프로덕션 코드 변경 없음 확인

---

## 📸 스크린샷 (선택)

> 테스트 코드 변경 PR이라 스크린샷 없음

---

## 📊 커버리지 개선

- 전체 커버리지
  - Before: Stmts 56.87 / Branches 50.25 / Funcs 56.01 / Lines 57.36
  - After:  Stmts 64.62 / Branches 58.82 / Funcs 63.53 / Lines 65.4
- 주요 파일
  - `CreateRoomModal.tsx`: 5.26% → 94.73%
  - `RoomChat.tsx`: 18.18% → 100%
  - `WaitingRoomPage.tsx`: 51.19% → 78.57%
