### PR TITLE
chore: coverage/playwright 산출물 lint/format 검사 제외

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,6 @@
 node_modules
 dist
 .vite
+coverage
+playwright-report
+test-results

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,9 @@ import tseslint from 'typescript-eslint'
 import eslintConfigPrettier from 'eslint-config-prettier'
 
 export default tseslint.config(
-  { ignores: ['dist', '.vite', 'coverage'] },
+  {
+    ignores: ['dist', '.vite', 'coverage', 'playwright-report', 'test-results'],
+  },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ['**/*.{ts,tsx}'],


### PR DESCRIPTION
## 📌 관련 이슈

> closes #208 

---

## 📝 작업 내용

- `.prettierignore`에 생성 산출물 디렉토리 추가
  - `coverage`
  - `playwright-report`
  - `test-results`
- `eslint.config.js`의 `ignores`에 동일 디렉토리 추가
- 리포트 HTML(`coverage/index.html`) 관련 에디터 경고가 린트/포맷 품질 게이트에 영향을 주지 않도록 정리

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

> 설정 변경 PR로 스크린샷 없음
