### PR TITLE
Feat : 게임 화면 store 단일 상태 렌더 구조 정리

### DIFF
--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -15,7 +15,6 @@ import AIPenaltyModal from '../game/modals/AIPenaltyModal'
 import BankruptModal from '../game/modals/BankruptModal'
 import { emitConfirmPenalty } from '../../services/socket/game.handler'
 import { gameApi } from '../../services/game/game.api'
-import { useGameStore } from '../../stores/game.store'
 import {
   TILES,
   TOP_ROW,
@@ -31,7 +30,12 @@ import {
   TileOwner,
   BuildingLevel,
 } from './board.constants'
-import type { BuildingLevel as StoreBuildingLevel } from '../../types/domain'
+import {
+  syncMockStoreBankrupt,
+  syncMockStoreCurrentTurn,
+  syncMockStorePlayers,
+  syncMockStoreTileOwners,
+} from './gameBoardStoreBridge'
 import '../../styles/board.css'
 import { IS_SOCKET_MOCK_ENABLED } from '../../config/env'
 import { formatWon } from '../../lib/utils'
@@ -286,9 +290,6 @@ function buildTileOwnersFromProps(
   return nextOwners
 }
 
-const toStoreBuildingLevel = (level: number): StoreBuildingLevel =>
-  Math.min(Math.max(level, 0), 5) as StoreBuildingLevel
-
 const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
   (
     {
@@ -326,101 +327,6 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
     const tileOwners =
       optimisticTileOwners === null ? derivedTileOwners : optimisticTileOwners
     const tileOwnersRef = useRef<Record<number, TileOwner>>(tileOwners)
-
-    function syncMockStorePlayers(nextPlayers: PlayerState[]) {
-      if (!USE_GAME_SOCKET_MOCK) {
-        return
-      }
-
-      const { players: storePlayers, setGameState } = useGameStore.getState()
-      if (storePlayers.length === 0) {
-        return
-      }
-
-      setGameState({
-        players: nextPlayers.map((player, index) => {
-          const storePlayer = storePlayers[index]
-
-          return {
-            id: storePlayer?.id ?? String(player.id),
-            nickname: player.name,
-            position: player.pos,
-            balance: player.money,
-            owned_tiles: storePlayer?.owned_tiles ?? [],
-            is_in_jail: storePlayer?.is_in_jail ?? false,
-            jail_turn_count: storePlayer?.jail_turn_count ?? 0,
-            is_bankrupt: storePlayer?.is_bankrupt ?? false,
-            color: player.color,
-            avatar: storePlayer?.avatar,
-          }
-        }),
-      })
-    }
-
-    function syncMockStoreCurrentTurn(playerIdx: number) {
-      if (!USE_GAME_SOCKET_MOCK) {
-        return
-      }
-
-      const { players: storePlayers, setCurrentTurn } = useGameStore.getState()
-      const nextTurnPlayer = storePlayers[playerIdx]
-      if (nextTurnPlayer) {
-        setCurrentTurn(nextTurnPlayer.id)
-      }
-    }
-
-    function syncMockStoreBankrupt(playerIdx: number) {
-      if (!USE_GAME_SOCKET_MOCK) {
-        return
-      }
-
-      const { players: storePlayers, updatePlayer } = useGameStore.getState()
-      const bankruptPlayer = storePlayers[playerIdx]
-      if (bankruptPlayer) {
-        updatePlayer(bankruptPlayer.id, { is_bankrupt: true })
-      }
-    }
-
-    function syncMockStoreTileOwners(
-      nextTileOwners: Record<number, TileOwner>
-    ) {
-      if (!USE_GAME_SOCKET_MOCK) {
-        return
-      }
-
-      const {
-        tiles: storeTiles,
-        players: storePlayers,
-        setGameState,
-      } = useGameStore.getState()
-
-      if (storeTiles.length === 0) {
-        return
-      }
-
-      setGameState({
-        tiles: storeTiles.map((tile) => {
-          const owner = nextTileOwners[tile.index]
-          if (!owner) {
-            return {
-              ...tile,
-              owner_id: null,
-              building: 0 as StoreBuildingLevel,
-            }
-          }
-
-          const ownerPlayer = storePlayers.find(
-            (player) => String(player.id) === String(owner.ownerId)
-          )
-
-          return {
-            ...tile,
-            owner_id: ownerPlayer?.id ?? String(owner.ownerId),
-            building: toStoreBuildingLevel(owner.level - 1),
-          }
-        }),
-      })
-    }
 
     useEffect(() => {
       setOptimisticTileOwners(null)

--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -15,6 +15,7 @@ import AIPenaltyModal from '../game/modals/AIPenaltyModal'
 import BankruptModal from '../game/modals/BankruptModal'
 import { emitConfirmPenalty } from '../../services/socket/game.handler'
 import { gameApi } from '../../services/game/game.api'
+import { useGameStore } from '../../stores/game.store'
 import {
   TILES,
   TOP_ROW,
@@ -30,6 +31,7 @@ import {
   TileOwner,
   BuildingLevel,
 } from './board.constants'
+import type { BuildingLevel as StoreBuildingLevel } from '../../types/domain'
 import '../../styles/board.css'
 import { IS_SOCKET_MOCK_ENABLED } from '../../config/env'
 import { formatWon } from '../../lib/utils'
@@ -284,6 +286,9 @@ function buildTileOwnersFromProps(
   return nextOwners
 }
 
+const toStoreBuildingLevel = (level: number): StoreBuildingLevel =>
+  Math.min(Math.max(level, 0), 5) as StoreBuildingLevel
+
 const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
   (
     {
@@ -321,6 +326,101 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
     const tileOwners =
       optimisticTileOwners === null ? derivedTileOwners : optimisticTileOwners
     const tileOwnersRef = useRef<Record<number, TileOwner>>(tileOwners)
+
+    function syncMockStorePlayers(nextPlayers: PlayerState[]) {
+      if (!USE_GAME_SOCKET_MOCK) {
+        return
+      }
+
+      const { players: storePlayers, setGameState } = useGameStore.getState()
+      if (storePlayers.length === 0) {
+        return
+      }
+
+      setGameState({
+        players: nextPlayers.map((player, index) => {
+          const storePlayer = storePlayers[index]
+
+          return {
+            id: storePlayer?.id ?? String(player.id),
+            nickname: player.name,
+            position: player.pos,
+            balance: player.money,
+            owned_tiles: storePlayer?.owned_tiles ?? [],
+            is_in_jail: storePlayer?.is_in_jail ?? false,
+            jail_turn_count: storePlayer?.jail_turn_count ?? 0,
+            is_bankrupt: storePlayer?.is_bankrupt ?? false,
+            color: player.color,
+            avatar: storePlayer?.avatar,
+          }
+        }),
+      })
+    }
+
+    function syncMockStoreCurrentTurn(playerIdx: number) {
+      if (!USE_GAME_SOCKET_MOCK) {
+        return
+      }
+
+      const { players: storePlayers, setCurrentTurn } = useGameStore.getState()
+      const nextTurnPlayer = storePlayers[playerIdx]
+      if (nextTurnPlayer) {
+        setCurrentTurn(nextTurnPlayer.id)
+      }
+    }
+
+    function syncMockStoreBankrupt(playerIdx: number) {
+      if (!USE_GAME_SOCKET_MOCK) {
+        return
+      }
+
+      const { players: storePlayers, updatePlayer } = useGameStore.getState()
+      const bankruptPlayer = storePlayers[playerIdx]
+      if (bankruptPlayer) {
+        updatePlayer(bankruptPlayer.id, { is_bankrupt: true })
+      }
+    }
+
+    function syncMockStoreTileOwners(
+      nextTileOwners: Record<number, TileOwner>
+    ) {
+      if (!USE_GAME_SOCKET_MOCK) {
+        return
+      }
+
+      const {
+        tiles: storeTiles,
+        players: storePlayers,
+        setGameState,
+      } = useGameStore.getState()
+
+      if (storeTiles.length === 0) {
+        return
+      }
+
+      setGameState({
+        tiles: storeTiles.map((tile) => {
+          const owner = nextTileOwners[tile.index]
+          if (!owner) {
+            return {
+              ...tile,
+              owner_id: null,
+              building: 0 as StoreBuildingLevel,
+            }
+          }
+
+          const ownerPlayer = storePlayers.find(
+            (player) => String(player.id) === String(owner.ownerId)
+          )
+
+          return {
+            ...tile,
+            owner_id: ownerPlayer?.id ?? String(owner.ownerId),
+            building: toStoreBuildingLevel(owner.level - 1),
+          }
+        }),
+      })
+    }
 
     useEffect(() => {
       setOptimisticTileOwners(null)
@@ -398,7 +498,11 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
 
         const nextPlayers = [...orderedPlayers, ...additionalPlayers]
         playersRef.current = nextPlayers
-        onPlayersChange?.(nextPlayers)
+        if (onPlayersChange) {
+          onPlayersChange(nextPlayers)
+        } else {
+          syncMockStorePlayers(nextPlayers)
+        }
       }
 
       if (payload.tiles) {
@@ -439,7 +543,11 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
 
         tileOwnersRef.current = nextOwners
         setOptimisticTileOwners(nextOwners)
-        onTileOwnersChange?.(nextOwners)
+        if (onTileOwnersChange) {
+          onTileOwnersChange(nextOwners)
+        } else {
+          syncMockStoreTileOwners(nextOwners)
+        }
       }
 
       const nextTurnRaw = payload.current_turn ?? payload.currentTurn
@@ -452,7 +560,11 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
         )
         if (nextTurnIndex >= 0) {
           curPlayerRef.current = nextTurnIndex
-          onCurPlayerChange?.(nextTurnIndex)
+          if (onCurPlayerChange) {
+            onCurPlayerChange(nextTurnIndex)
+          } else {
+            syncMockStoreCurrentTurn(nextTurnIndex)
+          }
         }
       }
 
@@ -496,7 +608,11 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       setOptimisticTileOwners(next)
 
       if (options?.notifyParent) {
-        onTileOwnersChange?.(next)
+        if (onTileOwnersChange) {
+          onTileOwnersChange(next)
+        } else {
+          syncMockStoreTileOwners(next)
+        }
       }
     }
 
@@ -510,7 +626,11 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
         return { ...p, money: Math.max(0, p.money + delta) }
       })
       playersRef.current = updated
-      onPlayersChange?.([...updated])
+      if (onPlayersChange) {
+        onPlayersChange([...updated])
+      } else {
+        syncMockStorePlayers(updated)
+      }
 
       const isBankrupt = updated[playerIdx].money <= 0
       if (isBankrupt) {
@@ -549,7 +669,11 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
         { notifyParent: true }
       )
 
-      onBankrupt?.(playerIdx)
+      if (onBankrupt) {
+        onBankrupt(playerIdx)
+      } else {
+        syncMockStoreBankrupt(playerIdx)
+      }
       advanceTurn(onDoneCallback)
     }
 
@@ -576,11 +700,19 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
           skipTurns: nextPlayer.skipTurns! - 1,
         }
         playersRef.current = updatedPlayers
-        onPlayersChange?.(updatedPlayers)
+        if (onPlayersChange) {
+          onPlayersChange(updatedPlayers)
+        } else {
+          syncMockStorePlayers(updatedPlayers)
+        }
 
         // 스킵 상태를 보여주기 위해 잠시 현재 턴으로 바꾼 뒤 다시 턴을 넘긴다
         curPlayerRef.current = next
-        onCurPlayerChange?.(next)
+        if (onCurPlayerChange) {
+          onCurPlayerChange(next)
+        } else {
+          syncMockStoreCurrentTurn(next)
+        }
 
         setTimeout(() => {
           advanceTurn(onDone)
@@ -589,7 +721,11 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       }
 
       curPlayerRef.current = next
-      onCurPlayerChange?.(next)
+      if (onCurPlayerChange) {
+        onCurPlayerChange(next)
+      } else {
+        syncMockStoreCurrentTurn(next)
+      }
       onDone?.()
     }
 
@@ -664,7 +800,11 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
             return { ...p, pos: newPos, skipTurns: newSkipTurns }
           })
           playersRef.current = movedPlayers
-          onPlayersChange?.([...movedPlayers])
+          if (onPlayersChange) {
+            onPlayersChange([...movedPlayers])
+          } else {
+            syncMockStorePlayers(movedPlayers)
+          }
 
           const landedTileId = movedPlayers[activeCurPlayer].pos
 
@@ -935,7 +1075,11 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
           skipTurns: (activePlayer.skipTurns ?? 0) + 1,
         }
         playersRef.current = updatedPlayers
-        onPlayersChange?.(updatedPlayers)
+        if (onPlayersChange) {
+          onPlayersChange(updatedPlayers)
+        } else {
+          syncMockStorePlayers(updatedPlayers)
+        }
         setStatus(`${activePlayer.name} 주사위 1턴 쉬기!`)
       }
 

--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -45,6 +45,12 @@ import {
   mapSyncPayloadPlayers,
   mapSyncPayloadTileOwners,
 } from './gameBoardSyncUtils'
+import {
+  createBoardPurchasedTileOwner,
+  findBoardSellTarget,
+  getBoardTollAmount,
+  upgradeBoardTileOwner,
+} from './gameBoardTransactionUtils'
 import '../../styles/board.css'
 import { IS_SOCKET_MOCK_ENABLED } from '../../config/env'
 import { formatWon } from '../../lib/utils'
@@ -714,14 +720,10 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
 
     async function sellOwnedTileForPlayer(playerIdx: number) {
       const playerId = getPlayerIdByIndex(playerIdx)
-      const ownedTileEntries = Object.entries(tileOwnersRef.current)
-        .filter(([, owner]) => owner.ownerId === playerId)
-        .sort(([, a], [, b]) => b.level - a.level)
+      const sellTarget = findBoardSellTarget(tileOwnersRef.current, playerId)
+      if (!sellTarget) return false
 
-      if (ownedTileEntries.length === 0) return false
-
-      const [tileIdText, owner] = ownedTileEntries[0]
-      const tileId = Number(tileIdText)
+      const { tileId, owner } = sellTarget
       if (!roomId) return false
 
       const sellResult = await gameApi.sellTile(roomId, {
@@ -774,11 +776,10 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
         updateTileOwners(
           (prev) => ({
             ...prev,
-            [tileId]: {
-              ownerId: activePlayerId,
-              ownerColor: activePlayerColor,
-              level: 1,
-            },
+            [tileId]: createBoardPurchasedTileOwner(
+              activePlayerId,
+              activePlayerColor
+            ),
           }),
           { notifyParent: true }
         )
@@ -819,20 +820,9 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       setBuildModal({ open: false, tileId: null })
       const bankrupt = applyMoney(active, -upgradeCost, onDoneCallback)
       if (!bankrupt) {
-        updateTileOwners(
-          (prev) => {
-            const existing = prev[tileId]
-            if (!existing) return prev
-            return {
-              ...prev,
-              [tileId]: {
-                ...existing,
-                level: Math.min(existing.level + 1, 5) as BuildingLevel,
-              },
-            }
-          },
-          { notifyParent: true }
-        )
+        updateTileOwners((prev) => upgradeBoardTileOwner(prev, tileId), {
+          notifyParent: true,
+        })
         if (USE_GAME_SOCKET_MOCK) {
           onDoneCallback?.()
         } else {
@@ -860,7 +850,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       if (tileId !== null) {
         const owner = tileOwnersRef.current[tileId]
         const price = TILES[tileId]?.price ?? 0
-        const tollAmount = owner ? calcToll(price, owner.level) : 0
+        const tollAmount = getBoardTollAmount(price, owner, calcToll)
         if (owner) {
           if (playersRef.current[active].money < tollAmount) {
             const sold = await sellOwnedTileForPlayer(active)

--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -14,7 +14,6 @@ import TollModal from '../game/modals/TollModal'
 import AIPenaltyModal from '../game/modals/AIPenaltyModal'
 import BankruptModal from '../game/modals/BankruptModal'
 import { emitConfirmPenalty } from '../../services/socket/game.handler'
-import { gameApi } from '../../services/game/game.api'
 import {
   TILES,
   TOP_ROW,
@@ -36,21 +35,15 @@ import {
   syncMockStorePlayers,
   syncMockStoreTileOwners,
 } from './gameBoardStoreBridge'
-import {
-  getBoardSellFallbackRefund,
-  toBoardActionErrorMessage,
-} from './gameBoardActionUtils'
-import {
-  findSyncTurnIndex,
-  mapSyncPayloadPlayers,
-  mapSyncPayloadTileOwners,
-} from './gameBoardSyncUtils'
-import {
-  createBoardPurchasedTileOwner,
-  findBoardSellTarget,
-  getBoardTollAmount,
-  upgradeBoardTileOwner,
-} from './gameBoardTransactionUtils'
+import { createGameBoardActionHandlers } from './gameBoardActionHandlers'
+import type {
+  AIPenaltyModalState,
+  BankruptModalState,
+  BuildModalState,
+  BuyModalState,
+  CardModalState,
+  TollModalState,
+} from './gameBoard.types'
 import '../../styles/board.css'
 import { IS_SOCKET_MOCK_ENABLED } from '../../config/env'
 import { formatWon } from '../../lib/utils'
@@ -202,64 +195,6 @@ interface GameBoardProps {
   onBankrupt?: (playerIdx: number) => void
 }
 
-interface BuyModalState {
-  open: boolean
-  tileId: number | null
-  onDoneCallback?: () => void
-}
-interface BuildModalState {
-  open: boolean
-  tileId: number | null
-  onDoneCallback?: () => void
-}
-interface CardModalState {
-  open: boolean
-  variant: 'event' | 'chance'
-  onDoneCallback?: () => void
-}
-interface TollModalState {
-  open: boolean
-  tileId: number | null
-  ownerName: string
-  tollText: string
-  onDoneCallback?: () => void
-}
-interface AIPenaltyModalState {
-  open: boolean
-  status: 'loading' | 'result' | 'error'
-  resultDescription?: string
-  onDoneCallback?: () => void
-}
-interface BankruptModalState {
-  open: boolean
-  playerIdx: number
-  playerName: string
-  onDoneCallback?: () => void
-}
-
-type SyncStatePayload = {
-  players?: Array<{
-    id: string | number
-    nickname?: string
-    name?: string
-    position?: number
-    pos?: number
-    balance?: number
-    money?: number
-    color?: string
-  }>
-  tiles?: Array<{
-    index?: number
-    id?: number
-    owner_id?: string | number | null
-    ownerId?: string | number | null
-    building?: number
-    level?: number
-  }>
-  current_turn?: string | number | null
-  currentTurn?: string | number | null
-}
-
 function toBoardBuildingLevel(
   tile: { building?: number; level?: number },
   hasOwner: boolean
@@ -363,65 +298,6 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       return playersRef.current.findIndex((player) => player.id === playerId)
     }
 
-    async function syncBoardStateFromServer() {
-      if (!roomId) return false
-
-      const syncResult = await gameApi.syncState(roomId)
-      if (!syncResult.ok) return false
-
-      const payload = syncResult.data as SyncStatePayload
-      const payloadPlayers = payload.players ?? []
-      let serverToBoardId = new Map<string, number>()
-
-      if (payloadPlayers.length > 0) {
-        const mappedPlayers = mapSyncPayloadPlayers(
-          payloadPlayers,
-          playersRef.current
-        )
-        serverToBoardId = mappedPlayers.serverToBoardId
-        const { nextPlayers } = mappedPlayers
-        playersRef.current = nextPlayers
-        if (onPlayersChange) {
-          onPlayersChange(nextPlayers)
-        } else {
-          syncMockStorePlayers(nextPlayers)
-        }
-      }
-
-      if (payload.tiles) {
-        const nextOwners = mapSyncPayloadTileOwners(
-          payload.tiles,
-          playersRef.current,
-          serverToBoardId,
-          toBoardBuildingLevel
-        )
-
-        tileOwnersRef.current = nextOwners
-        setOptimisticTileOwners(nextOwners)
-        if (onTileOwnersChange) {
-          onTileOwnersChange(nextOwners)
-        } else {
-          syncMockStoreTileOwners(nextOwners)
-        }
-      }
-
-      const nextTurnIndex = findSyncTurnIndex(
-        payload.current_turn ?? payload.currentTurn,
-        playersRef.current,
-        serverToBoardId
-      )
-      if (nextTurnIndex >= 0) {
-        curPlayerRef.current = nextTurnIndex
-        if (onCurPlayerChange) {
-          onCurPlayerChange(nextTurnIndex)
-        } else {
-          syncMockStoreCurrentTurn(nextTurnIndex)
-        }
-      }
-
-      return true
-    }
-
     const [buyModal, setBuyModal] = useState<BuyModalState>({
       open: false,
       tileId: null,
@@ -467,6 +343,30 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       }
     }
 
+    function publishPlayers(nextPlayers: PlayerState[]) {
+      if (onPlayersChange) {
+        onPlayersChange(nextPlayers)
+      } else {
+        syncMockStorePlayers(nextPlayers)
+      }
+    }
+
+    function publishCurrentTurn(nextTurnIndex: number) {
+      if (onCurPlayerChange) {
+        onCurPlayerChange(nextTurnIndex)
+      } else {
+        syncMockStoreCurrentTurn(nextTurnIndex)
+      }
+    }
+
+    function publishTileOwners(nextOwners: Record<number, TileOwner>) {
+      if (onTileOwnersChange) {
+        onTileOwnersChange(nextOwners)
+      } else {
+        syncMockStoreTileOwners(nextOwners)
+      }
+    }
+
     function applyMoney(
       playerIdx: number,
       delta: number,
@@ -500,6 +400,40 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       }
       return false
     }
+
+    const {
+      handleBuy,
+      handleBuyPass,
+      handleBuildConfirm,
+      handleBuildCancel,
+      handleTollConfirm,
+    } = createGameBoardActionHandlers({
+      roomId,
+      useGameSocketMock: USE_GAME_SOCKET_MOCK,
+      roomIdRequiredMessage: ROOM_ID_REQUIRED_MESSAGE,
+      setStatus,
+      setOptimisticTileOwners,
+      setBuyModal,
+      setBuildModal,
+      setTollModal,
+      playersRef,
+      curPlayerRef,
+      tileOwnersRef,
+      publishPlayers,
+      publishCurrentTurn,
+      publishTileOwners,
+      getPlayerIdByIndex,
+      getPlayerColorByIndex,
+      getPlayerIndexById,
+      toBoardBuildingLevel,
+      getPurchaseCost,
+      getUpgradeCost,
+      calcToll,
+      getTilePrice: (tileId) => TILES[tileId]?.price ?? 0,
+      updateTileOwners,
+      applyMoney,
+      advanceTurn,
+    })
 
     function handleBankruptConfirm() {
       const { playerIdx, onDoneCallback } = bankruptModal
@@ -718,160 +652,6 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       }, 70)
     }
 
-    async function sellOwnedTileForPlayer(playerIdx: number) {
-      const playerId = getPlayerIdByIndex(playerIdx)
-      const sellTarget = findBoardSellTarget(tileOwnersRef.current, playerId)
-      if (!sellTarget) return false
-
-      const { tileId, owner } = sellTarget
-      if (!roomId) return false
-
-      const sellResult = await gameApi.sellTile(roomId, {
-        tile_index: tileId,
-        level: owner.level,
-      })
-
-      if (!sellResult.ok) {
-        setStatus(toBoardActionErrorMessage(sellResult.status))
-        return false
-      }
-
-      const synced = await syncBoardStateFromServer()
-      if (!synced) {
-        updateTileOwners(
-          (prev) => {
-            const next = { ...prev }
-            delete next[tileId]
-            return next
-          },
-          { notifyParent: true }
-        )
-        applyMoney(playerIdx, +getBoardSellFallbackRefund(tileId, owner.level))
-      }
-
-      return true
-    }
-
-    async function handleBuy() {
-      const { tileId, onDoneCallback } = buyModal
-      if (tileId === null) return
-      if (!roomId) {
-        setStatus(ROOM_ID_REQUIRED_MESSAGE)
-        return
-      }
-      const active = curPlayerRef.current
-      const activePlayerId = getPlayerIdByIndex(active)
-      const activePlayerColor = getPlayerColorByIndex(active)
-      const price = getPurchaseCost(tileId)
-
-      const actionResult = await gameApi.buyTile(roomId, { tile_index: tileId })
-      if (!actionResult.ok) {
-        setStatus(toBoardActionErrorMessage(actionResult.status))
-        return
-      }
-
-      setBuyModal({ open: false, tileId: null })
-      const bankrupt = applyMoney(active, -price, onDoneCallback)
-      if (!bankrupt) {
-        updateTileOwners(
-          (prev) => ({
-            ...prev,
-            [tileId]: createBoardPurchasedTileOwner(
-              activePlayerId,
-              activePlayerColor
-            ),
-          }),
-          { notifyParent: true }
-        )
-        if (USE_GAME_SOCKET_MOCK) {
-          onDoneCallback?.()
-        } else {
-          advanceTurn(onDoneCallback)
-        }
-      }
-    }
-
-    function handleBuyPass() {
-      const { onDoneCallback } = buyModal
-      setBuyModal({ open: false, tileId: null })
-      advanceTurn(onDoneCallback)
-    }
-
-    async function handleBuildConfirm() {
-      const { tileId, onDoneCallback } = buildModal
-      if (tileId === null) return
-      if (!roomId) {
-        setStatus(ROOM_ID_REQUIRED_MESSAGE)
-        return
-      }
-      const active = curPlayerRef.current
-      const owner = tileOwnersRef.current[tileId]
-      const price = getPurchaseCost(tileId)
-      const upgradeCost = owner ? getUpgradeCost(price, owner.level) : 0
-
-      const actionResult = await gameApi.buildTile(roomId, {
-        tile_index: tileId,
-      })
-      if (!actionResult.ok) {
-        setStatus(toBoardActionErrorMessage(actionResult.status))
-        return
-      }
-
-      setBuildModal({ open: false, tileId: null })
-      const bankrupt = applyMoney(active, -upgradeCost, onDoneCallback)
-      if (!bankrupt) {
-        updateTileOwners((prev) => upgradeBoardTileOwner(prev, tileId), {
-          notifyParent: true,
-        })
-        if (USE_GAME_SOCKET_MOCK) {
-          onDoneCallback?.()
-        } else {
-          advanceTurn(onDoneCallback)
-        }
-      }
-    }
-
-    function handleBuildCancel() {
-      const { onDoneCallback } = buildModal
-      setBuildModal({ open: false, tileId: null })
-      advanceTurn(onDoneCallback)
-    }
-
-    async function handleTollConfirm() {
-      const { tileId, onDoneCallback } = tollModal
-      const active = curPlayerRef.current
-      setTollModal({
-        open: false,
-        tileId: null,
-        ownerName: '',
-        tollText: '',
-      })
-
-      if (tileId !== null) {
-        const owner = tileOwnersRef.current[tileId]
-        const price = TILES[tileId]?.price ?? 0
-        const tollAmount = getBoardTollAmount(price, owner, calcToll)
-        if (owner) {
-          if (playersRef.current[active].money < tollAmount) {
-            const sold = await sellOwnedTileForPlayer(active)
-            if (!sold) {
-              const bankrupt = applyMoney(active, -tollAmount, onDoneCallback)
-              if (!bankrupt) advanceTurn(onDoneCallback)
-              return
-            }
-          }
-          const ownerPlayerIndex = getPlayerIndexById(owner.ownerId)
-          if (ownerPlayerIndex >= 0) {
-            applyMoney(ownerPlayerIndex, +tollAmount)
-          }
-          const bankrupt = applyMoney(active, -tollAmount, onDoneCallback)
-          if (!bankrupt) advanceTurn(onDoneCallback)
-          return
-        }
-      }
-      advanceTurn(onDoneCallback)
-    }
-
     function handleCardConfirm() {
       const { onDoneCallback, variant } = cardModal
 
@@ -1007,8 +787,8 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
           purchaseCostText={formatWon(buyTile?.price ?? 0)}
           isUpgrade={false}
           currentLevel={0}
-          onPass={handleBuyPass}
-          onBuy={handleBuy}
+          onPass={() => handleBuyPass(buyModal)}
+          onBuy={() => handleBuy(buyModal)}
         />
         <BuildModal
           open={buildModal.open}
@@ -1023,8 +803,8 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
             calcToll(buildTile?.price ?? 0, (currentLevel + 1) as BuildingLevel)
           )}
           canBuild={currentLevel < 5}
-          onCancel={handleBuildCancel}
-          onConfirm={handleBuildConfirm}
+          onCancel={() => handleBuildCancel(buildModal)}
+          onConfirm={() => handleBuildConfirm(buildModal)}
         />
         <CardModal
           open={cardModal.open}
@@ -1036,7 +816,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
           cityName={tollTile?.name}
           ownerName={tollModal.ownerName}
           tollText={tollModal.tollText}
-          onConfirm={handleTollConfirm}
+          onConfirm={() => handleTollConfirm(tollModal)}
         />
         <AIPenaltyModal
           open={aiModal.open}

--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -2,6 +2,7 @@ import {
   useRef,
   useState,
   useEffect,
+  useMemo,
   forwardRef,
   useImperativeHandle,
 } from 'react'
@@ -238,6 +239,51 @@ type SyncStatePayload = {
   currentTurn?: string | number | null
 }
 
+function toBoardBuildingLevel(
+  tile: { building?: number; level?: number },
+  hasOwner: boolean
+) {
+  if (!hasOwner) return 0 as BuildingLevel
+  if (typeof tile.level === 'number') {
+    return Math.min(Math.max(tile.level, 1), 5) as BuildingLevel
+  }
+  const buildingLevel = typeof tile.building === 'number' ? tile.building : 0
+  return Math.min(Math.max(buildingLevel + 1, 1), 5) as BuildingLevel
+}
+
+function buildTileOwnersFromProps(
+  tiles: Array<{
+    index: number
+    owner_id?: string | number | null
+    building: number
+  }>,
+  players: PlayerState[]
+) {
+  const nextOwners: Record<number, TileOwner> = {}
+
+  tiles.forEach((tile) => {
+    if (!tile.owner_id) {
+      return
+    }
+
+    const ownerPlayer = players.find(
+      (player) => String(player.id) === String(tile.owner_id)
+    )
+
+    if (!ownerPlayer) {
+      return
+    }
+
+    nextOwners[tile.index] = {
+      ownerId: ownerPlayer.id,
+      ownerColor: ownerPlayer.color,
+      level: toBoardBuildingLevel(tile, true),
+    }
+  })
+
+  return nextOwners
+}
+
 const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
   (
     {
@@ -264,41 +310,22 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
     playersRef.current = players
 
     const bankruptSetRef = useRef<Set<number>>(new Set())
-    const [tileOwners, setTileOwners] = useState<Record<number, TileOwner>>({})
-    const tileOwnersRef = useRef<Record<number, TileOwner>>({})
+    const [optimisticTileOwners, setOptimisticTileOwners] = useState<Record<
+      number,
+      TileOwner
+    > | null>(null)
+    const derivedTileOwners = useMemo(
+      () => buildTileOwnersFromProps(tiles, players),
+      [tiles, players]
+    )
+    const tileOwners =
+      optimisticTileOwners === null ? derivedTileOwners : optimisticTileOwners
+    const tileOwnersRef = useRef<Record<number, TileOwner>>(tileOwners)
 
     useEffect(() => {
-      if (tiles.length === 0) {
-        tileOwnersRef.current = {}
-        setTileOwners({})
-        return
-      }
-
-      const nextOwners: Record<number, TileOwner> = {}
-
-      tiles.forEach((tile) => {
-        if (!tile.owner_id) {
-          return
-        }
-
-        const ownerPlayer = playersRef.current.find(
-          (player) => String(player.id) === String(tile.owner_id)
-        )
-
-        if (!ownerPlayer) {
-          return
-        }
-
-        nextOwners[tile.index] = {
-          ownerId: ownerPlayer.id,
-          ownerColor: ownerPlayer.color,
-          level: toBoardBuildingLevel(tile, true),
-        }
-      })
-
-      tileOwnersRef.current = nextOwners
-      setTileOwners(nextOwners)
-    }, [tiles])
+      setOptimisticTileOwners(null)
+      tileOwnersRef.current = derivedTileOwners
+    }, [derivedTileOwners])
 
     function getPlayerIdByIndex(playerIdx: number) {
       return playersRef.current[playerIdx]?.id ?? playerIdx
@@ -313,19 +340,6 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
 
     function getPlayerIndexById(playerId: number) {
       return playersRef.current.findIndex((player) => player.id === playerId)
-    }
-
-    function toBoardBuildingLevel(
-      tile: { building?: number; level?: number },
-      hasOwner: boolean
-    ) {
-      if (!hasOwner) return 0 as BuildingLevel
-      if (typeof tile.level === 'number') {
-        return Math.min(Math.max(tile.level, 1), 5) as BuildingLevel
-      }
-      const buildingLevel =
-        typeof tile.building === 'number' ? tile.building : 0
-      return Math.min(Math.max(buildingLevel + 1, 1), 5) as BuildingLevel
     }
 
     async function syncBoardStateFromServer() {
@@ -424,7 +438,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
         })
 
         tileOwnersRef.current = nextOwners
-        setTileOwners(nextOwners)
+        setOptimisticTileOwners(nextOwners)
         onTileOwnersChange?.(nextOwners)
       }
 
@@ -479,7 +493,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
     ) {
       const next = updater(tileOwnersRef.current)
       tileOwnersRef.current = next
-      setTileOwners(next)
+      setOptimisticTileOwners(next)
 
       if (options?.notifyParent) {
         onTileOwnersChange?.(next)

--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -40,6 +40,11 @@ import {
   getBoardSellFallbackRefund,
   toBoardActionErrorMessage,
 } from './gameBoardActionUtils'
+import {
+  findSyncTurnIndex,
+  mapSyncPayloadPlayers,
+  mapSyncPayloadTileOwners,
+} from './gameBoardSyncUtils'
 import '../../styles/board.css'
 import { IS_SOCKET_MOCK_ENABLED } from '../../config/env'
 import { formatWon } from '../../lib/utils'
@@ -360,53 +365,15 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
 
       const payload = syncResult.data as SyncStatePayload
       const payloadPlayers = payload.players ?? []
-      const prevById = new Map(
-        playersRef.current.map((player) => [String(player.id), player])
-      )
-      const serverToBoardId = new Map<string, number>()
+      let serverToBoardId = new Map<string, number>()
 
       if (payloadPlayers.length > 0) {
-        const nextById = new Map<string, PlayerState>()
-
-        payloadPlayers.forEach((player, idx) => {
-          const prevPlayer = prevById.get(String(player.id))
-          const parsedPlayerId =
-            typeof player.id === 'number'
-              ? player.id
-              : Number.parseInt(String(player.id), 10)
-          const boardPlayerId = Number.isNaN(parsedPlayerId)
-            ? (prevPlayer?.id ?? idx)
-            : parsedPlayerId
-
-          serverToBoardId.set(String(player.id), boardPlayerId)
-
-          nextById.set(String(player.id), {
-            id: boardPlayerId,
-            name:
-              player.nickname ??
-              player.name ??
-              prevPlayer?.name ??
-              `Player ${idx + 1}`,
-            color:
-              player.color ??
-              prevPlayer?.color ??
-              PLAYER_COLORS[idx % PLAYER_COLORS.length],
-            pos: player.position ?? player.pos ?? prevPlayer?.pos ?? 0,
-            money: player.balance ?? player.money ?? prevPlayer?.money ?? 0,
-          })
-        })
-
-        const orderedPlayers = playersRef.current.map((prevPlayer) => {
-          return nextById.get(String(prevPlayer.id)) ?? prevPlayer
-        })
-        const additionalPlayers = Array.from(nextById.values()).filter(
-          (nextPlayer) =>
-            !orderedPlayers.some(
-              (orderedPlayer) => orderedPlayer.id === nextPlayer.id
-            )
+        const mappedPlayers = mapSyncPayloadPlayers(
+          payloadPlayers,
+          playersRef.current
         )
-
-        const nextPlayers = [...orderedPlayers, ...additionalPlayers]
+        serverToBoardId = mappedPlayers.serverToBoardId
+        const { nextPlayers } = mappedPlayers
         playersRef.current = nextPlayers
         if (onPlayersChange) {
           onPlayersChange(nextPlayers)
@@ -416,40 +383,12 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       }
 
       if (payload.tiles) {
-        const nextOwners: Record<number, TileOwner> = {}
-
-        payload.tiles.forEach((tile) => {
-          const tileIndex = tile.index ?? tile.id
-          const ownerRaw = tile.owner_id ?? tile.ownerId
-          if (
-            tileIndex === undefined ||
-            ownerRaw === null ||
-            ownerRaw === undefined
-          ) {
-            return
-          }
-
-          const mappedOwnerId = serverToBoardId.get(String(ownerRaw))
-          const parsedOwnerId =
-            typeof ownerRaw === 'number'
-              ? ownerRaw
-              : Number.parseInt(String(ownerRaw), 10)
-          const ownerId =
-            mappedOwnerId ??
-            (Number.isNaN(parsedOwnerId) ? null : parsedOwnerId)
-          if (ownerId === null) return
-
-          const ownerPlayer = playersRef.current.find(
-            (player) => String(player.id) === String(ownerId)
-          )
-          nextOwners[tileIndex] = {
-            ownerId,
-            ownerColor:
-              ownerPlayer?.color ??
-              PLAYER_COLORS[ownerId % PLAYER_COLORS.length],
-            level: toBoardBuildingLevel(tile, true),
-          }
-        })
+        const nextOwners = mapSyncPayloadTileOwners(
+          payload.tiles,
+          playersRef.current,
+          serverToBoardId,
+          toBoardBuildingLevel
+        )
 
         tileOwnersRef.current = nextOwners
         setOptimisticTileOwners(nextOwners)
@@ -460,21 +399,17 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
         }
       }
 
-      const nextTurnRaw = payload.current_turn ?? payload.currentTurn
-      if (nextTurnRaw !== undefined && nextTurnRaw !== null) {
-        const mappedTurnId = serverToBoardId.get(String(nextTurnRaw))
-        const nextTurnIndex = playersRef.current.findIndex(
-          (player) =>
-            player.id === mappedTurnId ||
-            String(player.id) === String(nextTurnRaw)
-        )
-        if (nextTurnIndex >= 0) {
-          curPlayerRef.current = nextTurnIndex
-          if (onCurPlayerChange) {
-            onCurPlayerChange(nextTurnIndex)
-          } else {
-            syncMockStoreCurrentTurn(nextTurnIndex)
-          }
+      const nextTurnIndex = findSyncTurnIndex(
+        payload.current_turn ?? payload.currentTurn,
+        playersRef.current,
+        serverToBoardId
+      )
+      if (nextTurnIndex >= 0) {
+        curPlayerRef.current = nextTurnIndex
+        if (onCurPlayerChange) {
+          onCurPlayerChange(nextTurnIndex)
+        } else {
+          syncMockStoreCurrentTurn(nextTurnIndex)
         }
       }
 

--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -36,6 +36,10 @@ import {
   syncMockStorePlayers,
   syncMockStoreTileOwners,
 } from './gameBoardStoreBridge'
+import {
+  getBoardSellFallbackRefund,
+  toBoardActionErrorMessage,
+} from './gameBoardActionUtils'
 import '../../styles/board.css'
 import { IS_SOCKET_MOCK_ENABLED } from '../../config/env'
 import { formatWon } from '../../lib/utils'
@@ -773,30 +777,6 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       }, 70)
     }
 
-    function toActionErrorMessage(statusCode: number) {
-      if (statusCode === 401)
-        return '\uB85C\uADF8\uC778\uC774 \uD544\uC694\uD569\uB2C8\uB2E4.'
-      if (statusCode === 403)
-        return '\uD604\uC7AC \uD134\uC5D0\uB294 \uCC98\uB9AC\uD560 \uC218 \uC5C6\uC2B5\uB2C8\uB2E4.'
-      if (statusCode === 404)
-        return '\uB300\uC0C1\uC744 \uCC3E\uC744 \uC218 \uC5C6\uC2B5\uB2C8\uB2E4.'
-      if (statusCode === 409)
-        return '\uC870\uAC74\uC774 \uB9DE\uC9C0 \uC54A\uC544 \uCC98\uB9AC\uD560 \uC218 \uC5C6\uC2B5\uB2C8\uB2E4.'
-      return '\uC694\uCCAD \uCC98\uB9AC \uC911 \uC624\uB958\uAC00 \uBC1C\uC0DD\uD588\uC2B5\uB2C8\uB2E4.'
-    }
-
-    function getSellFallbackRefund(tileId: number, level: BuildingLevel) {
-      // calculate how much to refund when the server sync fails
-      // start with purchase price plus each upgrade cost up to current level
-      const basePrice = TILES[tileId]?.price ?? 0
-      if (level <= 0 || basePrice === 0) return 0
-      let refund = basePrice
-      for (let l = 1; l < level; l++) {
-        refund += getUpgradeCost(basePrice, l as BuildingLevel)
-      }
-      return refund
-    }
-
     async function sellOwnedTileForPlayer(playerIdx: number) {
       const playerId = getPlayerIdByIndex(playerIdx)
       const ownedTileEntries = Object.entries(tileOwnersRef.current)
@@ -815,7 +795,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       })
 
       if (!sellResult.ok) {
-        setStatus(toActionErrorMessage(sellResult.status))
+        setStatus(toBoardActionErrorMessage(sellResult.status))
         return false
       }
 
@@ -829,7 +809,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
           },
           { notifyParent: true }
         )
-        applyMoney(playerIdx, +getSellFallbackRefund(tileId, owner.level))
+        applyMoney(playerIdx, +getBoardSellFallbackRefund(tileId, owner.level))
       }
 
       return true
@@ -849,7 +829,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
 
       const actionResult = await gameApi.buyTile(roomId, { tile_index: tileId })
       if (!actionResult.ok) {
-        setStatus(toActionErrorMessage(actionResult.status))
+        setStatus(toBoardActionErrorMessage(actionResult.status))
         return
       }
 
@@ -897,7 +877,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
         tile_index: tileId,
       })
       if (!actionResult.ok) {
-        setStatus(toActionErrorMessage(actionResult.status))
+        setStatus(toBoardActionErrorMessage(actionResult.status))
         return
       }
 

--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -174,8 +174,8 @@ interface GameBoardProps {
     owner_id?: string | number | null
     building: number
   }>
-  onPlayersChange: (players: PlayerState[]) => void
-  onCurPlayerChange: (idx: number) => void
+  onPlayersChange?: (players: PlayerState[]) => void
+  onCurPlayerChange?: (idx: number) => void
   onTileOwnersChange?: (tileOwners: Record<number, TileOwner>) => void
   onBankrupt?: (playerIdx: number) => void
 }
@@ -384,7 +384,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
 
         const nextPlayers = [...orderedPlayers, ...additionalPlayers]
         playersRef.current = nextPlayers
-        onPlayersChange(nextPlayers)
+        onPlayersChange?.(nextPlayers)
       }
 
       if (payload.tiles) {
@@ -438,7 +438,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
         )
         if (nextTurnIndex >= 0) {
           curPlayerRef.current = nextTurnIndex
-          onCurPlayerChange(nextTurnIndex)
+          onCurPlayerChange?.(nextTurnIndex)
         }
       }
 
@@ -496,7 +496,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
         return { ...p, money: Math.max(0, p.money + delta) }
       })
       playersRef.current = updated
-      onPlayersChange([...updated])
+      onPlayersChange?.([...updated])
 
       const isBankrupt = updated[playerIdx].money <= 0
       if (isBankrupt) {
@@ -562,11 +562,11 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
           skipTurns: nextPlayer.skipTurns! - 1,
         }
         playersRef.current = updatedPlayers
-        onPlayersChange(updatedPlayers)
+        onPlayersChange?.(updatedPlayers)
 
         // 스킵 상태를 보여주기 위해 잠시 현재 턴으로 바꾼 뒤 다시 턴을 넘긴다
         curPlayerRef.current = next
-        onCurPlayerChange(next)
+        onCurPlayerChange?.(next)
 
         setTimeout(() => {
           advanceTurn(onDone)
@@ -575,7 +575,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       }
 
       curPlayerRef.current = next
-      onCurPlayerChange(next)
+      onCurPlayerChange?.(next)
       onDone?.()
     }
 
@@ -650,7 +650,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
             return { ...p, pos: newPos, skipTurns: newSkipTurns }
           })
           playersRef.current = movedPlayers
-          onPlayersChange([...movedPlayers])
+          onPlayersChange?.([...movedPlayers])
 
           const landedTileId = movedPlayers[activeCurPlayer].pos
 
@@ -921,7 +921,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
           skipTurns: (activePlayer.skipTurns ?? 0) + 1,
         }
         playersRef.current = updatedPlayers
-        onPlayersChange(updatedPlayers)
+        onPlayersChange?.(updatedPlayers)
         setStatus(`${activePlayer.name} 주사위 1턴 쉬기!`)
       }
 

--- a/src/components/board/gameBoard.types.ts
+++ b/src/components/board/gameBoard.types.ts
@@ -1,0 +1,62 @@
+export interface BuyModalState {
+  open: boolean
+  tileId: number | null
+  onDoneCallback?: () => void
+}
+
+export interface BuildModalState {
+  open: boolean
+  tileId: number | null
+  onDoneCallback?: () => void
+}
+
+export interface CardModalState {
+  open: boolean
+  variant: 'event' | 'chance'
+  onDoneCallback?: () => void
+}
+
+export interface TollModalState {
+  open: boolean
+  tileId: number | null
+  ownerName: string
+  tollText: string
+  onDoneCallback?: () => void
+}
+
+export interface AIPenaltyModalState {
+  open: boolean
+  status: 'loading' | 'result' | 'error'
+  resultDescription?: string
+  onDoneCallback?: () => void
+}
+
+export interface BankruptModalState {
+  open: boolean
+  playerIdx: number
+  playerName: string
+  onDoneCallback?: () => void
+}
+
+export type SyncStatePayload = {
+  players?: Array<{
+    id: string | number
+    nickname?: string
+    name?: string
+    position?: number
+    pos?: number
+    balance?: number
+    money?: number
+    color?: string
+  }>
+  tiles?: Array<{
+    index?: number
+    id?: number
+    owner_id?: string | number | null
+    ownerId?: string | number | null
+    building?: number
+    level?: number
+  }>
+  current_turn?: string | number | null
+  currentTurn?: string | number | null
+}

--- a/src/components/board/gameBoardActionHandlers.ts
+++ b/src/components/board/gameBoardActionHandlers.ts
@@ -1,0 +1,304 @@
+import type { Dispatch, MutableRefObject, SetStateAction } from 'react'
+import { gameApi } from '../../services/game/game.api'
+import type { PlayerState, TileOwner, BuildingLevel } from './board.constants'
+import {
+  getBoardSellFallbackRefund,
+  toBoardActionErrorMessage,
+} from './gameBoardActionUtils'
+import {
+  findSyncTurnIndex,
+  mapSyncPayloadPlayers,
+  mapSyncPayloadTileOwners,
+} from './gameBoardSyncUtils'
+import {
+  createBoardPurchasedTileOwner,
+  findBoardSellTarget,
+  getBoardTollAmount,
+  upgradeBoardTileOwner,
+} from './gameBoardTransactionUtils'
+import type {
+  BuildModalState,
+  BuyModalState,
+  SyncStatePayload,
+  TollModalState,
+} from './gameBoard.types'
+
+type UpdateTileOwners = (
+  updater: (prev: Record<number, TileOwner>) => Record<number, TileOwner>,
+  options?: { notifyParent?: boolean }
+) => void
+
+interface CreateGameBoardActionHandlersParams {
+  roomId: string | null
+  useGameSocketMock: boolean
+  roomIdRequiredMessage: string
+  setStatus: Dispatch<SetStateAction<string>>
+  setOptimisticTileOwners: Dispatch<
+    SetStateAction<Record<number, TileOwner> | null>
+  >
+  setBuyModal: Dispatch<SetStateAction<BuyModalState>>
+  setBuildModal: Dispatch<SetStateAction<BuildModalState>>
+  setTollModal: Dispatch<SetStateAction<TollModalState>>
+  playersRef: MutableRefObject<PlayerState[]>
+  curPlayerRef: MutableRefObject<number>
+  tileOwnersRef: MutableRefObject<Record<number, TileOwner>>
+  publishPlayers: (players: PlayerState[]) => void
+  publishCurrentTurn: (playerIdx: number) => void
+  publishTileOwners: (tileOwners: Record<number, TileOwner>) => void
+  getPlayerIdByIndex: (playerIdx: number) => number
+  getPlayerColorByIndex: (playerIdx: number) => string
+  getPlayerIndexById: (playerId: number) => number
+  toBoardBuildingLevel: (
+    tile: { building?: number; level?: number },
+    hasOwner: boolean
+  ) => BuildingLevel
+  getPurchaseCost: (tileId: number) => number
+  getUpgradeCost: (price: number, currentLevel: BuildingLevel) => number
+  calcToll: (price: number, level: BuildingLevel) => number
+  getTilePrice: (tileId: number) => number
+  updateTileOwners: UpdateTileOwners
+  applyMoney: (
+    playerIdx: number,
+    delta: number,
+    onDoneCallback?: () => void
+  ) => boolean
+  advanceTurn: (onDone?: () => void) => void
+}
+
+export function createGameBoardActionHandlers(
+  params: CreateGameBoardActionHandlersParams
+) {
+  const {
+    roomId,
+    useGameSocketMock,
+    roomIdRequiredMessage,
+    setStatus,
+    setOptimisticTileOwners,
+    setBuyModal,
+    setBuildModal,
+    setTollModal,
+    playersRef,
+    curPlayerRef,
+    tileOwnersRef,
+    publishPlayers,
+    publishCurrentTurn,
+    publishTileOwners,
+    getPlayerIdByIndex,
+    getPlayerColorByIndex,
+    getPlayerIndexById,
+    toBoardBuildingLevel,
+    getPurchaseCost,
+    getUpgradeCost,
+    calcToll,
+    getTilePrice,
+    updateTileOwners,
+    applyMoney,
+    advanceTurn,
+  } = params
+
+  async function syncBoardStateFromServer() {
+    if (!roomId) return false
+
+    const syncResult = await gameApi.syncState(roomId)
+    if (!syncResult.ok) return false
+
+    const payload = syncResult.data as SyncStatePayload
+    const payloadPlayers = payload.players ?? []
+    let serverToBoardId = new Map<string, number>()
+
+    if (payloadPlayers.length > 0) {
+      const mappedPlayers = mapSyncPayloadPlayers(
+        payloadPlayers,
+        playersRef.current
+      )
+      serverToBoardId = mappedPlayers.serverToBoardId
+      playersRef.current = mappedPlayers.nextPlayers
+      publishPlayers(mappedPlayers.nextPlayers)
+    }
+
+    if (payload.tiles) {
+      const nextOwners = mapSyncPayloadTileOwners(
+        payload.tiles,
+        playersRef.current,
+        serverToBoardId,
+        toBoardBuildingLevel
+      )
+
+      tileOwnersRef.current = nextOwners
+      setOptimisticTileOwners(nextOwners)
+      publishTileOwners(nextOwners)
+    }
+
+    const nextTurnIndex = findSyncTurnIndex(
+      payload.current_turn ?? payload.currentTurn,
+      playersRef.current,
+      serverToBoardId
+    )
+    if (nextTurnIndex >= 0) {
+      curPlayerRef.current = nextTurnIndex
+      publishCurrentTurn(nextTurnIndex)
+    }
+
+    return true
+  }
+
+  async function sellOwnedTileForPlayer(playerIdx: number) {
+    const playerId = getPlayerIdByIndex(playerIdx)
+    const sellTarget = findBoardSellTarget(tileOwnersRef.current, playerId)
+    if (!sellTarget) return false
+
+    const { tileId, owner } = sellTarget
+    if (!roomId) return false
+
+    const sellResult = await gameApi.sellTile(roomId, {
+      tile_index: tileId,
+      level: owner.level,
+    })
+
+    if (!sellResult.ok) {
+      setStatus(toBoardActionErrorMessage(sellResult.status))
+      return false
+    }
+
+    const synced = await syncBoardStateFromServer()
+    if (!synced) {
+      updateTileOwners(
+        (prev) => {
+          const next = { ...prev }
+          delete next[tileId]
+          return next
+        },
+        { notifyParent: true }
+      )
+      applyMoney(playerIdx, +getBoardSellFallbackRefund(tileId, owner.level))
+    }
+
+    return true
+  }
+
+  async function handleBuy(buyModal: BuyModalState) {
+    const { tileId, onDoneCallback } = buyModal
+    if (tileId === null) return
+    if (!roomId) {
+      setStatus(roomIdRequiredMessage)
+      return
+    }
+
+    const active = curPlayerRef.current
+    const activePlayerId = getPlayerIdByIndex(active)
+    const activePlayerColor = getPlayerColorByIndex(active)
+    const price = getPurchaseCost(tileId)
+
+    const actionResult = await gameApi.buyTile(roomId, { tile_index: tileId })
+    if (!actionResult.ok) {
+      setStatus(toBoardActionErrorMessage(actionResult.status))
+      return
+    }
+
+    setBuyModal({ open: false, tileId: null })
+    const bankrupt = applyMoney(active, -price, onDoneCallback)
+    if (!bankrupt) {
+      updateTileOwners(
+        (prev) => ({
+          ...prev,
+          [tileId]: createBoardPurchasedTileOwner(
+            activePlayerId,
+            activePlayerColor
+          ),
+        }),
+        { notifyParent: true }
+      )
+      if (useGameSocketMock) onDoneCallback?.()
+      else advanceTurn(onDoneCallback)
+    }
+  }
+
+  function handleBuyPass(buyModal: BuyModalState) {
+    setBuyModal({ open: false, tileId: null })
+    advanceTurn(buyModal.onDoneCallback)
+  }
+
+  async function handleBuildConfirm(buildModal: BuildModalState) {
+    const { tileId, onDoneCallback } = buildModal
+    if (tileId === null) return
+    if (!roomId) {
+      setStatus(roomIdRequiredMessage)
+      return
+    }
+
+    const active = curPlayerRef.current
+    const owner = tileOwnersRef.current[tileId]
+    const price = getPurchaseCost(tileId)
+    const upgradeCost = owner ? getUpgradeCost(price, owner.level) : 0
+
+    const actionResult = await gameApi.buildTile(roomId, {
+      tile_index: tileId,
+    })
+    if (!actionResult.ok) {
+      setStatus(toBoardActionErrorMessage(actionResult.status))
+      return
+    }
+
+    setBuildModal({ open: false, tileId: null })
+    const bankrupt = applyMoney(active, -upgradeCost, onDoneCallback)
+    if (!bankrupt) {
+      updateTileOwners((prev) => upgradeBoardTileOwner(prev, tileId), {
+        notifyParent: true,
+      })
+      if (useGameSocketMock) onDoneCallback?.()
+      else advanceTurn(onDoneCallback)
+    }
+  }
+
+  function handleBuildCancel(buildModal: BuildModalState) {
+    setBuildModal({ open: false, tileId: null })
+    advanceTurn(buildModal.onDoneCallback)
+  }
+
+  async function handleTollConfirm(tollModal: TollModalState) {
+    const { tileId, onDoneCallback } = tollModal
+    const active = curPlayerRef.current
+    setTollModal({
+      open: false,
+      tileId: null,
+      ownerName: '',
+      tollText: '',
+    })
+
+    if (tileId !== null) {
+      const owner = tileOwnersRef.current[tileId]
+      const price = getTilePrice(tileId)
+      const tollAmount = getBoardTollAmount(price, owner, calcToll)
+      if (owner) {
+        if (playersRef.current[active].money < tollAmount) {
+          const sold = await sellOwnedTileForPlayer(active)
+          if (!sold) {
+            const bankrupt = applyMoney(active, -tollAmount, onDoneCallback)
+            if (!bankrupt) advanceTurn(onDoneCallback)
+            return
+          }
+        }
+
+        const ownerPlayerIndex = getPlayerIndexById(owner.ownerId)
+        if (ownerPlayerIndex >= 0) {
+          applyMoney(ownerPlayerIndex, +tollAmount)
+        }
+        const bankrupt = applyMoney(active, -tollAmount, onDoneCallback)
+        if (!bankrupt) advanceTurn(onDoneCallback)
+        return
+      }
+    }
+
+    advanceTurn(onDoneCallback)
+  }
+
+  return {
+    syncBoardStateFromServer,
+    sellOwnedTileForPlayer,
+    handleBuy,
+    handleBuyPass,
+    handleBuildConfirm,
+    handleBuildCancel,
+    handleTollConfirm,
+  }
+}

--- a/src/components/board/gameBoardActionUtils.ts
+++ b/src/components/board/gameBoardActionUtils.ts
@@ -1,0 +1,28 @@
+import { TILES, type BuildingLevel } from './board.constants'
+
+export function toBoardActionErrorMessage(statusCode: number) {
+  if (statusCode === 401) return '로그인이 필요합니다.'
+  if (statusCode === 403) return '현재 턴에는 처리할 수 없습니다.'
+  if (statusCode === 404) return '대상을 찾을 수 없습니다.'
+  if (statusCode === 409) return '조건이 맞지 않아 처리할 수 없습니다.'
+  return '요청 처리 중 오류가 발생했습니다.'
+}
+
+export function getBoardSellFallbackRefund(
+  tileId: number,
+  level: BuildingLevel
+) {
+  const basePrice = TILES[tileId]?.price ?? 0
+  if (level <= 0 || basePrice === 0) return 0
+
+  let refund = basePrice
+
+  for (let currentLevel = 1; currentLevel < level; currentLevel += 1) {
+    if (currentLevel === 1) refund += basePrice * 0.5
+    else if (currentLevel === 2) refund += basePrice * 0.5
+    else if (currentLevel === 3) refund += basePrice * 0.5
+    else if (currentLevel === 4) refund += basePrice * 1.0
+  }
+
+  return refund
+}

--- a/src/components/board/gameBoardStoreBridge.test.ts
+++ b/src/components/board/gameBoardStoreBridge.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useGameStore } from '../../stores/game.store'
+import {
+  syncMockStoreBankrupt,
+  syncMockStoreCurrentTurn,
+  syncMockStorePlayers,
+  syncMockStoreTileOwners,
+} from './gameBoardStoreBridge'
+import type { PlayerState, TileOwner } from './board.constants'
+
+describe('gameBoardStoreBridge', () => {
+  beforeEach(() => {
+    useGameStore.getState().resetGame()
+    useGameStore.getState().setGameState({
+      players: [
+        {
+          id: 'p1',
+          nickname: 'Alpha',
+          position: 0,
+          balance: 1000,
+          owned_tiles: [],
+          is_in_jail: false,
+          jail_turn_count: 0,
+          is_bankrupt: false,
+          color: '#f00',
+        },
+        {
+          id: 'p2',
+          nickname: 'Beta',
+          position: 0,
+          balance: 1000,
+          owned_tiles: [],
+          is_in_jail: false,
+          jail_turn_count: 0,
+          is_bankrupt: false,
+          color: '#00f',
+        },
+      ],
+      tiles: [
+        {
+          index: 1,
+          owner_id: null,
+          building: 0,
+          name: '수원',
+          type: 'city',
+        },
+        {
+          index: 2,
+          owner_id: null,
+          building: 0,
+          name: '용인',
+          type: 'city',
+        },
+      ],
+    })
+  })
+
+  it('board players를 store players로 반영한다', () => {
+    const nextPlayers: PlayerState[] = [
+      { id: 0, name: 'Alpha', color: '#f00', pos: 3, money: 900 },
+      { id: 1, name: 'Beta', color: '#00f', pos: 5, money: 1100, skipTurns: 1 },
+    ]
+
+    syncMockStorePlayers(nextPlayers)
+
+    const { players } = useGameStore.getState()
+    expect(players).toEqual([
+      expect.objectContaining({
+        id: 'p1',
+        nickname: 'Alpha',
+        position: 3,
+        balance: 900,
+      }),
+      expect.objectContaining({
+        id: 'p2',
+        nickname: 'Beta',
+        position: 5,
+        balance: 1100,
+      }),
+    ])
+  })
+
+  it('현재 턴과 파산 상태를 store에 반영한다', () => {
+    syncMockStoreCurrentTurn(1)
+    syncMockStoreBankrupt(0)
+
+    const { currentTurn, currentPlayerId, players } = useGameStore.getState()
+    expect(currentTurn).toBe('p2')
+    expect(currentPlayerId).toBe('p2')
+    expect(players[0]?.is_bankrupt).toBe(true)
+  })
+
+  it('tile owner 정보를 store tiles로 반영한다', () => {
+    const nextTileOwners: Record<number, TileOwner> = {
+      1: { ownerId: 0, ownerColor: '#f00', level: 2 },
+      2: { ownerId: 1, ownerColor: '#00f', level: 5 },
+    }
+
+    syncMockStoreTileOwners(nextTileOwners)
+
+    const { tiles } = useGameStore.getState()
+    expect(tiles).toEqual([
+      expect.objectContaining({
+        index: 1,
+        owner_id: 'p1',
+        building: 1,
+      }),
+      expect.objectContaining({
+        index: 2,
+        owner_id: 'p2',
+        building: 4,
+      }),
+    ])
+  })
+})

--- a/src/components/board/gameBoardStoreBridge.ts
+++ b/src/components/board/gameBoardStoreBridge.ts
@@ -1,0 +1,85 @@
+import { useGameStore } from '../../stores/game.store'
+import type { BuildingLevel as StoreBuildingLevel } from '../../types/domain'
+import type { PlayerState, TileOwner } from './board.constants'
+
+const toStoreBuildingLevel = (level: number): StoreBuildingLevel =>
+  Math.min(Math.max(level, 0), 5) as StoreBuildingLevel
+
+export function syncMockStorePlayers(nextPlayers: PlayerState[]) {
+  const { players: storePlayers, setGameState } = useGameStore.getState()
+  if (storePlayers.length === 0) {
+    return
+  }
+
+  setGameState({
+    players: nextPlayers.map((player, index) => {
+      const storePlayer = storePlayers[index]
+
+      return {
+        id: storePlayer?.id ?? String(player.id),
+        nickname: player.name,
+        position: player.pos,
+        balance: player.money,
+        owned_tiles: storePlayer?.owned_tiles ?? [],
+        is_in_jail: storePlayer?.is_in_jail ?? false,
+        jail_turn_count: storePlayer?.jail_turn_count ?? 0,
+        is_bankrupt: storePlayer?.is_bankrupt ?? false,
+        color: player.color,
+        avatar: storePlayer?.avatar,
+      }
+    }),
+  })
+}
+
+export function syncMockStoreCurrentTurn(playerIdx: number) {
+  const { players: storePlayers, setCurrentTurn } = useGameStore.getState()
+  const nextTurnPlayer = storePlayers[playerIdx]
+  if (nextTurnPlayer) {
+    setCurrentTurn(nextTurnPlayer.id)
+  }
+}
+
+export function syncMockStoreBankrupt(playerIdx: number) {
+  const { players: storePlayers, updatePlayer } = useGameStore.getState()
+  const bankruptPlayer = storePlayers[playerIdx]
+  if (bankruptPlayer) {
+    updatePlayer(bankruptPlayer.id, { is_bankrupt: true })
+  }
+}
+
+export function syncMockStoreTileOwners(
+  nextTileOwners: Record<number, TileOwner>
+) {
+  const {
+    tiles: storeTiles,
+    players: storePlayers,
+    setGameState,
+  } = useGameStore.getState()
+
+  if (storeTiles.length === 0) {
+    return
+  }
+
+  setGameState({
+    tiles: storeTiles.map((tile) => {
+      const owner = nextTileOwners[tile.index]
+      if (!owner) {
+        return {
+          ...tile,
+          owner_id: null,
+          building: 0 as StoreBuildingLevel,
+        }
+      }
+
+      const ownerPlayer = storePlayers.find(
+        (player) => String(player.id) === String(owner.ownerId)
+      )
+
+      return {
+        ...tile,
+        owner_id: ownerPlayer?.id ?? String(owner.ownerId),
+        building: toStoreBuildingLevel(owner.level - 1),
+      }
+    }),
+  })
+}

--- a/src/components/board/gameBoardStoreBridge.ts
+++ b/src/components/board/gameBoardStoreBridge.ts
@@ -66,17 +66,23 @@ export function syncMockStoreTileOwners(
       if (!owner) {
         return {
           ...tile,
+          ownerId: null,
           owner_id: null,
           building: 0 as StoreBuildingLevel,
         }
       }
 
-      const ownerPlayer = storePlayers.find(
-        (player) => String(player.id) === String(owner.ownerId)
-      )
+      const ownerPlayer =
+        storePlayers.find(
+          (player) => String(player.id) === String(owner.ownerId)
+        ) ??
+        (typeof owner.ownerId === 'number'
+          ? storePlayers[owner.ownerId]
+          : undefined)
 
       return {
         ...tile,
+        ownerId: ownerPlayer?.id ?? String(owner.ownerId),
         owner_id: ownerPlayer?.id ?? String(owner.ownerId),
         building: toStoreBuildingLevel(owner.level - 1),
       }

--- a/src/components/board/gameBoardSyncUtils.ts
+++ b/src/components/board/gameBoardSyncUtils.ts
@@ -1,0 +1,142 @@
+import {
+  PLAYER_COLORS,
+  type PlayerState,
+  type TileOwner,
+  type BuildingLevel,
+} from './board.constants'
+
+type SyncPlayerPayload = {
+  id: string | number
+  nickname?: string
+  name?: string
+  position?: number
+  pos?: number
+  balance?: number
+  money?: number
+  color?: string
+}
+
+type SyncTilePayload = {
+  index?: number
+  id?: number
+  owner_id?: string | number | null
+  ownerId?: string | number | null
+  building?: number
+  level?: number
+}
+
+export function mapSyncPayloadPlayers(
+  payloadPlayers: SyncPlayerPayload[],
+  previousPlayers: PlayerState[]
+) {
+  const prevById = new Map(
+    previousPlayers.map((player) => [String(player.id), player])
+  )
+  const serverToBoardId = new Map<string, number>()
+  const nextById = new Map<string, PlayerState>()
+
+  payloadPlayers.forEach((player, index) => {
+    const prevPlayer = prevById.get(String(player.id))
+    const parsedPlayerId =
+      typeof player.id === 'number'
+        ? player.id
+        : Number.parseInt(String(player.id), 10)
+    const boardPlayerId = Number.isNaN(parsedPlayerId)
+      ? (prevPlayer?.id ?? index)
+      : parsedPlayerId
+
+    serverToBoardId.set(String(player.id), boardPlayerId)
+
+    nextById.set(String(player.id), {
+      id: boardPlayerId,
+      name:
+        player.nickname ??
+        player.name ??
+        prevPlayer?.name ??
+        `Player ${index + 1}`,
+      color:
+        player.color ??
+        prevPlayer?.color ??
+        PLAYER_COLORS[index % PLAYER_COLORS.length],
+      pos: player.position ?? player.pos ?? prevPlayer?.pos ?? 0,
+      money: player.balance ?? player.money ?? prevPlayer?.money ?? 0,
+    })
+  })
+
+  const orderedPlayers = previousPlayers.map((prevPlayer) => {
+    return nextById.get(String(prevPlayer.id)) ?? prevPlayer
+  })
+  const additionalPlayers = Array.from(nextById.values()).filter(
+    (nextPlayer) =>
+      !orderedPlayers.some(
+        (orderedPlayer) => orderedPlayer.id === nextPlayer.id
+      )
+  )
+
+  return {
+    nextPlayers: [...orderedPlayers, ...additionalPlayers],
+    serverToBoardId,
+  }
+}
+
+export function mapSyncPayloadTileOwners(
+  payloadTiles: SyncTilePayload[],
+  players: PlayerState[],
+  serverToBoardId: Map<string, number>,
+  toBoardBuildingLevel: (
+    tile: { building?: number; level?: number },
+    hasOwner: boolean
+  ) => BuildingLevel
+) {
+  const nextOwners: Record<number, TileOwner> = {}
+
+  payloadTiles.forEach((tile) => {
+    const tileIndex = tile.index ?? tile.id
+    const ownerRaw = tile.owner_id ?? tile.ownerId
+    if (
+      tileIndex === undefined ||
+      ownerRaw === null ||
+      ownerRaw === undefined
+    ) {
+      return
+    }
+
+    const mappedOwnerId = serverToBoardId.get(String(ownerRaw))
+    const parsedOwnerId =
+      typeof ownerRaw === 'number'
+        ? ownerRaw
+        : Number.parseInt(String(ownerRaw), 10)
+    const ownerId =
+      mappedOwnerId ?? (Number.isNaN(parsedOwnerId) ? null : parsedOwnerId)
+    if (ownerId === null) return
+
+    const ownerPlayer = players.find(
+      (player) => String(player.id) === String(ownerId)
+    )
+    nextOwners[tileIndex] = {
+      ownerId,
+      ownerColor:
+        ownerPlayer?.color ?? PLAYER_COLORS[ownerId % PLAYER_COLORS.length],
+      level: toBoardBuildingLevel(tile, true),
+    }
+  })
+
+  return nextOwners
+}
+
+export function findSyncTurnIndex(
+  nextTurnRaw: string | number | null | undefined,
+  players: PlayerState[],
+  serverToBoardId: Map<string, number>
+) {
+  if (nextTurnRaw === undefined || nextTurnRaw === null) {
+    return -1
+  }
+
+  const mappedTurnId = serverToBoardId.get(String(nextTurnRaw))
+
+  return players.findIndex(
+    (player) =>
+      player.id === mappedTurnId || String(player.id) === String(nextTurnRaw)
+  )
+}

--- a/src/components/board/gameBoardTransactionUtils.ts
+++ b/src/components/board/gameBoardTransactionUtils.ts
@@ -1,0 +1,58 @@
+import { type BuildingLevel, type TileOwner } from './board.constants'
+
+export function findBoardSellTarget(
+  tileOwners: Record<number, TileOwner>,
+  playerId: number
+) {
+  const ownedTileEntries = Object.entries(tileOwners)
+    .filter(([, owner]) => owner.ownerId === playerId)
+    .sort(([, left], [, right]) => right.level - left.level)
+
+  if (ownedTileEntries.length === 0) {
+    return null
+  }
+
+  const [tileIdText, owner] = ownedTileEntries[0]
+
+  return {
+    tileId: Number(tileIdText),
+    owner,
+  }
+}
+
+export function createBoardPurchasedTileOwner(
+  ownerId: number,
+  ownerColor: string
+): TileOwner {
+  return {
+    ownerId,
+    ownerColor,
+    level: 1,
+  }
+}
+
+export function upgradeBoardTileOwner(
+  tileOwners: Record<number, TileOwner>,
+  tileId: number
+) {
+  const existing = tileOwners[tileId]
+  if (!existing) {
+    return tileOwners
+  }
+
+  return {
+    ...tileOwners,
+    [tileId]: {
+      ...existing,
+      level: Math.min(existing.level + 1, 5) as BuildingLevel,
+    },
+  }
+}
+
+export function getBoardTollAmount(
+  price: number,
+  owner: TileOwner | undefined,
+  calcToll: (price: number, level: BuildingLevel) => number
+) {
+  return owner ? calcToll(price, owner.level) : 0
+}

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -2,7 +2,6 @@ import { useEffect, useMemo, useRef } from 'react'
 import { Settings } from 'lucide-react'
 import { useLocation, useParams } from 'react-router-dom'
 import BoardGame, { BoardGameHandle } from '../components/board/GameBoard'
-import type { PlayerState } from '../components/board/board.constants'
 import RollButton from '../components/game/controls/RollButton'
 import PlayerPanel from '../components/game/panels/PlayerPanel'
 import { IS_SOCKET_MOCK_ENABLED } from '../config/env'
@@ -15,7 +14,7 @@ import { useGameTimer } from '../hooks/game/useGameTimer'
 import { useTurn } from '../hooks/game/useTurn'
 import { socket } from '../lib/socket'
 import { useGameStore } from '../stores/game.store'
-import type { BuildingLevel, ChatMessage } from '../types/domain'
+import type { ChatMessage } from '../types/domain'
 import {
   findBoardCurrentPlayerIndex,
   mapStorePlayersToBoardPlayers,
@@ -34,9 +33,6 @@ const DEFAULT_MOCK_PLAYER_ID = 'mock-player-1'
 const DEFAULT_MOCK_NICKNAME = '플레이어 1'
 const DEFAULT_GUEST_ID = 'guest-local'
 const MOCK_LOCAL_PLAYER_INDEX = 0
-
-const toStoreBuildingLevel = (level: number): BuildingLevel =>
-  Math.min(Math.max(level, 0), 5) as BuildingLevel
 
 function mapGameChatEventToMessage(payload: ChatEventPayload): ChatMessage {
   return {
@@ -67,9 +63,6 @@ const GamePage: React.FC = () => {
     turnTimerKey,
     players: storePlayers,
     tiles: storeTiles,
-    setGameState,
-    setCurrentTurn,
-    updatePlayer,
   } = useGameStore()
   const [timeLeft] = useGameTimer({
     initialTime: turnTimeoutSec,
@@ -155,97 +148,6 @@ const GamePage: React.FC = () => {
 
   const diceRoll = useDiceRoll(boardRef)
 
-  const handlePlayersChange = (updated: PlayerState[]) => {
-    if (!USE_GAME_SOCKET_MOCK || storePlayers.length === 0) {
-      return
-    }
-
-    setGameState({
-      players: updated.map((player, index) => {
-        const storePlayer = storePlayers[index]
-
-        return {
-          id: storePlayer?.id ?? String(player.id),
-          nickname: player.name,
-          position: player.pos,
-          balance: player.money,
-          owned_tiles: storePlayer?.owned_tiles ?? [],
-          is_in_jail: storePlayer?.is_in_jail ?? false,
-          jail_turn_count: storePlayer?.jail_turn_count ?? 0,
-          is_bankrupt: storePlayer?.is_bankrupt ?? false,
-          color: player.color,
-          avatar: storePlayer?.avatar,
-        }
-      }),
-    })
-  }
-
-  const handleCurPlayerChange = (idx: number) => {
-    if (!USE_GAME_SOCKET_MOCK) {
-      return
-    }
-
-    const nextTurnPlayer = storePlayers[idx]
-    if (nextTurnPlayer) {
-      setCurrentTurn(nextTurnPlayer.id)
-    }
-  }
-
-  const handleBankrupt = (playerIdx: number) => {
-    if (!USE_GAME_SOCKET_MOCK) {
-      return
-    }
-
-    const bankruptPlayer = storePlayers[playerIdx]
-    if (!bankruptPlayer) {
-      return
-    }
-
-    updatePlayer(bankruptPlayer.id, { is_bankrupt: true })
-  }
-
-  const handleTileOwnersChange = (
-    nextTileOwners: Record<
-      number,
-      {
-        ownerId: number
-        level: number
-      }
-    >
-  ) => {
-    if (!USE_GAME_SOCKET_MOCK || storeTiles.length === 0) {
-      return
-    }
-
-    setGameState({
-      tiles: storeTiles.map((tile) => {
-        const owner = nextTileOwners[tile.index]
-        if (!owner) {
-          return {
-            ...tile,
-            owner_id: null,
-            building: 0 as BuildingLevel,
-          }
-        }
-
-        const ownerBoardIndex = boardPlayers.findIndex(
-          (player) => player.id === owner.ownerId
-        )
-        const ownerPlayer =
-          (ownerBoardIndex >= 0 ? storePlayers[ownerBoardIndex] : undefined) ??
-          storePlayers.find(
-            (player) => String(player.id) === String(owner.ownerId)
-          )
-
-        return {
-          ...tile,
-          owner_id: ownerPlayer?.id ?? String(owner.ownerId),
-          building: toStoreBuildingLevel(owner.level - 1),
-        }
-      }),
-    })
-  }
-
   const maxMoney = Math.max(...boardPlayers.map((player) => player.money))
   const currentPlayerState = boardPlayers[boardCurPlayer]
   const isCurrentPlayerBankrupt = currentPlayerState?.money <= 0
@@ -298,10 +200,6 @@ const GamePage: React.FC = () => {
               players={boardPlayers}
               curPlayer={boardCurPlayer}
               tiles={normalizedTilesForBoard}
-              onPlayersChange={handlePlayersChange}
-              onCurPlayerChange={handleCurPlayerChange}
-              onTileOwnersChange={handleTileOwnersChange}
-              onBankrupt={handleBankrupt}
             />
           </div>
         </div>

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -1,21 +1,26 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import { Settings } from 'lucide-react'
 import { useLocation, useParams } from 'react-router-dom'
-import PlayerPanel from '../components/game/panels/PlayerPanel'
-import RoomChat from '../features/room-chat/RoomChat'
-import { DevRoomChatControlPanel } from '../features/room-chat/DevRoomChatControlPanel'
+import BoardGame, { BoardGameHandle } from '../components/board/GameBoard'
+import type { PlayerState } from '../components/board/board.constants'
 import RollButton from '../components/game/controls/RollButton'
+import PlayerPanel from '../components/game/panels/PlayerPanel'
+import { IS_SOCKET_MOCK_ENABLED } from '../config/env'
 import { useAuthStore } from '../features/auth/store'
-import { useGameStore } from '../stores/game.store'
+import { DevRoomChatControlPanel } from '../features/room-chat/DevRoomChatControlPanel'
+import RoomChat from '../features/room-chat/RoomChat'
+import { useDiceRoll } from '../hooks/game/useDiceRoll'
 import { useGameState } from '../hooks/game/useGameState'
 import { useGameTimer } from '../hooks/game/useGameTimer'
-import { useDiceRoll } from '../hooks/game/useDiceRoll'
 import { useTurn } from '../hooks/game/useTurn'
-import BoardGame, { BoardGameHandle } from '../components/board/GameBoard'
-import { INIT_PLAYERS, PlayerState } from '../components/board/board.constants'
-import type { BuildingLevel, ChatMessage } from '../types/domain'
 import { socket } from '../lib/socket'
-import { IS_SOCKET_MOCK_ENABLED } from '../config/env'
+import { useGameStore } from '../stores/game.store'
+import type { BuildingLevel, ChatMessage } from '../types/domain'
+import {
+  findBoardCurrentPlayerIndex,
+  mapStorePlayersToBoardPlayers,
+  mapStoreTilesToBoardTiles,
+} from './game/gameViewModel'
 import { sendWaitingRoomChat } from './waiting-room/socket'
 import type { ChatEventPayload } from './waiting-room/types'
 
@@ -23,41 +28,16 @@ const USE_GAME_SOCKET_MOCK = IS_SOCKET_MOCK_ENABLED
 const ALLOW_ALL_MOCK_TURNS =
   import.meta.env.DEV && import.meta.env.VITE_ALLOW_ALL_MOCK_TURNS === 'true'
 
-const GAME_CHAT_TITLE = '\uC2E4\uC2DC\uAC04 \uCC44\uD305'
-const GAME_START_NOTICE =
-  '\uAC8C\uC784 \uC2DC\uC791! \uC21C\uC11C\uB97C \uC815\uD588\uC2B5\uB2C8\uB2E4.'
+const GAME_CHAT_TITLE = '실시간 채팅'
+const GAME_START_NOTICE = '게임 시작! 순서를 정했습니다.'
 const DEFAULT_MOCK_PLAYER_ID = 'mock-player-1'
-const DEFAULT_MOCK_NICKNAME = '\uD50C\uB808\uC774\uC5B4 1'
+const DEFAULT_MOCK_NICKNAME = '플레이어 1'
 const DEFAULT_GUEST_ID = 'guest-local'
 const MOCK_LOCAL_PLAYER_INDEX = 0
 
 const toStoreBuildingLevel = (level: number): BuildingLevel =>
   Math.min(Math.max(level, 0), 5) as BuildingLevel
 
-const mapStorePlayersToBoardPlayers = (
-  storePlayers: Array<{
-    nickname: string
-    position: number
-    balance: number
-    color?: string
-  }>
-) =>
-  INIT_PLAYERS.map((initialPlayer, index) => {
-    const storePlayer = storePlayers[index]
-    if (!storePlayer) {
-      return initialPlayer
-    }
-
-    return {
-      ...initialPlayer,
-      name: storePlayer.nickname || initialPlayer.name,
-      color: storePlayer.color || initialPlayer.color,
-      pos: storePlayer.position,
-      money: storePlayer.balance,
-    }
-  })
-
-// 채팅 이벤트 payload를 게임 채팅 메시지 모델로 정규화
 function mapGameChatEventToMessage(payload: ChatEventPayload): ChatMessage {
   return {
     id: `${payload.room_id}-${payload.sender_id}-${payload.sent_at}`,
@@ -78,7 +58,6 @@ const GamePage: React.FC = () => {
   const { gameId } = useParams<{ gameId: string }>()
   const location = useLocation()
   const locationState = location.state as GamePageLocationState | null
-  // URL은 gameId를 사용하고, room API 호출에는 전달받은 roomId를 우선 사용
   const activeRoomId = locationState?.roomId ?? gameId ?? null
   const session = useAuthStore((state) => state.session)
   const {
@@ -97,10 +76,6 @@ const GamePage: React.FC = () => {
     resetSignal: turnTimerKey,
   })
   const boardRef = useRef<BoardGameHandle>(null)
-  const hasHydratedMockBoardRef = useRef(false)
-
-  const [boardPlayers, setBoardPlayers] = useState<PlayerState[]>(INIT_PLAYERS)
-  const [boardCurPlayer, setBoardCurPlayer] = useState(0)
 
   useGameState(activeRoomId)
 
@@ -116,6 +91,18 @@ const GamePage: React.FC = () => {
       ? currentUserId
       : currentTurn
 
+  const boardPlayers = useMemo(
+    () => mapStorePlayersToBoardPlayers(storePlayers),
+    [storePlayers]
+  )
+  const boardCurPlayer = useMemo(
+    () => findBoardCurrentPlayerIndex(storePlayers, normalizedCurrentTurn),
+    [normalizedCurrentTurn, storePlayers]
+  )
+  const normalizedTilesForBoard = useMemo(
+    () => mapStoreTilesToBoardTiles(storeTiles, storePlayers, boardPlayers),
+    [boardPlayers, storePlayers, storeTiles]
+  )
   const isMyTurnFromStore = useTurn(normalizedCurrentTurn, currentUserId)
   const isMyTurn = USE_GAME_SOCKET_MOCK
     ? ALLOW_ALL_MOCK_TURNS || boardCurPlayer === MOCK_LOCAL_PLAYER_INDEX
@@ -123,14 +110,12 @@ const GamePage: React.FC = () => {
       ? true
       : isMyTurnFromStore
 
-  // 게임 채팅 이벤트를 구독해 메시지 목록을 실시간으로 동기화
   useEffect(() => {
     if (!activeRoomId) {
       return
     }
 
     const handleChat = (payload: ChatEventPayload) => {
-      // 다른 방 채팅 이벤트는 무시
       if (payload.room_id !== activeRoomId) {
         return
       }
@@ -141,7 +126,6 @@ const GamePage: React.FC = () => {
         (message) => message.id === nextMessage.id
       )
 
-      // 동일 메시지 중복 반영 방지
       if (hasSameMessage) {
         return
       }
@@ -157,7 +141,6 @@ const GamePage: React.FC = () => {
   }, [activeRoomId])
 
   const handleSendMessage = (content: string) => {
-    // roomId가 없으면 채팅 전송을 생략
     if (!activeRoomId) {
       return
     }
@@ -173,8 +156,6 @@ const GamePage: React.FC = () => {
   const diceRoll = useDiceRoll(boardRef)
 
   const handlePlayersChange = (updated: PlayerState[]) => {
-    setBoardPlayers(updated)
-
     if (!USE_GAME_SOCKET_MOCK || storePlayers.length === 0) {
       return
     }
@@ -200,8 +181,6 @@ const GamePage: React.FC = () => {
   }
 
   const handleCurPlayerChange = (idx: number) => {
-    setBoardCurPlayer(idx)
-
     if (!USE_GAME_SOCKET_MOCK) {
       return
     }
@@ -267,79 +246,18 @@ const GamePage: React.FC = () => {
     })
   }
 
-  const normalizedTilesForBoard = useMemo(() => {
-    if (storeTiles.length === 0) {
-      return storeTiles
-    }
-
-    return storeTiles.map((tile) => {
-      if (!tile.owner_id) {
-        return tile
-      }
-
-      const ownerStoreIndex = storePlayers.findIndex(
-        (player) => String(player.id) === String(tile.owner_id)
-      )
-
-      if (ownerStoreIndex < 0) {
-        return tile
-      }
-
-      const boardOwner = boardPlayers[ownerStoreIndex]
-      if (!boardOwner) {
-        return tile
-      }
-
-      return {
-        ...tile,
-        owner_id: boardOwner.id,
-      }
-    })
-  }, [boardPlayers, storePlayers, storeTiles])
-
-  useEffect(() => {
-    hasHydratedMockBoardRef.current = false
-  }, [activeRoomId])
-
-  useEffect(() => {
-    if (storePlayers.length === 0) {
-      return
-    }
-
-    const shouldHydrateBoardPlayers =
-      !USE_GAME_SOCKET_MOCK || !hasHydratedMockBoardRef.current
-
-    if (shouldHydrateBoardPlayers) {
-      setBoardPlayers(mapStorePlayersToBoardPlayers(storePlayers))
-
-      if (USE_GAME_SOCKET_MOCK) {
-        hasHydratedMockBoardRef.current = true
-      }
-    }
-
-    if (!normalizedCurrentTurn) {
-      return
-    }
-
-    const nextTurnIndex = storePlayers.findIndex(
-      (player) => player.id === normalizedCurrentTurn
-    )
-
-    if (nextTurnIndex >= 0) {
-      setBoardCurPlayer(nextTurnIndex)
-    }
-  }, [normalizedCurrentTurn, storePlayers])
-
-  const maxMoney = Math.max(...boardPlayers.map((p) => p.money))
+  const maxMoney = Math.max(...boardPlayers.map((player) => player.money))
   const currentPlayerState = boardPlayers[boardCurPlayer]
   const isCurrentPlayerBankrupt = currentPlayerState?.money <= 0
   const isCurrentPlayerSkipped = (currentPlayerState?.skipTurns ?? 0) > 0
-  const roomChatSenderOptions = useMemo(() => {
-    return storePlayers.map((player) => ({
-      id: String(player.id),
-      nickname: player.nickname,
-    }))
-  }, [storePlayers])
+  const roomChatSenderOptions = useMemo(
+    () =>
+      storePlayers.map((player) => ({
+        id: String(player.id),
+        nickname: player.nickname,
+      })),
+    [storePlayers]
+  )
   const currentUserIdForChat =
     currentUserId == null ? undefined : String(currentUserId)
   const preferredRoomChatSenderId =
@@ -390,27 +308,30 @@ const GamePage: React.FC = () => {
 
         <div className="flex h-full w-[320px] shrink-0 flex-col gap-4 overflow-y-auto py-8">
           {boardPlayers
-            .map((bp, idx) => ({ ...bp, originalIndex: idx }))
-            .sort((a, b) => {
-              const aBankrupt = a.money <= 0 ? 1 : 0
-              const bBankrupt = b.money <= 0 ? 1 : 0
-              if (aBankrupt !== bBankrupt) return aBankrupt - bBankrupt
-              return a.originalIndex - b.originalIndex
+            .map((player, index) => ({ ...player, originalIndex: index }))
+            .sort((left, right) => {
+              const leftBankrupt = left.money <= 0 ? 1 : 0
+              const rightBankrupt = right.money <= 0 ? 1 : 0
+              if (leftBankrupt !== rightBankrupt) {
+                return leftBankrupt - rightBankrupt
+              }
+
+              return left.originalIndex - right.originalIndex
             })
-            .map((bp) => (
+            .map((player) => (
               <PlayerPanel
-                key={bp.id}
+                key={player.id}
                 player={{
-                  id: String(bp.id),
-                  name: bp.name ?? `Player ${bp.id + 1}`,
-                  nickname: bp.name ?? `Player ${bp.id + 1}`,
-                  color: bp.color,
-                  money: bp.money,
-                  totalAssets: bp.money,
+                  id: String(player.id),
+                  name: player.name ?? `Player ${player.id + 1}`,
+                  nickname: player.name ?? `Player ${player.id + 1}`,
+                  color: player.color,
+                  money: player.money,
+                  totalAssets: player.money,
                 }}
-                isActive={bp.originalIndex === boardCurPlayer}
-                isRichest={bp.money > 0 && bp.money === maxMoney}
-                isBankrupt={bp.money <= 0}
+                isActive={player.originalIndex === boardCurPlayer}
+                isRichest={player.money > 0 && player.money === maxMoney}
+                isBankrupt={player.money <= 0}
               />
             ))}
         </div>

--- a/src/pages/game/gameViewModel.test.ts
+++ b/src/pages/game/gameViewModel.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+import {
+  findBoardCurrentPlayerIndex,
+  mapStorePlayersToBoardPlayers,
+  mapStoreTilesToBoardTiles,
+} from './gameViewModel'
+
+describe('game view model mapper', () => {
+  it('maps store players to board players using store state as the source', () => {
+    const boardPlayers = mapStorePlayersToBoardPlayers([
+      {
+        id: 'player-1',
+        nickname: 'Player 1',
+        position: 4,
+        balance: 900,
+        owned_tiles: [],
+        is_in_jail: false,
+        jail_turn_count: 0,
+        is_bankrupt: false,
+        color: '#111111',
+      },
+    ])
+
+    expect(boardPlayers[0]).toMatchObject({
+      id: 0,
+      name: 'Player 1',
+      pos: 4,
+      money: 900,
+      color: '#111111',
+    })
+    expect(boardPlayers[1]?.name).toBe('MarbleKing')
+  })
+
+  it('finds the current board player index by mixed player id values', () => {
+    const players = [
+      {
+        id: 'player-1',
+        nickname: 'Player 1',
+        position: 0,
+        balance: 1000,
+        owned_tiles: [],
+        is_in_jail: false,
+        jail_turn_count: 0,
+        is_bankrupt: false,
+        color: '#111111',
+      },
+      {
+        id: 2,
+        nickname: 'Player 2',
+        position: 1,
+        balance: 1200,
+        owned_tiles: [],
+        is_in_jail: false,
+        jail_turn_count: 0,
+        is_bankrupt: false,
+        color: '#222222',
+      },
+    ]
+
+    expect(findBoardCurrentPlayerIndex(players, '2')).toBe(1)
+    expect(findBoardCurrentPlayerIndex(players, null)).toBe(0)
+  })
+
+  it('maps tile owner ids to board player ids for board rendering', () => {
+    const storePlayers = [
+      {
+        id: 'player-1',
+        nickname: 'Player 1',
+        position: 0,
+        balance: 1000,
+        owned_tiles: [],
+        is_in_jail: false,
+        jail_turn_count: 0,
+        is_bankrupt: false,
+        color: '#111111',
+      },
+    ]
+    const boardPlayers = mapStorePlayersToBoardPlayers(storePlayers)
+    const boardTiles = mapStoreTilesToBoardTiles(
+      [
+        {
+          index: 1,
+          name: 'Seoul',
+          type: 'city',
+          owner_id: 'player-1',
+          building: 1,
+        },
+      ],
+      storePlayers,
+      boardPlayers
+    )
+
+    expect(boardTiles[0]?.owner_id).toBe(boardPlayers[0]?.id)
+  })
+})

--- a/src/pages/game/gameViewModel.ts
+++ b/src/pages/game/gameViewModel.ts
@@ -1,0 +1,81 @@
+import {
+  INIT_PLAYERS,
+  type PlayerState,
+} from '../../components/board/board.constants'
+import type { Player, PlayerId, Tile } from '../../types/domain'
+
+const toBoardPlayerId = (playerId: PlayerId, fallbackIndex: number) => {
+  if (typeof playerId === 'number') {
+    return playerId
+  }
+
+  const parsedPlayerId = Number.parseInt(String(playerId), 10)
+  return Number.isNaN(parsedPlayerId) ? fallbackIndex : parsedPlayerId
+}
+
+export const mapStorePlayersToBoardPlayers = (storePlayers: Player[]) =>
+  INIT_PLAYERS.map((initialPlayer, index) => {
+    const storePlayer = storePlayers[index]
+    if (!storePlayer) {
+      return initialPlayer
+    }
+
+    return {
+      ...initialPlayer,
+      id: toBoardPlayerId(storePlayer.id, initialPlayer.id),
+      name: storePlayer.nickname || initialPlayer.name,
+      color: storePlayer.color || initialPlayer.color,
+      pos: storePlayer.position,
+      money: storePlayer.balance,
+      skipTurns: storePlayer.jail_turn_count,
+    }
+  })
+
+export const findBoardCurrentPlayerIndex = (
+  storePlayers: Player[],
+  currentTurn: PlayerId | null
+) => {
+  if (currentTurn == null) {
+    return 0
+  }
+
+  const nextTurnIndex = storePlayers.findIndex(
+    (player) => String(player.id) === String(currentTurn)
+  )
+
+  return nextTurnIndex >= 0 ? nextTurnIndex : 0
+}
+
+export const mapStoreTilesToBoardTiles = (
+  storeTiles: Tile[],
+  storePlayers: Player[],
+  boardPlayers: PlayerState[]
+) => {
+  if (storeTiles.length === 0) {
+    return storeTiles
+  }
+
+  return storeTiles.map((tile) => {
+    if (!tile.owner_id) {
+      return tile
+    }
+
+    const ownerStoreIndex = storePlayers.findIndex(
+      (player) => String(player.id) === String(tile.owner_id)
+    )
+
+    if (ownerStoreIndex < 0) {
+      return tile
+    }
+
+    const boardOwner = boardPlayers[ownerStoreIndex]
+    if (!boardOwner) {
+      return tile
+    }
+
+    return {
+      ...tile,
+      owner_id: boardOwner.id,
+    }
+  })
+}

--- a/src/pages/waiting-room/WaitingRoomFlow.test.tsx
+++ b/src/pages/waiting-room/WaitingRoomFlow.test.tsx
@@ -98,7 +98,7 @@ describe('Waiting room start flow E2E', () => {
 
     await screen.findByText('E2E호스트님의 방')
 
-    const startButton = screen.getByRole('button', { name: '시작' })
+    const startButton = await screen.findByRole('button', { name: '시작' })
     expect(startButton).toBeDisabled()
 
     // 채팅 전송이 실제 화면에 반영되는지 확인
@@ -121,5 +121,5 @@ describe('Waiting room start flow E2E', () => {
     await waitFor(() => {
       expect(screen.getByText(/게임 화면:/)).toBeInTheDocument()
     })
-  })
+  }, 15000)
 })

--- a/src/pages/waiting-room/mockGateway.test.ts
+++ b/src/pages/waiting-room/mockGateway.test.ts
@@ -28,7 +28,7 @@ describe('mockGateway DEV control', () => {
     const secondHost = secondTransfer.players.find((player) => player.isHost)
 
     expect(secondHost?.id).toBe('room-5-user-1')
-  })
+  }, 15000)
 
   it('방장 넘기기는 1인 방에서 에러를 반환한다', async () => {
     const gateway = await loadMockGateway()


### PR DESCRIPTION
## 📌 관련 이슈

> closes #251 

---

## 📝 작업 내용

> 게임 화면이 `gameStore`를 단일 진실 소스로 사용하도록 `GamePage`와 `GameBoard`의 상태 이중화를 정리했습니다. page-level write-back을 제거하고, 보드 내부 액션/동기화 로직을 helper와 handler 모듈로 분리해 렌더/연출 중심 구조로 축소했습니다.

- `src/pages/game/gameViewModel.ts`
  - store snapshot을 board 렌더용 view model로 변환하는 mapper 추가

- `src/pages/game/gameViewModel.test.ts`
  - board view model 변환 규칙 회귀 테스트 추가

- `src/pages/GamePage.tsx`
  - `boardPlayers`, `boardCurPlayer` 로컬 상태 제거
  - `handlePlayersChange`, `handleCurPlayerChange`, `handleTileOwnersChange` write-back 제거
  - store 기반 view model만 읽도록 정리

- `src/components/board/GameBoard.tsx`
  - page/state write-back에 기대지 않도록 정리
  - 보드 본체에서 `buy/build/toll/sync` 세부 로직을 직접 들고 있지 않도록 축소
  - 렌더링과 모달/연출 조립 역할 중심으로 정리

- `src/components/board/gameBoardStoreBridge.ts`
  - board mock 상태를 `gameStore`에 반영하는 브리지 로직 분리

- `src/components/board/gameBoardStoreBridge.test.ts`
  - player/currentTurn/bankrupt/tile owner 매핑 회귀 테스트 추가

- `src/components/board/gameBoardActionUtils.ts`
  - 액션 에러 메시지 및 fallback 계산 유틸 분리

- `src/components/board/gameBoardSyncUtils.ts`
  - sync payload의 player/tile/turn 정규화 로직 분리

- `src/components/board/gameBoardTransactionUtils.ts`
  - 구매/건설/매각/통행료 계산 로직 분리

- `src/components/board/gameBoard.types.ts`
  - board modal state와 sync payload 타입 분리

- `src/components/board/gameBoardActionHandlers.ts`
  - `buy/build/toll/sync` 실행 흐름을 handler 모듈로 분리

- `src/pages/waiting-room/WaitingRoomFlow.test.tsx`
  - 시작 버튼 탐색을 렌더 완료 이후로 조정해 타임아웃성 실패 완화

- `src/pages/waiting-room/mockGateway.test.ts`
  - coverage 환경 타임아웃 budget 보정

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

> UI 변경 없음

---

## 🧪 검증

- `npm run lint`
- `npm run test`
- `npm run test:coverage`
- `npm run e2e`
- `npm run build`
