### PR TITLE
chore: Vitest 커버리지 기준선을 60/55/60/60으로 상향

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,12 +18,12 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'html', 'lcov'],
       reportsDirectory: './coverage',
-      // 현재 테스트 스위트 기준으로 유지 가능한 최소 커버리지 기준선
+      // 테스트 안정화 이후 상향된 최소 커버리지 기준선
       thresholds: {
-        statements: 55,
-        branches: 49,
-        functions: 55,
-        lines: 56,
+        statements: 60,
+        branches: 55,
+        functions: 60,
+        lines: 60,
       },
     },
   },


### PR DESCRIPTION
## 📌 관련 이슈

> closes #230 

---

## 📝 작업 내용

> 테스트 체계 안정화 상태를 반영해 Vitest 커버리지 기준선을 상향했습니다.

- `vitest.config.ts` coverage threshold 상향
  - `statements: 55 -> 60`
  - `branches: 49 -> 55`
  - `functions: 55 -> 60`
  - `lines: 56 -> 60`
- 주석 문구를 현재 정책에 맞게 수정
  - “테스트 안정화 이후 상향된 최소 커버리지 기준선”

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

> UI 변경이 있을 경우 첨부해주세요.
- 설정 변경 PR로 스크린샷 생략

---

### 검증 결과

- `npm run test:coverage` 통과
- 현재 전체 수치
  - `Statements: 66.93%`
  - `Branches: 58.29%`
  - `Functions: 68.27%`
  - `Lines: 67.32%`
- 상향된 기준선(`60/55/60/60`) 모두 충족