### PR TITLE
docs: 게임 이벤트 명세 기준 로드맵 문서 재정리

### DIFF
--- a/docs/game-delivery-roadmap.md
+++ b/docs/game-delivery-roadmap.md
@@ -1,154 +1,179 @@
-﻿# 게임 완료 로드맵 (현재 코드 기준)
+# 게임 완료 로드맵 (이벤트 명세서 기준, 2026-03-04)
 
-이 문서는 현재 `develop` 코드 기준으로 FE-B와 FE-C가 앞으로 무엇을 해야 하는지 실행 순서대로 정리한 로드맵이다.
+이 문서는 현재 프론트엔드 코드와 `이벤트 명세서.md`를 대조해서 다시 작성한 실행 로드맵이다.
+이전 로드맵의 진행도 수치는 구 소켓 이벤트와 REST 액션 구조를 전제로 한 값이었기 때문에 더 이상 기준으로 쓰지 않는다.
 
-## 1. 현재 상태 요약
+## 1. 기준 문서
 
-### FE-B
+- 요구사항 기준: `모두의마블_요구사항정의서_v8.xlsx`
+- API/데이터 기준: `모두의마블_API명세서_v4.xlsx`, `모두의마블_테이블명세서_v4.xlsx`
+- 실시간 게임 계약 기준: `이벤트 명세서.md`
+- 프론트 내부 기준: `docs/game-ownership.md`, `docs/game-ownership-corrected-table.md`
 
-- 진행도: 80%
-- 현재 단계: 연동 안정화 + 검증 + 남은 모달 구현
+## 2. 명세 변경 핵심
 
-### FE-C
+새 이벤트 명세 기준으로 게임 연동의 중심은 아래 네 가지다.
 
-- 진행도: 50%
-- 현재 단계: 보드 구조 정리 + store 중심 렌더링 전환 준비
+- 액션 전송은 `game:action` 하나로 통합된다.
+- 처리 결과는 `game:ack`, 상태 반영은 `game:patch`, 선택 요구는 `game:prompt`로 분리된다.
+- 클라이언트는 `revision` 기준으로 patch를 적용하고, 역순/중복 패킷을 무시해야 한다.
+- 주사위, 이동, 통행료, 소유권, 건물 단계, 파산은 서버 권위로 확정된다.
 
-## 2. FE-B 우선 작업
+즉, 현재 프론트의 "REST 요청 + 개별 소켓 이벤트 조합 + 보드 로컬 계산" 구조는 새 기준과 직접 충돌한다.
 
-### 2-1. 남은 모달 3개 구현
+## 3. 현재 코드 기준 핵심 갭
 
-우선순위는 아래 순서로 진행한다.
+### 구조 갭
 
-1. 주사위 타이머 팝업
+- `src/services/socket/game.handler.ts`
+  현재는 `game_start`, `turn_start`, `dice_rolled`, `player_moved` 같은 구 이벤트를 직접 구독한다.
+  새 명세 기준으로는 `game:ack`, `game:patch`, `game:prompt`, `game:error`만 처리하도록 바뀌어야 한다.
 
-- 구현 완료
+- `src/services/game/game.api.ts`
+  현재는 `buy`, `build`, `sell`, `state` REST 액션이 중심이다.
+  새 명세 기준으로는 게임 액션 전송을 socket 중심으로 재구성하고, REST는 제거하거나 보조 용도로 축소해야 한다.
 
-2. 도시 인수 팝업
+- `src/hooks/game/useGameState.ts`
+  현재는 진입 시 REST `getState`를 호출하고 기존 소켓 핸들러를 붙인다.
+  새 명세 기준으로는 진입/재접속 시 `game:sync`를 보내고 `snapshot` 또는 patch로 복구해야 한다.
 
-- 상대 도시를 인수하는 상황 UI
-- 비용/확인/취소 버튼 포함
+- `src/stores/game.store.ts`
+  현재 store에는 `revision`, `phase`, `prompt`, `pendingAction`, `lastAck`, `eventQueue`가 없다.
+  새 명세를 소화하려면 snapshot 교체, patch 적용, ack 상태 관리가 가능한 store로 바뀌어야 한다.
 
-3. 무인도 이동칸 팝업
+- `src/pages/GamePage.tsx`
+  `boardPlayers`, `boardCurPlayer`를 별도로 들고 있고 store와 서로 다시 동기화한다.
+  새 명세 기준으로는 store를 단일 소스로 삼고 페이지는 selector 조립만 담당해야 한다.
 
-- 무인도로 이동하는 단일 확인형 모달
+- `src/components/board/GameBoard.tsx`
+  현재 이 파일이 구매/건설/매각 API 호출, 통행료 계산, 파산 처리, 턴 전환, 타일 소유권 상태를 모두 들고 있다.
+  새 명세 기준으로는 보드 렌더링과 애니메이션, prompt 표시만 남기고 결과 계산은 제거해야 한다.
 
-4. 도시 매각 팝업
+### 타입 갭
 
-- 매각 예상 수익과 확인/취소 버튼 포함
+- `src/types/domain.ts`
+  현재 `Player.id`, `currentTurn` 등이 문자열 중심이고, `BuildingLevel`은 `0..5`만 지원한다.
+  새 명세 기준으로는 숫자 기반 ID, `revision`, `phase`, `playerState`, `BuildingLevel 0..7`, `TileType` 재정의가 필요하다.
 
-### 2-2. mock 한 턴 검증
+### 목업 갭
 
-아래 순서가 전부 콘솔 에러 없이 동작해야 한다.
+- `src/mocks/handlers/game.handler.ts`
+  현재 mock은 REST 액션과 구 소켓 이벤트를 함께 흉내 낸다.
+  새 명세 기준 검증을 하려면 `game:ack`, `game:patch`, `game:prompt`를 내보내는 형태로 다시 써야 한다.
 
-1. 게임 진입
-2. 주사위 굴리기
-3. 이동
-4. 구매
-5. 건설
-6. 매각
-7. 턴 전환
-8. 파산 또는 게임 종료 직전 상태 확인
+## 4. 진행도 재평가
 
-### 2-3. 서버 authoritative 흐름 마무리
+기존 80/50 평가는 더 이상 유효하지 않다. 새 이벤트 명세를 기준으로 다시 보면 다음이 더 현실적이다.
 
-- mock에서 로컬로 처리하는 부분과
-- 실제 서버 이벤트를 기다려야 하는 부분을 분리한다.
+### FE-B: 55%
 
-핵심 대상:
+완료된 축:
 
-- AI 패널티
-- 통행료
-- 파산
-- 게임 종료
+- 게임 store 기본 골격 보유
+- 게임 페이지/턴 UI/모달 자산 다수 확보
+- socket 연결 수명주기와 mock 흐름의 기본 토대 존재
+- 게임 API/에러 처리 래퍼와 연동 진입점 존재
 
-### 2-4. `GameBoard.tsx` 내부 FE-B 로직 분리 준비
+아직 비어 있는 축:
 
-현재 `GameBoard.tsx`는 다음 책임이 섞여 있다.
+- 새 이벤트 계약용 타입 재정의
+- `game:action`/`game:ack`/`game:patch`/`game:prompt` 중심 소켓 계층
+- revision 기반 patch 적용기
+- prompt 응답 흐름
+- REST 액션 의존 제거
 
-- 렌더링
-- 구매/건설/매각 API 호출
-- 통행료 계산
-- 파산 처리
-- 모달 제어
+### FE-C: 45%
 
-즉시 대수술은 하지 않되, 다음 기준으로 줄인다.
+완료된 축:
 
-- 계산/계약은 hook 또는 service로 이동
-- 렌더링과 로컬 상호작용만 보드에 남김
+- 보드 배치, 타일 렌더, 말 렌더, 건물 시각화 기본 구조 존재
+- 게임판 화면 자체는 이미 플레이 가능한 수준의 뼈대를 가짐
 
-## 3. FE-C 우선 작업
+아직 비어 있는 축:
 
-### 3-1. 보드 상태 단일화
+- 보드가 store 단일 상태만 읽도록 정리
+- 연출용 event queue 기반 이동/효과 재생
+- 새 tile/building/playerState 규격 반영
+- `GameBoard.tsx` 내부 로직 분리 후 시각 레이어로 수렴
 
-현재 보드는 다음 두 축이 섞여 있다.
+## 5. FE-B 우선 작업
 
-- store 상태
-- `GamePage` / `GameBoard` 로컬 상태
+### 5-1. 타입과 store 계약 재정의
 
-목표:
+- `src/types/domain.ts`를 새 이벤트 명세 기준으로 개편
+- `GameState`를 snapshot 중심 구조로 재설계
+- store에 `revision`, `phase`, `prompt`, `pendingAction`, `lastAck`, `lastError`, `eventQueue` 추가
 
-- store 중심으로 수렴
-- 보드 로컬 상태는 최소한으로 유지
+### 5-2. 소켓 계층 전환
 
-### 3-2. `LegacyBoardGame` 정리
+- `src/services/socket/game.handler.ts`를 구 이벤트 구독형에서 새 이벤트 구독형으로 변경
+- emit 함수는 `emitGameAction`, `emitGameSync`, `emitPromptResponse` 형태로 재구성
+- `src/hooks/game/useGameState.ts`는 진입/재접속 시 `game:sync`를 보내도록 수정
 
-현재 `LegacyBoardGame`은 `GameBoard`를 re-export 하는 래퍼다.
-선택지는 둘 중 하나다.
+### 5-3. patch/snapshot 적용기 구현
 
-1. 얇은 호환 래퍼로 유지
-2. import 경로를 직접 `GameBoard`로 수렴
+- `snapshot`이 오면 store를 통째로 교체
+- `patch`는 `set`, `inc`, `push`, `remove`를 순서대로 적용
+- `revision`이 같거나 작은 패킷은 무시
 
-### 3-3. 시각 안정화
+### 5-4. prompt/ack 기반 입력 UX 정리
 
-- 이동 후 말 표시
-- 건물 단계 표시
-- 타일 소유권 반영
-- 파산/소유 해제 후 stale 상태 제거
+- 구매/건설/매각/무인도 이동/턴 종료를 prompt 또는 ack 기준으로 처리
+- 즉시 실패는 `game:ack.ok=false` 기준으로 에러 표시
+- `DiceTimerModal`을 실제 turn timeout 또는 prompt timeout과 연결
 
-## 4. FE-B / FE-C 공동 체크포인트
+### 5-5. mock 전환
 
-### 계약
+- `src/mocks/handlers/game.handler.ts`를 새 계약으로 재작성
+- 한 턴 검증 시나리오를 `sync -> action -> ack -> patch -> prompt` 흐름으로 다시 정의
 
-- `roomId`
-- `currentTurn`
-- `player.id`
-- `tile.owner_id`
-- `building` 단계
+## 6. FE-C 우선 작업
 
-### 실제 확인 포인트
+### 6-1. 보드 presentational 전환
 
-- store 값과 보드 화면이 같은 상태를 가리키는지
-- socket 수신 후 보드가 한 박자 늦거나 stale 하지 않은지
-- mock과 real 흐름이 최소한 동일한 계약을 따르는지
+- `GameBoard.tsx`에서 서버 권위 계산과 API 호출을 제거
+- 보드 컴포넌트는 store selector에서 넘어온 상태만 렌더하도록 정리
 
-## 5. 권장 작업 순서
+### 6-2. store 단일 렌더 구조
 
-### 바로 다음 순서
+- `GamePage.tsx`의 `boardPlayers`, `boardCurPlayer`, `onTileOwnersChange` 중심 구조 제거
+- store snapshot을 보드용 view model로 변환하는 selector 또는 mapper 추가
 
-1. 도시 인수 팝업
-2. 무인도 이동칸 팝업
-3. 도시 매각 팝업
-4. mock 한 턴 전체 검증
-5. FE-B 재검토
-6. FE-C 보드 상태 단일화 착수
+### 6-3. 이벤트 기반 연출
 
-## 6. 완료 조건
+- `game:patch.events`를 이용해 주사위, 이동, 도착, 통행료, 찬스 효과를 순차 재생
+- 이벤트 연출이 끝나도 상태 기준은 store snapshot/patch가 유지하도록 분리
+
+### 6-4. 시각 규격 재반영
+
+- `BuildingLevel 0..7` 대응
+- `TileType` 명칭 통일
+- `playerState`, `stateDuration`에 따른 섬/잠금 상태 표시 추가
+
+## 7. 권장 실행 순서
+
+1. FE-B가 타입, store, 소켓 계층을 새 명세 기준으로 먼저 고친다.
+2. FE-B가 mock까지 새 계약으로 맞춘다.
+3. FE-C가 보드 로직을 걷어내고 store 단일 렌더 구조로 붙인다.
+4. FE-C가 event queue 기반 이동/연출을 붙인다.
+5. FE-B와 FE-C가 prompt 흐름과 timeout 흐름을 함께 검증한다.
+
+## 8. 완료 조건
 
 ### FE-B 완료 조건
 
-- 게임 API/socket 계약이 확정됨
-- 게임 전용 모달이 모두 구현됨
-- mock 검증 시나리오가 끝까지 돈다
-- 실서버 연결 전 준비가 완료된다
+- 구 REST 액션 의존이 제거되거나 보조 수단으로만 남는다.
+- 구 소켓 이벤트가 제거되고 새 이벤트 계약만 사용한다.
+- patch/snapshot/revision 처리와 prompt 응답이 안정적으로 동작한다.
+- mock이 실제 명세와 같은 계약을 따른다.
 
 ### FE-C 완료 조건
 
-- 보드가 store 기준으로 안정적으로 렌더된다
-- 로컬 상태 이중화가 최소화된다
-- 건물/타일/말 상태가 실제 게임 상태와 일치한다
+- 보드가 store 기준 단일 상태만 읽는다.
+- 이동/건물/소유권/잠금 상태가 새 snapshot 구조와 일치한다.
+- 연출용 events와 실제 상태 patch가 분리되어도 stale 없이 동작한다.
 
-## 7. 결론
+## 9. 결론
 
-현재 우선순위는 FE-B의 남은 모달 3개와 mock 검증 마무리다.
-그 다음 단계에서 FE-C가 보드 구조 정리를 본격적으로 진행하는 흐름이 가장 합리적이다.
+지금 가장 먼저 해야 할 일은 모달 추가가 아니라 게임 계약 계층을 새 이벤트 명세에 맞춰 다시 세우는 일이다.
+즉시 우선순위는 FE-B의 타입/store/socket/mock 전환이고, 그 다음 FE-C가 `GameBoard.tsx`를 시각 레이어로 축소하는 흐름이 맞다.

--- a/docs/game-event-spec-migration-plan.md
+++ b/docs/game-event-spec-migration-plan.md
@@ -1,0 +1,196 @@
+# 게임 이벤트 명세 전환 갭 분석
+
+이 문서는 `이벤트 명세서.md` 기준으로 현재 프론트엔드 코드에서 어디를 어떻게 고쳐야 하는지 파일 단위로 정리한 문서다.
+
+## 1. 핵심 결론
+
+현재 구현은 아래 구조를 전제로 한다.
+
+- 액션: REST `buy/build/sell/state`
+- 실시간 반영: `game_start`, `turn_start`, `dice_rolled`, `player_moved` 등 개별 소켓 이벤트
+- 보드 계산: `GameBoard.tsx` 내부 로컬 계산과 상태 갱신
+
+새 명세는 아래 구조를 요구한다.
+
+- 액션: `game:action`
+- 동기화: `game:sync`
+- 상태 반영: `game:patch`
+- 개인 선택: `game:prompt` / `game:prompt_response`
+- 빠른 입력 결과: `game:ack`
+
+즉, 현재 구조는 "이벤트 이름만 몇 개 바꾸는 수준"이 아니라 상태 흐름 자체를 재정렬해야 한다.
+
+## 2. 수정 대상과 방법
+
+| 파일 | 현재 문제 | 수정 방향 | 담당 |
+| --- | --- | --- | --- |
+| `src/types/domain.ts` | ID 타입, tile type, building level, game state shape가 새 명세와 불일치 | snapshot/patch/ack/prompt/event 타입 추가, 숫자 ID와 `0..7` building level 반영 | FE-B |
+| `src/stores/game.store.ts` | 단순 set/update store라 revision, prompt, patch 적용 불가 | `applySnapshot`, `applyPatch`, `setAck`, `setPrompt`, `consumeEvents` 추가 | FE-B |
+| `src/services/socket/game.handler.ts` | 구 소켓 이벤트 구독과 `roll_dice`, `confirm_penalty` emit 사용 | `game:ack`, `game:patch`, `game:prompt`, `game:error` 구독과 `game:action`, `game:sync`, `game:prompt_response` emit로 교체 | FE-B |
+| `src/hooks/game/useGameState.ts` | mount 시 REST state 조회 중심 | mount/reconnect 시 `game:sync` 전송, snapshot 또는 patch 적용으로 전환 | FE-B |
+| `src/services/game/game.api.ts` | `buyTile`, `buildTile`, `sellTile`, `syncState`가 핵심 액션 경로 | 게임 액션성 REST를 제거하거나 레거시 fallback으로 격리 | FE-B |
+| `src/hooks/game/useDiceRoll.ts` | `emitRollDice` 또는 로컬 보드 fallback 사용 | `ROLL_DICE`용 `game:action` 전송으로 단순화 | FE-B |
+| `src/pages/GamePage.tsx` | `boardPlayers`, `boardCurPlayer` 로컬 상태와 store 이중화 | store selector 기반 조립으로 단순화, 보드에 상태 역주입 금지 | FE-B 주도 / FE-C 협업 |
+| `src/components/board/GameBoard.tsx` | 타일 소유권, 통행료, 파산, 턴 전환, API 호출을 직접 수행 | 렌더링과 연출만 담당하도록 축소, prompt 표시용 표면만 유지 | FE-C 주도 / FE-B 선행 필요 |
+| `src/components/game/modals/*` | 일부 모달은 존재하지만 서버 prompt와 연결되지 않음 | prompt type 기준 wrapper 또는 container 추가, ack/error/timeout 연결 | FE-B |
+| `src/mocks/handlers/game.handler.ts` | 구 REST + 구 소켓 이벤트 mock | 새 이벤트 명세를 흉내 내는 socket mock으로 재작성 | FE-B |
+| `src/test/socketEmitter.ts` | 테스트 유틸이 구 이벤트 네이밍에 묶였을 가능성 높음 | 새 이벤트 네이밍과 patch payload 지원하도록 수정 | FE-B |
+| `src/components/board/*`, `src/styles/board.css` | 렌더 레이어는 usable하지만 새 state shape 미반영 | 새 tile/player/building 표현과 animation 상태를 view model 기준으로 재정렬 | FE-C |
+
+## 3. 파일별 상세 작업
+
+### 3-1. `src/types/domain.ts`
+
+반드시 추가하거나 바꿔야 하는 축:
+
+- `GameAck`
+- `GamePatchEnvelope`
+- `GamePatchOperation`
+- `GamePrompt`
+- `GamePromptResponse`
+- `GameSnapshot`
+- `ServerEvent`
+- `GamePhase`
+- `PlayerState`
+- `TileType`
+
+기존 타입 중 바로 손봐야 하는 부분:
+
+- `BuildingLevel`은 `0 | 1 | 2 | 3 | 4 | 5 | 6 | 7`
+- `Player.id`는 숫자 기준으로 정리
+- `Tile.owner_id` 대신 새 스냅샷 구조와 맞는 `ownerId`
+- `currentTurn` 중심 상태를 `turn`, `currentPlayerId`, `phase`, `revision` 중심으로 재구성
+
+### 3-2. `src/stores/game.store.ts`
+
+현재 store는 부분 업데이트에는 편하지만 새 명세 수용에는 부족하다.
+아래 액션이 필요하다.
+
+- `replaceFromSnapshot(snapshot, revision)`
+- `applyPatchEnvelope(envelope)`
+- `setPendingAction(actionId, type)`
+- `resolveAck(ack)`
+- `setPrompt(prompt)`
+- `clearPrompt(promptId)`
+- `enqueueEvents(events)`
+- `consumeNextEvent()`
+
+이 단계가 끝나야 FE-C가 안정적으로 보드 렌더를 store 하나만 보고 붙일 수 있다.
+
+### 3-3. `src/services/socket/game.handler.ts`
+
+현재 파일은 "이벤트 종류별 store mutation"에 너무 강하게 묶여 있다.
+새 구조에서는 아래 역할로 줄여야 한다.
+
+- 소켓 listener 등록/해제
+- payload를 store 액션으로 전달
+- emit helper 제공
+
+제거 대상:
+
+- `handleTurnStart`
+- `handlePlayerMoved`
+- `handleTilePurchased`
+- `handleTollPaid`
+- `emitRollDice`
+- `emitConfirmPenalty`
+
+대체 대상:
+
+- `emitGameAction`
+- `emitGameSync`
+- `emitPromptResponse`
+- `handleGameAck`
+- `handleGamePatch`
+- `handleGamePrompt`
+- `handleGameError`
+
+### 3-4. `src/services/game/game.api.ts`
+
+현재 `buy/build/sell/sync`는 새 명세 기준의 주 경로가 아니다.
+
+권장 처리:
+
+- `getState`, `buyTile`, `buildTile`, `sellTile`, `syncState`를 레거시로 표시
+- 새 소켓 경로 전환 후 사용처 제거
+- 당장 삭제가 부담되면 `deprecated` 성격의 얇은 래퍼로 격리
+
+### 3-5. `src/pages/GamePage.tsx`
+
+현재 문제:
+
+- store -> board hydrate
+- board -> store write-back
+- turn/current player를 두 군데서 관리
+
+수정 방향:
+
+- `boardPlayers`, `boardCurPlayer` 제거
+- `handlePlayersChange`, `handleCurPlayerChange`, `handleTileOwnersChange` 제거
+- store snapshot에서 보드용 `players`, `tiles`, `currentPlayerId`, `activePrompt`를 selector로 가공
+- `isMyTurn`도 store `currentPlayerId`와 auth session 기준으로 계산
+
+### 3-6. `src/components/board/GameBoard.tsx`
+
+현재 가장 큰 구조 부채가 이 파일이다.
+
+제거해야 하는 책임:
+
+- `gameApi.syncState`, `buyTile`, `buildTile`, `sellTile`
+- `calcToll` 기반 실제 돈 계산
+- `applyMoney`, 파산 판정, 턴 강제 전환
+- 타일 소유권의 로컬 진실 소스
+
+남겨야 하는 책임:
+
+- 보드 배치 렌더링
+- 토큰/건물/타일 시각화
+- 이벤트 큐 기반 이동 연출
+- prompt에 따라 모달 또는 오버레이 표면 표시
+
+즉, `GameBoard.tsx`는 "게임 엔진"이 아니라 "게임 화면"이 되어야 한다.
+
+### 3-7. `src/mocks/handlers/game.handler.ts`
+
+이 파일을 안 고치면 새 명세 기준 검증이 불가능하다.
+
+최소 필요 기능:
+
+- 초기 진입 시 `game:sync`에 대한 snapshot 응답
+- `ROLL_DICE`, `BUY_PROPERTY`, `SELL_PROPERTY`, `END_TURN` 액션 처리
+- 각 액션마다 `game:ack` 발행
+- 상태 확정 시 `game:patch` 발행
+- 필요 시 `game:prompt` 발행
+
+## 4. FE-B / FE-C 분리 기준
+
+### FE-B가 먼저 끝내야 하는 것
+
+- 타입 재정의
+- store 재설계
+- socket 계층 전환
+- mock 전환
+- prompt/ack/error 흐름 정의
+
+### FE-C가 그 다음 붙여야 하는 것
+
+- board presentational refactor
+- event queue 기반 연출
+- store selector 기반 렌더링
+- 새 building/tile/playerState 시각 반영
+
+## 5. 권장 순서
+
+1. `src/types/domain.ts`
+2. `src/stores/game.store.ts`
+3. `src/services/socket/game.handler.ts`
+4. `src/hooks/game/useGameState.ts`
+5. `src/mocks/handlers/game.handler.ts`
+6. `src/pages/GamePage.tsx`
+7. `src/components/board/GameBoard.tsx`
+8. `src/components/game/modals/*`
+
+## 6. 문서 사용법
+
+이 문서는 실제 코드 수정 전 체크리스트로 사용한다.
+파일을 건드릴 때는 "새 이벤트 명세를 수용하기 위한 변경인지" 아니면 "구 구조를 임시 연명하는 변경인지"를 먼저 구분해야 한다.

--- a/docs/game-ownership-corrected-table.md
+++ b/docs/game-ownership-corrected-table.md
@@ -1,83 +1,51 @@
-﻿# FE-B / FE-C 분업표 (현재 코드 기준)
+# FE-B / FE-C 분업표 (이벤트 명세서 기준)
 
 ## 요약 표
 
-| 구분                | FE-B    | FE-C    | 비고                           |
-| ------------------- | ------- | ------- | ------------------------------ |
-| 게임 API 연동       | 주 담당 | 보조    | roomId 기반 계약 유지          |
-| 게임 socket 연동    | 주 담당 | 보조    | emit/handler/store 반영        |
-| 게임 store          | 주 담당 | 보조    | `game.store.ts` 기준           |
-| 게임 페이지 조립    | 주 담당 | 보조    | `GamePage.tsx`                 |
-| 게임 모달 UI        | 주 담당 | 보조    | `src/components/game/modals/*` |
-| 주사위/턴 제어 UI   | 주 담당 | 보조    | `RollButton`, timer 등         |
-| 보드 렌더링         | 보조    | 주 담당 | `src/components/board/*`       |
-| 말 이동/건물 시각화 | 보조    | 주 담당 | 렌더/애니메이션 중심           |
-| 보드 로컬 상태 정리 | 공동    | 공동    | 현재 가장 큰 정리 대상         |
-| 공용 타입           | 공동    | 공동    | `src/types/domain.ts`          |
+| 구분 | FE-B | FE-C | 비고 |
+| --- | --- | --- | --- |
+| 이벤트 명세 타입 정의 | 주 담당 | 보조 | `src/types/domain.ts` |
+| 게임 store / patch 적용기 | 주 담당 | 보조 | revision, snapshot, prompt 포함 |
+| 게임 socket emit/listener | 주 담당 | 보조 | `game:action`, `game:ack`, `game:patch` |
+| 게임 mock / 테스트 유틸 | 주 담당 | 보조 | 새 명세 기준 검증 |
+| 게임 페이지 조립 | 주 담당 | 보조 | `GamePage.tsx`에서 상태 단일화 |
+| 게임 모달 / prompt UI | 주 담당 | 보조 | prompt container 중심 |
+| 보드 렌더링 | 보조 | 주 담당 | `src/components/board/*` |
+| 말 이동 / 타일 / 건물 시각화 | 보조 | 주 담당 | store snapshot 기준 |
+| patch events 애니메이션 | 보조 | 주 담당 | 연출만 담당 |
+| `GameBoard.tsx` 로직 제거 | 공동 | 공동 | FE-B 선행, FE-C 마무리 |
 
 ## 진행도 요약
 
-| 파트 | 진행도 | 상태                                |
-| ---- | ------ | ----------------------------------- |
-| FE-B | 80%    | 연동/검증/남은 모달 정리 단계       |
-| FE-C | 50%    | 보드 구조 정리와 시각화 안정화 단계 |
+| 파트 | 진행도 | 상태 |
+| --- | --- | --- |
+| FE-B | 55% | 새 이벤트 계약으로 상태/소켓 계층을 다시 세워야 하는 단계 |
+| FE-C | 45% | 보드를 store 단일 렌더와 연출 레이어로 정리해야 하는 단계 |
 
-## FE-B 완료된 내용
+## FE-B 최우선 작업
 
-- game store 구축 및 기본 액션 정리
-- roomId 기반 게임 API 정합화
-- socket emit/handler 주요 경로 정리
-- mock 환경 분기 및 테스트 모드 추가
-- 주요 게임 모달 UI 구현
-  - 구매
-  - 건설
-  - 카드
-  - 통행료
-  - AI 패널티
-  - 파산
-  - 게임 결과
-  - 주사위 타이머
+- `src/types/domain.ts`를 새 이벤트 명세 기준으로 재정의
+- `src/stores/game.store.ts`에 snapshot/patch/revision/prompt/ack 구조 추가
+- `src/services/socket/game.handler.ts`를 새 이벤트 계약으로 교체
+- `src/hooks/game/useGameState.ts`에서 `game:sync` 기반 복구로 전환
+- `src/mocks/handlers/game.handler.ts`를 새 명세 mock으로 재작성
+- `src/pages/GamePage.tsx`의 보드 상태 write-back 제거
 
-## FE-B 남은 내용
+## FE-C 최우선 작업
 
-- 남은 모달 UI 구현
-  - 도시 인수 팝업
-  - 무인도 이동칸 팝업
-  - 도시 매각 팝업
-- mock 한 턴 전체 시나리오 최종 검증
-- 실서버 authoritative 흐름 최종 점검
-- `GameBoard.tsx` 안의 FE-B 로직 일부 정리
+- `GameBoard.tsx`에서 API 호출, 통행료 계산, 파산 처리 제거
+- store selector 기반 보드 렌더 구조 정리
+- `game:patch.events` 기반 이동/효과 애니메이션 계층 추가
+- 새 `buildingLevel`, `tileType`, `playerState` 표시 반영
 
-## FE-C 완료된 내용
+## 현재 가장 큰 리스크
 
-- 보드 전체 배치 구조
-- 타일 렌더링 기본 구성
-- 플레이어 말 기본 렌더링
-- 건물 배지/아이콘 렌더링 구조
-- `GameBoard` 기반 게임판 동작 뼈대
+- `GameBoard.tsx`가 아직 게임 엔진처럼 동작한다.
+- `GamePage.tsx`가 store와 board 로컬 상태를 이중 관리한다.
+- mock이 새 이벤트 명세와 다른 프로토콜을 사용한다.
+- 타입 계층이 새 숫자 ID / revision / snapshot 구조를 표현하지 못한다.
 
-## FE-C 남은 내용
+## 완료 판단 기준
 
-- `LegacyBoardGame` 의존 제거 또는 얇은 래퍼화 유지 판단
-- store 기준 단일 렌더 구조로 정리
-- 보드 로컬 상태 제거 범위 확정
-- 이동/건물/타일 소유 상태 렌더 안정화
-- 시각 피드백과 애니메이션 보강
-
-## FE-A 제외 범위
-
-아래는 FE-B/FE-C 작업 범위에서 제외한다.
-
-- 로비
-- 로그인
-- 랜딩
-- 메신저/채팅방 일반 기능
-- 프레즌스
-- 게임 외 room UI
-
-## 공동 확인 필요 항목
-
-- `src/types/domain.ts`
-- 게임 상태 payload shape
-- tile type 명칭 정합화
-- player id / roomId / currentTurn 계약
+- FE-B 완료: 새 이벤트 계약만으로 한 턴 전체 흐름이 돈다.
+- FE-C 완료: 보드가 store 하나만 보고 정확히 렌더되며, 연출과 실제 상태가 분리돼도 stale 하지 않다.

--- a/docs/game-ownership.md
+++ b/docs/game-ownership.md
@@ -1,145 +1,125 @@
-﻿# 게임 영역 파일 소유권 및 분업 기준
+# 게임 영역 파일 소유권 및 분업 기준 (이벤트 명세서 반영)
 
-이 문서는 현재 프로젝트 코드 기준으로 FE-B와 FE-C의 게임 영역 책임을 다시 정리한 기준 문서다.
-기존 문서의 인코딩 손상과 초기 추정 분업표는 이 문서로 대체한다.
+이 문서는 새 `이벤트 명세서.md` 기준으로 FE-B와 FE-C의 게임 영역 책임을 다시 정리한 문서다.
+기존 분업 문서는 구 소켓 이벤트 구조를 전제로 했기 때문에 이 문서로 대체한다.
 
-## 1. 분업 범위
+## 1. 분업 원칙
 
-### 포함 범위
+- FE-B는 게임 계약, 상태, socket, prompt, mock을 책임진다.
+- FE-C는 보드 렌더링, 애니메이션, 시각 상태 표현을 책임진다.
+- 새 명세에서 결과 계산은 서버 권위이므로, FE-C가 게임 결과를 계산하는 구조는 금지한다.
 
-- 게임 페이지 진입 이후의 화면과 상태
-- 게임 전용 store, socket, API 연동
-- 보드 렌더링, 말 이동, 타일 소유 상태, 건물 표시
-- 게임 전용 모달과 턴 제어 UI
+## 2. FE-B 주 담당
 
-### 제외 범위
-
-다음 영역은 게임 외 영역으로 보고 FE-A 담당으로 제외한다.
-
-- 로비
-- 로그인
-- 랜딩
-- 대기방 일반 UI
-- 메신저/채팅방 전반
-- 프레즌스, 방 목록, 일반 room 공용 UI
-
-## 2. 파일 소유권
-
-### FE-B 주 담당
-
-게임 로직, 상태 계약, 소켓/API 연동, 게임 전용 모달/컨트롤
-
-- `src/stores/game.store.ts`
-- `src/services/game/game.api.ts`
-- `src/services/socket/game.handler.ts`
-- `src/hooks/game/*`
-- `src/components/game/controls/*`
-- `src/components/game/modals/*`
-- `src/pages/GamePage.tsx`
-- `src/mocks/gameMockData.ts`
-- `src/mocks/handlers/game.handler.ts`
-
-### FE-C 주 담당
-
-게임 보드 렌더링, 타일/말/건물 시각화, 보드 레이아웃과 애니메이션
-
-- `src/components/board/*`
-- `src/game/phaserConfig.tsx`
-- `src/styles/board.css`
-
-### 공동 관리
-
-양쪽이 계약을 맞춰야 하는 공용 타입/도메인
+아래 영역은 FE-B가 주도한다.
 
 - `src/types/domain.ts`
+- `src/stores/game.store.ts`
+- `src/services/socket/game.handler.ts`
+- `src/services/game/game.api.ts`
+- `src/hooks/game/*`
+- `src/mocks/handlers/game.handler.ts`
+- `src/test/socketEmitter.ts`
+- `src/pages/GamePage.tsx`
+- `src/components/game/modals/*`
 
-## 3. 현재 코드 기준 실제 경계
+핵심 책임:
 
-### FE-B가 이미 깊게 들어가 있는 파일
+- `game:action`, `game:ack`, `game:patch`, `game:prompt`, `game:error`
+- snapshot/patch/revision 처리
+- prompt 응답과 timeout 처리
+- mock과 실서버 계약 정렬
 
-다음 파일은 원래 FE-C와 경계가 닿지만, 현재 구조상 FE-B 로직이 일부 들어가 있다.
+## 3. FE-C 주 담당
 
-- `src/components/board/GameBoard.tsx`
+아래 영역은 FE-C가 주도한다.
 
-사유:
+- `src/components/board/*`
+- `src/styles/board.css`
+- 보드 화면의 애니메이션/시각 피드백
 
-- 구매/건설/매각 API 호출
+핵심 책임:
+
+- 플레이어 말, 타일, 건물, 소유권 시각화
+- patch events 기반 이동/도착/효과 연출
+- snapshot/store 상태 기반 보드 렌더 안정화
+
+## 4. 공동 관리
+
+둘이 같이 맞춰야 하는 영역은 아래와 같다.
+
+- store snapshot을 보드 view model로 바꾸는 기준
+- prompt를 어떤 UI 표면으로 보여줄지에 대한 계약
+- `playerState`, `buildingLevel`, `tileType`의 렌더 규칙
+
+## 5. 현재 코드 기준 예외 구간
+
+### `src/components/board/GameBoard.tsx`
+
+이 파일은 현재 FE-B 책임과 FE-C 책임이 가장 많이 섞여 있다.
+
+현재 들어 있는 FE-B 성격의 책임:
+
+- REST 액션 호출
 - 통행료 계산
-- AI 패널티 처리
 - 파산 처리
-- 각종 모달 open/close 로직
+- 턴 전환
+- 타일 소유 상태의 로컬 진실 소스
 
 정리 원칙:
 
-- 단기적으로는 이 파일에서 FE-B 로직을 허용한다.
-- 중기적으로는 FE-B 로직을 hooks/store/services 쪽으로 빼고, FE-C는 렌더링 책임만 남기는 방향이 맞다.
+- FE-B가 먼저 연동 로직을 바깥으로 뺀다.
+- FE-C는 그 이후 `GameBoard.tsx`를 렌더/연출 중심 컴포넌트로 정리한다.
+- 당분간 이 파일은 공동 정리 대상으로 본다.
 
-## 4. 진행도 평가
+## 6. 진행도 재평가
 
-### FE-B 진행도: 80%
+### FE-B 진행도: 55%
 
-완료된 축:
+이 수치는 "게임 UI가 어느 정도 있다"가 아니라 "새 이벤트 명세를 실제로 소화할 수 있는가" 기준이다.
 
-- roomId 기반 API/소켓 계약 정합화
-- game store 구축
-- socket handler lifecycle 및 주요 이벤트 반영
-- mock/real 분기 일부 정리
-- 게임 전용 주요 모달 UI 다수 구현
-- mock 자금/전체 턴 테스트 모드 보강
+완료된 것:
 
-남은 핵심:
+- 게임 store 골격
+- 페이지/모달/턴 UI 기본 자산
+- socket 연결과 mock 기본 토대
 
-- mock 한 턴 전체 검증 마무리
-- 서버 authoritative 흐름으로 최종 정리
-- `GameBoard` 안의 FE-B 로직 일부 분리
-- 남은 게임 모달 3개 구현
+남은 것:
 
-### FE-C 진행도: 50%
+- 새 타입 계약
+- patch/snapshot/revision store
+- prompt/ack 기반 입력 UX
+- 구 REST/구 이벤트 제거
+- mock 전환
 
-완료된 축:
+### FE-C 진행도: 45%
 
-- 보드 기본 레이아웃
-- 타일/말/건물 렌더링 기본 구조
-- `GameBoard` 기반 플레이 가능 화면 뼈대
+완료된 것:
 
-남은 핵심:
+- 보드 배치와 기본 시각화
+- 말/타일/건물 렌더 뼈대
 
-- `LegacyBoardGame` 의존 정리
-- store 중심 보드 렌더 구조로 수렴
-- 보드 로컬 상태와 store 이중화 제거
-- 이동/건물/소유권 표시의 최종 안정화
+남은 것:
 
-## 5. 현재 프로젝트 기준 핵심 리스크
+- store 단일 상태 렌더
+- event queue 기반 연출
+- `GameBoard.tsx` 로직 제거
+- 새 building/player state 시각 규칙 반영
 
-1. `GamePage`가 여전히 로컬 보드 상태를 많이 들고 있다.
-
-- `boardPlayers`
-- `boardCurPlayer`
-
-2. `GameBoard.tsx` 안에 FE-B와 FE-C 책임이 섞여 있다.
-
-3. mock 흐름과 실제 서버 authoritative 흐름이 100% 같지 않다.
-
-4. FE-A 영역과 겹치는 공용 UI 파일을 잘못 수정하면 분업이 다시 깨진다.
-
-## 6. 수정 원칙
+## 7. 작업 충돌 방지 규칙
 
 ### FE-B 작업 시
 
-- FE-A 영역 파일은 수정하지 않는다.
-- 보드 렌더링 자체보다 계약, 상태, API, socket에 집중한다.
-- 보드 파일 수정이 필요하면 "게임 로직 보강" 범위로 최소화한다.
+- 보드 파일을 건드리더라도 계약 제거와 상태 이관까지만 한다.
+- 보드 스타일과 시각 디테일을 임의로 바꾸지 않는다.
 
 ### FE-C 작업 시
 
-- socket/API/store 계약을 새로 만들지 않는다.
-- FE-B가 만든 상태를 읽어서 렌더링하는 쪽으로 정리한다.
-- 임의 로컬 상태를 늘리지 않는다.
+- 새 socket 이벤트나 store 계약을 독자적으로 만들지 않는다.
+- 서버 권위 계산을 보드 내부에 다시 넣지 않는다.
 
-## 7. 최종 목표
+## 8. 최종 목표
 
-- FE-B: 게임 상태와 연동 책임을 안정적으로 제공
-- FE-C: 그 상태를 보드에서 정확하게 시각화
-- FE-A: 게임 외 영역을 완전히 분리 관리
-
-이 문서 기준으로 분업 충돌이 생기면, 코드 소유권은 "현재 실제 책임"을 우선으로 판단한다.
+- FE-B: 새 이벤트 명세를 store와 socket 계층에서 안정적으로 흡수
+- FE-C: 그 상태를 보드에서 정확하고 자연스럽게 연출
+- 둘 사이 경계는 "계약/상태"와 "표현/연출"로 나눈다


### PR DESCRIPTION
## 📌 관련 이슈

> 연결 이슈 없음

---

## 📝 작업 내용

- 새 `이벤트 명세서.md` 기준으로 게임 문서 구조를 전면 재정리했습니다.
- 현재 프론트 코드와 명세의 차이를 기준으로 FE-B / FE-C 진행도와 우선순위를 다시 산정했습니다.
- 파일 단위 수정 포인트를 정리한 마이그레이션 문서(`docs/game-event-spec-migration-plan.md`)를 추가했습니다.
- 기존 로드맵/분업 문서를 새 이벤트 계약 기준으로 갱신했습니다.

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [ ] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

> 문서 변경만 포함되어 스크린샷은 없습니다.
