### PR TITLE
refactor: E2E 공통 헬퍼 추출로 중복 제거 및 안정성 개선

### DIFF
--- a/e2e/chat-flow-direct-message.spec.ts
+++ b/e2e/chat-flow-direct-message.spec.ts
@@ -1,20 +1,13 @@
 import { expect, test } from '@playwright/test'
+import { ensureDevPresencePanelOpen } from './helpers/devPanel'
+import { loginAsGuest, resetSessionAndOpenHome } from './helpers/session'
 
 test.describe('로비 1:1 DM 채팅 플로우', () => {
   test('접속자 목록에서 DM 패널을 열고 메시지 전송 후 수신 DM을 수동 주입해 확인한다', async ({
     page,
   }) => {
-    await page.goto('/')
-
-    // 이전 세션 영향 제거
-    await page.evaluate(() => {
-      window.localStorage.clear()
-      window.sessionStorage.clear()
-    })
-    await page.reload()
-
-    await page.getByRole('button', { name: '게스트로 시작' }).click()
-    await expect(page).toHaveURL(/\/lobby$/)
+    await resetSessionAndOpenHome(page)
+    await loginAsGuest(page)
 
     const openDmButton = page.getByRole('button', { name: '마블왕 채팅' })
     await openDmButton.click()
@@ -30,7 +23,7 @@ test.describe('로비 1:1 DM 채팅 플로우', () => {
 
     await expect(page.getByText('안녕 DM')).toBeVisible()
 
-    await page.getByRole('button', { name: 'DEV PRESENCE 열기' }).click()
+    await ensureDevPresencePanelOpen(page)
     await page.getByLabel('수신 DM').fill('수신 테스트 DM')
     await page.getByRole('button', { name: '선택 유저로 DM 수신' }).click()
 

--- a/e2e/chat-flow-game-room.spec.ts
+++ b/e2e/chat-flow-game-room.spec.ts
@@ -1,20 +1,13 @@
 import { expect, test } from '@playwright/test'
+import { ensureDevControlPanelOpen } from './helpers/devPanel'
+import { loginAsGuest, resetSessionAndOpenHome } from './helpers/session'
 
 test.describe('게임 채팅 플로우', () => {
   test('게임 진입 후 채팅 1건을 전송해 메시지 목록에 표시한다', async ({
     page,
   }) => {
-    await page.goto('/')
-
-    // 이전 세션 영향 제거
-    await page.evaluate(() => {
-      window.localStorage.clear()
-      window.sessionStorage.clear()
-    })
-    await page.reload()
-
-    await page.getByRole('button', { name: '게스트로 시작' }).click()
-    await expect(page).toHaveURL(/\/lobby$/)
+    await resetSessionAndOpenHome(page)
+    await loginAsGuest(page)
 
     await page.getByRole('button', { name: '방 만들기' }).click()
     await page.getByLabel('방 제목').fill('E2E 게임 채팅 방')
@@ -22,7 +15,7 @@ test.describe('게임 채팅 플로우', () => {
 
     await expect(page).toHaveURL(/\/rooms\/room-\d+$/)
 
-    await page.getByRole('button', { name: 'DEV CONTROL 열기' }).click()
+    await ensureDevControlPanelOpen(page)
     await page.getByRole('button', { name: '시작조건' }).click()
     await page.getByRole('button', { name: /^시작$/ }).click()
 

--- a/e2e/chat-flow-waiting-room.spec.ts
+++ b/e2e/chat-flow-waiting-room.spec.ts
@@ -1,20 +1,12 @@
 import { expect, test } from '@playwright/test'
+import { loginAsGuest, resetSessionAndOpenHome } from './helpers/session'
 
 test.describe('대기방 채팅 플로우', () => {
   test('방 생성 후 대기방에서 채팅 1건을 전송해 메시지 목록에 표시한다', async ({
     page,
   }) => {
-    await page.goto('/')
-
-    // 이전 세션 영향 제거
-    await page.evaluate(() => {
-      window.localStorage.clear()
-      window.sessionStorage.clear()
-    })
-    await page.reload()
-
-    await page.getByRole('button', { name: '게스트로 시작' }).click()
-    await expect(page).toHaveURL(/\/lobby$/)
+    await resetSessionAndOpenHome(page)
+    await loginAsGuest(page)
 
     await page.getByRole('button', { name: '방 만들기' }).click()
     await page.getByLabel('방 제목').fill('E2E 채팅 방')

--- a/e2e/helpers/devPanel.ts
+++ b/e2e/helpers/devPanel.ts
@@ -1,0 +1,24 @@
+import type { Page } from '@playwright/test'
+
+// 기본 숨김 정책의 DEV 패널을 필요 시 열고 없으면 그대로 진행
+async function openDevPanelIfCollapsed(page: Page, openButtonName: string) {
+  const openButton = page.getByRole('button', { name: openButtonName }).first()
+
+  if ((await openButton.count()) === 0) {
+    return
+  }
+
+  if (await openButton.isVisible()) {
+    await openButton.click()
+  }
+}
+
+// 대기방 통합 DEV 컨트롤 패널을 사용 가능한 상태로 보장
+export async function ensureDevControlPanelOpen(page: Page) {
+  await openDevPanelIfCollapsed(page, 'DEV CONTROL 열기')
+}
+
+// 로비 접속자 DEV 패널을 사용 가능한 상태로 보장
+export async function ensureDevPresencePanelOpen(page: Page) {
+  await openDevPanelIfCollapsed(page, 'DEV PRESENCE 열기')
+}

--- a/e2e/helpers/session.ts
+++ b/e2e/helpers/session.ts
@@ -1,0 +1,19 @@
+import { expect, type Page } from '@playwright/test'
+
+// 테스트 시작 시 브라우저 저장소를 초기화하고 홈으로 진입
+export async function resetSessionAndOpenHome(page: Page) {
+  await page.goto('/')
+
+  await page.evaluate(() => {
+    window.localStorage.clear()
+    window.sessionStorage.clear()
+  })
+
+  await page.reload()
+}
+
+// 게스트 로그인 후 로비 진입 완료까지 공통 처리
+export async function loginAsGuest(page: Page) {
+  await page.getByRole('button', { name: '게스트로 시작' }).click()
+  await expect(page).toHaveURL(/\/lobby$/)
+}

--- a/e2e/waiting-room-start-flow.spec.ts
+++ b/e2e/waiting-room-start-flow.spec.ts
@@ -1,20 +1,13 @@
 import { expect, test } from '@playwright/test'
+import { ensureDevControlPanelOpen } from './helpers/devPanel'
+import { loginAsGuest, resetSessionAndOpenHome } from './helpers/session'
 
 test.describe('대기방 시작 플로우', () => {
   test('게스트 로그인 후 방 생성 -> 시작조건 충족 -> 게임 화면 이동', async ({
     page,
   }) => {
-    await page.goto('/')
-
-    // 이전 실행 세션이 남아 있으면 홈 진입이 달라질 수 있어 초기화
-    await page.evaluate(() => {
-      window.localStorage.clear()
-      window.sessionStorage.clear()
-    })
-    await page.reload()
-
-    await page.getByRole('button', { name: '게스트로 시작' }).click()
-    await expect(page).toHaveURL(/\/lobby$/)
+    await resetSessionAndOpenHome(page)
+    await loginAsGuest(page)
 
     await page.getByRole('button', { name: '방 만들기' }).click()
     await expect(page.getByRole('dialog', { name: '방 만들기' })).toBeVisible()
@@ -33,7 +26,7 @@ test.describe('대기방 시작 플로우', () => {
     await page.getByPlaceholder('메시지 입력...').press('Enter')
     await expect(page.getByText('E2E 채팅 메시지')).toBeVisible()
 
-    await page.getByRole('button', { name: 'DEV CONTROL 열기' }).click()
+    await ensureDevControlPanelOpen(page)
     await page.getByRole('button', { name: '시작조건' }).click()
     await expect(startButton).toBeEnabled()
 


### PR DESCRIPTION
## 📌 관련 이슈

> closes #228 

---

## 📝 작업 내용

> E2E 시나리오에서 반복되던 초기화/로그인/DEV 패널 열기 코드를 공통 헬퍼로 추출해 중복을 줄이고 테스트 안정성을 높였습니다.

### 1) 공통 헬퍼 추가

- `e2e/helpers/session.ts`
  - `resetSessionAndOpenHome(page)`
  - `loginAsGuest(page)`
- `e2e/helpers/devPanel.ts`
  - `ensureDevControlPanelOpen(page)`
  - `ensureDevPresencePanelOpen(page)`

### 2) E2E 스펙 리팩토링 적용

- `e2e/chat-flow-direct-message.spec.ts`
- `e2e/chat-flow-game-room.spec.ts`
- `e2e/chat-flow-waiting-room.spec.ts`
- `e2e/waiting-room-start-flow.spec.ts`

적용 내용:
- 반복되는 `localStorage/sessionStorage` 초기화 로직 제거
- 반복되는 게스트 로그인/로비 진입 검증 로직 제거
- DEV 패널 기본 숨김 정책 대응 로직을 helper로 통일

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

> UI 변경이 있을 경우 첨부해주세요.
- 테스트 코드 리팩토링 PR로 스크린샷 없음

---

### 검증 결과

- `npm run e2e` 통과 (4 passed)
- `npm run lint` 통과