### PR TITLE
chore: game_start 계약 정합화 및 CI E2E 게이트 분리

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         run: npm run test:coverage
 
       - name: E2E
-        run: npm run e2e
+        run: npm run e2e:ci
 
       - name: Build
         run: npm run build

--- a/e2e/chat-flow-game-room.spec.ts
+++ b/e2e/chat-flow-game-room.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@playwright/test'
 import { ensureDevControlPanelOpen } from './helpers/devPanel'
 import { loginAsGuest, resetSessionAndOpenHome } from './helpers/session'
 
-test.describe('게임 채팅 플로우', () => {
+test.describe('@game 게임 채팅 플로우', () => {
   test('게임 진입 후 채팅 1건을 전송해 메시지 목록에 표시한다', async ({
     page,
   }) => {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "e2e": "playwright test",
+    "e2e:ci": "playwright test --grep-invert @game",
+    "e2e:game": "playwright test --grep @game",
     "e2e:ui": "playwright test --ui",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,7 +21,8 @@ export default defineConfig({
     command: 'npm run dev -- --host 127.0.0.1 --port 4173',
     env: {
       ...process.env,
-      VITE_USE_SOCKET_MOCK: 'true',
+      // 기본은 mock 모드로 CI 안정성을 유지하고, 필요 시 환경변수로 실소켓 모드 실행
+      VITE_USE_SOCKET_MOCK: process.env.VITE_USE_SOCKET_MOCK ?? 'true',
     },
     url: 'http://127.0.0.1:4173',
     reuseExistingServer: !process.env.CI,

--- a/src/pages/waiting-room/WaitingRoomPage.test.tsx
+++ b/src/pages/waiting-room/WaitingRoomPage.test.tsx
@@ -237,12 +237,7 @@ describe('WaitingRoomPage interaction', () => {
     act(() => {
       gameStartHandlerRef.current?.({
         game_id: 'game-123',
-        game_state: {
-          players: [],
-          tiles: [],
-          current_turn: null,
-          round: 1,
-        },
+        room_id: 'room-5',
       })
     })
 

--- a/src/pages/waiting-room/WaitingRoomPage.tsx
+++ b/src/pages/waiting-room/WaitingRoomPage.tsx
@@ -62,11 +62,11 @@ function WaitingRoomPage() {
       navigate(`/game/${payload.game_id}`, {
         state: {
           gameId: payload.game_id,
-          roomId: currentRoomId,
+          roomId: payload.room_id,
         },
       })
     },
-    [currentRoomId, navigate]
+    [navigate]
   )
 
   const {

--- a/src/pages/waiting-room/controller/socketSync.ts
+++ b/src/pages/waiting-room/controller/socketSync.ts
@@ -94,6 +94,11 @@ export function useWaitingRoomSocketSync({
         })
       },
       onGameStart: (payload) => {
+        // 다른 방 시작 이벤트는 무시
+        if (payload.room_id !== activeRoomId) {
+          return
+        }
+
         onGameStart(payload)
       },
     })

--- a/src/pages/waiting-room/mockGateway.ts
+++ b/src/pages/waiting-room/mockGateway.ts
@@ -13,11 +13,9 @@ import type {
   WaitingRoomSnapshot,
 } from './types'
 
-// 목 게이트웨이 네트워크 지연/게임 초기값/비밀방 기본 비밀번호
+// 목 게이트웨이 네트워크 지연/비밀방 기본 비밀번호
 const MOCK_NETWORK_DELAY_MS = 220
 const DEFAULT_ROOM_PASSWORD = '1234'
-const GAME_START_BALANCE = 1_000_000_000
-const GAME_PLAYER_COLORS = ['#FF6B6B', '#4F86F7', '#F8B500', '#2CCF9A']
 const DEV_BOT_NICKNAME_PREFIX = '테스터봇'
 const ROOM_PRIVATE_PASSWORDS: Record<string, string> = {
   'room-2': DEFAULT_ROOM_PASSWORD,
@@ -259,26 +257,11 @@ function findRoomOrThrow(roomId: string) {
   return room
 }
 
-// 게임 시작 소켓 payload를 목 게임 상태와 함께 생성
+// 게임 시작 소켓 payload를 명세 필수 필드(game_id, room_id)로 생성
 function createGameStartPayload(room: MockRoom): GameStartEventPayload {
   return {
     game_id: `game-${room.id}-${Date.now()}`,
-    game_state: {
-      players: room.players.map((player, index) => ({
-        id: player.id,
-        nickname: player.nickname,
-        position: 0,
-        balance: GAME_START_BALANCE,
-        owned_tiles: [],
-        is_in_jail: false,
-        jail_turn_count: 0,
-        is_bankrupt: false,
-        color: GAME_PLAYER_COLORS[index % GAME_PLAYER_COLORS.length],
-      })),
-      tiles: [],
-      current_turn: room.players[0]?.id ?? null,
-      round: 1,
-    },
+    room_id: room.id,
   }
 }
 

--- a/src/pages/waiting-room/types.ts
+++ b/src/pages/waiting-room/types.ts
@@ -1,4 +1,3 @@
-import type { Player, Tile } from '../../types/domain'
 import type { LobbyRoomStatus } from '../lobby/types'
 
 // 대기방 플레이어 화면 모델
@@ -154,9 +153,10 @@ export interface LobbyUpdatedEventPayload {
 // 게임 시작 이벤트 payload 타입
 export interface GameStartEventPayload {
   game_id: string
-  game_state: {
-    players: Player[]
-    tiles: Tile[]
+  room_id: string
+  game_state?: {
+    players: unknown[]
+    tiles: unknown[]
     current_turn: string | null
     round: number
   }


### PR DESCRIPTION
## 📌 관련 이슈

> closes #256 

---

## 📝 작업 내용

> 백엔드 확정안(`game_start` 유지, `game_id`/`room_id` 필수, 게임 URL은 `/game/:gameId`)에 맞춰 대기방→게임 진입 계약을 정합화하고, CI E2E 게이트를 안정 구간 중심으로 분리했습니다.

### 1) 대기방 시작 이벤트 계약 정합화
- `GameStartEventPayload`를 `game_id` + `room_id` 필수 구조로 변경
- `game_state`는 선택 필드로 변경
- 대기방에서 게임 이동 시 `roomId`를 `payload.room_id`로 전달
- 소켓 수신 시 다른 방의 `game_start` 이벤트는 무시하도록 필터링 추가
- mock gateway의 `game_start` payload도 명세와 동일하게 정리

### 2) E2E 게이트 분리(@game)
- 게임 E2E에 `@game` 태그 부여
- 스크립트 추가
  - `e2e:ci`: `playwright test --grep-invert @game`
  - `e2e:game`: `playwright test --grep @game`
- CI 워크플로우 E2E step을 `npm run e2e:ci`로 변경

### 3) Playwright mock 모드 오버라이드 가능화
- `playwright.config.ts`에서
  - `VITE_USE_SOCKET_MOCK: process.env.VITE_USE_SOCKET_MOCK ?? 'true'`
- 기본은 mock 유지, 필요 시 env로 실소켓 E2E 실행 가능

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

> UI 변경 없음 (이벤트 계약/테스트/CI 설정 변경)

---

## 🧪 검증 내역

- `npm run lint` ✅
- `npm run test` ✅ (86 passed)
- `npm run test:coverage` ✅ (threshold 통과)
- `npm run e2e:ci` ✅ (3 passed, 게임 E2E 제외)
- `npm run e2e:game` ✅ (1 passed, 게임 E2E만 실행)
- `npm run build` ✅