### PR TITLE
chore: 테스트 게이트 정책 분리 및 owner 커버리지 운영 정리

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
       - develop
 
 jobs:
-  build:
+  quality-gate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -52,3 +52,26 @@ jobs:
           path: |
             playwright-report
             test-results
+
+  owner-coverage:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - name: Owner Coverage
+        run: npm run test:coverage:owner
+
+      - name: Upload Owner Coverage Report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-owner-report
+          path: coverage-owner

--- a/.github/workflows/e2e-game.yml
+++ b/.github/workflows/e2e-game.yml
@@ -1,0 +1,34 @@
+name: E2E Game
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 18 * * *'
+
+jobs:
+  e2e-game:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - name: Install Playwright Browser
+        run: npx playwright install --with-deps chromium
+
+      - name: E2E Game
+        run: npm run e2e:game
+
+      - name: Upload Playwright Report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-game-report
+          path: |
+            playwright-report
+            test-results

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules
 dist
 .vite
 coverage
+coverage-owner
 tsconfig.tsbuildinfo
 playwright-report
 test-results

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -21,7 +21,7 @@ if [ $? -ne 0 ]; then
 fi
 
 echo "push 전 E2E 검증을 시작합니다..."
-npm run e2e
+npm run e2e:ci
 if [ $? -ne 0 ]; then
   echo "e2e 실패. 오류를 수정한 후 다시 push 해주세요."
   exit 1

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -28,12 +28,32 @@
 npm run lint
 npm run test
 npm run test:coverage
-npm run e2e
+npm run test:coverage:owner
+npm run e2e:ci
 npm run build
 ```
 
 - 로컬 pre-push 훅에서도 같은 순서로 검증한다
-- CI에서도 동일 게이트(`lint + test + coverage + e2e + build`)를 실행한다
+- CI 게이트는 `lint + test + coverage + e2e:ci + build`를 실행한다
+- 게임 E2E는 `npm run e2e:game`으로 분리 실행한다
+- 내 파트 전용 커버리지는 `npm run test:coverage:owner`로 측정한다
+  - 범위: `lobby`, `waiting-room`, `presence`, `room-chat`
+  - 리포트 경로: `coverage-owner/index.html`
+
+## 2.1 게이트 정책
+
+- `quality-gate`는 머지 차단용 필수 게이트다
+- `owner-coverage`는 담당 모듈 품질 추적용 보조 게이트다
+- `owner-coverage`는 초기에는 non-blocking으로 운영하고, 팀 합의 시 blocking으로 전환한다
+- 게임 E2E는 `E2E Game` 워크플로우로 분리해 수동/야간 실행한다
+
+## 2.2 WIP 예외 운영 규칙
+
+- 커버리지 또는 테스트에서 WIP 예외를 두려면 반드시 이슈 번호를 남긴다
+- 예외는 임시이며 PR 본문에 복귀 조건과 만료 시점을 명시한다
+- 복귀 조건은 기능 완료 기준으로 작성한다
+- 예시 복귀 조건: `게임 액션/패치 계약 반영 + game E2E 2개 이상 green`
+- 예외가 해소되면 해당 제외 설정과 주석을 같은 PR에서 제거한다
 
 ## 3. flaky 대응 규칙
 
@@ -81,7 +101,7 @@ await waitFor(() => {
 - [ ] 변경된 기능에 대응하는 테스트가 최소 1개 이상 추가/수정되었는가
 - [ ] 성공 케이스와 실패(예외) 케이스를 최소 1개씩 검증했는가
 - [ ] 비동기 로직을 `waitFor`/`findBy*`로 안정적으로 검증했는가
-- [ ] 로컬에서 `lint`, `test`, `test:coverage`, `e2e`, `build`를 통과했는가
+- [ ] 로컬에서 `lint`, `test`, `test:coverage`, `e2e:ci`, `build`를 통과했는가
 - [ ] 테스트 코드가 구현 상세가 아니라 사용자 행위/도메인 규칙을 검증하는가
 
 ## 5. 작성 원칙

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,7 +7,14 @@ import eslintConfigPrettier from 'eslint-config-prettier'
 
 export default tseslint.config(
   {
-    ignores: ['dist', '.vite', 'coverage', 'playwright-report', 'test-results'],
+    ignores: [
+      'dist',
+      '.vite',
+      'coverage',
+      'coverage-owner',
+      'playwright-report',
+      'test-results',
+    ],
   },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "test:coverage:owner": "vitest run --config vitest.owner.config.ts --coverage",
     "e2e": "playwright test",
     "e2e:ci": "playwright test --grep-invert @game",
     "e2e:game": "playwright test --grep @game",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'html', 'lcov'],
       reportsDirectory: './coverage',
+      // WIP 예외는 임시 운영만 허용하며, 이슈 번호/복귀 조건/만료 시점을 주석으로 남긴다.
       // 테스트 안정화 이후 상향된 최소 커버리지 기준선
       thresholds: {
         statements: 60,

--- a/vitest.owner.config.ts
+++ b/vitest.owner.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    css: true,
+    setupFiles: ['./src/test/setup.ts'],
+    include: [
+      'src/pages/lobby/**/*.test.ts',
+      'src/pages/lobby/**/*.test.tsx',
+      'src/pages/waiting-room/**/*.test.ts',
+      'src/pages/waiting-room/**/*.test.tsx',
+      'src/features/presence/**/*.test.ts',
+      'src/features/presence/**/*.test.tsx',
+      'src/features/room-chat/**/*.test.ts',
+      'src/features/room-chat/**/*.test.tsx',
+    ],
+    exclude: [
+      'e2e/**',
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/.{idea,git,cache,output,temp}/**',
+    ],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html', 'lcov'],
+      reportsDirectory: './coverage-owner',
+      include: [
+        'src/pages/lobby/**/*.{ts,tsx}',
+        'src/pages/waiting-room/**/*.{ts,tsx}',
+        'src/features/presence/**/*.{ts,tsx}',
+        'src/features/room-chat/**/*.{ts,tsx}',
+      ],
+      exclude: ['**/*.test.ts', '**/*.test.tsx', '**/*.d.ts'],
+    },
+  },
+})


### PR DESCRIPTION
## 📌 관련 이슈

> closes #262 

---

## 📝 작업 내용

- CI 필수 게이트를 `quality-gate`로 정리하고 기존 파이프라인(`lint`, `test`, `test:coverage`, `e2e:ci`, `build`) 유지
- 게임 전용 E2E를 별도 워크플로우(`E2E Game`)로 분리해 메인 머지 게이트 안정화
- owner 파트 전용 커버리지 스크립트/설정(`test:coverage:owner`, `vitest.owner.config.ts`) 추가
- `coverage-owner` 산출물에 대한 ignore 설정(`.gitignore`, `eslint.config.js`) 반영
- 로컬 pre-push 훅을 CI 정책과 맞춰 `e2e` → `e2e:ci`로 변경
- `docs/testing.md`에 게이트 정책, owner 커버리지 운영, WIP 예외 규칙 문서화

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

- 해당 없음 (CI/테스트 정책 변경)
