### PR TITLE
test: 채팅 플로우 Playwright E2E 추가 및 게임 채팅 소켓 통일

### DIFF
--- a/e2e/chat-flow-direct-message.spec.ts
+++ b/e2e/chat-flow-direct-message.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('로비 1:1 DM 채팅 플로우', () => {
+  test('접속자 목록에서 DM 패널을 열고 메시지 전송/수신을 확인한다', async ({
+    page,
+  }) => {
+    await page.goto('/')
+
+    // 이전 세션 영향 제거
+    await page.evaluate(() => {
+      window.localStorage.clear()
+      window.sessionStorage.clear()
+    })
+    await page.reload()
+
+    await page.getByRole('button', { name: '게스트로 시작' }).click()
+    await expect(page).toHaveURL(/\/lobby$/)
+
+    const openDmButton = page.getByRole('button', { name: '마블왕 채팅' })
+    await openDmButton.click()
+
+    const dmPanel = page
+      .locator('section')
+      .filter({ has: page.getByRole('button', { name: 'DM 닫기' }) })
+    await expect(dmPanel).toBeVisible()
+    await expect(dmPanel.getByText('마블왕')).toBeVisible()
+
+    await page.getByPlaceholder('메시지를 입력하세요...').fill('안녕 DM')
+    await page.getByRole('button', { name: 'DM 전송' }).click()
+
+    await expect(page.getByText('안녕 DM')).toBeVisible()
+    await expect(page.getByText('확인했어요: 안녕 DM')).toBeVisible()
+  })
+})

--- a/e2e/chat-flow-game-room.spec.ts
+++ b/e2e/chat-flow-game-room.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('게임 채팅 플로우', () => {
+  test('게임 진입 후 채팅 1건을 전송해 메시지 목록에 표시한다', async ({
+    page,
+  }) => {
+    await page.goto('/')
+
+    // 이전 세션 영향 제거
+    await page.evaluate(() => {
+      window.localStorage.clear()
+      window.sessionStorage.clear()
+    })
+    await page.reload()
+
+    await page.getByRole('button', { name: '게스트로 시작' }).click()
+    await expect(page).toHaveURL(/\/lobby$/)
+
+    await page.getByRole('button', { name: '방 만들기' }).click()
+    await page.getByLabel('방 제목').fill('E2E 게임 채팅 방')
+    await page.getByRole('button', { name: '방 만들기 완료' }).click()
+
+    await expect(page).toHaveURL(/\/rooms\/room-\d+$/)
+
+    await page.getByRole('button', { name: '시작조건' }).click()
+    await page.getByRole('button', { name: /^시작$/ }).click()
+
+    await expect(page).toHaveURL(/\/game\/room-\d+$/)
+
+    await page.getByPlaceholder('메시지...').fill('게임 채팅 e2e')
+    await page.getByPlaceholder('메시지...').press('Enter')
+
+    await expect(page.getByText('게임 채팅 e2e')).toBeVisible()
+  })
+})

--- a/e2e/chat-flow-waiting-room.spec.ts
+++ b/e2e/chat-flow-waiting-room.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('대기방 채팅 플로우', () => {
+  test('방 생성 후 대기방에서 채팅 1건을 전송해 메시지 목록에 표시한다', async ({
+    page,
+  }) => {
+    await page.goto('/')
+
+    // 이전 세션 영향 제거
+    await page.evaluate(() => {
+      window.localStorage.clear()
+      window.sessionStorage.clear()
+    })
+    await page.reload()
+
+    await page.getByRole('button', { name: '게스트로 시작' }).click()
+    await expect(page).toHaveURL(/\/lobby$/)
+
+    await page.getByRole('button', { name: '방 만들기' }).click()
+    await page.getByLabel('방 제목').fill('E2E 채팅 방')
+    await page.getByRole('button', { name: '방 만들기 완료' }).click()
+
+    await expect(page).toHaveURL(/\/rooms\/room-\d+$/)
+    await expect(page.getByText('E2E 채팅 방')).toBeVisible()
+
+    await page.getByPlaceholder('메시지 입력...').fill('대기방 채팅 e2e')
+    await page.getByPlaceholder('메시지 입력...').press('Enter')
+
+    await expect(page.getByText('대기방 채팅 e2e')).toBeVisible()
+  })
+})

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -12,7 +12,10 @@ import { useDiceRoll } from '../hooks/game/useDiceRoll'
 import { useTurn } from '../hooks/game/useTurn'
 import BoardGame, { BoardGameHandle } from '../components/board/LegacyBoardGame'
 import { INIT_PLAYERS, PlayerState } from '../components/board/board.constants'
-import type { BuildingLevel } from '../types/domain'
+import type { BuildingLevel, ChatMessage } from '../types/domain'
+import { socket } from '../lib/socket'
+import { sendWaitingRoomChat } from './waiting-room/socket'
+import type { ChatEventPayload } from './waiting-room/types'
 
 const USE_GAME_SOCKET_MOCK =
   import.meta.env.DEV && import.meta.env.VITE_USE_SOCKET_MOCK !== 'false'
@@ -53,13 +56,24 @@ const mapStorePlayersToBoardPlayers = (
     }
   })
 
+// 채팅 이벤트 payload를 게임 채팅 메시지 모델로 정규화
+function mapGameChatEventToMessage(payload: ChatEventPayload): ChatMessage {
+  return {
+    id: `${payload.room_id}-${payload.sender_id}-${payload.sent_at}`,
+    sender_id: payload.sender_id,
+    sender_nickname: payload.sender_nickname,
+    content: payload.message,
+    timestamp: payload.sent_at,
+    type: 'talk',
+  }
+}
+
 const GamePage: React.FC = () => {
   const { roomId } = useParams<{ roomId: string }>()
   const session = useAuthStore((state) => state.session)
   const {
     currentTurn,
     messages,
-    addMessage,
     turnTimeoutSec,
     turnTimerKey,
     players: storePlayers,
@@ -99,14 +113,50 @@ const GamePage: React.FC = () => {
       ? true
       : isMyTurnFromStore
 
+  // 게임 채팅 이벤트를 구독해 메시지 목록을 실시간으로 동기화
+  useEffect(() => {
+    if (!roomId) {
+      return
+    }
+
+    const handleChat = (payload: ChatEventPayload) => {
+      // 다른 방 채팅 이벤트는 무시
+      if (payload.room_id !== roomId) {
+        return
+      }
+
+      const nextMessage = mapGameChatEventToMessage(payload)
+      const gameStore = useGameStore.getState()
+      const hasSameMessage = gameStore.messages.some(
+        (message) => message.id === nextMessage.id
+      )
+
+      // 동일 메시지 중복 반영 방지
+      if (hasSameMessage) {
+        return
+      }
+
+      gameStore.addMessage(nextMessage)
+    }
+
+    socket.on('chat', handleChat)
+
+    return () => {
+      socket.off('chat', handleChat)
+    }
+  }, [roomId])
+
   const handleSendMessage = (content: string) => {
-    addMessage({
-      id: Date.now().toString(),
-      sender_id: currentUserId ?? DEFAULT_GUEST_ID,
-      sender_nickname: currentNickname,
-      content,
-      timestamp: new Date().toISOString(),
-      type: 'talk',
+    // roomId가 없으면 채팅 전송을 생략
+    if (!roomId) {
+      return
+    }
+
+    sendWaitingRoomChat({
+      roomId,
+      senderId: currentUserId ?? DEFAULT_GUEST_ID,
+      senderNickname: currentNickname,
+      message: content,
     })
   }
 


### PR DESCRIPTION
## 📌 관련 이슈

> closes #204

---

## 📝 작업 내용

- 채팅 E2E 시나리오 3개 추가
  - `e2e/chat-flow-waiting-room.spec.ts`
  - `e2e/chat-flow-direct-message.spec.ts`
  - `e2e/chat-flow-game-room.spec.ts`
- 게임 채팅 전송 로직을 로컬 state append 방식에서 소켓 기반으로 통일
  - `src/pages/GamePage.tsx`
  - `sendWaitingRoomChat` 사용
  - `chat` 이벤트 구독으로 메시지 동기화
  - 다른 room 이벤트 무시 + 중복 메시지 방지 처리

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

<img width="1083" height="678" alt="스크린샷 2026-03-03 오후 11 40 51" src="https://github.com/user-attachments/assets/53710bac-d3da-4383-8c40-8aa2fd0305ed" />

