### PR TITLE
test: presence 소켓 mock/real 분기 경계 테스트 추가

### DIFF
--- a/src/features/presence/directMessageSocket.test.ts
+++ b/src/features/presence/directMessageSocket.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { DirectMessageReceiveSocketPayload } from './types'
+
+interface MockSocket {
+  connected: boolean
+  on: ReturnType<typeof vi.fn>
+  off: ReturnType<typeof vi.fn>
+  emit: ReturnType<typeof vi.fn>
+  listeners: ReturnType<typeof vi.fn>
+}
+
+interface LoadedDirectMessageSocketModule {
+  socket: MockSocket
+  connectSocketWithAuthIfNeededMock: ReturnType<typeof vi.fn>
+  module: typeof import('./directMessageSocket')
+}
+
+// 테스트마다 mock/real 환경을 다르게 주입해 모듈을 다시 로드
+async function loadDirectMessageSocketModule(
+  useSocketMock: boolean,
+  isConnected = false
+): Promise<LoadedDirectMessageSocketModule> {
+  vi.resetModules()
+  vi.stubEnv('VITE_USE_SOCKET_MOCK', useSocketMock ? 'true' : 'false')
+
+  const listenersMap = new Map<string, Array<(payload: unknown) => void>>()
+
+  const socket: MockSocket = {
+    connected: isConnected,
+    on: vi.fn((eventName: string, listener: (payload: unknown) => void) => {
+      const listeners = listenersMap.get(eventName) ?? []
+      listeners.push(listener)
+      listenersMap.set(eventName, listeners)
+    }),
+    off: vi.fn((eventName: string, listener: (payload: unknown) => void) => {
+      const listeners = listenersMap.get(eventName) ?? []
+      listenersMap.set(
+        eventName,
+        listeners.filter(
+          (registeredListener) => registeredListener !== listener
+        )
+      )
+    }),
+    emit: vi.fn(),
+    listeners: vi.fn((eventName: string) => listenersMap.get(eventName) ?? []),
+  }
+
+  const connectSocketWithAuthIfNeededMock = vi.fn(() => {
+    socket.connected = true
+  })
+
+  vi.doMock('../../lib/socket', () => ({
+    socket,
+    connectSocketWithAuthIfNeeded: connectSocketWithAuthIfNeededMock,
+  }))
+
+  const module = await import('./directMessageSocket')
+
+  return {
+    socket,
+    connectSocketWithAuthIfNeededMock,
+    module,
+  }
+}
+
+describe('directMessageSocket', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+    vi.unstubAllEnvs()
+    vi.resetModules()
+  })
+
+  it('mock 모드에서 sendDirectMessage는 connect/emit 없이 종료된다', async () => {
+    const { module, socket, connectSocketWithAuthIfNeededMock } =
+      await loadDirectMessageSocketModule(true)
+
+    module.sendDirectMessage({
+      receiverId: 'user-2',
+      message: '안녕하세요',
+    })
+
+    expect(connectSocketWithAuthIfNeededMock).not.toHaveBeenCalled()
+    expect(socket.emit).not.toHaveBeenCalled()
+  })
+
+  it('real 모드에서 sendDirectMessage는 trim 후 dm_send emit을 호출한다', async () => {
+    const { module, socket, connectSocketWithAuthIfNeededMock } =
+      await loadDirectMessageSocketModule(false, false)
+
+    module.sendDirectMessage({
+      receiverId: 'user-2',
+      message: '  안녕하세요  ',
+    })
+
+    expect(connectSocketWithAuthIfNeededMock).toHaveBeenCalledTimes(1)
+    expect(socket.emit).toHaveBeenCalledWith('dm_send', {
+      receiver_id: 'user-2',
+      message: '안녕하세요',
+    })
+  })
+
+  it('공백 메시지는 real/mock 모드 모두 전송하지 않는다', async () => {
+    const { module: realModule, socket: realSocket } =
+      await loadDirectMessageSocketModule(false)
+    const { module: mockModule, socket: mockSocket } =
+      await loadDirectMessageSocketModule(true)
+
+    realModule.sendDirectMessage({
+      receiverId: 'user-2',
+      message: '   ',
+    })
+    mockModule.sendDirectMessage({
+      receiverId: 'user-2',
+      message: '\n\t',
+    })
+
+    expect(realSocket.emit).not.toHaveBeenCalled()
+    expect(mockSocket.emit).not.toHaveBeenCalled()
+  })
+
+  it('subscribeDirectMessageSocketEvents는 on 등록 후 unsubscribe 시 off 해제한다', async () => {
+    const { module, socket } = await loadDirectMessageSocketModule(false)
+    const onReceive = vi.fn()
+
+    const unsubscribe = module.subscribeDirectMessageSocketEvents({
+      onReceive,
+    })
+
+    expect(socket.on).toHaveBeenCalledWith('dm_receive', onReceive)
+
+    unsubscribe()
+
+    expect(socket.off).toHaveBeenCalledWith('dm_receive', onReceive)
+  })
+
+  it('mock 모드에서 emitDirectMessageReceiveMockForDev는 dm_receive 리스너에 payload를 전파한다', async () => {
+    const { module, socket } = await loadDirectMessageSocketModule(true)
+    const onReceive = vi.fn()
+    const payload: DirectMessageReceiveSocketPayload = {
+      sender_id: 'user-2',
+      sender_nickname: '상대',
+      message: '수신 테스트',
+      sent_at: '2026-03-04T00:00:00.000Z',
+    }
+
+    module.subscribeDirectMessageSocketEvents({
+      onReceive,
+    })
+    module.emitDirectMessageReceiveMockForDev(payload)
+
+    expect(socket.listeners).toHaveBeenCalledWith('dm_receive')
+    expect(onReceive).toHaveBeenCalledWith(payload)
+  })
+
+  it('real 모드에서 emitDirectMessageReceiveMockForDev는 동작하지 않는다', async () => {
+    const { module, socket } = await loadDirectMessageSocketModule(false)
+    const onReceive = vi.fn()
+
+    module.subscribeDirectMessageSocketEvents({
+      onReceive,
+    })
+    module.emitDirectMessageReceiveMockForDev({
+      sender_id: 'user-2',
+      sender_nickname: '상대',
+      message: '수신 테스트',
+      sent_at: '2026-03-04T00:00:00.000Z',
+    })
+
+    expect(socket.listeners).not.toHaveBeenCalledWith('dm_receive')
+    expect(onReceive).not.toHaveBeenCalled()
+  })
+})

--- a/src/features/presence/onlineUsersSocket.test.ts
+++ b/src/features/presence/onlineUsersSocket.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { OnlineUserPayload } from './types'
+
+interface MockSocket {
+  connected: boolean
+  listeners: ReturnType<typeof vi.fn>
+}
+
+interface LoadedOnlineUsersSocketModule {
+  socket: MockSocket
+  connectSocketWithAuthIfNeededMock: ReturnType<typeof vi.fn>
+  getMockOnlineUsersSnapshotMock: ReturnType<typeof vi.fn>
+  listenerMock: ReturnType<typeof vi.fn>
+  module: typeof import('./onlineUsersSocket')
+}
+
+// mock/real 환경에 따라 onlineUsersSocket 모듈을 새로 로드
+async function loadOnlineUsersSocketModule(
+  useSocketMock: boolean,
+  isConnected = false,
+  mockUsers: OnlineUserPayload[] = []
+): Promise<LoadedOnlineUsersSocketModule> {
+  vi.resetModules()
+  vi.stubEnv('VITE_USE_SOCKET_MOCK', useSocketMock ? 'true' : 'false')
+
+  const listenerMock = vi.fn()
+
+  const socket: MockSocket = {
+    connected: isConnected,
+    listeners: vi.fn((eventName: string) => {
+      if (eventName !== 'online_users') {
+        return []
+      }
+
+      return [listenerMock]
+    }),
+  }
+
+  const connectSocketWithAuthIfNeededMock = vi.fn(() => {
+    socket.connected = true
+  })
+  const getMockOnlineUsersSnapshotMock = vi.fn(() =>
+    mockUsers.map((user) => ({ ...user }))
+  )
+
+  vi.doMock('../../lib/socket', () => ({
+    socket,
+    connectSocketWithAuthIfNeeded: connectSocketWithAuthIfNeededMock,
+  }))
+
+  vi.doMock('./mockData', () => ({
+    getMockOnlineUsersSnapshot: getMockOnlineUsersSnapshotMock,
+  }))
+
+  const module = await import('./onlineUsersSocket')
+
+  return {
+    socket,
+    connectSocketWithAuthIfNeededMock,
+    getMockOnlineUsersSnapshotMock,
+    listenerMock,
+    module,
+  }
+}
+
+describe('onlineUsersSocket', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.clearAllMocks()
+    vi.unstubAllEnvs()
+    vi.resetModules()
+  })
+
+  it('VITE_USE_SOCKET_MOCK 값에 따라 mock 모드 여부를 반환한다', async () => {
+    const { module: mockModeModule } = await loadOnlineUsersSocketModule(true)
+    const { module: realModeModule } = await loadOnlineUsersSocketModule(false)
+
+    expect(mockModeModule.isOnlineUsersSocketMockMode()).toBe(true)
+    expect(realModeModule.isOnlineUsersSocketMockMode()).toBe(false)
+  })
+
+  it('emitMockOnlineUsersSnapshot은 online_users 리스너로 스냅샷을 전달한다', async () => {
+    const users: OnlineUserPayload[] = [
+      {
+        id: 'user-1',
+        nickname: '마블왕',
+        status: 'lobby',
+      },
+    ]
+    const { module, listenerMock, getMockOnlineUsersSnapshotMock, socket } =
+      await loadOnlineUsersSocketModule(true, false, users)
+
+    module.emitMockOnlineUsersSnapshot()
+
+    expect(getMockOnlineUsersSnapshotMock).toHaveBeenCalledTimes(1)
+    expect(socket.listeners).toHaveBeenCalledWith('online_users')
+    expect(listenerMock).toHaveBeenCalledWith({
+      users,
+    })
+  })
+
+  it('startOnlineUsersMockBroadcast는 즉시 1회 + 주기 브로드캐스트 후 stop으로 정지된다', async () => {
+    const users: OnlineUserPayload[] = [
+      {
+        id: 'user-1',
+        nickname: '마블왕',
+        status: 'lobby',
+      },
+    ]
+    const { module, listenerMock } = await loadOnlineUsersSocketModule(
+      true,
+      false,
+      users
+    )
+
+    const stopBroadcast = module.startOnlineUsersMockBroadcast()
+
+    // 시작 시 즉시 1회 브로드캐스트
+    expect(listenerMock).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(5_000)
+    expect(listenerMock).toHaveBeenCalledTimes(2)
+
+    stopBroadcast()
+
+    vi.advanceTimersByTime(5_000)
+    expect(listenerMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('ensureOnlineUsersSocketConnection은 미연결 상태에서만 connect를 호출한다', async () => {
+    const disconnected = await loadOnlineUsersSocketModule(true, false)
+    disconnected.module.ensureOnlineUsersSocketConnection()
+
+    expect(
+      disconnected.connectSocketWithAuthIfNeededMock
+    ).toHaveBeenCalledTimes(1)
+
+    const connected = await loadOnlineUsersSocketModule(true, true)
+    connected.module.ensureOnlineUsersSocketConnection()
+
+    expect(connected.connectSocketWithAuthIfNeededMock).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## 📌 관련 이슈

> closes #226 

---

## 📝 작업 내용

> Presence 소켓 레이어의 mock/real 분기 경계 동작을 고정하기 위해 테스트 2개를 추가했습니다.

- `src/features/presence/directMessageSocket.test.ts` 추가
  - mock 모드에서 `sendDirectMessage` no-op 검증
  - real 모드에서 trim + `dm_send` emit payload 검증
  - 공백 메시지 전송 차단 검증
  - subscribe/unsubscribe(on/off) 계약 검증
  - `emitDirectMessageReceiveMockForDev` mock/real 모드 분기 검증
- `src/features/presence/onlineUsersSocket.test.ts` 추가
  - env 기반 mock 모드 판별 검증
  - `emitMockOnlineUsersSnapshot` 브로드캐스트 검증
  - `startOnlineUsersMockBroadcast` 즉시/주기/stop 검증
  - `ensureOnlineUsersSocketConnection` 연결 상태 분기 검증

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

> UI 변경이 있을 경우 첨부해주세요.
- 테스트 코드 변경 PR로 스크린샷 없음

---

### 테스트 결과

- `npm run test` 통과
- 총 `15 files / 81 tests passed` (presence 경계 테스트 포함)