### PR TITLE
Feat : 게임 이벤트 소켓 계층 전환 및 mock/fallback 정리

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,8 +18,11 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command:
-      'VITE_USE_SOCKET_MOCK=true npm run dev -- --host 127.0.0.1 --port 4173',
+    command: 'npm run dev -- --host 127.0.0.1 --port 4173',
+    env: {
+      ...process.env,
+      VITE_USE_SOCKET_MOCK: 'true',
+    },
     url: 'http://127.0.0.1:4173',
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,

--- a/src/hooks/game/useDiceRoll.ts
+++ b/src/hooks/game/useDiceRoll.ts
@@ -2,7 +2,7 @@ import { RefObject, useCallback } from 'react'
 import type { BoardGameHandle } from '../../components/board/GameBoard'
 import { IS_SOCKET_MOCK_ENABLED } from '../../config/env'
 import { socket } from '../../lib/socket'
-import { emitRollDice } from '../../services/socket/game.handler'
+import { emitGameAction } from '../../services/socket/game.handler'
 import { useGameStore } from '../../stores/game.store'
 
 const USE_GAME_SOCKET_MOCK = IS_SOCKET_MOCK_ENABLED
@@ -18,7 +18,10 @@ export const useDiceRoll = (boardRef: RefObject<BoardGameHandle | null>) => {
 
       // Prefer server-authoritative roll via socket.
       if (!USE_GAME_SOCKET_MOCK && socket.connected && currentTurn) {
-        emitRollDice({ room_id: roomId })
+        emitGameAction({
+          type: 'ROLL_DICE',
+          roomId,
+        })
         return
       }
 

--- a/src/hooks/game/useGameState.ts
+++ b/src/hooks/game/useGameState.ts
@@ -2,7 +2,10 @@ import { useEffect, useRef } from 'react'
 import { IS_SOCKET_MOCK_ENABLED } from '../../config/env'
 import { connectSocketWithAuthIfNeeded, socket } from '../../lib/socket'
 import { gameApi } from '../../services/game/game.api'
-import { setupGameHandlers } from '../../services/socket/game.handler'
+import {
+  emitGameSync,
+  setupGameHandlers,
+} from '../../services/socket/game.handler'
 import { useGameStore } from '../../stores/game.store'
 
 const USE_GAME_SOCKET_MOCK = IS_SOCKET_MOCK_ENABLED
@@ -16,7 +19,7 @@ export const useGameState = (roomId: string | null) => {
       return
     }
 
-    const teardownHandlers = setupGameHandlers()
+    const teardownHandlers = setupGameHandlers({ roomId })
 
     // mock 환경에서는 공유 소켓이 불필요하게 재연결되지 않도록 차단한다.
     if (USE_GAME_SOCKET_MOCK) {
@@ -25,12 +28,18 @@ export const useGameState = (roomId: string | null) => {
       connectSocketWithAuthIfNeeded()
     }
 
-    const fetchGameState = async () => {
+    const syncGameState = async () => {
       const roomChanged = syncedRoomIdRef.current !== roomId
 
-      // 같은 방에서 이미 상태를 들고 있으면 초기 조회를 반복하지 않는다.
+      // 같은 방에서 이미 상태를 들고 있으면 초기 동기화를 반복하지 않는다.
       if (!roomChanged && players.length > 0) return
 
+      emitGameSync({
+        roomId,
+        reset: USE_GAME_SOCKET_MOCK && roomChanged,
+      })
+
+      // mock/socket rollout 전까지는 REST snapshot을 bootstrap fallback으로 유지한다.
       const result = await gameApi.getState(roomId, {
         reset: USE_GAME_SOCKET_MOCK && roomChanged,
       })
@@ -58,7 +67,7 @@ export const useGameState = (roomId: string | null) => {
       syncedRoomIdRef.current = roomId
     }
 
-    void fetchGameState()
+    void syncGameState()
 
     return () => {
       teardownHandlers()

--- a/src/mocks/handlers/game.handler.ts
+++ b/src/mocks/handlers/game.handler.ts
@@ -1,6 +1,17 @@
 import { delay, http, HttpResponse } from 'msw'
 import { socket } from '../../lib/socket'
-import { BuildingLevel, Player, PlayerId, Tile } from '../../types/domain'
+import type {
+  BuildingLevel,
+  GameAck,
+  GameError,
+  GamePatchEnvelope,
+  GamePrompt,
+  GamePromptResponse,
+  GameSnapshot,
+  Player,
+  PlayerId,
+  Tile,
+} from '../../types/domain'
 import { mockMessages, mockPlayers, mockTiles } from '../gameMockData'
 
 const MOCK_PLAYER_ID = 'mock-player-1'
@@ -17,12 +28,33 @@ type TileActionRequestBody = {
   level?: number
 }
 
+type SocketWithListeners = {
+  listeners: (name: string) => Array<(eventPayload: unknown) => void>
+}
+
 type GameStateResponse = {
   players: Player[]
   tiles: Tile[]
   messages: typeof mockMessages
   currentTurn: PlayerId
   round: number
+  revision: number
+  phase: GameSnapshot['phase']
+  prompt: GamePrompt | null
+}
+
+type MockGameActionPayload = {
+  actionId?: string
+  type: string
+  roomId?: string | null
+  gameId?: string | null
+  payload?: Record<string, unknown>
+}
+
+type MockGameSyncPayload = {
+  roomId?: string | null
+  gameId?: string | null
+  reset?: boolean
 }
 
 const clonePlayers = () => structuredClone(mockPlayers)
@@ -35,6 +67,9 @@ const createInitialGameState = (): GameStateResponse => ({
   messages: cloneMessages(),
   currentTurn: MOCK_PLAYER_ID,
   round: 1,
+  revision: 1,
+  phase: 'waiting',
+  prompt: null,
 })
 
 const mockGameState: GameStateResponse = createInitialGameState()
@@ -46,7 +81,13 @@ const resetMockGameState = () => {
   mockGameState.messages = initialState.messages
   mockGameState.currentTurn = initialState.currentTurn
   mockGameState.round = initialState.round
+  mockGameState.revision = initialState.revision
+  mockGameState.phase = initialState.phase
+  mockGameState.prompt = initialState.prompt
 }
+
+const getMockGameId = (roomId?: string | null, gameId?: string | null) =>
+  gameId ?? (roomId ? `game-${roomId}` : 'game-mock-room')
 
 const buildStateResponse = () => ({
   players: structuredClone(mockGameState.players),
@@ -54,19 +95,38 @@ const buildStateResponse = () => ({
   messages: structuredClone(mockGameState.messages),
   currentTurn: mockGameState.currentTurn,
   round: mockGameState.round,
+  revision: mockGameState.revision,
+})
+
+const buildSnapshot = (
+  roomId?: string | null,
+  gameId?: string | null
+): GameSnapshot => ({
+  roomId: roomId ?? null,
+  gameId: getMockGameId(roomId, gameId),
+  revision: mockGameState.revision,
+  phase: mockGameState.phase,
+  players: structuredClone(mockGameState.players),
+  tiles: structuredClone(mockGameState.tiles),
+  currentPlayerId: mockGameState.currentTurn,
+  currentTurn: mockGameState.currentTurn,
+  round: mockGameState.round,
+  turnTimeoutSec: MOCK_TURN_TIMEOUT_SEC,
+  prompt: mockGameState.prompt,
+  gameResult: null,
+  isGameOver: false,
+  winnerId: null,
 })
 
 const emitSocketEvent = (eventName: string, payload: unknown) => {
-  const socketWithListeners = socket as unknown as {
-    listeners: (name: string) => Array<(eventPayload: unknown) => void>
-  }
+  const socketWithListeners = socket as unknown as SocketWithListeners
 
   socketWithListeners.listeners(eventName).forEach((listener) => {
     listener(payload)
   })
 }
 
-const emitGameState = () => {
+const emitLegacyGameState = () => {
   emitSocketEvent('game_state', {
     players: structuredClone(mockGameState.players),
     tiles: structuredClone(mockGameState.tiles),
@@ -76,12 +136,31 @@ const emitGameState = () => {
   })
 }
 
-const emitTurnStart = () => {
+const emitLegacyTurnStart = () => {
   emitSocketEvent('turn_start', {
     player_id: mockGameState.currentTurn,
     round: mockGameState.round,
     timeout_sec: MOCK_TURN_TIMEOUT_SEC,
   })
+}
+
+const emitGameAck = (ack: GameAck) => {
+  emitSocketEvent('game:ack', ack)
+}
+
+const emitGamePatch = (
+  payload: GamePatchEnvelope & { snapshot?: GameSnapshot }
+) => {
+  emitSocketEvent('game:patch', payload)
+}
+
+const emitGamePrompt = (prompt: GamePrompt) => {
+  mockGameState.prompt = prompt
+  emitSocketEvent('game:prompt', prompt)
+}
+
+const emitGameError = (error: GameError) => {
+  emitSocketEvent('game:error', error)
 }
 
 const getCurrentPlayer = () =>
@@ -152,8 +231,397 @@ const advanceMockTurn = () => {
   mockGameState.currentTurn = getNextActivePlayerId(mockGameState.currentTurn)
 }
 
+const nextRevision = () => {
+  mockGameState.revision += 1
+  return mockGameState.revision
+}
+
 const buildErrorResponse = (message: string, status: number) =>
   HttpResponse.json({ message }, { status })
+
+const emitSnapshotPatch = (
+  roomId?: string | null,
+  gameId?: string | null,
+  events?: GamePatchEnvelope['events']
+) => {
+  emitGamePatch({
+    revision: mockGameState.revision,
+    patch: [],
+    events,
+    snapshot: buildSnapshot(roomId, gameId),
+  })
+}
+
+const handleRollDiceAction = (
+  action: Required<Pick<MockGameActionPayload, 'type' | 'actionId'>> &
+    Pick<MockGameActionPayload, 'roomId' | 'gameId'>
+) => {
+  const currentPlayer = getCurrentPlayer()
+
+  if (!currentPlayer) {
+    emitGameAck({
+      actionId: action.actionId,
+      type: action.type,
+      ok: false,
+      message: '현재 턴 플레이어를 찾을 수 없습니다.',
+      errorCode: 'PLAYER_NOT_FOUND',
+    })
+    return
+  }
+
+  const dice1 = Math.floor(Math.random() * 6) + 1
+  const dice2 = Math.floor(Math.random() * 6) + 1
+  const total = dice1 + dice2
+  const fromIndex = currentPlayer.position
+  const toIndex = (fromIndex + total) % mockGameState.tiles.length
+  const passGo = fromIndex + total >= mockGameState.tiles.length
+
+  currentPlayer.position = toIndex
+  if (passGo) {
+    currentPlayer.balance += MOCK_PASS_GO_SALARY
+  }
+
+  advanceMockTurn()
+  mockGameState.phase = 'rolling'
+  const revision = nextRevision()
+
+  emitGameAck({
+    actionId: action.actionId,
+    type: action.type,
+    ok: true,
+    revision,
+  })
+
+  emitSnapshotPatch(action.roomId, action.gameId, [
+    {
+      type: 'ROLL_DICE',
+      playerId: currentPlayer.id,
+      payload: {
+        dice: [dice1, dice2],
+        total,
+      },
+    },
+    {
+      type: 'MOVE_PLAYER',
+      playerId: currentPlayer.id,
+      tileIndex: toIndex,
+      amount: passGo ? MOCK_PASS_GO_SALARY : undefined,
+      payload: {
+        fromIndex,
+        toIndex,
+        passGo,
+      },
+    },
+  ])
+}
+
+const handleBuyPropertyAction = (
+  action: Required<Pick<MockGameActionPayload, 'type' | 'actionId'>> &
+    Pick<MockGameActionPayload, 'roomId' | 'gameId' | 'payload'>
+) => {
+  const tileIndex = Number(action.payload?.tile_index)
+  const player = getCurrentPlayer()
+  const tile = getTileByIndex(tileIndex)
+
+  if (!player || !isOwnableTile(tile)) {
+    emitGameAck({
+      actionId: action.actionId,
+      type: action.type,
+      ok: false,
+      message: '구매할 수 없는 타일입니다.',
+      errorCode: 'TILE_NOT_OWNABLE',
+    })
+    return
+  }
+
+  if (tile.owner_id) {
+    emitGameAck({
+      actionId: action.actionId,
+      type: action.type,
+      ok: false,
+      message: '이미 소유된 타일입니다.',
+      errorCode: 'TILE_ALREADY_OWNED',
+    })
+    return
+  }
+
+  const price = tile.price ?? 0
+  if (player.balance < price) {
+    emitGameAck({
+      actionId: action.actionId,
+      type: action.type,
+      ok: false,
+      message: '보유 금액이 부족합니다.',
+      errorCode: 'INSUFFICIENT_BALANCE',
+    })
+    return
+  }
+
+  player.balance -= price
+  tile.owner_id = player.id
+  tile.ownerId = player.id
+  tile.building = 0
+  ensureOwnedTiles(player, tileIndex)
+  const revision = nextRevision()
+
+  emitGameAck({
+    actionId: action.actionId,
+    type: action.type,
+    ok: true,
+    revision,
+  })
+
+  emitSnapshotPatch(action.roomId, action.gameId, [
+    {
+      type: 'BUY_PROPERTY',
+      playerId: player.id,
+      tileIndex,
+      amount: price,
+    },
+  ])
+}
+
+const handleBuildPropertyAction = (
+  action: Required<Pick<MockGameActionPayload, 'type' | 'actionId'>> &
+    Pick<MockGameActionPayload, 'roomId' | 'gameId' | 'payload'>
+) => {
+  const tileIndex = Number(action.payload?.tile_index)
+  const player = getCurrentPlayer()
+  const tile = getTileByIndex(tileIndex)
+
+  if (!player || !isOwnableTile(tile)) {
+    emitGameAck({
+      actionId: action.actionId,
+      type: action.type,
+      ok: false,
+      message: '건설할 수 없는 타일입니다.',
+      errorCode: 'TILE_NOT_BUILDABLE',
+    })
+    return
+  }
+
+  if (String(tile.owner_id) !== String(player.id)) {
+    emitGameAck({
+      actionId: action.actionId,
+      type: action.type,
+      ok: false,
+      message: '본인 소유 타일만 건설할 수 있습니다.',
+      errorCode: 'FORBIDDEN_BUILD',
+    })
+    return
+  }
+
+  if (tile.building >= 5) {
+    emitGameAck({
+      actionId: action.actionId,
+      type: action.type,
+      ok: false,
+      message: '최대 단계까지 건설했습니다.',
+      errorCode: 'MAX_BUILDING_LEVEL',
+    })
+    return
+  }
+
+  if (player.balance < MOCK_BUILD_COST) {
+    emitGameAck({
+      actionId: action.actionId,
+      type: action.type,
+      ok: false,
+      message: '건설 비용이 부족합니다.',
+      errorCode: 'INSUFFICIENT_BALANCE',
+    })
+    return
+  }
+
+  player.balance -= MOCK_BUILD_COST
+  tile.building = (tile.building + 1) as BuildingLevel
+  const revision = nextRevision()
+
+  emitGameAck({
+    actionId: action.actionId,
+    type: action.type,
+    ok: true,
+    revision,
+  })
+
+  emitSnapshotPatch(action.roomId, action.gameId, [
+    {
+      type: 'BUILD_PROPERTY',
+      playerId: player.id,
+      tileIndex,
+      amount: MOCK_BUILD_COST,
+      payload: { buildingLevel: tile.building },
+    },
+  ])
+}
+
+const handleSellPropertyAction = (
+  action: Required<Pick<MockGameActionPayload, 'type' | 'actionId'>> &
+    Pick<MockGameActionPayload, 'roomId' | 'gameId' | 'payload'>
+) => {
+  const tileIndex = Number(action.payload?.tile_index)
+  const level =
+    typeof action.payload?.level === 'number' ? action.payload.level : undefined
+  const player = getCurrentPlayer()
+  const tile = getTileByIndex(tileIndex)
+
+  if (!player || !isOwnableTile(tile)) {
+    emitGameAck({
+      actionId: action.actionId,
+      type: action.type,
+      ok: false,
+      message: '매각할 수 없는 타일입니다.',
+      errorCode: 'TILE_NOT_SELLABLE',
+    })
+    return
+  }
+
+  if (String(tile.owner_id) !== String(player.id)) {
+    emitGameAck({
+      actionId: action.actionId,
+      type: action.type,
+      ok: false,
+      message: '본인 소유 타일만 매각할 수 있습니다.',
+      errorCode: 'FORBIDDEN_SELL',
+    })
+    return
+  }
+
+  const { refund, nextBuilding, releaseOwnership } = getSellRefund(tile, level)
+  player.balance += refund
+  tile.building = nextBuilding
+
+  if (releaseOwnership) {
+    tile.owner_id = null
+    tile.ownerId = null
+    removeOwnedTile(player, tileIndex)
+  }
+
+  const revision = nextRevision()
+
+  emitGameAck({
+    actionId: action.actionId,
+    type: action.type,
+    ok: true,
+    revision,
+  })
+
+  emitSnapshotPatch(action.roomId, action.gameId, [
+    {
+      type: 'SELL_PROPERTY',
+      playerId: player.id,
+      tileIndex,
+      amount: refund,
+      payload: {
+        buildingLevel: tile.building,
+        releaseOwnership,
+      },
+    },
+  ])
+}
+
+export const mockEmitGameSync = ({
+  roomId,
+  gameId,
+  reset,
+}: MockGameSyncPayload) => {
+  if (reset) {
+    resetMockGameState()
+  }
+
+  setTimeout(() => {
+    emitSnapshotPatch(roomId, gameId)
+  }, 0)
+}
+
+export const mockEmitGameAction = ({
+  actionId = `mock-action-${Date.now()}`,
+  type,
+  roomId,
+  gameId,
+  payload,
+}: MockGameActionPayload) => {
+  const action = {
+    actionId,
+    type,
+    roomId,
+    gameId,
+    payload,
+  }
+
+  setTimeout(() => {
+    switch (type) {
+      case 'ROLL_DICE':
+        handleRollDiceAction(action)
+        break
+      case 'BUY_PROPERTY':
+        handleBuyPropertyAction(action)
+        break
+      case 'BUILD_PROPERTY':
+        handleBuildPropertyAction(action)
+        break
+      case 'SELL_PROPERTY':
+        handleSellPropertyAction(action)
+        break
+      case 'REQUEST_BUY_PROPERTY_PROMPT': {
+        emitGamePrompt({
+          id: `prompt-buy-${Date.now()}`,
+          type: 'buy',
+          playerId: mockGameState.currentTurn,
+          title: '도시 구매',
+          message: '이 도시를 구매하시겠습니까?',
+          timeoutSec: MOCK_TURN_TIMEOUT_SEC,
+          payload,
+        })
+        break
+      }
+      default:
+        emitGameError({
+          code: 'UNSUPPORTED_GAME_ACTION',
+          message: `지원하지 않는 게임 액션입니다: ${type}`,
+          actionId,
+        })
+        emitGameAck({
+          actionId,
+          type,
+          ok: false,
+          message: '지원하지 않는 게임 액션입니다.',
+          errorCode: 'UNSUPPORTED_GAME_ACTION',
+        })
+    }
+  }, 0)
+
+  return actionId
+}
+
+export const mockEmitPromptResponse = (response: GamePromptResponse) => {
+  if (mockGameState.prompt?.id !== response.promptId) {
+    emitGameError({
+      code: 'PROMPT_NOT_FOUND',
+      message: '유효하지 않은 prompt 응답입니다.',
+    })
+    return
+  }
+
+  mockGameState.prompt = null
+  const revision = nextRevision()
+
+  emitGameAck({
+    actionId: `prompt-response-${Date.now()}`,
+    type: 'PROMPT_RESPONSE',
+    ok: true,
+    revision,
+    promptId: response.promptId,
+  })
+
+  emitSnapshotPatch(undefined, undefined, [
+    {
+      type: 'PROMPT_RESPONSE',
+      playerId: response.playerId,
+      payload: { value: response.value },
+    },
+  ])
+}
 
 export const gameHandlers = [
   http.post('/api/game/:roomId/roll-dice', async ({ request }) => {
@@ -195,7 +663,7 @@ export const gameHandlers = [
           pass_go: passGo,
           pass_go_salary: MOCK_PASS_GO_SALARY,
         })
-        emitGameState()
+        emitLegacyGameState()
       }, 800)
     }, 100)
 
@@ -244,6 +712,7 @@ export const gameHandlers = [
 
     player.balance -= price
     tile.owner_id = player.id
+    tile.ownerId = player.id
     tile.building = 0
     ensureOwnedTiles(player, tile_index)
     advanceMockTurn()
@@ -255,8 +724,8 @@ export const gameHandlers = [
         tile_name: tile.name,
         price,
       })
-      emitGameState()
-      emitTurnStart()
+      emitLegacyGameState()
+      emitLegacyTurnStart()
     }, 0)
 
     await delay(150)
@@ -305,8 +774,8 @@ export const gameHandlers = [
     advanceMockTurn()
 
     setTimeout(() => {
-      emitGameState()
-      emitTurnStart()
+      emitLegacyGameState()
+      emitLegacyTurnStart()
     }, 0)
 
     await delay(150)
@@ -348,11 +817,12 @@ export const gameHandlers = [
 
     if (releaseOwnership) {
       tile.owner_id = null
+      tile.ownerId = null
       removeOwnedTile(player, tile_index)
     }
 
     setTimeout(() => {
-      emitGameState()
+      emitLegacyGameState()
     }, 0)
 
     await delay(150)

--- a/src/services/game/game.api.ts
+++ b/src/services/game/game.api.ts
@@ -46,6 +46,9 @@ const buildGamePath = (roomId: string, action?: string) => {
 }
 
 export const gameApi = {
+  /**
+   * @deprecated Event socket rollout 동안 bootstrap/fallback 용도로만 유지한다.
+   */
   async getState(roomId: string, options?: { reset?: boolean }) {
     try {
       const { data } = await apiClient.get(buildGamePath(roomId), {
@@ -57,7 +60,9 @@ export const gameApi = {
     }
   },
 
-  // GAME-001
+  /**
+   * @deprecated 새 이벤트 명세 기준에서는 `game:action`으로 대체된다.
+   */
   async buyTile(roomId: string, payload: { tile_index: number }) {
     try {
       const { data } = await apiClient.post(
@@ -70,7 +75,9 @@ export const gameApi = {
     }
   },
 
-  // GAME-002
+  /**
+   * @deprecated 새 이벤트 명세 기준에서는 `game:action`으로 대체된다.
+   */
   async buildTile(roomId: string, payload: { tile_index: number }) {
     try {
       const { data } = await apiClient.post(
@@ -83,7 +90,9 @@ export const gameApi = {
     }
   },
 
-  // GAME-003
+  /**
+   * @deprecated 새 이벤트 명세 기준에서는 `game:action`으로 대체된다.
+   */
   async sellTile(
     roomId: string,
     payload: { tile_index: number; level?: number }
@@ -99,7 +108,9 @@ export const gameApi = {
     }
   },
 
-  // GAME-004
+  /**
+   * @deprecated `game:sync` 전환 완료 전까지 유지하는 레거시 별칭이다.
+   */
   async syncState(roomId: string, options?: { reset?: boolean }) {
     return this.getState(roomId, options)
   },

--- a/src/services/socket/game.handler.ts
+++ b/src/services/socket/game.handler.ts
@@ -1,4 +1,10 @@
+import { IS_SOCKET_MOCK_ENABLED } from '../../config/env'
 import { socket } from '../../lib/socket'
+import {
+  mockEmitGameAction,
+  mockEmitGameSync,
+  mockEmitPromptResponse,
+} from '../../mocks/handlers/game.handler'
 import { useGameStore } from '../../stores/game.store'
 import type {
   GameAck,
@@ -43,6 +49,7 @@ type PromptResponsePayload = GamePromptResponse & {
 }
 
 let teardownGameHandlersRef: Teardown | null = null
+const USE_GAME_SOCKET_MOCK = IS_SOCKET_MOCK_ENABLED
 
 const createActionId = () => `game-action-${Date.now()}`
 
@@ -141,6 +148,17 @@ export const emitGameAction = ({
     })
   )
 
+  if (USE_GAME_SOCKET_MOCK) {
+    mockEmitGameAction({
+      actionId,
+      type,
+      roomId,
+      gameId,
+      payload,
+    })
+    return actionId
+  }
+
   socket.emit('game:action', {
     actionId,
     type,
@@ -153,6 +171,15 @@ export const emitGameAction = ({
 }
 
 export const emitGameSync = ({ roomId, gameId, reset }: GameSyncPayload) => {
+  if (USE_GAME_SOCKET_MOCK) {
+    mockEmitGameSync({
+      roomId,
+      gameId,
+      reset,
+    })
+    return
+  }
+
   socket.emit('game:sync', {
     roomId,
     gameId,
@@ -167,6 +194,15 @@ export const emitPromptResponse = ({
   roomId,
   gameId,
 }: PromptResponsePayload) => {
+  if (USE_GAME_SOCKET_MOCK) {
+    mockEmitPromptResponse({
+      promptId,
+      playerId,
+      value,
+    })
+    return
+  }
+
   socket.emit('game:prompt_response', {
     promptId,
     playerId,

--- a/src/services/socket/game.handler.ts
+++ b/src/services/socket/game.handler.ts
@@ -1,251 +1,198 @@
 import { socket } from '../../lib/socket'
 import { useGameStore } from '../../stores/game.store'
-import type { Card, GameResult, Player, Tile } from '../../types/domain'
+import type {
+  GameAck,
+  GameError,
+  GamePatchEnvelope,
+  GamePrompt,
+  GamePromptResponse,
+  GameSnapshot,
+  PendingGameAction,
+  RoomId,
+  GameId,
+} from '../../types/domain'
 
 type Teardown = () => void
 
-type GameStatePayload = {
-  players: Player[]
-  tiles: Tile[]
-  current_turn: string | null
-  round: number
-  timeout_sec?: number
+type SetupGameHandlersOptions = {
+  roomId?: RoomId | null
+  gameId?: GameId | null
 }
 
-type TurnStartPayload = {
-  player_id: string
-  round: number
-  timeout_sec: number
+type GamePatchPayload = GamePatchEnvelope & {
+  snapshot?: GameSnapshot
 }
 
-type DiceRolledPayload = {
-  player_id: string
-  dice: number[]
-  is_double: boolean
-  double_count: number
+type GameActionPayload = {
+  actionId?: string
+  type: string
+  roomId?: RoomId | null
+  gameId?: GameId | null
+  payload?: Record<string, unknown>
 }
 
-type PlayerMovedPayload = {
-  player_id: string
-  from_index: number
-  to_index: number
-  trigger: string
-  pass_go: boolean
-  pass_go_salary: number
+type GameSyncPayload = {
+  roomId?: RoomId | null
+  gameId?: GameId | null
+  reset?: boolean
 }
 
-type TilePurchasedPayload = {
-  player_id: string
-  tile_index: number
-  tile_name: string
-  price: number
-}
-
-type TollPaidPayload = {
-  payer_id: string
-  owner_id: string
-  tile_index: number
-  amount: number
-}
-
-type CardDrawnPayload = {
-  player_id: string
-  card: Card
-}
-
-type PlayerSentToJailPayload = {
-  player_id: string
-}
-
-type PlayerBankruptPayload = {
-  player_id: string
+type PromptResponsePayload = GamePromptResponse & {
+  roomId?: RoomId | null
+  gameId?: GameId | null
 }
 
 let teardownGameHandlersRef: Teardown | null = null
 
-const applyGameState = (payload: GameStatePayload) => {
-  const gameStore = useGameStore.getState()
-  gameStore.setGameState({
-    players: payload.players,
-    tiles: payload.tiles,
-    currentTurn: payload.current_turn,
-    round: payload.round,
-    turnTimeoutSec: payload.timeout_sec ?? gameStore.turnTimeoutSec,
-  })
-}
+const createActionId = () => `game-action-${Date.now()}`
 
-const appendOwnedTile = (player: Player, tileIndex: number) => {
-  if (player.owned_tiles.includes(tileIndex)) {
-    return player.owned_tiles
-  }
+const createPendingAction = (
+  action: Required<Pick<GameActionPayload, 'actionId' | 'type'>> &
+    Pick<GameActionPayload, 'payload'>
+): PendingGameAction => ({
+  actionId: action.actionId,
+  type: action.type,
+  requestedAt: Date.now(),
+  payload: action.payload,
+})
 
-  return [...player.owned_tiles, tileIndex]
-}
-
-export const setupGameHandlers = (): Teardown => {
+export const setupGameHandlers = (
+  options: SetupGameHandlersOptions = {}
+): Teardown => {
   teardownGameHandlersRef?.()
 
-  const gameStore = useGameStore.getState()
+  const handleGameAck = (ack: GameAck) => {
+    const gameStore = useGameStore.getState()
+    gameStore.resolveAck(ack)
 
-  const handleGameStart = ({
-    game_state,
-  }: {
-    game_state: GameStatePayload
-  }) => {
-    applyGameState(game_state)
-  }
-
-  const handleGameState = (state: GameStatePayload) => {
-    applyGameState(state)
-  }
-
-  const handleTurnStart = ({
-    player_id,
-    round,
-    timeout_sec,
-  }: TurnStartPayload) => {
-    gameStore.setGameState({
-      currentTurn: player_id,
-      round,
-      turnTimeoutSec: timeout_sec,
-      turnTimerKey: Date.now(),
-    })
-  }
-
-  const handleDiceRolled = ({ player_id, dice }: DiceRolledPayload) => {
-    // 보드 애니메이션 연결 전까지는 수신만 보장한다.
-    void player_id
-    void dice
-  }
-
-  const handlePlayerMoved = ({
-    player_id,
-    to_index,
-    pass_go,
-    pass_go_salary,
-  }: PlayerMovedPayload) => {
-    const state = useGameStore.getState()
-    const player = state.players.find((candidate) => candidate.id === player_id)
-
-    state.updatePlayer(player_id, {
-      position: to_index,
-      balance:
-        player && pass_go ? player.balance + pass_go_salary : player?.balance,
-    })
-  }
-
-  const handleTilePurchased = ({
-    player_id,
-    tile_index,
-    price,
-  }: TilePurchasedPayload) => {
-    const state = useGameStore.getState()
-    const player = state.players.find((candidate) => candidate.id === player_id)
-
-    state.updateTile(tile_index, { owner_id: player_id })
-
-    if (player) {
-      state.updatePlayer(player_id, {
-        balance: Math.max(0, player.balance - price),
-        owned_tiles: appendOwnedTile(player, tile_index),
-      })
-    }
-
-    state.setModal(null)
-  }
-
-  const handleTollPaid = ({ payer_id, owner_id, amount }: TollPaidPayload) => {
-    const state = useGameStore.getState()
-    const payer = state.players.find((player) => player.id === payer_id)
-    const owner = state.players.find((player) => player.id === owner_id)
-
-    if (payer) {
-      state.updatePlayer(payer_id, {
-        balance: Math.max(0, payer.balance - amount),
-      })
-    }
-
-    if (owner) {
-      state.updatePlayer(owner_id, {
-        balance: owner.balance + amount,
-      })
+    if (typeof ack.revision === 'number' && ack.revision > gameStore.revision) {
+      gameStore.setGameState({ revision: ack.revision })
     }
   }
 
-  const handleCardDrawn = ({ card }: CardDrawnPayload) => {
-    void card
-    gameStore.setModal('card')
-  }
+  const handleGamePatch = (payload: GamePatchPayload) => {
+    const gameStore = useGameStore.getState()
 
-  const handlePlayerSentToJail = ({ player_id }: PlayerSentToJailPayload) => {
-    gameStore.updatePlayer(player_id, { is_in_jail: true })
-  }
+    if (payload.snapshot) {
+      gameStore.replaceFromSnapshot(payload.snapshot)
+      return
+    }
 
-  const handlePlayerBankrupt = ({ player_id }: PlayerBankruptPayload) => {
-    gameStore.updatePlayer(player_id, { is_bankrupt: true })
-    gameStore.setModal('bankrupt')
-  }
-
-  const handleGameOver = (payload: GameResult) => {
-    const winner = payload.rankings.find((ranking) => ranking.is_winner)
-    gameStore.setGameState({
-      gameResult: payload,
-      isGameOver: true,
-      winnerId: winner?.player_id ?? null,
+    gameStore.applyPatchEnvelope({
+      revision: payload.revision,
+      patch: payload.patch,
+      events: payload.events,
     })
   }
 
-  const handleAIPenaltyLoading = () => {
-    gameStore.setModal('penalty')
+  const handleGamePrompt = (prompt: GamePrompt) => {
+    useGameStore.getState().setPrompt(prompt)
   }
 
-  const handleAIPenalty = () => {
-    gameStore.setModal('penalty')
+  const handleGameError = (error: GameError) => {
+    useGameStore.getState().setLastError(error)
   }
 
-  socket.on('game_start', handleGameStart)
-  socket.on('game_state', handleGameState)
-  socket.on('turn_start', handleTurnStart)
-  socket.on('dice_rolled', handleDiceRolled)
-  socket.on('player_moved', handlePlayerMoved)
-  socket.on('tile_purchased', handleTilePurchased)
-  socket.on('toll_paid', handleTollPaid)
-  socket.on('event_card_drawn', handleCardDrawn)
-  socket.on('chance_card_drawn', handleCardDrawn)
-  socket.on('player_sent_to_jail', handlePlayerSentToJail)
-  socket.on('player_bankrupt', handlePlayerBankrupt)
-  socket.on('game_over', handleGameOver)
-  socket.on('ai_penalty_loading', handleAIPenaltyLoading)
-  socket.on('ai_penalty', handleAIPenalty)
+  socket.on('game:ack', handleGameAck)
+  socket.on('game:patch', handleGamePatch)
+  socket.on('game:prompt', handleGamePrompt)
+  socket.on('game:error', handleGameError)
 
   const teardown = () => {
-    socket.off('game_start', handleGameStart)
-    socket.off('game_state', handleGameState)
-    socket.off('turn_start', handleTurnStart)
-    socket.off('dice_rolled', handleDiceRolled)
-    socket.off('player_moved', handlePlayerMoved)
-    socket.off('tile_purchased', handleTilePurchased)
-    socket.off('toll_paid', handleTollPaid)
-    socket.off('event_card_drawn', handleCardDrawn)
-    socket.off('chance_card_drawn', handleCardDrawn)
-    socket.off('player_sent_to_jail', handlePlayerSentToJail)
-    socket.off('player_bankrupt', handlePlayerBankrupt)
-    socket.off('game_over', handleGameOver)
-    socket.off('ai_penalty_loading', handleAIPenaltyLoading)
-    socket.off('ai_penalty', handleAIPenalty)
+    socket.off('game:ack', handleGameAck)
+    socket.off('game:patch', handleGamePatch)
+    socket.off('game:prompt', handleGamePrompt)
+    socket.off('game:error', handleGameError)
   }
 
   teardownGameHandlersRef = teardown
+
+  if (options.roomId || options.gameId) {
+    const gameStore = useGameStore.getState()
+    gameStore.setGameState({
+      roomId: options.roomId ?? gameStore.roomId,
+      gameId: options.gameId ?? gameStore.gameId,
+      session: {
+        ...gameStore.session,
+        roomId: options.roomId ?? gameStore.session.roomId,
+        gameId: options.gameId ?? gameStore.session.gameId,
+        transport: 'event-socket',
+      },
+    })
+  }
+
   return teardown
 }
 
-export const emitRollDice = (payload: { room_id: string }) => {
-  socket.emit('roll_dice', payload)
+export const emitGameAction = ({
+  actionId = createActionId(),
+  type,
+  roomId,
+  gameId,
+  payload,
+}: GameActionPayload) => {
+  const gameStore = useGameStore.getState()
+
+  gameStore.setPendingAction(
+    createPendingAction({
+      actionId,
+      type,
+      payload,
+    })
+  )
+
+  socket.emit('game:action', {
+    actionId,
+    type,
+    roomId,
+    gameId,
+    payload,
+  })
+
+  return actionId
 }
 
+export const emitGameSync = ({ roomId, gameId, reset }: GameSyncPayload) => {
+  socket.emit('game:sync', {
+    roomId,
+    gameId,
+    reset,
+  })
+}
+
+export const emitPromptResponse = ({
+  promptId,
+  playerId,
+  value,
+  roomId,
+  gameId,
+}: PromptResponsePayload) => {
+  socket.emit('game:prompt_response', {
+    promptId,
+    playerId,
+    value,
+    roomId,
+    gameId,
+  })
+}
+
+// Deprecated compatibility wrapper until all callers move to emitGameAction.
+export const emitRollDice = (payload: { room_id: string }) => {
+  emitGameAction({
+    type: 'ROLL_DICE',
+    roomId: payload.room_id,
+  })
+}
+
+// Deprecated compatibility wrapper until board prompt flow is migrated.
 export const emitConfirmPenalty = (payload: {
   room_id: string
   player_id: string
 }) => {
-  socket.emit('confirm_penalty', payload)
+  emitPromptResponse({
+    promptId: 'legacy-penalty-confirm',
+    playerId: payload.player_id,
+    value: 'confirm',
+    roomId: payload.room_id,
+  })
 }

--- a/src/stores/game.store.test.ts
+++ b/src/stores/game.store.test.ts
@@ -1,0 +1,212 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import type { GamePrompt, Player, Tile } from '../types/domain'
+import { useGameStore } from './game.store'
+
+const createPlayer = (overrides: Partial<Player> = {}): Player => ({
+  id: 'player-1',
+  nickname: 'Player 1',
+  color: '#ff0000',
+  position: 0,
+  balance: 1000,
+  owned_tiles: [],
+  is_in_jail: false,
+  jail_turn_count: 0,
+  is_bankrupt: false,
+  ...overrides,
+})
+
+const createTile = (overrides: Partial<Tile> = {}): Tile => ({
+  index: 1,
+  name: 'Seoul',
+  type: 'city',
+  price: 100,
+  owner_id: null,
+  building: 0,
+  ...overrides,
+})
+
+describe('game store partial updates', () => {
+  afterEach(() => {
+    useGameStore.getState().resetGame()
+  })
+
+  it('preserves existing players and tiles when metadata only updates are applied', () => {
+    const store = useGameStore.getState()
+
+    store.setGameState({
+      players: [createPlayer()],
+      tiles: [createTile()],
+    })
+
+    store.setGameState({
+      roomId: 'room-1',
+      session: {
+        roomId: 'room-1',
+        gameId: null,
+        transport: 'event-socket',
+        syncedAt: null,
+      },
+    })
+
+    const nextState = useGameStore.getState()
+
+    expect(nextState.players).toHaveLength(1)
+    expect(nextState.tiles).toHaveLength(1)
+    expect(nextState.roomId).toBe('room-1')
+    expect(nextState.session.transport).toBe('event-socket')
+  })
+
+  it('normalizes players, tiles, and current turn aliases', () => {
+    const store = useGameStore.getState()
+
+    store.setGameState({
+      currentTurn: 'player-2',
+      players: [
+        createPlayer({
+          id: 'player-2',
+          is_in_jail: true,
+        }),
+      ],
+      tiles: [
+        createTile({
+          owner_id: 'player-2',
+        }),
+      ],
+      prompt: null,
+      eventQueue: undefined,
+    })
+
+    const nextState = useGameStore.getState()
+
+    expect(nextState.currentPlayerId).toBe('player-2')
+    expect(nextState.players[0]?.state).toBe('island')
+    expect(nextState.tiles[0]?.ownerId).toBe('player-2')
+    expect(nextState.tiles[0]?.owner_id).toBe('player-2')
+    expect(nextState.eventQueue).toEqual([])
+  })
+
+  it('updates player and tile fields while preserving normalized aliases', () => {
+    const store = useGameStore.getState()
+
+    store.setGameState({
+      players: [createPlayer()],
+      tiles: [createTile()],
+    })
+
+    store.updatePlayer('player-1', {
+      is_bankrupt: true,
+    })
+    store.updateTile(1, {
+      ownerId: 'player-1',
+    })
+
+    const nextState = useGameStore.getState()
+
+    expect(nextState.players[0]?.is_bankrupt).toBe(true)
+    expect(nextState.players[0]?.state).toBe('normal')
+    expect(nextState.tiles[0]?.owner_id).toBe('player-1')
+    expect(nextState.tiles[0]?.ownerId).toBe('player-1')
+  })
+
+  it('applies patch envelopes and ignores stale revisions', () => {
+    const store = useGameStore.getState()
+
+    store.setGameState({
+      revision: 1,
+      round: 1,
+      players: [createPlayer()],
+      messages: [],
+      eventQueue: [],
+    })
+
+    store.applyPatchEnvelope({
+      revision: 3,
+      patch: [
+        { op: 'set', path: 'players.0.balance', value: 1200 },
+        { op: 'inc', path: 'round', value: 1 },
+        {
+          op: 'push',
+          path: 'messages',
+          value: {
+            id: 'message-1',
+            sender_id: 'player-1',
+            sender_nickname: 'Player 1',
+            content: 'hello',
+            timestamp: '2026-03-04T00:00:00.000Z',
+            type: 'talk',
+          },
+        },
+        {
+          op: 'push',
+          path: 'eventQueue',
+          value: {
+            type: 'MOVE',
+            playerId: 'player-1',
+          },
+        },
+        {
+          op: 'remove',
+          path: 'messages',
+          index: 0,
+        },
+      ],
+      events: [
+        {
+          type: 'TURN_START',
+          playerId: 'player-1',
+        },
+      ],
+    })
+
+    store.applyPatchEnvelope({
+      revision: 2,
+      patch: [{ op: 'set', path: 'round', value: 99 }],
+    })
+
+    const nextState = useGameStore.getState()
+
+    expect(nextState.revision).toBe(3)
+    expect(nextState.players[0]?.balance).toBe(1200)
+    expect(nextState.round).toBe(2)
+    expect(nextState.messages).toEqual([])
+    expect(nextState.eventQueue).toHaveLength(2)
+  })
+
+  it('tracks pending actions, acknowledgements, prompts, and queue consumption', () => {
+    const store = useGameStore.getState()
+    const prompt: GamePrompt = {
+      id: 'prompt-1',
+      type: 'select',
+    }
+
+    store.setPendingAction({
+      actionId: 'action-1',
+      type: 'ROLL_DICE',
+      requestedAt: Date.now(),
+    })
+    store.resolveAck({
+      actionId: 'action-1',
+      ok: false,
+      errorCode: 'GAME_ACTION_REJECTED',
+      message: 'rejected',
+    })
+    store.setPrompt(prompt)
+    store.clearPrompt('other-prompt')
+    store.clearPrompt('prompt-1')
+    store.enqueueEvents([
+      {
+        type: 'MOVE',
+        playerId: 'player-1',
+      },
+    ])
+
+    const consumedEvent = store.consumeNextEvent()
+    const nextState = useGameStore.getState()
+
+    expect(consumedEvent?.type).toBe('MOVE')
+    expect(nextState.pendingAction).toBeNull()
+    expect(nextState.lastError?.code).toBe('GAME_ACTION_REJECTED')
+    expect(nextState.prompt).toBeNull()
+    expect(nextState.eventQueue).toEqual([])
+  })
+})

--- a/src/stores/game.store.ts
+++ b/src/stores/game.store.ts
@@ -60,26 +60,48 @@ const normalizePlayer = (player: Player): Player => ({
 })
 
 const normalizeState = (state: Partial<GameState>): Partial<GameState> => {
-  const currentPlayerId =
-    state.currentPlayerId !== undefined
-      ? state.currentPlayerId
-      : (state.currentTurn ?? null)
+  const normalizedState: Partial<GameState> = { ...state }
 
-  const currentTurn =
-    state.currentTurn !== undefined ? state.currentTurn : currentPlayerId
+  if ('currentPlayerId' in state || 'currentTurn' in state) {
+    const currentPlayerId =
+      state.currentPlayerId !== undefined
+        ? state.currentPlayerId
+        : (state.currentTurn ?? null)
 
-  return {
-    ...state,
-    currentPlayerId,
-    currentTurn,
-    tiles: state.tiles?.map(normalizeTile),
-    players: state.players?.map(normalizePlayer),
-    prompt: state.prompt ?? null,
-    pendingAction: state.pendingAction ?? null,
-    lastAck: state.lastAck ?? null,
-    lastError: state.lastError ?? null,
-    eventQueue: state.eventQueue ?? [],
+    normalizedState.currentPlayerId = currentPlayerId
+    normalizedState.currentTurn =
+      state.currentTurn !== undefined ? state.currentTurn : currentPlayerId
   }
+
+  if ('tiles' in state) {
+    normalizedState.tiles = state.tiles?.map(normalizeTile) ?? []
+  }
+
+  if ('players' in state) {
+    normalizedState.players = state.players?.map(normalizePlayer) ?? []
+  }
+
+  if ('prompt' in state) {
+    normalizedState.prompt = state.prompt ?? null
+  }
+
+  if ('pendingAction' in state) {
+    normalizedState.pendingAction = state.pendingAction ?? null
+  }
+
+  if ('lastAck' in state) {
+    normalizedState.lastAck = state.lastAck ?? null
+  }
+
+  if ('lastError' in state) {
+    normalizedState.lastError = state.lastError ?? null
+  }
+
+  if ('eventQueue' in state) {
+    normalizedState.eventQueue = state.eventQueue ?? []
+  }
+
+  return normalizedState
 }
 
 const toPathSegments = (


### PR DESCRIPTION
## 📌 관련 이슈

> closes #246 

---

## 📝 작업 내용

> 게임 이벤트 명세 이행을 위해 FE-B 소켓 계층을 `game:action`, `game:sync`, `game:ack`, `game:patch`, `game:prompt` 중심으로 전환하고, mock/fallback 경계를 정리했습니다. 추가로 PR CI 실패 원인이던 game store partial update 회귀와 Playwright 실행 환경 문제를 함께 수정했습니다.

- `src/services/socket/game.handler.ts`
  - 구 개별 게임 이벤트 listener를 제거하고 새 이벤트 계약 listener 추가
  - `emitGameAction`, `emitGameSync`, `emitPromptResponse` 추가
  - mock 모드에서 event-socket mock 브리지를 타도록 연결
  - 기존 호출부 호환을 위해 `emitRollDice`, `emitConfirmPenalty` 래퍼는 임시 유지

- `src/hooks/game/useGameState.ts`
  - 게임 진입 시 `game:sync`를 먼저 보내도록 변경
  - mock/socket rollout 전까지 REST `getState`는 bootstrap fallback으로 유지

- `src/hooks/game/useDiceRoll.ts`
  - 주사위 액션을 기존 `roll_dice` emit 대신 `game:action`의 `ROLL_DICE`로 전송

- `src/mocks/handlers/game.handler.ts`
  - `game:sync`, `game:action`, `game:prompt_response`에 대응하는 event-socket mock 추가
  - `game:ack`, `game:patch`, `game:prompt`, `game:error` 발행 흐름 추가
  - snapshot 기반 patch 응답과 revision 증가 흐름 추가
  - 기존 REST mock은 레거시 fallback 용도로 유지

- `src/services/game/game.api.ts`
  - `getState`, `buyTile`, `buildTile`, `sellTile`, `syncState`를 레거시 fallback 경로로 명시

- `playwright.config.ts`
  - `webServer` 환경변수 주입을 `env` 기반으로 변경해 OS 종속 실행 문제 제거
  - 로컬/CI 모두 동일하게 socket mock 기반 E2E를 실행하도록 정리

- `src/stores/game.store.ts`
  - partial `setGameState` 호출 시 기존 `players`, `tiles`, `eventQueue` 등 상태가 의도치 않게 초기화되지 않도록 정규화 로직 수정
  - metadata/session 업데이트만 발생해도 기존 게임 상태가 유지되도록 보정

- `src/stores/game.store.test.ts`
  - partial update 보존
  - alias 정규화
  - patch envelope 적용
  - ack/prompt/event queue 흐름
  - 위 시나리오를 검증하는 회귀 테스트 추가

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

> UI 변경 없음

---

## 🧪 검증

- `npm run lint`
- `npm run test`
- `npm run test:coverage`
- `npm run e2e`
- `npm run build`
