### PR TITLE
refactor: 인증/리다이렉트 가드 훅 통합

### DIFF
--- a/src/features/auth/hooks/useNicknameSetupForm.ts
+++ b/src/features/auth/hooks/useNicknameSetupForm.ts
@@ -1,5 +1,6 @@
 import { FormEvent, useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { useRequireNicknameSetupSession } from './useRequireNicknameSetupSession'
 import {
   mockCheckNicknameAvailability,
   mockSetNickname,
@@ -17,6 +18,7 @@ export function useNicknameSetupForm() {
   const navigate = useNavigate()
   const session = useAuthStore((state) => state.session)
   const updateNickname = useAuthStore((state) => state.updateNickname)
+  const shouldRender = useRequireNicknameSetupSession(session)
 
   const [nickname, setNickname] = useState('')
   const [submitMessage, setSubmitMessage] = useState<string | null>(null)
@@ -27,20 +29,6 @@ export function useNicknameSetupForm() {
     boolean | null
   >(null)
   const [showValidationMessage, setShowValidationMessage] = useState(false)
-
-  // 세션 상태에 따라 접근 경로를 홈/로비로 정리
-  useEffect(() => {
-    // 세션이 없으면 닉네임 설정 페이지 접근 차단
-    if (!session) {
-      navigate('/', { replace: true })
-      return
-    }
-
-    // 이미 닉네임 설정이 끝났으면 로비로 이동
-    if (!session.needsNicknameSetup) {
-      navigate('/lobby', { replace: true })
-    }
-  }, [navigate, session])
 
   // 입력값이 바뀔 때마다 로컬 형식 검증 결과 계산
   const nicknameValidation = useMemo(
@@ -193,7 +181,7 @@ export function useNicknameSetupForm() {
   }
 
   return {
-    shouldRender: Boolean(session && session.needsNicknameSetup),
+    shouldRender,
     nickname,
     helperFeedback,
     isSubmitting,

--- a/src/features/auth/hooks/useRedirectAuthenticatedToLobby.ts
+++ b/src/features/auth/hooks/useRedirectAuthenticatedToLobby.ts
@@ -1,0 +1,16 @@
+import { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import type { AuthSession } from '../types'
+
+// 홈 화면에서 로그인 완료 사용자(닉네임 설정 완료)를 로비로 리다이렉트
+export function useRedirectAuthenticatedToLobby(session: AuthSession | null) {
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    if (!session || session.needsNicknameSetup) {
+      return
+    }
+
+    navigate('/lobby', { replace: true })
+  }, [navigate, session])
+}

--- a/src/features/auth/hooks/useRequireActiveSession.ts
+++ b/src/features/auth/hooks/useRequireActiveSession.ts
@@ -1,0 +1,23 @@
+import { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import type { AuthSession } from '../types'
+
+// 보호 페이지에서 로그인 세션 + 닉네임 설정 완료 상태를 강제
+export function useRequireActiveSession(session: AuthSession | null) {
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    // 비로그인 사용자는 홈으로 이동
+    if (!session) {
+      navigate('/', { replace: true })
+      return
+    }
+
+    // 닉네임 미설정 사용자는 닉네임 설정 화면으로 이동
+    if (session.needsNicknameSetup) {
+      navigate('/nickname-setup', { replace: true })
+    }
+  }, [navigate, session])
+
+  return Boolean(session && !session.needsNicknameSetup)
+}

--- a/src/features/auth/hooks/useRequireNicknameSetupSession.ts
+++ b/src/features/auth/hooks/useRequireNicknameSetupSession.ts
@@ -1,0 +1,23 @@
+import { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import type { AuthSession } from '../types'
+
+// 닉네임 설정 페이지에서 닉네임 미설정 세션만 접근 허용
+export function useRequireNicknameSetupSession(session: AuthSession | null) {
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    // 세션이 없으면 홈으로 이동
+    if (!session) {
+      navigate('/', { replace: true })
+      return
+    }
+
+    // 이미 닉네임 설정이 끝났으면 로비로 이동
+    if (!session.needsNicknameSetup) {
+      navigate('/lobby', { replace: true })
+    }
+  }, [navigate, session])
+
+  return Boolean(session && session.needsNicknameSetup)
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -10,8 +10,9 @@ import {
   Zap,
 } from 'lucide-react'
 import { motion } from 'framer-motion'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { useRedirectAuthenticatedToLobby } from '../features/auth/hooks/useRedirectAuthenticatedToLobby'
 import { mockGuestLogin, mockKakaoLogin } from '../features/auth/mockApi'
 import { useAuthStore } from '../features/auth/store'
 
@@ -46,20 +47,7 @@ function HomePage() {
   const [isKakaoLoading, setIsKakaoLoading] = useState(false)
   const [isGuestLoading, setIsGuestLoading] = useState(false)
 
-  // 세션이 이미 유효하면 홈 대신 로비로 리다이렉트
-  useEffect(() => {
-    // 비로그인 상태에서는 홈 화면 유지
-    if (!session) {
-      return
-    }
-
-    // 닉네임 설정이 필요한 경우에는 홈에서 이동시키지 않음
-    if (session.needsNicknameSetup) {
-      return
-    }
-
-    navigate('/lobby', { replace: true })
-  }, [navigate, session])
+  useRedirectAuthenticatedToLobby(session)
 
   const isAnyLoading = isKakaoLoading || isGuestLoading
 

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useMemo } from 'react'
+import { useMemo } from 'react'
 import { ArrowLeft, Gamepad2, Shield, Trophy } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
+import { useRequireActiveSession } from '../features/auth/hooks/useRequireActiveSession'
 import { useAuthStore } from '../features/auth/store'
 import { useMyPageProfileQuery } from '../features/auth/hooks/useMyPageProfileQuery'
 import { getAvatarText } from '../components/header/profileMenu'
@@ -34,21 +35,8 @@ const myPageStatsCardMeta = [
 function MyPage() {
   const navigate = useNavigate()
   const session = useAuthStore((state) => state.session)
+  const isAllowedSession = useRequireActiveSession(session)
   const { data: profile, isLoading, isError } = useMyPageProfileQuery(session)
-
-  // 세션 상태에 따라 홈/닉네임 설정 페이지로 진입 차단
-  useEffect(() => {
-    // 비로그인이면 홈으로 이동
-    if (!session) {
-      navigate('/', { replace: true })
-      return
-    }
-
-    // 닉네임 미설정 사용자는 먼저 설정 화면으로 이동
-    if (session.needsNicknameSetup) {
-      navigate('/nickname-setup', { replace: true })
-    }
-  }, [navigate, session])
 
   // 프로필 이미지가 없을 때 사용할 아바타 텍스트 계산
   const fallbackAvatarText = useMemo(() => {
@@ -56,7 +44,7 @@ function MyPage() {
   }, [session?.nickname])
 
   // 리다이렉트 조건에서는 화면을 렌더링하지 않음
-  if (!session || session.needsNicknameSetup) {
+  if (!isAllowedSession || !session) {
     return null
   }
 

--- a/src/pages/lobby/LobbyPage.tsx
+++ b/src/pages/lobby/LobbyPage.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import toast from 'react-hot-toast'
 import { useNavigate } from 'react-router-dom'
 import Header from '../../components/header/Header'
+import { useRequireActiveSession } from '../../features/auth/hooks/useRequireActiveSession'
 import { useAuthStore } from '../../features/auth/store'
 import {
   createProfileMenuItems,
@@ -47,20 +48,7 @@ function LobbyPage() {
     useState(false)
   const [isPrivateRoomPasswordInvalid, setIsPrivateRoomPasswordInvalid] =
     useState(false)
-
-  // 세션 유효성에 따라 홈 또는 닉네임 설정 페이지로 이동
-  useEffect(() => {
-    // 로그인 세션이 없으면 홈으로 이동
-    if (!session) {
-      navigate('/', { replace: true })
-      return
-    }
-
-    // 닉네임 미설정 세션은 닉네임 설정 페이지로 이동
-    if (session.needsNicknameSetup) {
-      navigate('/nickname-setup', { replace: true })
-    }
-  }, [navigate, session])
+  const isAllowedSession = useRequireActiveSession(session)
 
   const {
     data: rooms = [],
@@ -215,7 +203,7 @@ function LobbyPage() {
   }
 
   // 리다이렉트 대상 세션 상태면 화면 렌더링 생략
-  if (!session || session.needsNicknameSetup) {
+  if (!isAllowedSession || !session) {
     return null
   }
 

--- a/src/pages/waiting-room/WaitingRoomPage.tsx
+++ b/src/pages/waiting-room/WaitingRoomPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import toast from 'react-hot-toast'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
+import { useRequireActiveSession } from '../../features/auth/hooks/useRequireActiveSession'
 import { useAuthStore } from '../../features/auth/store'
 import {
   createProfileMenuItems,
@@ -47,6 +48,7 @@ function WaitingRoomPage() {
   const session = useAuthStore((state) => state.session)
   const clearSession = useAuthStore((state) => state.clearSession)
   const [isUserListOpen, setIsUserListOpen] = useState(true)
+  const isAllowedSession = useRequireActiveSession(session)
 
   const locationState = location.state as WaitingRoomLocationState | null
   const isSameRoomState = locationState?.roomId === currentRoomId
@@ -114,24 +116,12 @@ function WaitingRoomPage() {
     },
   })
 
-  // URL/세션 상태 검증 후 잘못된 진입을 리다이렉트
+  // roomId 파라미터가 없으면 로비로 복귀
   useEffect(() => {
     if (!currentRoomId) {
       navigate('/lobby', { replace: true })
-      return
     }
-
-    // 비로그인 사용자는 홈으로 이동
-    if (!session) {
-      navigate('/', { replace: true })
-      return
-    }
-
-    // 닉네임 미설정 사용자는 닉네임 설정 화면으로 이동
-    if (session.needsNicknameSetup) {
-      navigate('/nickname-setup', { replace: true })
-    }
-  }, [currentRoomId, navigate, session])
+  }, [currentRoomId, navigate])
 
   // 대기방 로딩 에러를 토스트로 표시
   useEffect(() => {
@@ -201,7 +191,7 @@ function WaitingRoomPage() {
   }, [handleStartGame])
 
   // 리다이렉트 대상 상태에서는 화면 렌더링 생략
-  if (!session || session.needsNicknameSetup) {
+  if (!isAllowedSession || !session) {
     return null
   }
   if (!currentRoomId) {


### PR DESCRIPTION
## 📌 관련 이슈

> closes #234

---

## 📝 작업 내용

- 인증/리다이렉트 가드 공통 훅 추가
  - `useRedirectAuthenticatedToLobby`
  - `useRequireActiveSession`
  - `useRequireNicknameSetupSession`
- 페이지/폼에 분산되어 있던 중복 `useEffect` 가드 로직 제거 후 공통 훅으로 치환
  - 홈, 로비, 대기방, 마이페이지, 닉네임 설정 폼
- 페이지 본문에서 가드 분기를 걷어내고 화면 의도 중심으로 정리

---

## ✅ 체크리스트

- [x] 기존 기능 동작 유지 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료
- [x] `npm run lint` 통과
- [x] `npm run test -- --run` 통과
- [x] `npm run build` 통과

---

## 📸 스크린샷 (선택)

- UI 변경 없음 (리팩터링)

---

## 📌 추가 메모

- 기능 변경 없는 구조 리팩터링입니다.
- `docs/rules.md` 기준:
  - R2(페이지는 의도 중심), U3(책임 분리), P2(가드 동작 예측 가능성) 개선 목적
