### PR TITLE
feat: 대기방→게임 진입 gameId 라우팅 정합성 반영

### DIFF
--- a/e2e/chat-flow-game-room.spec.ts
+++ b/e2e/chat-flow-game-room.spec.ts
@@ -19,7 +19,7 @@ test.describe('게임 채팅 플로우', () => {
     await page.getByRole('button', { name: '시작조건' }).click()
     await page.getByRole('button', { name: /^시작$/ }).click()
 
-    await expect(page).toHaveURL(/\/game\/room-\d+$/)
+    await expect(page).toHaveURL(/\/game\/game-room-\d+-\d+$/)
 
     await page.getByPlaceholder('메시지...').fill('게임 채팅 e2e')
     await page.getByPlaceholder('메시지...').press('Enter')

--- a/e2e/waiting-room-start-flow.spec.ts
+++ b/e2e/waiting-room-start-flow.spec.ts
@@ -31,6 +31,6 @@ test.describe('대기방 시작 플로우', () => {
     await expect(startButton).toBeEnabled()
 
     await startButton.click()
-    await expect(page).toHaveURL(/\/game\/room-\d+$/)
+    await expect(page).toHaveURL(/\/game\/game-room-\d+-\d+$/)
   })
 })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ function App() {
       <Route path="/" element={<HomePage />} />
       <Route path="/nickname-setup" element={<NicknameSetupPage />} />
       <Route path="/my-page" element={<MyPage />} />
-      <Route path="/game/:roomId" element={<GamePage />} />
+      <Route path="/game/:gameId" element={<GamePage />} />
       <Route path="/lobby" element={<LobbyPage />} />
       <Route path="/rooms/:roomId" element={<WaitingRoomPage />} />
     </Routes>

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { Settings } from 'lucide-react'
-import { useParams } from 'react-router-dom'
+import { useLocation, useParams } from 'react-router-dom'
 import PlayerPanel from '../components/game/panels/PlayerPanel'
 import RoomChat from '../features/room-chat/RoomChat'
 import { DevRoomChatControlPanel } from '../features/room-chat/DevRoomChatControlPanel'
@@ -69,8 +69,17 @@ function mapGameChatEventToMessage(payload: ChatEventPayload): ChatMessage {
   }
 }
 
+interface GamePageLocationState {
+  roomId?: string
+  gameId?: string
+}
+
 const GamePage: React.FC = () => {
-  const { roomId } = useParams<{ roomId: string }>()
+  const { gameId } = useParams<{ gameId: string }>()
+  const location = useLocation()
+  const locationState = location.state as GamePageLocationState | null
+  // URL은 gameId를 사용하고, room API 호출에는 전달받은 roomId를 우선 사용
+  const activeRoomId = locationState?.roomId ?? gameId ?? null
   const session = useAuthStore((state) => state.session)
   const {
     currentTurn,
@@ -93,7 +102,7 @@ const GamePage: React.FC = () => {
   const [boardPlayers, setBoardPlayers] = useState<PlayerState[]>(INIT_PLAYERS)
   const [boardCurPlayer, setBoardCurPlayer] = useState(0)
 
-  useGameState(roomId ?? null)
+  useGameState(activeRoomId)
 
   const currentUserId =
     session?.userId ?? (USE_GAME_SOCKET_MOCK ? DEFAULT_MOCK_PLAYER_ID : null)
@@ -116,13 +125,13 @@ const GamePage: React.FC = () => {
 
   // 게임 채팅 이벤트를 구독해 메시지 목록을 실시간으로 동기화
   useEffect(() => {
-    if (!roomId) {
+    if (!activeRoomId) {
       return
     }
 
     const handleChat = (payload: ChatEventPayload) => {
       // 다른 방 채팅 이벤트는 무시
-      if (payload.room_id !== roomId) {
+      if (payload.room_id !== activeRoomId) {
         return
       }
 
@@ -145,16 +154,16 @@ const GamePage: React.FC = () => {
     return () => {
       socket.off('chat', handleChat)
     }
-  }, [roomId])
+  }, [activeRoomId])
 
   const handleSendMessage = (content: string) => {
     // roomId가 없으면 채팅 전송을 생략
-    if (!roomId) {
+    if (!activeRoomId) {
       return
     }
 
     sendWaitingRoomChat({
-      roomId,
+      roomId: activeRoomId,
       senderId: currentUserId ?? DEFAULT_GUEST_ID,
       senderNickname: currentNickname,
       message: content,
@@ -290,7 +299,7 @@ const GamePage: React.FC = () => {
 
   useEffect(() => {
     hasHydratedMockBoardRef.current = false
-  }, [roomId])
+  }, [activeRoomId])
 
   useEffect(() => {
     if (storePlayers.length === 0) {
@@ -365,7 +374,7 @@ const GamePage: React.FC = () => {
           >
             <BoardGame
               ref={boardRef}
-              roomId={roomId ?? ''}
+              roomId={activeRoomId ?? ''}
               players={boardPlayers}
               curPlayer={boardCurPlayer}
               tiles={normalizedTilesForBoard}
@@ -410,13 +419,13 @@ const GamePage: React.FC = () => {
           <RollButton
             timeLeft={timeLeft}
             isMyTurn={isMyTurn}
-            onRoll={() => diceRoll(roomId ?? null)}
+            onRoll={() => diceRoll(activeRoomId)}
           />
         )}
       </div>
 
       <DevRoomChatControlPanel
-        roomId={roomId ?? ''}
+        roomId={activeRoomId ?? ''}
         senderOptions={roomChatSenderOptions}
         preferredSenderId={preferredRoomChatSenderId}
       />

--- a/src/pages/waiting-room/WaitingRoomFlow.test.tsx
+++ b/src/pages/waiting-room/WaitingRoomFlow.test.tsx
@@ -36,9 +36,9 @@ vi.mock('../../features/presence/useDirectMessageController', () => ({
 
 // game route 도착 여부 확인용 스텁 페이지
 function GamePageStub() {
-  const { roomId } = useParams<{ roomId: string }>()
+  const { gameId } = useParams<{ gameId: string }>()
 
-  return <div>게임 화면: {roomId}</div>
+  return <div>게임 화면: {gameId}</div>
 }
 
 // 로비→대기방→게임 라우트 흐름 테스트용 렌더 헬퍼
@@ -47,7 +47,7 @@ function renderWaitingRoomFlow() {
     <Routes>
       <Route path="/lobby" element={<LobbyPage />} />
       <Route path="/rooms/:roomId" element={<WaitingRoomPage />} />
-      <Route path="/game/:roomId" element={<GamePageStub />} />
+      <Route path="/game/:gameId" element={<GamePageStub />} />
     </Routes>,
     {
       initialEntries: ['/lobby'],

--- a/src/pages/waiting-room/WaitingRoomPage.test.tsx
+++ b/src/pages/waiting-room/WaitingRoomPage.test.tsx
@@ -231,7 +231,7 @@ describe('WaitingRoomPage interaction', () => {
     expect(screen.getByRole('button', { name: '준비하기' })).toBeEnabled()
   })
 
-  it('game_start 이벤트 수신 시 /game/:roomId로 이동하며 state(gameId, roomId)를 전달한다', () => {
+  it('game_start 이벤트 수신 시 /game/:gameId로 이동하며 state(gameId, roomId)를 전달한다', () => {
     renderWaitingRoomPage()
 
     act(() => {
@@ -246,7 +246,7 @@ describe('WaitingRoomPage interaction', () => {
       })
     })
 
-    expect(navigateMock).toHaveBeenCalledWith('/game/room-5', {
+    expect(navigateMock).toHaveBeenCalledWith('/game/game-123', {
       state: {
         gameId: 'game-123',
         roomId: 'room-5',

--- a/src/pages/waiting-room/WaitingRoomPage.tsx
+++ b/src/pages/waiting-room/WaitingRoomPage.tsx
@@ -59,7 +59,7 @@ function WaitingRoomPage() {
 
   const handleGameStart = useCallback(
     (payload: GameStartEventPayload) => {
-      navigate(`/game/${currentRoomId}`, {
+      navigate(`/game/${payload.game_id}`, {
         state: {
           gameId: payload.game_id,
           roomId: currentRoomId,


### PR DESCRIPTION
## 📌 관련 이슈

> closes #241 

---

## 📝 작업 내용

> 대기방 → 게임 진입 라우팅을 `roomId` 중심에서 `gameId` 중심으로 정렬하고, 기존 room 기반 API 호출이 깨지지 않도록 호환 처리를 추가했습니다.

- 게임 라우트 파라미터를 `/game/:gameId`로 변경
- 대기방 `game_start` 수신 시 이동 경로를 `/game/${game_id}`로 변경
- `GamePage`에서 URL 파라미터는 `gameId`를 사용하고, 실제 room 기반 API/채팅은 `location.state.roomId` 우선 사용으로 호환 유지
- 관련 Unit 테스트/E2E URL 기대값을 새 라우팅 규칙에 맞게 수정

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

> UI 변경 없음 (라우팅/상태 전달 정합성 변경)

---

### 로컬 검증 결과

- `npm run lint` 통과
- `npm run test` 통과 (81 passed)
- `npm run test:coverage` 통과
- `npm run e2e` 통과 (4 passed)
- `npm run build` 통과