### PR TITLE
docs: 변경된 이벤트 명세 기준으로 게임 문서 재정렬

### DIFF
--- a/docs/game-delivery-roadmap.md
+++ b/docs/game-delivery-roadmap.md
@@ -1,7 +1,14 @@
-# 게임 완료 로드맵 (이벤트 명세서 기준, 2026-03-04)
+# 게임 완료 로드맵 (새 이벤트 명세 기준 / 기존 명세 호환 포함, 2026-03-04)
 
-이 문서는 현재 프론트엔드 코드와 `이벤트 명세서.md`를 대조해서 다시 작성한 실행 로드맵이다.
-이전 로드맵의 진행도 수치는 구 소켓 이벤트와 REST 액션 구조를 전제로 한 값이었기 때문에 더 이상 기준으로 쓰지 않는다.
+이 문서는 현재 프론트엔드 코드와 `이벤트 명세서.md`, `모두의마블_API명세서_v4.xlsx`,
+`모두의마블_요구사항정의서_v8.xlsx`, `모두의마블_테이블명세서_v4.xlsx`를 함께 대조해서
+다시 작성한 실행 로드맵이다.
+
+중요한 전제는 아래와 같다.
+
+- `이벤트 명세서.md`는 앞으로 이행해야 할 **목표 런타임 계약**이다.
+- API/요구사항/테이블 명세 v4는 현재 코드와 더 가까운 **레거시/현행 계약**이다.
+- 따라서 이 문서는 "새 명세로 바로 단절"이 아니라 "기존 계약을 유지하면서 새 명세로 이행"하는 기준 문서다.
 
 ## 1. 기준 문서
 
@@ -9,6 +16,17 @@
 - API/데이터 기준: `모두의마블_API명세서_v4.xlsx`, `모두의마블_테이블명세서_v4.xlsx`
 - 실시간 게임 계약 기준: `이벤트 명세서.md`
 - 프론트 내부 기준: `docs/game-ownership.md`, `docs/game-ownership-corrected-table.md`
+
+### 기준 우선순위
+
+1. **새 이벤트 명세서**
+   - 목표 구조(`game:action`, `game:ack`, `game:patch`, `game:prompt`) 정의
+2. **API/요구사항/테이블 명세**
+   - 현재 운영/저장 구조, 화폐 단위, room 식별자, 타일/건물 규칙 확인
+3. **현재 코드**
+   - 실제 구현 상태와 이행 비용 확인
+
+즉, 새 명세서가 목표 방향을 정하고, 기존 명세가 현재 제약을 설명한다.
 
 ## 2. 명세 변경 핵심
 
@@ -21,6 +39,48 @@
 
 즉, 현재 프론트의 "REST 요청 + 개별 소켓 이벤트 조합 + 보드 로컬 계산" 구조는 새 기준과 직접 충돌한다.
 
+다만 기존 명세와 충돌하는 항목은 아래처럼 해석한다.
+
+### 2-1. roomId vs gameId
+
+- 기존 API/테이블 명세는 `room_id` 기준이다.
+- 새 이벤트 명세는 `gameId` 기준 room(`game:{gameId}`)을 전제로 한다.
+
+현재 프론트 기준 정책:
+
+- 라우팅과 레거시 REST fallback은 **`roomId` 유지**
+- 새 이벤트 계층에서는 **`gameId`를 별도 보관**
+- FE-B는 이 둘의 매핑을 담당한다
+
+즉, 이행 완료 전까지는 `roomId`와 `gameId`가 동시에 존재할 수 있다.
+
+### 2-2. 화폐 단위
+
+- 요구사항/API 명세 v4: **원(₩) 정수**
+- 새 이벤트 명세: 설명상 **만 단위 정수**를 가정
+
+현재 프론트 기준 정책:
+
+- 프론트 내부 canonical money unit은 **원 정수**를 유지한다.
+- 표시만 `억/만`으로 변환한다.
+- 새 이벤트 payload가 만 단위로 바뀌면 FE-B ingress/egress 변환기로 흡수한다.
+
+즉, store/domain 내부에서 단위를 섞지 않는다.
+
+### 2-3. TileType / BuildingLevel
+
+- 요구사항/현재 보드 기준 타일: `start`, `city`, `chance`, `event`, `ai`, `travel`, `island`, `go_to_island`
+- 새 이벤트 명세 기준 타일: `START`, `PROPERTY`, `CHANCE`, `MOVE_TO_ISLAND`, `ISLAND`
+
+- API v4 build 레벨: 사실상 `0..5`
+- 새 이벤트 명세 build 레벨: `0..7`
+
+현재 프론트 기준 정책:
+
+- FE 내부 view model은 현재 보드 규격을 유지한다.
+- 새 이벤트 계층과의 차이는 FE-B mapper가 흡수한다.
+- FE-C는 transport enum이 아니라 **정규화된 view model**만 받는다.
+
 ## 3. 현재 코드 기준 핵심 갭
 
 ### 구조 갭
@@ -31,7 +91,7 @@
 
 - `src/services/game/game.api.ts`
   현재는 `buy`, `build`, `sell`, `state` REST 액션이 중심이다.
-  새 명세 기준으로는 게임 액션 전송을 socket 중심으로 재구성하고, REST는 제거하거나 보조 용도로 축소해야 한다.
+  새 명세 기준으로는 게임 액션 전송을 socket 중심으로 재구성하고, REST는 제거하거나 **이행 중 레거시 fallback으로 격리**해야 한다.
 
 - `src/hooks/game/useGameState.ts`
   현재는 진입 시 REST `getState`를 호출하고 기존 소켓 핸들러를 붙인다.
@@ -54,6 +114,7 @@
 - `src/types/domain.ts`
   현재 `Player.id`, `currentTurn` 등이 문자열 중심이고, `BuildingLevel`은 `0..5`만 지원한다.
   새 명세 기준으로는 숫자 기반 ID, `revision`, `phase`, `playerState`, `BuildingLevel 0..7`, `TileType` 재정의가 필요하다.
+  동시에 `roomId <-> gameId`, `원 <-> 만단위`, `city <-> PROPERTY`를 잇는 compatibility layer도 필요하다.
 
 ### 목업 갭
 
@@ -63,7 +124,7 @@
 
 ## 4. 진행도 재평가
 
-기존 80/50 평가는 더 이상 유효하지 않다. 새 이벤트 명세를 기준으로 다시 보면 다음이 더 현실적이다.
+기존 80/50 평가는 더 이상 유효하지 않다. 새 이벤트 명세 **이행 진행도** 기준으로 다시 보면 다음이 더 현실적이다.
 
 ### FE-B: 55%
 
@@ -80,7 +141,8 @@
 - `game:action`/`game:ack`/`game:patch`/`game:prompt` 중심 소켓 계층
 - revision 기반 patch 적용기
 - prompt 응답 흐름
-- REST 액션 의존 제거
+- REST 액션 의존 제거 또는 fallback 격리
+- roomId/gameId, money unit, tile/building enum 매핑기
 
 ### FE-C: 45%
 
@@ -109,6 +171,7 @@
 - `src/services/socket/game.handler.ts`를 구 이벤트 구독형에서 새 이벤트 구독형으로 변경
 - emit 함수는 `emitGameAction`, `emitGameSync`, `emitPromptResponse` 형태로 재구성
 - `src/hooks/game/useGameState.ts`는 진입/재접속 시 `game:sync`를 보내도록 수정
+- `game:error`는 선택 이벤트이므로, 없을 때도 ack/patch만으로 복구 가능한 흐름으로 설계
 
 ### 5-3. patch/snapshot 적용기 구현
 
@@ -126,6 +189,7 @@
 
 - `src/mocks/handlers/game.handler.ts`를 새 계약으로 재작성
 - 한 턴 검증 시나리오를 `sync -> action -> ack -> patch -> prompt` 흐름으로 다시 정의
+- 단, 이행 완료 전까지는 레거시 REST fallback 시나리오도 최소 회귀 검증 범위에 남긴다
 
 ## 6. FE-C 우선 작업
 
@@ -177,3 +241,4 @@
 
 지금 가장 먼저 해야 할 일은 모달 추가가 아니라 게임 계약 계층을 새 이벤트 명세에 맞춰 다시 세우는 일이다.
 즉시 우선순위는 FE-B의 타입/store/socket/mock 전환이고, 그 다음 FE-C가 `GameBoard.tsx`를 시각 레이어로 축소하는 흐름이 맞다.
+단, 이 과정에서도 `roomId`, 원 단위 금액, 현재 보드 view model은 갑자기 제거하지 않고 compatibility layer로 안전하게 이행해야 한다.

--- a/docs/game-event-spec-migration-plan.md
+++ b/docs/game-event-spec-migration-plan.md
@@ -1,6 +1,8 @@
 # 게임 이벤트 명세 전환 갭 분석
 
 이 문서는 `이벤트 명세서.md` 기준으로 현재 프론트엔드 코드에서 어디를 어떻게 고쳐야 하는지 파일 단위로 정리한 문서다.
+단, 실제 이행 작업은 `모두의마블_API명세서_v4.xlsx`, `모두의마블_요구사항정의서_v8.xlsx`,
+`모두의마블_테이블명세서_v4.xlsx`의 제약을 동시에 고려해야 한다.
 
 ## 1. 핵심 결론
 
@@ -20,22 +22,68 @@
 
 즉, 현재 구조는 "이벤트 이름만 몇 개 바꾸는 수준"이 아니라 상태 흐름 자체를 재정렬해야 한다.
 
+## 1-1. 충돌 지점과 문서 기준 해석
+
+### 식별자
+
+- 구 명세: `room_id`
+- 새 이벤트 명세: `gameId`
+
+이행 기준:
+
+- URL/레거시 REST는 `roomId`
+- 새 이벤트 계층은 `gameId`
+- FE-B가 `roomId <-> gameId` 매핑을 관리
+
+### 화폐 단위
+
+- 구 명세: 원 정수
+- 새 이벤트 명세: 설명상 만 단위 정수
+
+이행 기준:
+
+- FE 내부 store/domain canonical money unit은 **원 정수**
+- transport 차이는 FE-B mapper로 흡수
+
+### 타일 타입
+
+| 현재 보드/요구사항      | 새 이벤트 명세                            |
+| ----------------------- | ----------------------------------------- |
+| `city`                  | `PROPERTY`                                |
+| `chance`                | `CHANCE`                                  |
+| `go_to_island`          | `MOVE_TO_ISLAND`                          |
+| `island`                | `ISLAND`                                  |
+| `start`                 | `START`                                   |
+| `travel`, `ai`, `event` | 별도 확장 또는 compatibility mapping 필요 |
+
+### 건물 레벨
+
+| 출처           | 정의                        |
+| -------------- | --------------------------- |
+| API v4         | `0..5`에 가까운 레거시 구조 |
+| 새 이벤트 명세 | `0..7`                      |
+
+이행 기준:
+
+- transport 모델은 새 명세(`0..7`)를 목표로 설계
+- 현재 렌더/레거시 fallback은 compatibility mapping 유지
+
 ## 2. 수정 대상과 방법
 
-| 파일 | 현재 문제 | 수정 방향 | 담당 |
-| --- | --- | --- | --- |
-| `src/types/domain.ts` | ID 타입, tile type, building level, game state shape가 새 명세와 불일치 | snapshot/patch/ack/prompt/event 타입 추가, 숫자 ID와 `0..7` building level 반영 | FE-B |
-| `src/stores/game.store.ts` | 단순 set/update store라 revision, prompt, patch 적용 불가 | `applySnapshot`, `applyPatch`, `setAck`, `setPrompt`, `consumeEvents` 추가 | FE-B |
-| `src/services/socket/game.handler.ts` | 구 소켓 이벤트 구독과 `roll_dice`, `confirm_penalty` emit 사용 | `game:ack`, `game:patch`, `game:prompt`, `game:error` 구독과 `game:action`, `game:sync`, `game:prompt_response` emit로 교체 | FE-B |
-| `src/hooks/game/useGameState.ts` | mount 시 REST state 조회 중심 | mount/reconnect 시 `game:sync` 전송, snapshot 또는 patch 적용으로 전환 | FE-B |
-| `src/services/game/game.api.ts` | `buyTile`, `buildTile`, `sellTile`, `syncState`가 핵심 액션 경로 | 게임 액션성 REST를 제거하거나 레거시 fallback으로 격리 | FE-B |
-| `src/hooks/game/useDiceRoll.ts` | `emitRollDice` 또는 로컬 보드 fallback 사용 | `ROLL_DICE`용 `game:action` 전송으로 단순화 | FE-B |
-| `src/pages/GamePage.tsx` | `boardPlayers`, `boardCurPlayer` 로컬 상태와 store 이중화 | store selector 기반 조립으로 단순화, 보드에 상태 역주입 금지 | FE-B 주도 / FE-C 협업 |
-| `src/components/board/GameBoard.tsx` | 타일 소유권, 통행료, 파산, 턴 전환, API 호출을 직접 수행 | 렌더링과 연출만 담당하도록 축소, prompt 표시용 표면만 유지 | FE-C 주도 / FE-B 선행 필요 |
-| `src/components/game/modals/*` | 일부 모달은 존재하지만 서버 prompt와 연결되지 않음 | prompt type 기준 wrapper 또는 container 추가, ack/error/timeout 연결 | FE-B |
-| `src/mocks/handlers/game.handler.ts` | 구 REST + 구 소켓 이벤트 mock | 새 이벤트 명세를 흉내 내는 socket mock으로 재작성 | FE-B |
-| `src/test/socketEmitter.ts` | 테스트 유틸이 구 이벤트 네이밍에 묶였을 가능성 높음 | 새 이벤트 네이밍과 patch payload 지원하도록 수정 | FE-B |
-| `src/components/board/*`, `src/styles/board.css` | 렌더 레이어는 usable하지만 새 state shape 미반영 | 새 tile/player/building 표현과 animation 상태를 view model 기준으로 재정렬 | FE-C |
+| 파일                                             | 현재 문제                                                               | 수정 방향                                                                                                                   | 담당                       |
+| ------------------------------------------------ | ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | -------------------------- |
+| `src/types/domain.ts`                            | ID 타입, tile type, building level, game state shape가 새 명세와 불일치 | snapshot/patch/ack/prompt/event 타입 추가, 숫자 ID와 `0..7` building level 반영, compatibility mapper 타입 정의             | FE-B                       |
+| `src/stores/game.store.ts`                       | 단순 set/update store라 revision, prompt, patch 적용 불가               | `applySnapshot`, `applyPatch`, `setAck`, `setPrompt`, `consumeEvents` 추가                                                  | FE-B                       |
+| `src/services/socket/game.handler.ts`            | 구 소켓 이벤트 구독과 `roll_dice`, `confirm_penalty` emit 사용          | `game:ack`, `game:patch`, `game:prompt`, `game:error` 구독과 `game:action`, `game:sync`, `game:prompt_response` emit로 교체 | FE-B                       |
+| `src/hooks/game/useGameState.ts`                 | mount 시 REST state 조회 중심                                           | mount/reconnect 시 `game:sync` 전송, snapshot 또는 patch 적용으로 전환                                                      | FE-B                       |
+| `src/services/game/game.api.ts`                  | `buyTile`, `buildTile`, `sellTile`, `syncState`가 핵심 액션 경로        | 게임 액션성 REST를 제거하거나 레거시 fallback으로 격리, roomId 기준 호환 계층 유지                                          | FE-B                       |
+| `src/hooks/game/useDiceRoll.ts`                  | `emitRollDice` 또는 로컬 보드 fallback 사용                             | `ROLL_DICE`용 `game:action` 전송으로 단순화                                                                                 | FE-B                       |
+| `src/pages/GamePage.tsx`                         | `boardPlayers`, `boardCurPlayer` 로컬 상태와 store 이중화               | store selector 기반 조립으로 단순화, 보드에 상태 역주입 금지                                                                | FE-B 주도 / FE-C 협업      |
+| `src/components/board/GameBoard.tsx`             | 타일 소유권, 통행료, 파산, 턴 전환, API 호출을 직접 수행                | 렌더링과 연출만 담당하도록 축소, prompt 표시용 표면만 유지                                                                  | FE-C 주도 / FE-B 선행 필요 |
+| `src/components/game/modals/*`                   | 일부 모달은 존재하지만 서버 prompt와 연결되지 않음                      | prompt type 기준 wrapper 또는 container 추가, ack/error/timeout 연결                                                        | FE-B                       |
+| `src/mocks/handlers/game.handler.ts`             | 구 REST + 구 소켓 이벤트 mock                                           | 새 이벤트 명세를 흉내 내는 socket mock으로 재작성                                                                           | FE-B                       |
+| `src/test/socketEmitter.ts`                      | 테스트 유틸이 구 이벤트 네이밍에 묶였을 가능성 높음                     | 새 이벤트 네이밍과 patch payload 지원하도록 수정                                                                            | FE-B                       |
+| `src/components/board/*`, `src/styles/board.css` | 렌더 레이어는 usable하지만 새 state shape 미반영                        | 새 tile/player/building 표현과 animation 상태를 view model 기준으로 재정렬                                                  | FE-C                       |
 
 ## 3. 파일별 상세 작업
 
@@ -57,9 +105,11 @@
 기존 타입 중 바로 손봐야 하는 부분:
 
 - `BuildingLevel`은 `0 | 1 | 2 | 3 | 4 | 5 | 6 | 7`
-- `Player.id`는 숫자 기준으로 정리
-- `Tile.owner_id` 대신 새 스냅샷 구조와 맞는 `ownerId`
+- `Player.id`는 숫자 기준으로 정리하되, 레거시 문자열 ID에서 변환 경로를 둔다
+- `Tile.owner_id` 대신 새 스냅샷 구조와 맞는 `ownerId`를 canonical로 두고 레거시 alias를 흡수
 - `currentTurn` 중심 상태를 `turn`, `currentPlayerId`, `phase`, `revision` 중심으로 재구성
+- `roomId`, `gameId`를 모두 담을 수 있는 connection/session 메타 타입 추가
+- `Money`는 transport 단위와 관계없이 원 정수로 해석되는 타입/설명 유지
 
 ### 3-2. `src/stores/game.store.ts`
 
@@ -114,6 +164,7 @@
 - `getState`, `buyTile`, `buildTile`, `sellTile`, `syncState`를 레거시로 표시
 - 새 소켓 경로 전환 후 사용처 제거
 - 당장 삭제가 부담되면 `deprecated` 성격의 얇은 래퍼로 격리
+- 단, backend rollout 전까지는 `roomId` 기준 fallback이므로 FE-B 소유 범위에 둔다
 
 ### 3-5. `src/pages/GamePage.tsx`
 
@@ -161,6 +212,7 @@
 - 각 액션마다 `game:ack` 발행
 - 상태 확정 시 `game:patch` 발행
 - 필요 시 `game:prompt` 발행
+- 레거시 REST fallback 검증용 최소 핸들러는 별도 호환 계층으로 유지
 
 ## 4. FE-B / FE-C 분리 기준
 
@@ -193,4 +245,9 @@
 ## 6. 문서 사용법
 
 이 문서는 실제 코드 수정 전 체크리스트로 사용한다.
-파일을 건드릴 때는 "새 이벤트 명세를 수용하기 위한 변경인지" 아니면 "구 구조를 임시 연명하는 변경인지"를 먼저 구분해야 한다.
+파일을 건드릴 때는 아래 둘을 먼저 구분해야 한다.
+
+- 새 이벤트 명세를 수용하기 위한 변경인지
+- 기존 roomId/REST/원 단위 계약을 안전하게 유지하기 위한 호환 변경인지
+
+둘을 섞을 때는 반드시 mapper/adapter 계층을 명시적으로 둔다.

--- a/docs/game-ownership-corrected-table.md
+++ b/docs/game-ownership-corrected-table.md
@@ -2,25 +2,26 @@
 
 ## 요약 표
 
-| 구분 | FE-B | FE-C | 비고 |
-| --- | --- | --- | --- |
-| 이벤트 명세 타입 정의 | 주 담당 | 보조 | `src/types/domain.ts` |
-| 게임 store / patch 적용기 | 주 담당 | 보조 | revision, snapshot, prompt 포함 |
-| 게임 socket emit/listener | 주 담당 | 보조 | `game:action`, `game:ack`, `game:patch` |
-| 게임 mock / 테스트 유틸 | 주 담당 | 보조 | 새 명세 기준 검증 |
-| 게임 페이지 조립 | 주 담당 | 보조 | `GamePage.tsx`에서 상태 단일화 |
-| 게임 모달 / prompt UI | 주 담당 | 보조 | prompt container 중심 |
-| 보드 렌더링 | 보조 | 주 담당 | `src/components/board/*` |
-| 말 이동 / 타일 / 건물 시각화 | 보조 | 주 담당 | store snapshot 기준 |
-| patch events 애니메이션 | 보조 | 주 담당 | 연출만 담당 |
-| `GameBoard.tsx` 로직 제거 | 공동 | 공동 | FE-B 선행, FE-C 마무리 |
+| 구분                         | FE-B    | FE-C    | 비고                                      |
+| ---------------------------- | ------- | ------- | ----------------------------------------- |
+| 이벤트 명세 타입 정의        | 주 담당 | 보조    | `src/types/domain.ts`                     |
+| 게임 store / patch 적용기    | 주 담당 | 보조    | revision, snapshot, prompt 포함           |
+| 게임 socket emit/listener    | 주 담당 | 보조    | `game:action`, `game:ack`, `game:patch`   |
+| 레거시 계약 호환 계층        | 주 담당 | 보조    | `roomId/gameId`, money unit, enum mapping |
+| 게임 mock / 테스트 유틸      | 주 담당 | 보조    | 새 명세 기준 검증                         |
+| 게임 페이지 조립             | 주 담당 | 보조    | `GamePage.tsx`에서 상태 단일화            |
+| 게임 모달 / prompt UI        | 주 담당 | 보조    | prompt container 중심                     |
+| 보드 렌더링                  | 보조    | 주 담당 | `src/components/board/*`                  |
+| 말 이동 / 타일 / 건물 시각화 | 보조    | 주 담당 | store snapshot 기준                       |
+| patch events 애니메이션      | 보조    | 주 담당 | 연출만 담당                               |
+| `GameBoard.tsx` 로직 제거    | 공동    | 공동    | FE-B 선행, FE-C 마무리                    |
 
 ## 진행도 요약
 
-| 파트 | 진행도 | 상태 |
-| --- | --- | --- |
-| FE-B | 55% | 새 이벤트 계약으로 상태/소켓 계층을 다시 세워야 하는 단계 |
-| FE-C | 45% | 보드를 store 단일 렌더와 연출 레이어로 정리해야 하는 단계 |
+| 파트 | 진행도 | 상태                                                      |
+| ---- | ------ | --------------------------------------------------------- |
+| FE-B | 55%    | 새 이벤트 계약 + 레거시 호환 계층을 함께 세워야 하는 단계 |
+| FE-C | 45%    | 보드를 store 단일 렌더와 연출 레이어로 정리해야 하는 단계 |
 
 ## FE-B 최우선 작업
 
@@ -30,6 +31,7 @@
 - `src/hooks/game/useGameState.ts`에서 `game:sync` 기반 복구로 전환
 - `src/mocks/handlers/game.handler.ts`를 새 명세 mock으로 재작성
 - `src/pages/GamePage.tsx`의 보드 상태 write-back 제거
+- `roomId/gameId`, money unit, tile/building enum mapper 명시화
 
 ## FE-C 최우선 작업
 
@@ -44,8 +46,10 @@
 - `GamePage.tsx`가 store와 board 로컬 상태를 이중 관리한다.
 - mock이 새 이벤트 명세와 다른 프로토콜을 사용한다.
 - 타입 계층이 새 숫자 ID / revision / snapshot 구조를 표현하지 못한다.
+- 새 이벤트 명세와 기존 API v4 사이의 식별자/화폐 단위/enum 차이가 아직 문서와 코드 모두에 남아 있다.
 
 ## 완료 판단 기준
 
 - FE-B 완료: 새 이벤트 계약만으로 한 턴 전체 흐름이 돈다.
+- FE-B 완료: 새 이벤트 계약을 기본으로 사용하면서도 레거시 fallback이 의도적으로만 남아 있다.
 - FE-C 완료: 보드가 store 하나만 보고 정확히 렌더되며, 연출과 실제 상태가 분리돼도 stale 하지 않다.

--- a/docs/game-ownership.md
+++ b/docs/game-ownership.md
@@ -1,11 +1,13 @@
 # 게임 영역 파일 소유권 및 분업 기준 (이벤트 명세서 반영)
 
-이 문서는 새 `이벤트 명세서.md` 기준으로 FE-B와 FE-C의 게임 영역 책임을 다시 정리한 문서다.
-기존 분업 문서는 구 소켓 이벤트 구조를 전제로 했기 때문에 이 문서로 대체한다.
+이 문서는 새 `이벤트 명세서.md`를 목표 기준으로 삼되,
+`모두의마블_API명세서_v4.xlsx`, `모두의마블_요구사항정의서_v8.xlsx`,
+`모두의마블_테이블명세서_v4.xlsx`와 충돌하는 영역은 호환 계층까지 포함해 FE-B/FE-C 책임을 다시 정리한 문서다.
 
 ## 1. 분업 원칙
 
 - FE-B는 게임 계약, 상태, socket, prompt, mock을 책임진다.
+- FE-B는 기존 계약과 새 계약 사이의 compatibility layer도 책임진다.
 - FE-C는 보드 렌더링, 애니메이션, 시각 상태 표현을 책임진다.
 - 새 명세에서 결과 계산은 서버 권위이므로, FE-C가 게임 결과를 계산하는 구조는 금지한다.
 
@@ -29,6 +31,9 @@
 - snapshot/patch/revision 처리
 - prompt 응답과 timeout 처리
 - mock과 실서버 계약 정렬
+- `roomId <-> gameId` 매핑
+- 원 단위 money와 새 transport 단위 간 변환
+- 레거시 REST/socket fallback 유지와 제거 시점 관리
 
 ## 3. FE-C 주 담당
 
@@ -51,6 +56,7 @@
 - store snapshot을 보드 view model로 바꾸는 기준
 - prompt를 어떤 UI 표면으로 보여줄지에 대한 계약
 - `playerState`, `buildingLevel`, `tileType`의 렌더 규칙
+- transport enum과 현재 보드 enum 간 매핑 결과
 
 ## 5. 현재 코드 기준 예외 구간
 
@@ -76,7 +82,7 @@
 
 ### FE-B 진행도: 55%
 
-이 수치는 "게임 UI가 어느 정도 있다"가 아니라 "새 이벤트 명세를 실제로 소화할 수 있는가" 기준이다.
+이 수치는 "게임 UI가 어느 정도 있다"가 아니라 "새 이벤트 명세와 기존 계약의 차이를 흡수할 수 있는가" 기준이다.
 
 완료된 것:
 
@@ -91,6 +97,7 @@
 - prompt/ack 기반 입력 UX
 - 구 REST/구 이벤트 제거
 - mock 전환
+- roomId/gameId, money unit, tile/building enum mapper
 
 ### FE-C 진행도: 45%
 


### PR DESCRIPTION
## 🔗 관련 이슈

> closes #이슈번호

---

## 📌 작업 내용

- 변경된 `이벤트 명세서.md`와 기존 API/요구사항/테이블 명세를 함께 기준으로 삼아 게임 문서를 다시 정리했습니다.
- 새 이벤트 명세는 **목표 런타임 계약**, 기존 API/요구사항/테이블 명세는 **레거시/현행 제약**이라는 관점으로 문서 기준을 명확히 했습니다.
- `roomId vs gameId`, `원 단위 vs 만 단위`, `현재 보드 enum vs 새 이벤트 enum` 충돌 지점을 문서에서 명시적으로 해석했습니다.
- FE-B가 책임져야 하는 compatibility layer 범위를 문서에 반영했습니다.
- 기존 문서가 “현재 구현 설명서”처럼 읽히던 부분을 “이행 기준 문서” 관점으로 수정했습니다.
- FE-B / FE-C 진행도와 남은 작업도 새 이벤트 명세 이행 기준으로 다시 정리했습니다.

---

## ✅ 수정 문서

- `docs/game-delivery-roadmap.md`
- `docs/game-event-spec-migration-plan.md`
- `docs/game-ownership.md`
- `docs/game-ownership-corrected-table.md`

---

## ✅ 체크리스트

- [x] 변경된 이벤트 명세서 반영
- [x] 기존 API/요구사항/테이블 명세와의 충돌 지점 문서화
- [x] FE-B compatibility layer 책임 명시
- [x] FE-B / FE-C 진행도 및 남은 작업 재정리
- [x] 원격 브랜치 push 완료

---

## 📎 핵심 정리

### 문서 기준
- 새 이벤트 명세: 앞으로 이행해야 할 목표 계약
- API/요구사항/테이블 명세 v4: 현재 운영/저장 구조를 설명하는 레거시/현행 제약

### FE-B 핵심 책임
- 새 이벤트 계약 수용
- roomId / gameId 매핑
- money unit 변환
- tile/building enum compatibility mapping
- 레거시 REST/socket fallback 관리

### FE-C 핵심 책임
- 보드 렌더링/연출
- 정규화된 view model 기반 UI 표현
- FE-B가 제공한 상태를 단일 소스로 사용하도록 전환

---

## 🖼 스크린샷

> 문서 정리 PR이라 스크린샷은 생략합니다.
