### PR TITLE
chore: pre-push 훅과 CI 워크플로우에 E2E 및 Coverage 게이트 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,36 @@ jobs:
 
       - run: npm ci
 
+      - name: Install Playwright Browser
+        run: npx playwright install --with-deps chromium
+
       - name: Lint
         run: npm run lint
 
       - name: Test
         run: npm run test
 
+      - name: Test Coverage
+        run: npm run test:coverage
+
+      - name: E2E
+        run: npm run e2e
+
       - name: Build
         run: npm run build
+
+      - name: Upload Coverage Report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage
+
+      - name: Upload Playwright Report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            playwright-report
+            test-results

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,8 +1,37 @@
 #!/usr/bin/env sh
+echo "push 전 lint 검증을 시작합니다..."
+npm run lint
+if [ $? -ne 0 ]; then
+  echo "lint 실패. 오류를 수정한 후 다시 push 해주세요."
+  exit 1
+fi
+
+echo "push 전 unit/integration 테스트 검증을 시작합니다..."
+npm run test
+if [ $? -ne 0 ]; then
+  echo "test 실패. 오류를 수정한 후 다시 push 해주세요."
+  exit 1
+fi
+
+echo "push 전 커버리지 검증을 시작합니다..."
+npm run test:coverage
+if [ $? -ne 0 ]; then
+  echo "coverage 실패. 오류를 수정한 후 다시 push 해주세요."
+  exit 1
+fi
+
+echo "push 전 E2E 검증을 시작합니다..."
+npm run e2e
+if [ $? -ne 0 ]; then
+  echo "e2e 실패. 오류를 수정한 후 다시 push 해주세요."
+  exit 1
+fi
+
 echo "push 전 빌드 검증을 시작합니다..."
 npm run build
 if [ $? -ne 0 ]; then
-  echo "빌드 오류가 발생했습니다. 코드를 수정한 후 다시 push 해주세요."
+  echo "build 실패. 오류를 수정한 후 다시 push 해주세요."
   exit 1
 fi
-echo "빌드 검증 완료. push를 진행합니다."
+
+echo "모든 pre-push 검증 통과. push를 진행합니다."


### PR DESCRIPTION
## 📌 관련 이슈

> closes #217 

---

## 📝 작업 내용

> 로컬/원격 모두에서 테스트 품질을 게이트로 강제하기 위해 pre-push 훅과 CI 워크플로우를 보강했습니다.

- `.husky/pre-push` 검증 단계 확장
  - `npm run lint`
  - `npm run test`
  - `npm run test:coverage`
  - `npm run e2e`
  - `npm run build`
- `.github/workflows/ci.yml`에 테스트 게이트 추가
  - Playwright 브라우저 설치(`npx playwright install --with-deps chromium`)
  - `npm run test:coverage` 단계 추가
  - `npm run e2e` 단계 추가
- CI 아티팩트 업로드 추가
  - `coverage` 리포트
  - `playwright-report`, `test-results`

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

> UI 변경이 있을 경우 첨부해주세요.
- 해당 PR은 인프라/워크플로우 변경으로 스크린샷 생략

---

### 로컬 검증 결과

- `npm run lint` 통과
- `npm run test` 통과 (`71 passed`)
- `npm run e2e` 통과 (`4 passed`)
- `npm run build` 통과