### PR TITLE
FIX :mock 보드 위치 초기화 및 도시 구매 404 계약 불일치 수정

### DIFF
--- a/src/mocks/gameMockData.ts
+++ b/src/mocks/gameMockData.ts
@@ -5,7 +5,7 @@ export const mockTiles: Tile[] = [
   {
     index: 1,
     name: '\uC218\uC6D0',
-    type: 'property',
+    type: 'city',
     building: 0,
     price: 60,
     color: '#EF5350',
@@ -13,7 +13,7 @@ export const mockTiles: Tile[] = [
   {
     index: 2,
     name: '\uC6A9\uC778',
-    type: 'property',
+    type: 'city',
     building: 0,
     price: 60,
     color: '#FFD15B',
@@ -22,7 +22,7 @@ export const mockTiles: Tile[] = [
   {
     index: 4,
     name: '\uAD70\uC0B0',
-    type: 'property',
+    type: 'city',
     building: 0,
     price: 60,
     color: '#66BB6A',
@@ -30,7 +30,7 @@ export const mockTiles: Tile[] = [
   {
     index: 5,
     name: '\uD3C9\uD0DD',
-    type: 'property',
+    type: 'city',
     building: 0,
     price: 60,
     color: '#42A5F5',
@@ -38,7 +38,7 @@ export const mockTiles: Tile[] = [
   {
     index: 6,
     name: '\uC775\uC0B0',
-    type: 'property',
+    type: 'city',
     building: 0,
     price: 60,
     color: '#42A5F5',
@@ -48,7 +48,7 @@ export const mockTiles: Tile[] = [
   {
     index: 9,
     name: '\uC548\uC591',
-    type: 'property',
+    type: 'city',
     building: 0,
     price: 60,
     color: '#FF7043',
@@ -57,7 +57,7 @@ export const mockTiles: Tile[] = [
   {
     index: 11,
     name: '\uAD70\uD3EC',
-    type: 'property',
+    type: 'city',
     building: 0,
     price: 60,
     color: '#26A69A',
@@ -65,7 +65,7 @@ export const mockTiles: Tile[] = [
   {
     index: 12,
     name: '\uB098\uD3EC',
-    type: 'property',
+    type: 'city',
     building: 0,
     price: 60,
     color: '#66BB6A',
@@ -73,7 +73,7 @@ export const mockTiles: Tile[] = [
   {
     index: 13,
     name: '\uD3EC\uD56D',
-    type: 'property',
+    type: 'city',
     building: 0,
     price: 60,
     color: '#7E57C2',
@@ -81,7 +81,7 @@ export const mockTiles: Tile[] = [
   {
     index: 14,
     name: '\uBAA9\uD3EC',
-    type: 'property',
+    type: 'city',
     building: 0,
     price: 60,
     color: '#EF5350',
@@ -89,7 +89,7 @@ export const mockTiles: Tile[] = [
   {
     index: 15,
     name: '\uC5EC\uC218',
-    type: 'property',
+    type: 'city',
     building: 0,
     price: 60,
     color: '#EF5350',
@@ -98,7 +98,7 @@ export const mockTiles: Tile[] = [
   {
     index: 17,
     name: '\uC81C\uC8FC',
-    type: 'property',
+    type: 'city',
     building: 0,
     price: 60,
     color: '#42A5F5',
@@ -106,7 +106,7 @@ export const mockTiles: Tile[] = [
   {
     index: 18,
     name: '\uCC3D\uC6D0',
-    type: 'property',
+    type: 'city',
     building: 0,
     price: 60,
     color: '#26A69A',
@@ -114,7 +114,7 @@ export const mockTiles: Tile[] = [
   {
     index: 19,
     name: '\uAD11\uC8FC',
-    type: 'property',
+    type: 'city',
     building: 0,
     price: 60,
     color: '#66BB6A',
@@ -123,7 +123,7 @@ export const mockTiles: Tile[] = [
   {
     index: 21,
     name: '\uCD98\uCC9C',
-    type: 'property',
+    type: 'city',
     building: 0,
     price: 60,
     color: '#7E57C2',
@@ -131,7 +131,7 @@ export const mockTiles: Tile[] = [
   {
     index: 22,
     name: '\uAC15\uB989',
-    type: 'property',
+    type: 'city',
     building: 0,
     price: 60,
     color: '#7E57C2',
@@ -139,7 +139,7 @@ export const mockTiles: Tile[] = [
   {
     index: 23,
     name: '\uC6D0\uC8FC',
-    type: 'property',
+    type: 'city',
     building: 0,
     price: 60,
     color: '#FF7043',
@@ -153,7 +153,7 @@ export const mockTiles: Tile[] = [
   {
     index: 25,
     name: '\uBD80\uC0B0',
-    type: 'property',
+    type: 'city',
     building: 0,
     price: 60,
     color: '#42A5F5',
@@ -161,7 +161,7 @@ export const mockTiles: Tile[] = [
   {
     index: 26,
     name: '\uB300\uAD6C',
-    type: 'property',
+    type: 'city',
     building: 0,
     price: 60,
     color: '#42A5F5',
@@ -170,7 +170,7 @@ export const mockTiles: Tile[] = [
   {
     index: 28,
     name: '\uB300\uC804',
-    type: 'property',
+    type: 'city',
     building: 0,
     price: 60,
     color: '#66BB6A',
@@ -178,7 +178,7 @@ export const mockTiles: Tile[] = [
   {
     index: 29,
     name: '\uC778\uCC9C',
-    type: 'property',
+    type: 'city',
     building: 0,
     price: 60,
     color: '#7E57C2',
@@ -187,7 +187,7 @@ export const mockTiles: Tile[] = [
   {
     index: 31,
     name: '\uC11C\uC6B8',
-    type: 'property',
+    type: 'city',
     building: 0,
     price: 100,
     color: '#FF7043',

--- a/src/mocks/handlers/game.handler.ts
+++ b/src/mocks/handlers/game.handler.ts
@@ -92,6 +92,9 @@ const getCurrentPlayer = () =>
 const getTileByIndex = (tileIndex: number) =>
   mockGameState.tiles.find((tile) => tile.index === tileIndex)
 
+const isOwnableTile = (tile: Tile | undefined): tile is Tile =>
+  !!tile && (tile.type === 'city' || tile.type === 'property')
+
 const ensureOwnedTiles = (player: Player, tileIndex: number) => {
   if (!player.owned_tiles.includes(tileIndex)) {
     player.owned_tiles.push(tileIndex)
@@ -217,7 +220,7 @@ export const gameHandlers = [
     const player = getCurrentPlayer()
     const tile = getTileByIndex(tile_index)
 
-    if (!player || !tile || tile.type !== 'property') {
+    if (!player || !isOwnableTile(tile)) {
       return buildErrorResponse(
         '\uAD6C\uB9E4\uD560 \uC218 \uC5C6\uB294 \uD0C0\uC77C\uC785\uB2C8\uB2E4.',
         404
@@ -269,7 +272,7 @@ export const gameHandlers = [
     const player = getCurrentPlayer()
     const tile = getTileByIndex(tile_index)
 
-    if (!player || !tile || tile.type !== 'property') {
+    if (!player || !isOwnableTile(tile)) {
       return buildErrorResponse(
         '\uAC74\uC124\uD560 \uC218 \uC5C6\uB294 \uD0C0\uC77C\uC785\uB2C8\uB2E4.',
         404
@@ -321,7 +324,7 @@ export const gameHandlers = [
     const player = getCurrentPlayer()
     const tile = getTileByIndex(tile_index)
 
-    if (!player || !tile || tile.type !== 'property') {
+    if (!player || !isOwnableTile(tile)) {
       return buildErrorResponse(
         '\uB9E4\uAC01\uD560 \uC218 \uC5C6\uB294 \uD0C0\uC77C\uC785\uB2C8\uB2E4.',
         404

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -30,6 +30,29 @@ const MOCK_LOCAL_PLAYER_INDEX = 0
 const toStoreBuildingLevel = (level: number): BuildingLevel =>
   Math.min(Math.max(level, 0), 5) as BuildingLevel
 
+const mapStorePlayersToBoardPlayers = (
+  storePlayers: Array<{
+    nickname: string
+    position: number
+    balance: number
+    color?: string
+  }>
+) =>
+  INIT_PLAYERS.map((initialPlayer, index) => {
+    const storePlayer = storePlayers[index]
+    if (!storePlayer) {
+      return initialPlayer
+    }
+
+    return {
+      ...initialPlayer,
+      name: storePlayer.nickname || initialPlayer.name,
+      color: storePlayer.color || initialPlayer.color,
+      pos: storePlayer.position,
+      money: storePlayer.balance,
+    }
+  })
+
 const GamePage: React.FC = () => {
   const { roomId } = useParams<{ roomId: string }>()
   const session = useAuthStore((state) => state.session)
@@ -50,6 +73,7 @@ const GamePage: React.FC = () => {
     resetSignal: turnTimerKey,
   })
   const boardRef = useRef<BoardGameHandle>(null)
+  const hasHydratedMockBoardRef = useRef(false)
 
   const [boardPlayers, setBoardPlayers] = useState<PlayerState[]>(INIT_PLAYERS)
   const [boardCurPlayer, setBoardCurPlayer] = useState(0)
@@ -214,26 +238,24 @@ const GamePage: React.FC = () => {
   }, [boardPlayers, storePlayers, storeTiles])
 
   useEffect(() => {
+    hasHydratedMockBoardRef.current = false
+  }, [roomId])
+
+  useEffect(() => {
     if (storePlayers.length === 0) {
       return
     }
 
-    const nextBoardPlayers = INIT_PLAYERS.map((initialPlayer, index) => {
-      const storePlayer = storePlayers[index]
-      if (!storePlayer) {
-        return initialPlayer
-      }
+    const shouldHydrateBoardPlayers =
+      !USE_GAME_SOCKET_MOCK || !hasHydratedMockBoardRef.current
 
-      return {
-        ...initialPlayer,
-        name: storePlayer.nickname || initialPlayer.name,
-        color: storePlayer.color || initialPlayer.color,
-        pos: storePlayer.position,
-        money: storePlayer.balance,
-      }
-    })
+    if (shouldHydrateBoardPlayers) {
+      setBoardPlayers(mapStorePlayersToBoardPlayers(storePlayers))
 
-    setBoardPlayers(nextBoardPlayers)
+      if (USE_GAME_SOCKET_MOCK) {
+        hasHydratedMockBoardRef.current = true
+      }
+    }
 
     if (!normalizedCurrentTurn) {
       return


### PR DESCRIPTION
## 🔗 관련 이슈

> closes #196 

---

## 📌 작업 내용

- mock 환경에서 말 이동 직후 store 동기화로 인해 위치가 START로 되돌아가던 문제를 수정했습니다.
- `GamePage`에서 mock 보드 상태를 room 단위로 1회 hydrate 하도록 변경해 로컬 이동 상태가 불필요하게 덮어써지지 않도록 보정했습니다.
- mock 게임 API와 실제 보드 계약 간 타일 타입 불일치를 수정했습니다.
- 기존 mock API는 구매/건설/매각 가능 타일을 `property`로만 처리하고 있었는데,
  현재 보드 런타임은 도시 타일을 `city`로 처리하고 있어 `POST /api/game/:roomId/buy`가 404로 떨어지는 문제가 있었습니다.
- mock handler의 구매/건설/매각 가능 타일 판정을 `city | property` 호환으로 수정했습니다.
- mock 게임 데이터의 도시 타일 타입을 `property`에서 `city`로 통일했습니다.
- 최신 `develop`을 반영했습니다.

---

## ✅ 체크리스트

- [x] mock 이동 후 말 위치 유지 보정
- [x] `buy/build/sell` mock API 도시 타입 계약 정합화
- [x] mock 타일 타입 `city` 통일
- [x] 최신 `develop` 반영
- [x] `npm run build` 통과
- [x] 브랜치 push 완료

---

## 🧪 테스트 방법

1. 게임 페이지 진입
2. 주사위를 굴려 도시 타일에 도착
3. 구매 모달에서 `구매하기` 클릭
4. 아래 항목 확인
   - `POST /api/game/room-1/buy` 404가 발생하지 않는지
   - 구매 후 말 위치가 START로 되돌아가지 않는지
   - 구매 후 턴 전환/상태 동기화가 정상 동작하는지

---

## 📎 참고

- 이번 수정은 FE-B 범위의 mock/runtime 계약 정합화와 보드 상태 안정화에 한정했습니다.
