### PR TITLE
refactor: LobbyPage 액션 훅 분리 (방 생성/입장/비밀방 모달 흐름)

### DIFF
--- a/src/pages/lobby/LobbyPage.tsx
+++ b/src/pages/lobby/LobbyPage.tsx
@@ -19,15 +19,8 @@ import { useLobbyRoomsQuery } from './hooks'
 import { LobbyControls } from './LobbyControls'
 import { RoomGrid } from './RoomGrid'
 import { PrivateRoomJoinModal } from './PrivateRoomJoinModal'
-import { CreateRoomModal, type CreateRoomFormValues } from './CreateRoomModal'
-import {
-  createWaitingRoom,
-  getWaitingRoomErrorMessage,
-  isJoinPasswordMismatchError,
-  joinWaitingRoom,
-} from '../waiting-room/api'
-import type { LobbyRoom } from './types'
-import type { WaitingRoomSnapshot } from '../waiting-room/types'
+import { CreateRoomModal } from './CreateRoomModal'
+import { useLobbyRoomActions } from './useLobbyRoomActions'
 
 // 로비 화면 상태 관리와 방/접속자/DM 상호작용 통합 처리
 function LobbyPage() {
@@ -39,16 +32,22 @@ function LobbyPage() {
   const [roomFilter, setRoomFilter] = useState<LobbyRoomFilter>('ALL')
   const [excludePrivateRoom, setExcludePrivateRoom] = useState(false)
   const [isUserListOpen, setIsUserListOpen] = useState(true)
-  const [isCreateRoomModalOpen, setIsCreateRoomModalOpen] = useState(false)
-  const [isCreateRoomPending, setIsCreateRoomPending] = useState(false)
-  const [selectedPrivateRoom, setSelectedPrivateRoom] =
-    useState<LobbyRoom | null>(null)
-  const [privateRoomPassword, setPrivateRoomPassword] = useState('')
-  const [isPrivateRoomJoinPending, setIsPrivateRoomJoinPending] =
-    useState(false)
-  const [isPrivateRoomPasswordInvalid, setIsPrivateRoomPasswordInvalid] =
-    useState(false)
   const isAllowedSession = useRequireActiveSession(session)
+  const {
+    isCreateRoomModalOpen,
+    isCreateRoomPending,
+    selectedPrivateRoom,
+    privateRoomPassword,
+    isPrivateRoomJoinPending,
+    isPrivateRoomPasswordInvalid,
+    openCreateRoomModal,
+    closeCreateRoomModal,
+    joinRoom,
+    closePrivateRoomModal,
+    changePrivateRoomPassword,
+    submitCreateRoom,
+    submitPrivateRoomJoin,
+  } = useLobbyRoomActions({ session })
 
   const {
     data: rooms = [],
@@ -91,117 +90,6 @@ function LobbyPage() {
     navigate('/my-page')
   }
 
-  function handleOpenCreateRoomModal() {
-    setIsCreateRoomModalOpen(true)
-  }
-
-  // 방 생성 요청 중에는 모달 닫기를 막아 중복 동작 방지
-  function handleCloseCreateRoomModal() {
-    if (isCreateRoomPending) {
-      return
-    }
-
-    setIsCreateRoomModalOpen(false)
-  }
-
-  // 비밀방은 비밀번호 모달을 열고, 일반방은 바로 입장 처리
-  function handleJoinRoom(room: LobbyRoom) {
-    if (room.isPrivate) {
-      setSelectedPrivateRoom(room)
-      setPrivateRoomPassword('')
-      setIsPrivateRoomPasswordInvalid(false)
-      return
-    }
-
-    handleEnterWaitingRoom(room)
-  }
-
-  function handleClosePrivateRoomModal() {
-    setSelectedPrivateRoom(null)
-    setPrivateRoomPassword('')
-    setIsPrivateRoomPasswordInvalid(false)
-  }
-
-  // 대기방 페이지로 이동하면서 roomId/title/snapshot을 전달
-  function handleEnterWaitingRoom(
-    room: LobbyRoom,
-    preJoinedSnapshot?: WaitingRoomSnapshot
-  ) {
-    navigate(`/rooms/${room.id}`, {
-      state: {
-        roomId: room.id,
-        roomTitle: room.title,
-        preJoinedSnapshot,
-      },
-    })
-  }
-
-  // 방 생성 API를 호출하고 성공 시 생성된 대기방으로 이동
-  async function handleSubmitCreateRoom(values: CreateRoomFormValues) {
-    // 세션이 없으면 생성 요청을 보내지 않음
-    if (!session) {
-      return
-    }
-
-    setIsCreateRoomPending(true)
-
-    try {
-      const createdRoom = await createWaitingRoom({
-        title: values.title,
-        isPrivate: values.isPrivate,
-        password: values.password,
-        hostUserId: session.userId,
-        hostNickname: session.nickname,
-      })
-
-      setIsCreateRoomModalOpen(false)
-      navigate(`/rooms/${createdRoom.roomId}`, {
-        state: {
-          roomId: createdRoom.roomId,
-          roomTitle: createdRoom.roomTitle,
-          preJoinedSnapshot: createdRoom.preJoinedSnapshot,
-        },
-      })
-    } catch (error) {
-      toast.error(getWaitingRoomErrorMessage(error, '방 생성에 실패했습니다.'))
-    } finally {
-      setIsCreateRoomPending(false)
-    }
-  }
-
-  // 비밀방 비밀번호 검증 입장 요청 처리
-  async function handleSubmitPrivateRoomJoin() {
-    if (!selectedPrivateRoom || !session) {
-      return
-    }
-
-    setIsPrivateRoomJoinPending(true)
-
-    try {
-      const joinedRoomSnapshot = await joinWaitingRoom({
-        roomId: selectedPrivateRoom.id,
-        userId: session.userId,
-        nickname: session.nickname,
-        fallbackTitle: selectedPrivateRoom.title,
-        password: privateRoomPassword,
-      })
-
-      handleEnterWaitingRoom(selectedPrivateRoom, joinedRoomSnapshot)
-      handleClosePrivateRoomModal()
-    } catch (error) {
-      // 비밀번호 불일치 에러는 인풋 에러 상태를 별도 표시
-      if (isJoinPasswordMismatchError(error)) {
-        setIsPrivateRoomPasswordInvalid(true)
-      }
-
-      toast.error(
-        getWaitingRoomErrorMessage(error, '비밀방 입장에 실패했습니다.')
-      )
-    } finally {
-      setIsPrivateRoomJoinPending(false)
-    }
-  }
-
   // 리다이렉트 대상 세션 상태면 화면 렌더링 생략
   if (!isAllowedSession || !session) {
     return null
@@ -233,7 +121,7 @@ function LobbyPage() {
             onSearchKeywordChange={setSearchRoom}
             onRoomFilterChange={setRoomFilter}
             onExcludePrivateRoomChange={setExcludePrivateRoom}
-            onCreateRoom={handleOpenCreateRoomModal}
+            onCreateRoom={openCreateRoomModal}
           />
 
           <RoomGrid
@@ -241,7 +129,7 @@ function LobbyPage() {
             isLoading={isRoomsLoading}
             isError={isRoomsError}
             isUserListOpen={isUserListOpen}
-            onJoinRoom={handleJoinRoom}
+            onJoinRoom={joinRoom}
           />
         </section>
 
@@ -263,15 +151,10 @@ function LobbyPage() {
           password={privateRoomPassword}
           isSubmitting={isPrivateRoomJoinPending}
           isPasswordInvalid={isPrivateRoomPasswordInvalid}
-          onPasswordChange={(password) => {
-            setPrivateRoomPassword(password)
-            if (isPrivateRoomPasswordInvalid) {
-              setIsPrivateRoomPasswordInvalid(false)
-            }
-          }}
-          onClose={handleClosePrivateRoomModal}
+          onPasswordChange={changePrivateRoomPassword}
+          onClose={closePrivateRoomModal}
           onSubmit={() => {
-            void handleSubmitPrivateRoomJoin()
+            void submitPrivateRoomJoin()
           }}
         />
       ) : null}
@@ -280,9 +163,9 @@ function LobbyPage() {
         <CreateRoomModal
           defaultRoomTitle={`${session.nickname}님의 방`}
           isSubmitting={isCreateRoomPending}
-          onClose={handleCloseCreateRoomModal}
+          onClose={closeCreateRoomModal}
           onSubmit={(values) => {
-            void handleSubmitCreateRoom(values)
+            void submitCreateRoom(values)
           }}
         />
       ) : null}

--- a/src/pages/lobby/useLobbyRoomActions.ts
+++ b/src/pages/lobby/useLobbyRoomActions.ts
@@ -1,0 +1,170 @@
+import { useState } from 'react'
+import toast from 'react-hot-toast'
+import { useNavigate } from 'react-router-dom'
+import type { AuthSession } from '../../features/auth/types'
+import type { CreateRoomFormValues } from './CreateRoomModal'
+import {
+  createWaitingRoom,
+  getWaitingRoomErrorMessage,
+  isJoinPasswordMismatchError,
+  joinWaitingRoom,
+} from '../waiting-room/api'
+import type { LobbyRoom } from './types'
+import type { WaitingRoomSnapshot } from '../waiting-room/types'
+
+// 로비 방 생성/입장 액션 훅 입력값 타입
+interface UseLobbyRoomActionsParams {
+  session: AuthSession | null
+}
+
+// 방 생성/입장/비밀방 모달 상태와 액션을 통합 관리
+export function useLobbyRoomActions({ session }: UseLobbyRoomActionsParams) {
+  const navigate = useNavigate()
+  const [isCreateRoomModalOpen, setIsCreateRoomModalOpen] = useState(false)
+  const [isCreateRoomPending, setIsCreateRoomPending] = useState(false)
+  const [selectedPrivateRoom, setSelectedPrivateRoom] =
+    useState<LobbyRoom | null>(null)
+  const [privateRoomPassword, setPrivateRoomPassword] = useState('')
+  const [isPrivateRoomJoinPending, setIsPrivateRoomJoinPending] =
+    useState(false)
+  const [isPrivateRoomPasswordInvalid, setIsPrivateRoomPasswordInvalid] =
+    useState(false)
+
+  // 대기방 페이지로 이동하면서 roomId/title/snapshot을 전달
+  function enterWaitingRoom(
+    room: LobbyRoom,
+    preJoinedSnapshot?: WaitingRoomSnapshot
+  ) {
+    navigate(`/rooms/${room.id}`, {
+      state: {
+        roomId: room.id,
+        roomTitle: room.title,
+        preJoinedSnapshot,
+      },
+    })
+  }
+
+  // 방 생성 모달 열기
+  function openCreateRoomModal() {
+    setIsCreateRoomModalOpen(true)
+  }
+
+  // 방 생성 요청 중에는 모달 닫기를 막아 중복 동작 방지
+  function closeCreateRoomModal() {
+    if (isCreateRoomPending) {
+      return
+    }
+
+    setIsCreateRoomModalOpen(false)
+  }
+
+  // 비밀방은 비밀번호 모달을 열고, 일반방은 바로 입장 처리
+  function joinRoom(room: LobbyRoom) {
+    if (room.isPrivate) {
+      setSelectedPrivateRoom(room)
+      setPrivateRoomPassword('')
+      setIsPrivateRoomPasswordInvalid(false)
+      return
+    }
+
+    enterWaitingRoom(room)
+  }
+
+  // 비밀방 모달 상태 초기화 후 닫기
+  function closePrivateRoomModal() {
+    setSelectedPrivateRoom(null)
+    setPrivateRoomPassword('')
+    setIsPrivateRoomPasswordInvalid(false)
+  }
+
+  // 비밀번호 입력 변경 시 값 반영 + 오류 상태 해제
+  function changePrivateRoomPassword(password: string) {
+    setPrivateRoomPassword(password)
+
+    if (isPrivateRoomPasswordInvalid) {
+      setIsPrivateRoomPasswordInvalid(false)
+    }
+  }
+
+  // 방 생성 API를 호출하고 성공 시 생성된 대기방으로 이동
+  async function submitCreateRoom(values: CreateRoomFormValues) {
+    // 세션이 없으면 생성 요청을 보내지 않음
+    if (!session) {
+      return
+    }
+
+    setIsCreateRoomPending(true)
+
+    try {
+      const createdRoom = await createWaitingRoom({
+        title: values.title,
+        isPrivate: values.isPrivate,
+        password: values.password,
+        hostUserId: session.userId,
+        hostNickname: session.nickname,
+      })
+
+      setIsCreateRoomModalOpen(false)
+      navigate(`/rooms/${createdRoom.roomId}`, {
+        state: {
+          roomId: createdRoom.roomId,
+          roomTitle: createdRoom.roomTitle,
+          preJoinedSnapshot: createdRoom.preJoinedSnapshot,
+        },
+      })
+    } catch (error) {
+      toast.error(getWaitingRoomErrorMessage(error, '방 생성에 실패했습니다.'))
+    } finally {
+      setIsCreateRoomPending(false)
+    }
+  }
+
+  // 비밀방 비밀번호 검증 입장 요청 처리
+  async function submitPrivateRoomJoin() {
+    if (!selectedPrivateRoom || !session) {
+      return
+    }
+
+    setIsPrivateRoomJoinPending(true)
+
+    try {
+      const joinedRoomSnapshot = await joinWaitingRoom({
+        roomId: selectedPrivateRoom.id,
+        userId: session.userId,
+        nickname: session.nickname,
+        fallbackTitle: selectedPrivateRoom.title,
+        password: privateRoomPassword,
+      })
+
+      enterWaitingRoom(selectedPrivateRoom, joinedRoomSnapshot)
+      closePrivateRoomModal()
+    } catch (error) {
+      // 비밀번호 불일치 에러는 인풋 에러 상태를 별도 표시
+      if (isJoinPasswordMismatchError(error)) {
+        setIsPrivateRoomPasswordInvalid(true)
+      }
+
+      toast.error(
+        getWaitingRoomErrorMessage(error, '비밀방 입장에 실패했습니다.')
+      )
+    } finally {
+      setIsPrivateRoomJoinPending(false)
+    }
+  }
+
+  return {
+    isCreateRoomModalOpen,
+    isCreateRoomPending,
+    selectedPrivateRoom,
+    privateRoomPassword,
+    isPrivateRoomJoinPending,
+    isPrivateRoomPasswordInvalid,
+    openCreateRoomModal,
+    closeCreateRoomModal,
+    joinRoom,
+    closePrivateRoomModal,
+    changePrivateRoomPassword,
+    submitCreateRoom,
+    submitPrivateRoomJoin,
+  }
+}

--- a/src/pages/waiting-room/WaitingRoomFlow.test.tsx
+++ b/src/pages/waiting-room/WaitingRoomFlow.test.tsx
@@ -8,6 +8,10 @@ import { renderWithProviders } from '../../test/renderWithProviders'
 import LobbyPage from '../lobby/LobbyPage'
 import WaitingRoomPage from './WaitingRoomPage'
 
+vi.mock('../../config/env', () => ({
+  IS_SOCKET_MOCK_ENABLED: true,
+}))
+
 const {
   useLobbyRoomsQueryMock,
   useOnlineUsersSocketMock,


### PR DESCRIPTION
## 📌 관련 이슈

> closes #236

---

## 📝 작업 내용

- `LobbyPage`에 섞여 있던 방 액션 흐름을 전용 훅으로 분리
  - 신규: `src/pages/lobby/useLobbyRoomActions.ts`
- 아래 책임을 `useLobbyRoomActions`로 이동
  - 방 생성 모달 열기/닫기/제출
  - 공개방/비밀방 입장 분기
  - 비밀방 모달 상태(선택 방, 비밀번호, 에러, pending)
  - 비밀방 입장 제출 + 에러 처리
  - 대기방 이동 state(`roomId`, `roomTitle`, `preJoinedSnapshot`) 구성
- `LobbyPage`는 화면 상태(검색/필터/패널 열림)와 렌더링 의도 중심으로 정리
- CI 안정화 보강
  - `src/pages/waiting-room/WaitingRoomFlow.test.tsx`에서 `IS_SOCKET_MOCK_ENABLED`를 테스트 내부에서 고정해 환경 의존 실패 제거

---

## ✅ 체크리스트

- [x] 기존 기능 동작 유지 확인
- [x] 코드 리뷰 완료
- [x] `npm run lint` 통과
- [x] `npm run test -- --run` 통과
- [x] `npm run build` 통과

---

## 📌 추가 메모

- 기능 변경 없는 구조 리팩터링 + 테스트 안정화 반영
- `docs/rules.md`의 R1/R3/U3 기준(맥락 분리/책임 분리) 개선 목적
