### PR TITLE
test: DEV 패널 기본 숨김 정책 반영해 e2e 시나리오 수정

### DIFF
--- a/e2e/chat-flow-direct-message.spec.ts
+++ b/e2e/chat-flow-direct-message.spec.ts
@@ -30,6 +30,7 @@ test.describe('로비 1:1 DM 채팅 플로우', () => {
 
     await expect(page.getByText('안녕 DM')).toBeVisible()
 
+    await page.getByRole('button', { name: 'DEV PRESENCE 열기' }).click()
     await page.getByLabel('수신 DM').fill('수신 테스트 DM')
     await page.getByRole('button', { name: '선택 유저로 DM 수신' }).click()
 

--- a/e2e/chat-flow-game-room.spec.ts
+++ b/e2e/chat-flow-game-room.spec.ts
@@ -22,6 +22,7 @@ test.describe('게임 채팅 플로우', () => {
 
     await expect(page).toHaveURL(/\/rooms\/room-\d+$/)
 
+    await page.getByRole('button', { name: 'DEV CONTROL 열기' }).click()
     await page.getByRole('button', { name: '시작조건' }).click()
     await page.getByRole('button', { name: /^시작$/ }).click()
 

--- a/e2e/waiting-room-start-flow.spec.ts
+++ b/e2e/waiting-room-start-flow.spec.ts
@@ -33,6 +33,7 @@ test.describe('대기방 시작 플로우', () => {
     await page.getByPlaceholder('메시지 입력...').press('Enter')
     await expect(page.getByText('E2E 채팅 메시지')).toBeVisible()
 
+    await page.getByRole('button', { name: 'DEV CONTROL 열기' }).click()
     await page.getByRole('button', { name: '시작조건' }).click()
     await expect(startButton).toBeEnabled()
 


### PR DESCRIPTION
## 📌 관련 이슈

> closes #215 

---

## 📝 작업 내용

> DEV 패널이 기본 숨김으로 바뀐 뒤 실패한 E2E 시나리오를 현재 UX 흐름에 맞게 수정했습니다.

- `e2e/waiting-room-start-flow.spec.ts`
  - `시작조건` 클릭 전 `DEV CONTROL 열기` 단계 추가
- `e2e/chat-flow-game-room.spec.ts`
  - `시작조건` 클릭 전 `DEV CONTROL 열기` 단계 추가
- `e2e/chat-flow-direct-message.spec.ts`
  - `수신 DM` 입력 전 `DEV PRESENCE 열기` 단계 추가

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

---

### 테스트 결과
- `npm run e2e` 통과
- `4 passed (Playwright)`