### PR TITLE
refactor: mock 환경 플래그와 방 비밀번호 규칙을 공통 상수로 통합

### DIFF
--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -30,6 +30,7 @@ import {
   BuildingLevel,
 } from './board.constants'
 import '../../styles/board.css'
+import { IS_SOCKET_MOCK_ENABLED } from '../../config/env'
 import { formatWon } from '../../lib/utils'
 
 // cost helpers are computed per-tile based on price
@@ -57,8 +58,7 @@ function calcToll(price: number, level: BuildingLevel): number {
   return price
 }
 
-const USE_GAME_SOCKET_MOCK =
-  import.meta.env.DEV && import.meta.env.VITE_USE_SOCKET_MOCK !== 'false'
+const USE_GAME_SOCKET_MOCK = IS_SOCKET_MOCK_ENABLED
 
 const AI_PENALTY_RESULTS = [
   '\uB2E4\uC74C \uD134 \uC2DC\uC791 \uC804\uAE4C\uC9C0 \uD1B5\uD589\uB8CC\uAC00 10M \uC99D\uAC00\uD569\uB2C8\uB2E4.',

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,0 +1,3 @@
+// DEV + 환경변수 조합으로 소켓 목 모드 활성 여부를 단일 규칙으로 계산
+export const IS_SOCKET_MOCK_ENABLED =
+  import.meta.env.DEV && import.meta.env.VITE_USE_SOCKET_MOCK !== 'false'

--- a/src/constants/room.ts
+++ b/src/constants/room.ts
@@ -1,0 +1,5 @@
+// 비밀방 비밀번호 자리수 고정값
+export const ROOM_PASSWORD_LENGTH = 4
+
+// 비밀방 비밀번호는 숫자 4자리만 허용
+export const ROOM_PASSWORD_PATTERN = /^\d{4}$/

--- a/src/features/presence/directMessageSocket.ts
+++ b/src/features/presence/directMessageSocket.ts
@@ -1,4 +1,5 @@
 import { connectSocketWithAuthIfNeeded, socket } from '../../lib/socket'
+import { IS_SOCKET_MOCK_ENABLED } from '../../config/env'
 import type {
   DirectMessageReceiveSocketPayload,
   DirectMessageSendSocketPayload,
@@ -10,8 +11,7 @@ const DIRECT_MESSAGE_EVENT_NAMES = {
   receive: 'dm_receive',
 } as const
 
-const USE_SOCKET_MOCK =
-  import.meta.env.DEV && import.meta.env.VITE_USE_SOCKET_MOCK !== 'false'
+const USE_SOCKET_MOCK = IS_SOCKET_MOCK_ENABLED
 
 // DM 전송 함수 입력값 타입
 interface SendDirectMessageParams {

--- a/src/features/presence/onlineUsersSocket.ts
+++ b/src/features/presence/onlineUsersSocket.ts
@@ -1,12 +1,12 @@
 import { connectSocketWithAuthIfNeeded, socket } from '../../lib/socket'
+import { IS_SOCKET_MOCK_ENABLED } from '../../config/env'
 import { getMockOnlineUsersSnapshot } from './mockData'
 import type { OnlineUserPayload, OnlineUsersEventPayload } from './types'
 
 // 접속자 목록 소켓 이벤트 이름
 export const ONLINE_USERS_EVENT_NAME = 'online_users'
 const SOCKET_MOCK_INTERVAL_MS = 5_000
-const USE_SOCKET_MOCK =
-  import.meta.env.DEV && import.meta.env.VITE_USE_SOCKET_MOCK !== 'false'
+const USE_SOCKET_MOCK = IS_SOCKET_MOCK_ENABLED
 
 // 테스트용 리스너 접근을 위한 socket 타입 확장
 interface SocketWithListeners {

--- a/src/features/room-chat/DevRoomChatControlPanel.tsx
+++ b/src/features/room-chat/DevRoomChatControlPanel.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useMemo, useState } from 'react'
+import { IS_SOCKET_MOCK_ENABLED } from '../../config/env'
 import { cn } from '../../lib/utils'
 import { sendWaitingRoomChat } from '../../pages/waiting-room/socket'
 
-const IS_DEV_ROOM_CHAT_CONTROL_ENABLED =
-  import.meta.env.DEV && import.meta.env.VITE_USE_SOCKET_MOCK !== 'false'
+const IS_DEV_ROOM_CHAT_CONTROL_ENABLED = IS_SOCKET_MOCK_ENABLED
 
 // DEV 채팅 제어 패널에서 사용할 발신자 정보 타입
 interface RoomChatSenderOption {

--- a/src/hooks/game/useDiceRoll.ts
+++ b/src/hooks/game/useDiceRoll.ts
@@ -1,11 +1,11 @@
 import { RefObject, useCallback } from 'react'
 import type { BoardGameHandle } from '../../components/board/GameBoard'
+import { IS_SOCKET_MOCK_ENABLED } from '../../config/env'
 import { socket } from '../../lib/socket'
 import { emitRollDice } from '../../services/socket/game.handler'
 import { useGameStore } from '../../stores/game.store'
 
-const USE_GAME_SOCKET_MOCK =
-  import.meta.env.DEV && import.meta.env.VITE_USE_SOCKET_MOCK !== 'false'
+const USE_GAME_SOCKET_MOCK = IS_SOCKET_MOCK_ENABLED
 
 export const useDiceRoll = (boardRef: RefObject<BoardGameHandle | null>) => {
   const currentTurn = useGameStore((state) => state.currentTurn)

--- a/src/hooks/game/useGameState.ts
+++ b/src/hooks/game/useGameState.ts
@@ -1,11 +1,11 @@
 import { useEffect, useRef } from 'react'
+import { IS_SOCKET_MOCK_ENABLED } from '../../config/env'
 import { connectSocketWithAuthIfNeeded, socket } from '../../lib/socket'
 import { gameApi } from '../../services/game/game.api'
 import { setupGameHandlers } from '../../services/socket/game.handler'
 import { useGameStore } from '../../stores/game.store'
 
-const USE_GAME_SOCKET_MOCK =
-  import.meta.env.DEV && import.meta.env.VITE_USE_SOCKET_MOCK !== 'false'
+const USE_GAME_SOCKET_MOCK = IS_SOCKET_MOCK_ENABLED
 
 export const useGameState = (roomId: string | null) => {
   const { setGameState, players } = useGameStore()

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -15,11 +15,11 @@ import BoardGame, { BoardGameHandle } from '../components/board/GameBoard'
 import { INIT_PLAYERS, PlayerState } from '../components/board/board.constants'
 import type { BuildingLevel, ChatMessage } from '../types/domain'
 import { socket } from '../lib/socket'
+import { IS_SOCKET_MOCK_ENABLED } from '../config/env'
 import { sendWaitingRoomChat } from './waiting-room/socket'
 import type { ChatEventPayload } from './waiting-room/types'
 
-const USE_GAME_SOCKET_MOCK =
-  import.meta.env.DEV && import.meta.env.VITE_USE_SOCKET_MOCK !== 'false'
+const USE_GAME_SOCKET_MOCK = IS_SOCKET_MOCK_ENABLED
 const ALLOW_ALL_MOCK_TURNS =
   import.meta.env.DEV && import.meta.env.VITE_ALLOW_ALL_MOCK_TURNS === 'true'
 

--- a/src/pages/lobby/CreateRoomModal.tsx
+++ b/src/pages/lobby/CreateRoomModal.tsx
@@ -1,9 +1,11 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Lock, X } from 'lucide-react'
+import {
+  ROOM_PASSWORD_LENGTH,
+  ROOM_PASSWORD_PATTERN,
+} from '../../constants/room'
 import { cn } from '../../lib/utils'
 
-// 비밀방 비밀번호는 숫자 4자리만 허용
-const ROOM_PASSWORD_PATTERN = /^\d{4}$/
 // 방 제목 최대 글자수 제한
 const ROOM_TITLE_MAX_LENGTH = 16
 
@@ -184,12 +186,12 @@ export function CreateRoomModal({
               type="password"
               inputMode="numeric"
               pattern="[0-9]*"
-              maxLength={4}
+              maxLength={ROOM_PASSWORD_LENGTH}
               value={roomPassword}
               onChange={(event) => {
                 const nextValue = event.target.value
                   .replace(/\D/g, '')
-                  .slice(0, 4)
+                  .slice(0, ROOM_PASSWORD_LENGTH)
                 setRoomPassword(nextValue)
               }}
               placeholder="비밀번호 (4자리)"

--- a/src/pages/lobby/PrivateRoomJoinModal.tsx
+++ b/src/pages/lobby/PrivateRoomJoinModal.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useState } from 'react'
 import { Lock, X } from 'lucide-react'
+import {
+  ROOM_PASSWORD_LENGTH,
+  ROOM_PASSWORD_PATTERN,
+} from '../../constants/room'
 import { cn } from '../../lib/utils'
-
-// 비밀방 입장 비밀번호는 숫자 4자리 고정
-const PASSWORD_PATTERN = /^\d{4}$/
 
 // 비밀방 입장 모달 입력값 타입
 interface PrivateRoomJoinModalProps {
@@ -27,7 +28,7 @@ export function PrivateRoomJoinModal({
   onSubmit,
 }: PrivateRoomJoinModalProps) {
   const [isPasswordInputFocused, setIsPasswordInputFocused] = useState(false)
-  const isJoinDisabled = !PASSWORD_PATTERN.test(password) || isSubmitting
+  const isJoinDisabled = !ROOM_PASSWORD_PATTERN.test(password) || isSubmitting
   const shouldShowHelperMessage = isPasswordInputFocused || isPasswordInvalid
   const helperMessage = isPasswordInvalid
     ? '비밀번호가 올바르지 않습니다.'
@@ -109,14 +110,14 @@ export function PrivateRoomJoinModal({
             type="password"
             inputMode="numeric"
             pattern="[0-9]*"
-            maxLength={4}
+            maxLength={ROOM_PASSWORD_LENGTH}
             value={password}
             onFocus={() => setIsPasswordInputFocused(true)}
             onBlur={() => setIsPasswordInputFocused(false)}
             onChange={(event) => {
               const nextValue = event.target.value
                 .replace(/\D/g, '')
-                .slice(0, 4)
+                .slice(0, ROOM_PASSWORD_LENGTH)
               onPasswordChange(nextValue)
             }}
             placeholder="비밀번호 입력"

--- a/src/pages/lobby/hooks.ts
+++ b/src/pages/lobby/hooks.ts
@@ -1,12 +1,12 @@
 import { useEffect } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { IS_SOCKET_MOCK_ENABLED } from '../../config/env'
 import { connectSocketWithAuthIfNeeded, socket } from '../../lib/socket'
 import { getLobbyRooms, type GetLobbyRoomsParams } from './api'
 
 const LOBBY_QUERY_STALE_TIME_MS = 20_000
 const LOBBY_UPDATED_EVENT = 'lobby_updated'
-const USE_SOCKET_MOCK =
-  import.meta.env.DEV && import.meta.env.VITE_USE_SOCKET_MOCK !== 'false'
+const USE_SOCKET_MOCK = IS_SOCKET_MOCK_ENABLED
 
 // 로비 방 목록 조회와 소켓 기반 갱신을 함께 처리
 export function useLobbyRoomsQuery(params: GetLobbyRoomsParams) {

--- a/src/pages/waiting-room/api.ts
+++ b/src/pages/waiting-room/api.ts
@@ -1,5 +1,6 @@
 import { apiClient } from '../../lib/axios'
 import { parseApiError } from '../../lib/apiError'
+import { IS_SOCKET_MOCK_ENABLED } from '../../config/env'
 import {
   mockCreateWaitingRoom,
   mockJoinWaitingRoom,
@@ -22,8 +23,7 @@ import type {
 // 대기방 기본 제목/정원과 모드 전환 플래그
 const DEFAULT_WAITING_ROOM_TITLE = '즐거운 게임 한판!'
 const DEFAULT_WAITING_ROOM_MAX_PLAYERS = 4
-const USE_WAITING_ROOM_MOCK =
-  import.meta.env.DEV && import.meta.env.VITE_USE_SOCKET_MOCK !== 'false'
+const USE_WAITING_ROOM_MOCK = IS_SOCKET_MOCK_ENABLED
 // 비밀번호 불일치로 간주할 서버 에러 코드 집합
 const JOIN_PASSWORD_MISMATCH_ERROR_CODES = new Set([
   'ROOM_PASSWORD_MISMATCH',

--- a/src/pages/waiting-room/components/DevControlPanel.tsx
+++ b/src/pages/waiting-room/components/DevControlPanel.tsx
@@ -19,9 +19,9 @@ import {
 } from '../mockGateway'
 import { sendWaitingRoomChat } from '../socket'
 import type { WaitingRoomPlayer, WaitingRoomSnapshot } from '../types'
+import { IS_SOCKET_MOCK_ENABLED } from '../../../config/env'
 
-const IS_DEV_CONTROL_ENABLED =
-  import.meta.env.DEV && import.meta.env.VITE_USE_SOCKET_MOCK !== 'false'
+const IS_DEV_CONTROL_ENABLED = IS_SOCKET_MOCK_ENABLED
 
 type DevControlMode = 'room' | 'presence' | 'chat'
 

--- a/src/pages/waiting-room/mockGateway.ts
+++ b/src/pages/waiting-room/mockGateway.ts
@@ -1,4 +1,5 @@
 import { socket } from '../../lib/socket'
+import { ROOM_PASSWORD_PATTERN } from '../../constants/room'
 import { mockLobbyRooms } from '../lobby/mockData'
 import type { LobbyRoom, LobbyRoomStatus } from '../lobby/types'
 import type {
@@ -436,7 +437,7 @@ export async function mockCreateWaitingRoom({
   }
 
   // 비밀방이면 숫자 4자리 비밀번호를 강제
-  if (isPrivate && !/^\d{4}$/.test(password ?? '')) {
+  if (isPrivate && !ROOM_PASSWORD_PATTERN.test(password ?? '')) {
     throw new WaitingRoomMockError(400, '비밀번호는 숫자 4자리여야 합니다.', {
       code: 'INVALID_ROOM_PASSWORD',
       detail: '비밀번호는 숫자 4자리여야 합니다.',

--- a/src/pages/waiting-room/socket.ts
+++ b/src/pages/waiting-room/socket.ts
@@ -1,4 +1,5 @@
 import { connectSocketWithAuthIfNeeded, socket } from '../../lib/socket'
+import { IS_SOCKET_MOCK_ENABLED } from '../../config/env'
 import {
   mockEnterWaitingRoomSocket,
   mockLeaveWaitingRoomSocket,
@@ -25,8 +26,7 @@ const WAITING_ROOM_EVENT_NAMES = {
   gameStart: 'game_start',
 } as const
 
-const USE_WAITING_ROOM_SOCKET_MOCK =
-  import.meta.env.DEV && import.meta.env.VITE_USE_SOCKET_MOCK !== 'false'
+const USE_WAITING_ROOM_SOCKET_MOCK = IS_SOCKET_MOCK_ENABLED
 
 // 소켓 송신 함수 파라미터 타입
 interface EnterWaitingRoomSocketParams {


### PR DESCRIPTION
## 📌 관련 이슈

> closes #232 

---

## 📝 작업 내용

- socket mock 모드 판별식을 공통 설정으로 통합
  - `src/config/env.ts` 추가
  - `IS_SOCKET_MOCK_ENABLED` 도입 후 사용처 일괄 치환
- 비밀방 비밀번호 규칙(숫자 4자리)을 공통 상수로 통합
  - `src/constants/room.ts` 추가
  - `ROOM_PASSWORD_PATTERN`, `ROOM_PASSWORD_LENGTH` 도입 후 사용처 치환
- 기존 중복 선언 제거
  - 로비 방 생성/비밀방 입장
  - 대기방 API/socket/mockGateway
  - presence socket 모듈
  - 게임/보드/DEV 패널의 mock 분기

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료
- [x] `npm run lint` 통과
- [x] `npm run test -- --run` 통과
- [x] `npm run build` 통과

---

## 📸 스크린샷 (선택)

- UI 변경 없음 (리팩터링)

---

## 📌 추가 메모

- 기능 변경 없이 SSOT 중심 구조 개선 리팩터링입니다.
- `docs/rules.md`의 C2(같이 바뀌는 값 SSOT), U3(책임 경계) 개선 목적입니다.
