### PR TITLE
FIX : mock 보드 상태 동기화와 턴 전환 충돌 수정

### DIFF
--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -807,7 +807,11 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
           }),
           { notifyParent: true }
         )
-        advanceTurn(onDoneCallback)
+        if (USE_GAME_SOCKET_MOCK) {
+          onDoneCallback?.()
+        } else {
+          advanceTurn(onDoneCallback)
+        }
       }
     }
 
@@ -854,7 +858,11 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
           },
           { notifyParent: true }
         )
-        advanceTurn(onDoneCallback)
+        if (USE_GAME_SOCKET_MOCK) {
+          onDoneCallback?.()
+        } else {
+          advanceTurn(onDoneCallback)
+        }
       }
     }
 

--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -474,14 +474,16 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
     })
 
     function updateTileOwners(
-      updater: (prev: Record<number, TileOwner>) => Record<number, TileOwner>
+      updater: (prev: Record<number, TileOwner>) => Record<number, TileOwner>,
+      options?: { notifyParent?: boolean }
     ) {
-      setTileOwners((prev) => {
-        const next = updater(prev)
-        tileOwnersRef.current = next
+      const next = updater(tileOwnersRef.current)
+      tileOwnersRef.current = next
+      setTileOwners(next)
+
+      if (options?.notifyParent) {
         onTileOwnersChange?.(next)
-        return next
-      })
+      }
     }
 
     function applyMoney(
@@ -521,14 +523,17 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       bankruptSetRef.current.add(playerIdx)
       const bankruptPlayerId = getPlayerIdByIndex(playerIdx)
 
-      updateTileOwners((prev) => {
-        const next = { ...prev }
-        Object.keys(next).forEach((k) => {
-          if (next[Number(k)].ownerId === bankruptPlayerId)
-            delete next[Number(k)]
-        })
-        return next
-      })
+      updateTileOwners(
+        (prev) => {
+          const next = { ...prev }
+          Object.keys(next).forEach((k) => {
+            if (next[Number(k)].ownerId === bankruptPlayerId)
+              delete next[Number(k)]
+          })
+          return next
+        },
+        { notifyParent: true }
+      )
 
       onBankrupt?.(playerIdx)
       advanceTurn(onDoneCallback)
@@ -756,11 +761,14 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
 
       const synced = await syncBoardStateFromServer()
       if (!synced) {
-        updateTileOwners((prev) => {
-          const next = { ...prev }
-          delete next[tileId]
-          return next
-        })
+        updateTileOwners(
+          (prev) => {
+            const next = { ...prev }
+            delete next[tileId]
+            return next
+          },
+          { notifyParent: true }
+        )
         applyMoney(playerIdx, +getSellFallbackRefund(tileId, owner.level))
       }
 
@@ -788,14 +796,17 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       setBuyModal({ open: false, tileId: null })
       const bankrupt = applyMoney(active, -price, onDoneCallback)
       if (!bankrupt) {
-        updateTileOwners((prev) => ({
-          ...prev,
-          [tileId]: {
-            ownerId: activePlayerId,
-            ownerColor: activePlayerColor,
-            level: 1,
-          },
-        }))
+        updateTileOwners(
+          (prev) => ({
+            ...prev,
+            [tileId]: {
+              ownerId: activePlayerId,
+              ownerColor: activePlayerColor,
+              level: 1,
+            },
+          }),
+          { notifyParent: true }
+        )
         advanceTurn(onDoneCallback)
       }
     }
@@ -829,17 +840,20 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       setBuildModal({ open: false, tileId: null })
       const bankrupt = applyMoney(active, -upgradeCost, onDoneCallback)
       if (!bankrupt) {
-        updateTileOwners((prev) => {
-          const existing = prev[tileId]
-          if (!existing) return prev
-          return {
-            ...prev,
-            [tileId]: {
-              ...existing,
-              level: Math.min(existing.level + 1, 5) as BuildingLevel,
-            },
-          }
-        })
+        updateTileOwners(
+          (prev) => {
+            const existing = prev[tileId]
+            if (!existing) return prev
+            return {
+              ...prev,
+              [tileId]: {
+                ...existing,
+                level: Math.min(existing.level + 1, 5) as BuildingLevel,
+              },
+            }
+          },
+          { notifyParent: true }
+        )
         advanceTurn(onDoneCallback)
       }
     }


### PR DESCRIPTION
## 🔗 관련 이슈

> closes #이슈번호

---



## 📌 작업 내용

- `GameBoard`에서 `setTileOwners` state updater 내부에서 부모 `onTileOwnersChange`를 바로 호출하던 구조를 정리했습니다.
- 렌더 중 부모(`GamePage`)와 store를 업데이트하면서 발생하던 React warning을 제거할 수 있도록 보드-부모 업데이트 경계를 분리했습니다.
- mock 환경에서 `buy/build` 성공 후 mock handler가 이미 턴을 넘기는데도 프런트가 `advanceTurn()`을 한 번 더 호출하던 문제를 수정했습니다.
- mock 환경에서는 `buy/build` 성공 후 로컬에서 추가 턴 전환을 하지 않고, handler가 보낸 상태를 따르도록 정리했습니다.

---

## ✅ 체크리스트

- [x] `GameBoard -> GamePage/store` render-phase update 경고 원인 제거
- [x] mock `buy/build` 후 이중 턴 전환 제거
- [x] `npm run build` 통과
- [x] 브랜치 push 완료

---

## 🧪 테스트 방법

1. 게임 페이지 진입
2. 주사위를 굴려 도시 타일에 도착
3. 구매 모달에서 `구매하기` 클릭
4. 본인 소유 도시에서 건설 시도
5. 아래 항목 확인
   - 콘솔에 `Cannot update a component (GamePage) while rendering a different component (GameBoard)` 경고가 발생하지 않는지
   - mock 환경에서 구매/건설 후 턴이 한 번만 넘어가는지
   - 본인 소유 도시 건설 시 잘못된 `403 (Forbidden)`이 재현되지 않는지

---

## 📎 참고

- 이번 수정은 FE-B 범위의 mock/runtime 상태 동기화 문제에 한정했습니다.
- 보드 렌더 구조 자체 개편은 포함하지 않았습니다.
