### PR TITLE
Feat : 게임 이벤트 명세 이행을 위한 타입 및 스토어 계약 정리

### DIFF
--- a/src/hooks/game/useTurn.ts
+++ b/src/hooks/game/useTurn.ts
@@ -1,7 +1,12 @@
-export const useTurn = (currentTurn: string | null, myId?: string | null) => {
+import type { PlayerId } from '../../types/domain'
+
+export const useTurn = (
+  currentTurn: PlayerId | null,
+  myId?: PlayerId | null
+) => {
   if (!currentTurn || !myId) {
     return false
   }
 
-  return currentTurn === myId
+  return String(currentTurn) === String(myId)
 }

--- a/src/mocks/handlers/game.handler.ts
+++ b/src/mocks/handlers/game.handler.ts
@@ -1,6 +1,6 @@
 import { delay, http, HttpResponse } from 'msw'
 import { socket } from '../../lib/socket'
-import { BuildingLevel, Player, Tile } from '../../types/domain'
+import { BuildingLevel, Player, PlayerId, Tile } from '../../types/domain'
 import { mockMessages, mockPlayers, mockTiles } from '../gameMockData'
 
 const MOCK_PLAYER_ID = 'mock-player-1'
@@ -21,7 +21,7 @@ type GameStateResponse = {
   players: Player[]
   tiles: Tile[]
   messages: typeof mockMessages
-  currentTurn: string
+  currentTurn: PlayerId
   round: number
 }
 
@@ -86,7 +86,7 @@ const emitTurnStart = () => {
 
 const getCurrentPlayer = () =>
   mockGameState.players.find(
-    (player) => player.id === mockGameState.currentTurn
+    (player) => String(player.id) === String(mockGameState.currentTurn)
   )
 
 const getTileByIndex = (tileIndex: number) =>
@@ -125,9 +125,9 @@ const getSellRefund = (tile: Tile, requestedLevel?: number) => {
   }
 }
 
-const getNextActivePlayerId = (currentPlayerId: string) => {
+const getNextActivePlayerId = (currentPlayerId: PlayerId) => {
   const currentIndex = mockGameState.players.findIndex(
-    (player) => player.id === currentPlayerId
+    (player) => String(player.id) === String(currentPlayerId)
   )
 
   if (currentIndex < 0) {
@@ -173,7 +173,7 @@ export const gameHandlers = [
       })
 
       const currentPlayer = mockGameState.players.find(
-        (player) => player.id === player_id
+        (player) => String(player.id) === String(player_id)
       )
       const fromIndex = currentPlayer?.position ?? 0
       const toIndex = (fromIndex + total) % mockGameState.tiles.length
@@ -279,7 +279,7 @@ export const gameHandlers = [
       )
     }
 
-    if (tile.owner_id !== player.id) {
+    if (String(tile.owner_id) !== String(player.id)) {
       return buildErrorResponse(
         '\uBCF8\uC778 \uC18C\uC720 \uD0C0\uC77C\uB9CC \uAC74\uC124\uD560 \uC218 \uC788\uC2B5\uB2C8\uB2E4.',
         403
@@ -331,7 +331,7 @@ export const gameHandlers = [
       )
     }
 
-    if (tile.owner_id !== player.id) {
+    if (String(tile.owner_id) !== String(player.id)) {
       return buildErrorResponse(
         '\uBCF8\uC778 \uC18C\uC720 \uD0C0\uC77C\uB9CC \uB9E4\uAC01\uD560 \uC218 \uC788\uC2B5\uB2C8\uB2E4.',
         403

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -336,13 +336,15 @@ const GamePage: React.FC = () => {
   const isCurrentPlayerSkipped = (currentPlayerState?.skipTurns ?? 0) > 0
   const roomChatSenderOptions = useMemo(() => {
     return storePlayers.map((player) => ({
-      id: player.id,
+      id: String(player.id),
       nickname: player.nickname,
     }))
   }, [storePlayers])
+  const currentUserIdForChat =
+    currentUserId == null ? undefined : String(currentUserId)
   const preferredRoomChatSenderId =
     roomChatSenderOptions.find(
-      (senderOption) => senderOption.id !== currentUserId
+      (senderOption) => senderOption.id !== currentUserIdForChat
     )?.id ?? roomChatSenderOptions[0]?.id
 
   return (

--- a/src/stores/game.store.ts
+++ b/src/stores/game.store.ts
@@ -1,53 +1,248 @@
 import { create } from 'zustand'
 import { immer } from 'zustand/middleware/immer'
 import type {
-  Player,
-  Tile,
   ActiveModal,
-  GameResult,
-  GameState,
   ChatMessage,
+  GameAck,
+  GameError,
+  GamePatchEnvelope,
+  GameResult,
+  GameSnapshot,
+  GameState,
+  PendingGameAction,
+  Player,
+  PlayerId,
+  ServerEvent,
+  Tile,
 } from '../types/domain'
 
 interface GameActions {
   setGameState: (state: Partial<GameState>) => void
-  updatePlayer: (playerId: string, updates: Partial<Player>) => void
+  updatePlayer: (playerId: PlayerId, updates: Partial<Player>) => void
   updateTile: (tileIndex: number, updates: Partial<Tile>) => void
-  setCurrentTurn: (playerId: string) => void
+  setCurrentTurn: (playerId: PlayerId | null) => void
   setModal: (modal: ActiveModal) => void
   setGameResult: (result: GameResult) => void
   addMessage: (message: ChatMessage) => void
+  replaceFromSnapshot: (snapshot: GameSnapshot) => void
+  applyPatchEnvelope: (envelope: GamePatchEnvelope) => void
+  setPendingAction: (action: PendingGameAction | null) => void
+  resolveAck: (ack: GameAck) => void
+  setPrompt: (prompt: GameState['prompt']) => void
+  clearPrompt: (promptId?: string) => void
+  enqueueEvents: (events: ServerEvent[]) => void
+  consumeNextEvent: () => ServerEvent | null
+  setLastError: (error: GameError | null) => void
   resetGame: () => void
 }
 
+type GameStoreState = GameState & GameActions
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null
+
+const normalizeTile = (tile: Tile): Tile => {
+  const ownerId =
+    tile.ownerId !== undefined ? tile.ownerId : (tile.owner_id ?? null)
+
+  return {
+    ...tile,
+    ownerId,
+    owner_id: ownerId,
+  }
+}
+
+const normalizePlayer = (player: Player): Player => ({
+  ...player,
+  state:
+    player.state ??
+    (player.is_bankrupt ? 'bankrupt' : player.is_in_jail ? 'island' : 'normal'),
+})
+
+const normalizeState = (state: Partial<GameState>): Partial<GameState> => {
+  const currentPlayerId =
+    state.currentPlayerId !== undefined
+      ? state.currentPlayerId
+      : (state.currentTurn ?? null)
+
+  const currentTurn =
+    state.currentTurn !== undefined ? state.currentTurn : currentPlayerId
+
+  return {
+    ...state,
+    currentPlayerId,
+    currentTurn,
+    tiles: state.tiles?.map(normalizeTile),
+    players: state.players?.map(normalizePlayer),
+    prompt: state.prompt ?? null,
+    pendingAction: state.pendingAction ?? null,
+    lastAck: state.lastAck ?? null,
+    lastError: state.lastError ?? null,
+    eventQueue: state.eventQueue ?? [],
+  }
+}
+
+const toPathSegments = (
+  path: string | Array<string | number>
+): Array<string | number> => {
+  if (Array.isArray(path)) {
+    return path
+  }
+
+  return path
+    .split('.')
+    .map((segment) =>
+      /^\d+$/.test(segment) ? Number.parseInt(segment, 10) : segment
+    )
+}
+
+const getTargetContainer = (
+  draft: Record<string, unknown>,
+  path: Array<string | number>
+) => {
+  const parentPath = path.slice(0, -1)
+  let cursor: unknown = draft
+
+  for (const segment of parentPath) {
+    if (Array.isArray(cursor) && typeof segment === 'number') {
+      cursor = cursor[segment]
+      continue
+    }
+
+    if (isRecord(cursor)) {
+      cursor = cursor[String(segment)]
+      continue
+    }
+
+    return null
+  }
+
+  return cursor
+}
+
+const setValueAtPath = (
+  draft: Record<string, unknown>,
+  path: Array<string | number>,
+  value: unknown
+) => {
+  const target = getTargetContainer(draft, path)
+  const key = path[path.length - 1]
+
+  if (key === undefined || target === null) {
+    return
+  }
+
+  if (Array.isArray(target) && typeof key === 'number') {
+    target[key] = value
+    return
+  }
+
+  if (isRecord(target)) {
+    target[String(key)] = value
+  }
+}
+
+const getValueAtPath = (
+  draft: Record<string, unknown>,
+  path: Array<string | number>
+) => {
+  let cursor: unknown = draft
+
+  for (const segment of path) {
+    if (Array.isArray(cursor) && typeof segment === 'number') {
+      cursor = cursor[segment]
+      continue
+    }
+
+    if (isRecord(cursor)) {
+      cursor = cursor[String(segment)]
+      continue
+    }
+
+    return undefined
+  }
+
+  return cursor
+}
+
+const removeValueAtPath = (
+  draft: Record<string, unknown>,
+  path: Array<string | number>,
+  index?: number,
+  value?: unknown
+) => {
+  const target = getValueAtPath(draft, path)
+
+  if (Array.isArray(target)) {
+    if (typeof index === 'number') {
+      target.splice(index, 1)
+      return
+    }
+
+    if (value !== undefined) {
+      const matchedIndex = target.findIndex((item) => item === value)
+      if (matchedIndex >= 0) {
+        target.splice(matchedIndex, 1)
+      }
+    }
+    return
+  }
+
+  const container = getTargetContainer(draft, path)
+  const key = path[path.length - 1]
+
+  if (key !== undefined && isRecord(container)) {
+    delete container[String(key)]
+  }
+}
+
 const INITIAL_STATE: GameState = {
+  roomId: null,
+  gameId: null,
+  revision: 0,
+  phase: 'waiting',
   players: [],
   tiles: [],
   messages: [],
   currentTurn: null,
+  currentPlayerId: null,
   round: 1,
   turnTimeoutSec: 30,
   turnTimerKey: 0,
   activeModal: null,
+  prompt: null,
+  pendingAction: null,
+  lastAck: null,
+  lastError: null,
+  eventQueue: [],
+  session: {
+    roomId: null,
+    gameId: null,
+    transport: null,
+    syncedAt: null,
+  },
   gameResult: null,
   isGameOver: false,
   winnerId: null,
 }
 
-export const useGameStore = create<GameState & GameActions>()(
-  immer((set) => ({
+export const useGameStore = create<GameStoreState>()(
+  immer<GameStoreState>((set, get) => ({
     ...INITIAL_STATE,
 
     setGameState: (state) =>
       set((draft) => {
-        Object.assign(draft, state)
+        Object.assign(draft, normalizeState(state))
       }),
 
     updatePlayer: (playerId, updates) =>
       set((draft) => {
-        const player = draft.players.find((p) => p.id === playerId)
+        const player = draft.players.find(
+          (p) => String(p.id) === String(playerId)
+        )
         if (player) {
           Object.assign(player, updates)
+          Object.assign(player, normalizePlayer(player))
         }
       }),
 
@@ -56,12 +251,14 @@ export const useGameStore = create<GameState & GameActions>()(
         const tile = draft.tiles.find((t) => t.index === tileIndex)
         if (tile) {
           Object.assign(tile, updates)
+          Object.assign(tile, normalizeTile(tile))
         }
       }),
 
     setCurrentTurn: (playerId) =>
       set((draft) => {
         draft.currentTurn = playerId
+        draft.currentPlayerId = playerId
       }),
 
     setModal: (modal) =>
@@ -77,6 +274,138 @@ export const useGameStore = create<GameState & GameActions>()(
     addMessage: (message) =>
       set((draft) => {
         draft.messages.push(message)
+      }),
+
+    replaceFromSnapshot: (snapshot) =>
+      set((draft) => {
+        Object.assign(draft, normalizeState(snapshot))
+        draft.session.roomId = snapshot.roomId ?? draft.session.roomId
+        draft.session.gameId = snapshot.gameId ?? draft.session.gameId
+        draft.session.transport = 'event-socket'
+        draft.session.syncedAt = new Date().toISOString()
+        draft.turnTimerKey = Date.now()
+      }),
+
+    applyPatchEnvelope: (envelope) =>
+      set((draft) => {
+        if (envelope.revision <= draft.revision) {
+          return
+        }
+
+        for (const operation of envelope.patch) {
+          const path = toPathSegments(operation.path)
+
+          switch (operation.op) {
+            case 'set':
+              setValueAtPath(
+                draft as unknown as Record<string, unknown>,
+                path,
+                operation.value
+              )
+              break
+            case 'inc': {
+              const currentValue = getValueAtPath(
+                draft as unknown as Record<string, unknown>,
+                path
+              )
+              if (typeof currentValue === 'number') {
+                setValueAtPath(
+                  draft as unknown as Record<string, unknown>,
+                  path,
+                  currentValue + operation.value
+                )
+              }
+              break
+            }
+            case 'push': {
+              const target = getValueAtPath(
+                draft as unknown as Record<string, unknown>,
+                path
+              )
+              if (Array.isArray(target)) {
+                target.push(operation.value)
+              }
+              break
+            }
+            case 'remove':
+              removeValueAtPath(
+                draft as unknown as Record<string, unknown>,
+                path,
+                operation.index,
+                operation.value
+              )
+              break
+          }
+        }
+
+        draft.revision = envelope.revision
+        draft.eventQueue.push(...(envelope.events ?? []))
+        Object.assign(draft, normalizeState(draft))
+      }),
+
+    setPendingAction: (action) =>
+      set((draft) => {
+        draft.pendingAction = action
+      }),
+
+    resolveAck: (ack) =>
+      set((draft) => {
+        draft.lastAck = ack
+        draft.lastError = ack.ok
+          ? null
+          : {
+              code: ack.errorCode ?? 'GAME_ACTION_REJECTED',
+              message: ack.message ?? '게임 액션이 거부되었습니다.',
+              actionId: ack.actionId,
+            }
+
+        if (draft.pendingAction?.actionId === ack.actionId) {
+          draft.pendingAction = null
+        }
+      }),
+
+    setPrompt: (prompt) =>
+      set((draft) => {
+        draft.prompt = prompt
+        draft.phase = prompt ? 'prompt' : draft.phase
+      }),
+
+    clearPrompt: (promptId) =>
+      set((draft) => {
+        if (!draft.prompt) {
+          return
+        }
+
+        if (promptId && draft.prompt.id !== promptId) {
+          return
+        }
+
+        draft.prompt = null
+      }),
+
+    enqueueEvents: (events) =>
+      set((draft) => {
+        draft.eventQueue.push(...events)
+      }),
+
+    consumeNextEvent: (): ServerEvent | null => {
+      const state = get()
+      const nextEvent = state.eventQueue[0] ?? null
+
+      if (!nextEvent) {
+        return null
+      }
+
+      set((draft) => {
+        draft.eventQueue.shift()
+      })
+
+      return nextEvent
+    },
+
+    setLastError: (error: GameError | null) =>
+      set((draft) => {
+        draft.lastError = error
       }),
 
     resetGame: () =>

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -1,4 +1,9 @@
-export type BuildingLevel = 0 | 1 | 2 | 3 | 4 | 5
+export type RoomId = string
+export type GameId = string
+export type PlayerId = number | string
+export type Money = number
+
+export type BuildingLevel = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7
 
 export type TileType =
   | 'start'
@@ -16,6 +21,28 @@ export type TileType =
   | 'city'
   | 'event'
   | 'ai'
+
+export type TransportTileType =
+  | 'START'
+  | 'PROPERTY'
+  | 'CHANCE'
+  | 'MOVE_TO_ISLAND'
+  | 'ISLAND'
+
+export type GamePhase =
+  | 'waiting'
+  | 'rolling'
+  | 'moving'
+  | 'resolving'
+  | 'prompt'
+  | 'finished'
+
+export type PlayerStateType =
+  | 'normal'
+  | 'island'
+  | 'locked'
+  | 'bankrupt'
+  | 'disconnected'
 
 export interface Card {
   title: string
@@ -35,23 +62,27 @@ export interface ChatMessage {
 
 export interface Tile {
   index: number
-  owner_id?: string | null
+  ownerId?: PlayerId | null
+  owner_id?: PlayerId | null
   building: BuildingLevel
   name: string
   type: TileType
-  price?: number
+  transportType?: TransportTileType
+  price?: Money
   color?: string
 }
 
 export interface Player {
-  id: string
+  id: PlayerId
   nickname: string
   position: number
-  balance: number
+  balance: Money
   owned_tiles: number[]
   is_in_jail: boolean
   jail_turn_count: number
   is_bankrupt: boolean
+  state?: PlayerStateType
+  stateDuration?: number
   color: string
   avatar?: string
 }
@@ -68,9 +99,9 @@ export type ActiveModal =
 
 export type GameRanking = {
   rank: number
-  player_id: string
+  player_id: PlayerId
   nickname: string
-  final_assets: number
+  final_assets: Money
   is_winner: boolean
 }
 
@@ -79,17 +110,132 @@ export type GameResult = {
   rankings: GameRanking[]
 }
 
-export interface GameState {
+export interface GamePromptChoice {
+  id: string
+  label: string
+  value: string
+  description?: string
+}
+
+export interface GamePrompt {
+  id: string
+  type: string
+  playerId?: PlayerId | null
+  title?: string
+  message?: string
+  timeoutSec?: number
+  choices?: GamePromptChoice[]
+  payload?: Record<string, unknown>
+}
+
+export interface GamePromptResponse {
+  promptId: string
+  playerId?: PlayerId | null
+  value: string
+}
+
+export interface GameAck {
+  actionId: string
+  type?: string
+  ok: boolean
+  revision?: number
+  promptId?: string | null
+  message?: string
+  errorCode?: string
+  payload?: Record<string, unknown>
+}
+
+export interface GameError {
+  code: string
+  message: string
+  retryable?: boolean
+  actionId?: string
+}
+
+export interface ServerEvent {
+  id?: string
+  type: string
+  playerId?: PlayerId | null
+  tileIndex?: number | null
+  amount?: Money
+  payload?: Record<string, unknown>
+}
+
+export type GamePatchPath = string | Array<string | number>
+
+export type GamePatchOperation =
+  | {
+      op: 'set'
+      path: GamePatchPath
+      value: unknown
+    }
+  | {
+      op: 'inc'
+      path: GamePatchPath
+      value: number
+    }
+  | {
+      op: 'push'
+      path: GamePatchPath
+      value: unknown
+    }
+  | {
+      op: 'remove'
+      path: GamePatchPath
+      index?: number
+      value?: unknown
+    }
+
+export interface PendingGameAction {
+  actionId: string
+  type: string
+  requestedAt: number
+  payload?: Record<string, unknown>
+}
+
+export interface GameConnectionMeta {
+  roomId: RoomId | null
+  gameId: GameId | null
+  transport: 'legacy-rest' | 'legacy-socket' | 'event-socket' | null
+  syncedAt: string | null
+}
+
+export interface GameSnapshot {
+  roomId?: RoomId | null
+  gameId?: GameId | null
+  revision: number
+  phase: GamePhase
   players: Player[]
   tiles: Tile[]
-  messages: ChatMessage[]
-  // 프런트는 게임 상태를 camelCase 기준으로 관리한다.
-  currentTurn: string | null
+  currentPlayerId: PlayerId | null
+  currentTurn?: PlayerId | null
   round: number
   turnTimeoutSec: number
+  prompt?: GamePrompt | null
+  gameResult?: GameResult | null
+  isGameOver?: boolean
+  winnerId?: PlayerId | null
+}
+
+export interface GamePatchEnvelope {
+  revision: number
+  patch: GamePatchOperation[]
+  events?: ServerEvent[]
+}
+
+export interface GameState extends GameSnapshot {
+  messages: ChatMessage[]
+  // 기존 화면과의 호환을 위해 currentTurn alias를 유지한다.
+  currentTurn: PlayerId | null
   turnTimerKey: number
   activeModal: ActiveModal
+  prompt: GamePrompt | null
+  pendingAction: PendingGameAction | null
+  lastAck: GameAck | null
+  lastError: GameError | null
+  eventQueue: ServerEvent[]
+  session: GameConnectionMeta
   gameResult: GameResult | null
   isGameOver: boolean
-  winnerId: string | null
+  winnerId: PlayerId | null
 }


### PR DESCRIPTION
## 📌 관련 이슈

> closes #242 

---

## 📝 작업 내용

> 게임 이벤트 명세 이행을 위한 FE-B 선행 작업으로 타입과 스토어 계약을 정리했습니다.

- `src/types/domain.ts`
  - `RoomId`, `GameId`, `PlayerId`, `Money` 추가
  - `GamePhase`, `GamePrompt`, `GameAck`, `GameError`, `GamePatchEnvelope`, `ServerEvent` 추가
  - `BuildingLevel`을 `0..7`로 확장
  - 기존 화면 호환을 위해 `currentTurn`, `owner_id` alias 유지

- `src/stores/game.store.ts`
  - `replaceFromSnapshot`, `applyPatchEnvelope`, `setPendingAction`, `resolveAck` 추가
  - `setPrompt`, `clearPrompt`, `enqueueEvents`, `consumeNextEvent`, `setLastError` 추가
  - player/tile/currentTurn 정규화 로직 추가

- `src/hooks/game/useTurn.ts`
  - 숫자/문자 혼합 `PlayerId` 비교가 가능하도록 수정

- `src/mocks/handlers/game.handler.ts`
  - mock current turn 및 player id 비교를 `PlayerId` 기준으로 정리

- `src/pages/GamePage.tsx`
  - 채팅 sender option으로 전달하는 player id를 문자열로 정규화

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

> UI 변경 없음
