### PR TITLE
FIX : 건물 SVG 색상 매핑을 플레이어 테마 기준으로 정리

### DIFF
--- a/src/components/board/BuildingBadge.tsx
+++ b/src/components/board/BuildingBadge.tsx
@@ -5,11 +5,20 @@ interface BuildingBadgeProps {
   ownerColor?: string
 }
 
+const RED_THEME = { folder: 'redbuildingIcon', prefix: 'red' }
+const BLUE_THEME = { folder: 'bluebuildingIcon', prefix: 'blue' }
+const GREEN_THEME = { folder: 'greenbuildingIcon', prefix: 'green' }
+const YELLOW_THEME = { folder: 'yellowbuildingIcon', prefix: 'yellow' }
+
 const COLOR_TO_THEME: Record<string, { folder: string; prefix: string }> = {
-  '#EF5350': { folder: 'redbuildingIcon', prefix: 'red' },
-  '#42A5F5': { folder: 'bluebuildingIcon', prefix: 'blue' },
-  '#66BB6A': { folder: 'greenbuildingIcon', prefix: 'green' },
-  '#FFD15B': { folder: 'yellowbuildingIcon', prefix: 'yellow' },
+  '#EF5350': RED_THEME,
+  '#EF4444': RED_THEME,
+  '#42A5F5': BLUE_THEME,
+  '#3B82F6': BLUE_THEME,
+  '#66BB6A': GREEN_THEME,
+  '#22C55E': GREEN_THEME,
+  '#FFD15B': YELLOW_THEME,
+  '#EAB308': YELLOW_THEME,
 }
 
 const BUILDING_SUFFIX: Record<number, string> = {
@@ -24,16 +33,12 @@ const BuildingBadge: React.FC<BuildingBadgeProps> = ({ level, ownerColor }) => {
   if (!level || level < 1 || level > 5) return null
 
   const normalizedColor = ownerColor?.trim().toUpperCase() ?? ''
-  const theme = COLOR_TO_THEME[normalizedColor] ?? {
-    folder: 'redbuildingIcon',
-    prefix: 'red',
-  }
+  const theme = COLOR_TO_THEME[normalizedColor] ?? RED_THEME
   const suffix = BUILDING_SUFFIX[level]
+
   if (!suffix) return null
 
   const src = `/${theme.folder}/${theme.prefix}${suffix}`
-
-  console.log('ownerColor:', ownerColor, '→ theme:', theme.prefix)
 
   return (
     <div
@@ -58,7 +63,7 @@ const BuildingBadge: React.FC<BuildingBadgeProps> = ({ level, ownerColor }) => {
           display: 'block',
         }}
         onError={(e) => {
-          console.error('❌ 이미지 로드 실패:', src)
+          console.error('Failed to load building icon:', src)
           e.currentTarget.style.display = 'none'
           const fallback = e.currentTarget
             .nextElementSibling as HTMLElement | null

--- a/src/mocks/gameMockData.ts
+++ b/src/mocks/gameMockData.ts
@@ -204,7 +204,7 @@ export const mockPlayers: Player[] = [
     is_in_jail: false,
     jail_turn_count: 0,
     is_bankrupt: false,
-    color: '#ef4444',
+    color: '#EF5350',
     avatar: '\uD83D\uDD34',
   },
   {
@@ -216,7 +216,7 @@ export const mockPlayers: Player[] = [
     is_in_jail: false,
     jail_turn_count: 0,
     is_bankrupt: false,
-    color: '#3b82f6',
+    color: '#42A5F5',
     avatar: '\uD83D\uDD35',
   },
   {
@@ -228,7 +228,7 @@ export const mockPlayers: Player[] = [
     is_in_jail: false,
     jail_turn_count: 0,
     is_bankrupt: false,
-    color: '#22c55e',
+    color: '#66BB6A',
     avatar: '\uD83D\uDFE2',
   },
   {
@@ -240,7 +240,7 @@ export const mockPlayers: Player[] = [
     is_in_jail: false,
     jail_turn_count: 0,
     is_bankrupt: false,
-    color: '#eab308',
+    color: '#FFD15B',
     avatar: '\uD83D\uDFE1',
   },
 ]


### PR DESCRIPTION
## 🔗 관련 이슈

> closes #197 

---

## 📌 작업 내용

- 건물 SVG가 플레이어 색상과 무관하게 빨간색으로만 보이던 문제를 수정했습니다.
- `BuildingBadge`의 색상 매핑 테이블에 실제 mock/runtime에서 들어오는 색상 hex alias를 추가했습니다.
- mock 플레이어 색상을 보드 표준 색상값과 동일하게 통일했습니다.
- 디버깅용 `console.log`를 제거하고, 깨진 에러 문구를 정리했습니다.

---

## ✅ 체크리스트

- [x] 빨강/파랑/초록/노랑 플레이어 색상별 건물 SVG 매핑 수정
- [x] mock 플레이어 색상값을 보드 표준 색상과 통일
- [x] 디버그 로그 제거
- [x] `npm run build` 통과
- [x] 브랜치 push 완료

---

## 🧪 테스트 방법

1. 게임 페이지 진입
2. 서로 다른 색상의 플레이어로 도시 구매
3. 구매 후 건물 SVG 확인
4. 아래 항목 확인
   - 빨강 플레이어는 빨강 건물
   - 파랑 플레이어는 파랑 건물
   - 초록 플레이어는 초록 건물
   - 노랑 플레이어는 노랑 건물
   - 콘솔에 `ownerColor -> theme: red` 로그가 더 이상 반복되지 않는지 확인

---

## 📎 참고

- 이번 수정은 FE-B 범위에서 건물 테마 매핑만 정리한 변경입니다.
- 건물 소유 상태나 턴 흐름 로직은 별도 이슈로 분리해 다루는 것이 맞습니다.
