### PR TITLE
Chore : 중앙 docs 기준으로 게임 이행 문서 정리

### DIFF
--- a/docs/game-delivery-roadmap.md
+++ b/docs/game-delivery-roadmap.md
@@ -1,32 +1,39 @@
-# 게임 완료 로드맵 (새 이벤트 명세 기준 / 기존 명세 호환 포함, 2026-03-04)
+# 게임 완료 로드맵 (중앙 docs 기준 / 기존 명세 호환 포함, 2026-03-04)
 
-이 문서는 현재 프론트엔드 코드와 `이벤트 명세서.md`, `모두의마블_API명세서_v4.xlsx`,
+이 문서는 현재 프론트엔드 코드와 중앙 문서 저장소 `https://github.com/modoo-marble-team/docs`의
+`gamesocket.md`, `api.md`, `erd.md`, 그리고 기존 `모두의마블_API명세서_v4.xlsx`,
 `모두의마블_요구사항정의서_v8.xlsx`, `모두의마블_테이블명세서_v4.xlsx`를 함께 대조해서
 다시 작성한 실행 로드맵이다.
 
 중요한 전제는 아래와 같다.
 
-- `이벤트 명세서.md`는 앞으로 이행해야 할 **목표 런타임 계약**이다.
+- 중앙 docs의 `gamesocket.md`는 앞으로 이행해야 할 **게임 런타임 단일 계약**이다.
+- 중앙 docs의 `api.md`는 게임 영역에서 `gamesocket.md`를 우선 기준으로 삼고, REST를 로비/대기방 중심으로 제한한다.
 - API/요구사항/테이블 명세 v4는 현재 코드와 더 가까운 **레거시/현행 계약**이다.
 - 따라서 이 문서는 "새 명세로 바로 단절"이 아니라 "기존 계약을 유지하면서 새 명세로 이행"하는 기준 문서다.
 
 ## 1. 기준 문서
 
-- 요구사항 기준: `모두의마블_요구사항정의서_v8.xlsx`
-- API/데이터 기준: `모두의마블_API명세서_v4.xlsx`, `모두의마블_테이블명세서_v4.xlsx`
-- 실시간 게임 계약 기준: `이벤트 명세서.md`
+- 실시간 게임 계약 기준: 중앙 docs `gamesocket.md`
+- API/WebSocket 기준: 중앙 docs `api.md`
+- 데이터 기준: 중앙 docs `erd.md`
+- 요구사항/레거시 API 기준: `모두의마블_요구사항정의서_v8.xlsx`, `모두의마블_API명세서_v4.xlsx`, `모두의마블_테이블명세서_v4.xlsx`
 - 프론트 내부 기준: `docs/game-ownership.md`, `docs/game-ownership-corrected-table.md`
 
 ### 기준 우선순위
 
-1. **새 이벤트 명세서**
+1. **중앙 docs `gamesocket.md`**
    - 목표 구조(`game:action`, `game:ack`, `game:patch`, `game:prompt`) 정의
-2. **API/요구사항/테이블 명세**
-   - 현재 운영/저장 구조, 화폐 단위, room 식별자, 타일/건물 규칙 확인
-3. **현재 코드**
+   - 게임 영역의 단일 런타임 계약
+2. **중앙 docs `api.md` / `erd.md`**
+   - 게임은 `game:*` 소켓, 로비/대기방은 REST 중심이라는 경계 확인
+   - 게임 식별자, 공통 에러 포맷, 데이터 저장 구조 확인
+3. **기존 API/요구사항/테이블 명세**
+   - 현재 운영 제약, 레거시 payload, 호환 범위 확인
+4. **현재 코드**
    - 실제 구현 상태와 이행 비용 확인
 
-즉, 새 명세서가 목표 방향을 정하고, 기존 명세가 현재 제약을 설명한다.
+즉, 중앙 docs가 목표 방향을 정하고, 기존 명세가 현재 제약을 설명한다.
 
 ## 2. 명세 변경 핵심
 
@@ -43,37 +50,38 @@
 
 ### 2-1. roomId vs gameId
 
+- 중앙 docs `gamesocket.md`는 게임 이벤트를 `gameId` 기준 room(`game:{gameId}`)으로 정의한다.
 - 기존 API/테이블 명세는 `room_id` 기준이다.
-- 새 이벤트 명세는 `gameId` 기준 room(`game:{gameId}`)을 전제로 한다.
 
 현재 프론트 기준 정책:
 
-- 라우팅과 레거시 REST fallback은 **`roomId` 유지**
-- 새 이벤트 계층에서는 **`gameId`를 별도 보관**
-- FE-B는 이 둘의 매핑을 담당한다
+- 게임 소켓 이벤트의 canonical identifier는 **`gameId`**
+- 로비/대기방/레거시 fallback 경계에서는 **`roomId`** 가 남을 수 있다
+- FE-B는 `roomId -> gameId` 매핑과 점진 제거 전략을 담당한다
 
-즉, 이행 완료 전까지는 `roomId`와 `gameId`가 동시에 존재할 수 있다.
+즉, 이행 완료 전까지는 둘이 공존할 수 있지만, 신규 게임 흐름의 기준점은 `gameId`다.
 
 ### 2-2. 화폐 단위
 
 - 요구사항/API 명세 v4: **원(₩) 정수**
-- 새 이벤트 명세: 설명상 **만 단위 정수**를 가정
+- 중앙 docs `gamesocket.md`: 예시는 만 단위 정수를 쓰지만, 실제 단위는 **프로젝트 합의 단일 기준으로 고정**한다고 명시
+- 중앙 docs `api.md`: 프론트/백엔드가 동일 단위를 써야 한다고 명시
 
 현재 프론트 기준 정책:
 
-- 프론트 내부 canonical money unit은 **원 정수**를 유지한다.
-- 표시만 `억/만`으로 변환한다.
-- 새 이벤트 payload가 만 단위로 바뀌면 FE-B ingress/egress 변환기로 흡수한다.
+- 현재 프론트는 원 정수 중심 표현을 쓰고 있다.
+- 단, 앞으로는 프론트/백엔드 공통 canonical money unit을 명시적으로 확정해야 한다.
+- transport와 내부 표현이 다를 경우 FE-B mapper/adapter가 이를 흡수한다.
 
-즉, store/domain 내부에서 단위를 섞지 않는다.
+즉, store/domain 내부에서 단위를 섞지 않고, 중앙 docs 기준으로 하나의 canonical unit을 유지해야 한다.
 
 ### 2-3. TileType / BuildingLevel
 
 - 요구사항/현재 보드 기준 타일: `start`, `city`, `chance`, `event`, `ai`, `travel`, `island`, `go_to_island`
-- 새 이벤트 명세 기준 타일: `START`, `PROPERTY`, `CHANCE`, `MOVE_TO_ISLAND`, `ISLAND`
+- 중앙 docs `gamesocket.md` 기준 타일: `START`, `PROPERTY`, `EVENT`, `CHANCE`, `MOVE_TO_ISLAND`, `ISLAND`
 
 - API v4 build 레벨: 사실상 `0..5`
-- 새 이벤트 명세 build 레벨: `0..7`
+- 중앙 docs `gamesocket.md` build 레벨: `0..7`
 
 현재 프론트 기준 정책:
 
@@ -91,7 +99,7 @@
 
 - `src/services/game/game.api.ts`
   현재는 `buy`, `build`, `sell`, `state` REST 액션이 중심이다.
-  새 명세 기준으로는 게임 액션 전송을 socket 중심으로 재구성하고, REST는 제거하거나 **이행 중 레거시 fallback으로 격리**해야 한다.
+  중앙 docs `api.md` 기준으로 게임 로직은 `game:*` 소켓이 중심이므로, REST는 제거하거나 **이행 중 레거시 fallback으로 격리**해야 한다.
 
 - `src/hooks/game/useGameState.ts`
   현재는 진입 시 REST `getState`를 호출하고 기존 소켓 핸들러를 붙인다.
@@ -126,7 +134,7 @@
 
 기존 80/50 평가는 더 이상 유효하지 않다. 새 이벤트 명세 **이행 진행도** 기준으로 다시 보면 다음이 더 현실적이다.
 
-### FE-B: 55%
+### FE-B: 상태 구조 전환 완료, UI 연결 단계 진입
 
 완료된 축:
 
@@ -135,16 +143,15 @@
 - socket 연결 수명주기와 mock 흐름의 기본 토대 존재
 - 게임 API/에러 처리 래퍼와 연동 진입점 존재
 
-아직 비어 있는 축:
+현재 남은 핵심 축:
 
-- 새 이벤트 계약용 타입 재정의
-- `game:action`/`game:ack`/`game:patch`/`game:prompt` 중심 소켓 계층
-- revision 기반 patch 적용기
-- prompt 응답 흐름
-- REST 액션 의존 제거 또는 fallback 격리
-- roomId/gameId, money unit, tile/building enum 매핑기
+- `prompt`, `ack`, `error`, `pendingAction`의 실제 UI 연결
+- `game:prompt_response` 기반 입력 흐름 정리
+- REST 액션 의존 추가 축소 또는 fallback 격리
+- `gameId` 중심 식별자 정리
+- money unit, tile/building enum의 중앙 docs 기준 명시화
 
-### FE-C: 45%
+### FE-C: 보드 표현/연출 정리 단계
 
 완료된 축:
 
@@ -181,9 +188,13 @@
 
 ### 5-4. prompt/ack 기반 입력 UX 정리
 
+중앙 docs `gamesocket.md` 기준으로 **현재 FE-B의 다음 최우선 작업**이다.
+
 - 구매/건설/매각/무인도 이동/턴 종료를 prompt 또는 ack 기준으로 처리
 - 즉시 실패는 `game:ack.ok=false` 기준으로 에러 표시
 - `DiceTimerModal`을 실제 turn timeout 또는 prompt timeout과 연결
+- `pendingAction`을 버튼 비활성화/로딩과 연결
+- 기존 로컬 modal 분기를 `game:prompt` 소비 구조로 전환
 
 ### 5-5. mock 전환
 
@@ -239,6 +250,6 @@
 
 ## 9. 결론
 
-지금 가장 먼저 해야 할 일은 모달 추가가 아니라 게임 계약 계층을 새 이벤트 명세에 맞춰 다시 세우는 일이다.
-즉시 우선순위는 FE-B의 타입/store/socket/mock 전환이고, 그 다음 FE-C가 `GameBoard.tsx`를 시각 레이어로 축소하는 흐름이 맞다.
-단, 이 과정에서도 `roomId`, 원 단위 금액, 현재 보드 view model은 갑자기 제거하지 않고 compatibility layer로 안전하게 이행해야 한다.
+지금 가장 먼저 해야 할 일은 `game:*` 계약을 실제 UI 입력 흐름에 연결하는 일이다.
+즉시 우선순위는 FE-B의 `prompt/ack/error/pendingAction` UI 연결이고, 그 다음 FE-C가 `GameBoard.tsx`를 더 명확한 시각 레이어로 축소하는 흐름이 맞다.
+단, 이 과정에서도 `roomId`, money unit, 현재 보드 view model은 갑자기 제거하지 않고 compatibility layer로 안전하게 이행해야 한다.

--- a/docs/game-event-spec-migration-plan.md
+++ b/docs/game-event-spec-migration-plan.md
@@ -1,8 +1,9 @@
 # 게임 이벤트 명세 전환 갭 분석
 
-이 문서는 `이벤트 명세서.md` 기준으로 현재 프론트엔드 코드에서 어디를 어떻게 고쳐야 하는지 파일 단위로 정리한 문서다.
+이 문서는 중앙 문서 저장소 `https://github.com/modoo-marble-team/docs`의 `gamesocket.md`,
+`api.md`, `erd.md` 기준으로 현재 프론트엔드 코드에서 어디를 어떻게 고쳐야 하는지 파일 단위로 정리한 문서다.
 단, 실제 이행 작업은 `모두의마블_API명세서_v4.xlsx`, `모두의마블_요구사항정의서_v8.xlsx`,
-`모두의마블_테이블명세서_v4.xlsx`의 제약을 동시에 고려해야 한다.
+`모두의마블_테이블명세서_v4.xlsx`의 레거시 제약도 동시에 고려해야 한다.
 
 ## 1. 핵심 결론
 
@@ -12,13 +13,14 @@
 - 실시간 반영: `game_start`, `turn_start`, `dice_rolled`, `player_moved` 등 개별 소켓 이벤트
 - 보드 계산: `GameBoard.tsx` 내부 로컬 계산과 상태 갱신
 
-새 명세는 아래 구조를 요구한다.
+중앙 docs는 아래 구조를 요구한다.
 
 - 액션: `game:action`
 - 동기화: `game:sync`
 - 상태 반영: `game:patch`
 - 개인 선택: `game:prompt` / `game:prompt_response`
 - 빠른 입력 결과: `game:ack`
+- 오류 보고: `game:error`
 
 즉, 현재 구조는 "이벤트 이름만 몇 개 바꾸는 수준"이 아니라 상태 흐름 자체를 재정렬해야 한다.
 
@@ -27,23 +29,23 @@
 ### 식별자
 
 - 구 명세: `room_id`
-- 새 이벤트 명세: `gameId`
+- 중앙 docs: `gameId`
 
 이행 기준:
 
-- URL/레거시 REST는 `roomId`
-- 새 이벤트 계층은 `gameId`
-- FE-B가 `roomId <-> gameId` 매핑을 관리
+- 게임 소켓 이벤트는 `gameId`를 canonical로 삼는다
+- URL/로비/대기방/레거시 REST는 `roomId`가 남을 수 있다
+- FE-B가 `roomId -> gameId` 매핑과 제거 전략을 관리한다
 
 ### 화폐 단위
 
 - 구 명세: 원 정수
-- 새 이벤트 명세: 설명상 만 단위 정수
+- 중앙 docs: 예시는 만 단위를 쓰지만, 실제 프로젝트 canonical unit을 하나로 고정해야 함
 
 이행 기준:
 
-- FE 내부 store/domain canonical money unit은 **원 정수**
-- transport 차이는 FE-B mapper로 흡수
+- 프론트/백엔드가 동일한 canonical unit을 공유해야 한다
+- 현재 프론트 구현과 transport 차이는 FE-B mapper/adapter가 흡수한다
 
 ### 타일 타입
 
@@ -76,7 +78,7 @@
 | `src/stores/game.store.ts`                       | 단순 set/update store라 revision, prompt, patch 적용 불가               | `applySnapshot`, `applyPatch`, `setAck`, `setPrompt`, `consumeEvents` 추가                                                  | FE-B                       |
 | `src/services/socket/game.handler.ts`            | 구 소켓 이벤트 구독과 `roll_dice`, `confirm_penalty` emit 사용          | `game:ack`, `game:patch`, `game:prompt`, `game:error` 구독과 `game:action`, `game:sync`, `game:prompt_response` emit로 교체 | FE-B                       |
 | `src/hooks/game/useGameState.ts`                 | mount 시 REST state 조회 중심                                           | mount/reconnect 시 `game:sync` 전송, snapshot 또는 patch 적용으로 전환                                                      | FE-B                       |
-| `src/services/game/game.api.ts`                  | `buyTile`, `buildTile`, `sellTile`, `syncState`가 핵심 액션 경로        | 게임 액션성 REST를 제거하거나 레거시 fallback으로 격리, roomId 기준 호환 계층 유지                                          | FE-B                       |
+| `src/services/game/game.api.ts`                  | `buyTile`, `buildTile`, `sellTile`, `syncState`가 핵심 액션 경로        | 중앙 docs 기준 게임 액션성 REST를 제거하거나 레거시 fallback으로 격리, roomId 기준 호환 계층 유지                           | FE-B                       |
 | `src/hooks/game/useDiceRoll.ts`                  | `emitRollDice` 또는 로컬 보드 fallback 사용                             | `ROLL_DICE`용 `game:action` 전송으로 단순화                                                                                 | FE-B                       |
 | `src/pages/GamePage.tsx`                         | `boardPlayers`, `boardCurPlayer` 로컬 상태와 store 이중화               | store selector 기반 조립으로 단순화, 보드에 상태 역주입 금지                                                                | FE-B 주도 / FE-C 협업      |
 | `src/components/board/GameBoard.tsx`             | 타일 소유권, 통행료, 파산, 턴 전환, API 호출을 직접 수행                | 렌더링과 연출만 담당하도록 축소, prompt 표시용 표면만 유지                                                                  | FE-C 주도 / FE-B 선행 필요 |
@@ -223,6 +225,7 @@
 - socket 계층 전환
 - mock 전환
 - prompt/ack/error 흐름 정의
+- 실제 UI에서 `prompt`, `ack`, `pendingAction`, `error`를 소비하는 연결
 
 ### FE-C가 그 다음 붙여야 하는 것
 
@@ -241,6 +244,42 @@
 6. `src/pages/GamePage.tsx`
 7. `src/components/board/GameBoard.tsx`
 8. `src/components/game/modals/*`
+
+## 5-1. 현재 상태(2026-03-04 기준)
+
+아래 항목은 이미 1차 반영이 끝난 상태다.
+
+- `src/types/domain.ts`
+  - `GameAck`, `GamePatchEnvelope`, `GamePrompt`, `ServerEvent`, `GamePhase` 등 도입
+- `src/stores/game.store.ts`
+  - snapshot/patch/ack/prompt/eventQueue 수용 구조 도입
+- `src/services/socket/game.handler.ts`
+  - `game:ack`, `game:patch`, `game:prompt`, `game:error` listener 추가
+  - `emitGameAction`, `emitGameSync`, `emitPromptResponse` 도입
+- `src/hooks/game/useGameState.ts`
+  - `game:sync` 우선, REST bootstrap fallback 병행
+- `src/mocks/handlers/game.handler.ts`
+  - event-socket mock flow 추가
+- `src/pages/GamePage.tsx`
+  - store 단일 상태 렌더 구조로 1차 정리
+- `src/components/board/GameBoard.tsx`
+  - 액션/동기화/거래 로직 helper/handler 분리 진행
+
+즉, 현재의 다음 실제 우선순위는 타입/store/socket 골격 재작성 자체가 아니라,
+`prompt/ack/error/pendingAction`을 실제 게임 UI와 연결하는 일이다.
+
+## 5-2. 현재 다음 우선순위
+
+중앙 docs 기준으로 현재 FE-B의 다음 우선순위는 아래다.
+
+1. `src/components/game/modals/*`, `src/pages/GamePage.tsx`, `src/components/board/GameBoard.tsx`
+   - `gameStore.prompt`를 실제 modal/overlay 열림 조건과 연결
+2. `src/services/socket/game.handler.ts`, `src/components/board/GameBoard.tsx`
+   - `emitPromptResponse`를 실제 사용자 응답 흐름과 연결
+3. `src/stores/game.store.ts`, `src/pages/GamePage.tsx`
+   - `pendingAction`, `lastAck`, `lastError`를 버튼 상태/에러 UI와 연결
+4. `src/services/game/game.api.ts`, `src/components/board/gameBoardActionHandlers.ts`
+   - 남아 있는 게임 REST fallback을 추가 축소하고 compatibility layer로 더 명확히 격리
 
 ## 6. 문서 사용법
 

--- a/docs/game-ownership-corrected-table.md
+++ b/docs/game-ownership-corrected-table.md
@@ -1,4 +1,4 @@
-# FE-B / FE-C 분업표 (이벤트 명세서 기준)
+# FE-B / FE-C 분업표 (중앙 docs 기준)
 
 ## 요약 표
 
@@ -18,35 +18,32 @@
 
 ## 진행도 요약
 
-| 파트 | 진행도 | 상태                                                      |
-| ---- | ------ | --------------------------------------------------------- |
-| FE-B | 55%    | 새 이벤트 계약 + 레거시 호환 계층을 함께 세워야 하는 단계 |
-| FE-C | 45%    | 보드를 store 단일 렌더와 연출 레이어로 정리해야 하는 단계 |
+| 파트 | 진행도  | 상태                                                        |
+| ---- | ------- | ----------------------------------------------------------- |
+| FE-B | 진행 중 | 타입/store/socket/mock 골격 정리 후 prompt/ack UI 연결 단계 |
+| FE-C | 진행 중 | 보드를 표현/연출 중심 레이어로 더 줄여야 하는 단계          |
 
-## FE-B 최우선 작업
+## FE-B 현재 최우선 작업
 
-- `src/types/domain.ts`를 새 이벤트 명세 기준으로 재정의
-- `src/stores/game.store.ts`에 snapshot/patch/revision/prompt/ack 구조 추가
-- `src/services/socket/game.handler.ts`를 새 이벤트 계약으로 교체
-- `src/hooks/game/useGameState.ts`에서 `game:sync` 기반 복구로 전환
-- `src/mocks/handlers/game.handler.ts`를 새 명세 mock으로 재작성
-- `src/pages/GamePage.tsx`의 보드 상태 write-back 제거
-- `roomId/gameId`, money unit, tile/building enum mapper 명시화
+- `src/components/game/modals/*`를 `gameStore.prompt`와 연결
+- `src/pages/GamePage.tsx`에서 `pendingAction`, `lastAck`, `lastError`를 실제 UI 상태와 연결
+- `src/components/board/GameBoard.tsx`의 로컬 modal 분기를 `game:prompt` 소비 구조로 전환
+- `src/services/socket/game.handler.ts`의 `emitPromptResponse`를 실사용 UI 흐름과 연결
+- 남아 있는 게임 REST fallback을 compatibility layer로 더 명확히 격리
 
-## FE-C 최우선 작업
+## FE-C 현재 최우선 작업
 
-- `GameBoard.tsx`에서 API 호출, 통행료 계산, 파산 처리 제거
-- store selector 기반 보드 렌더 구조 정리
-- `game:patch.events` 기반 이동/효과 애니메이션 계층 추가
+- `GameBoard.tsx`에서 남아 있는 로컬 게임 로직 추가 축소
+- `eventQueue` 기반 이동/효과 애니메이션 계층 추가
+- store selector 기반 보드 렌더 구조 추가 정리
 - 새 `buildingLevel`, `tileType`, `playerState` 표시 반영
 
 ## 현재 가장 큰 리스크
 
-- `GameBoard.tsx`가 아직 게임 엔진처럼 동작한다.
-- `GamePage.tsx`가 store와 board 로컬 상태를 이중 관리한다.
-- mock이 새 이벤트 명세와 다른 프로토콜을 사용한다.
-- 타입 계층이 새 숫자 ID / revision / snapshot 구조를 표현하지 못한다.
-- 새 이벤트 명세와 기존 API v4 사이의 식별자/화폐 단위/enum 차이가 아직 문서와 코드 모두에 남아 있다.
+- `prompt`, `ack`, `pendingAction`이 store에는 있지만 실제 UI 소비가 아직 불완전하다.
+- `GameBoard.tsx`가 여전히 일부 게임 엔진 성격 로직을 들고 있다.
+- 게임 REST fallback이 장기화되면 중앙 docs 기준과 실제 런타임이 다시 벌어질 수 있다.
+- `gameId`, money unit, tile/building enum 기준이 문서와 코드에서 완전히 수렴하지 않았다.
 
 ## 완료 판단 기준
 

--- a/docs/game-ownership.md
+++ b/docs/game-ownership.md
@@ -1,6 +1,7 @@
-# 게임 영역 파일 소유권 및 분업 기준 (이벤트 명세서 반영)
+# 게임 영역 파일 소유권 및 분업 기준 (중앙 docs 반영)
 
-이 문서는 새 `이벤트 명세서.md`를 목표 기준으로 삼되,
+이 문서는 중앙 문서 저장소 `https://github.com/modoo-marble-team/docs`의
+`gamesocket.md`, `api.md`, `erd.md`를 목표 기준으로 삼되,
 `모두의마블_API명세서_v4.xlsx`, `모두의마블_요구사항정의서_v8.xlsx`,
 `모두의마블_테이블명세서_v4.xlsx`와 충돌하는 영역은 호환 계층까지 포함해 FE-B/FE-C 책임을 다시 정리한 문서다.
 
@@ -9,7 +10,7 @@
 - FE-B는 게임 계약, 상태, socket, prompt, mock을 책임진다.
 - FE-B는 기존 계약과 새 계약 사이의 compatibility layer도 책임진다.
 - FE-C는 보드 렌더링, 애니메이션, 시각 상태 표현을 책임진다.
-- 새 명세에서 결과 계산은 서버 권위이므로, FE-C가 게임 결과를 계산하는 구조는 금지한다.
+- 중앙 docs 기준으로 결과 계산은 서버 권위이므로, FE-C가 게임 결과를 계산하는 구조는 금지한다.
 
 ## 2. FE-B 주 담당
 
@@ -30,9 +31,10 @@
 - `game:action`, `game:ack`, `game:patch`, `game:prompt`, `game:error`
 - snapshot/patch/revision 처리
 - prompt 응답과 timeout 처리
+- 실제 UI에서 `prompt`, `ack`, `pendingAction`, `error`를 소비하는 연결
 - mock과 실서버 계약 정렬
 - `roomId <-> gameId` 매핑
-- 원 단위 money와 새 transport 단위 간 변환
+- money canonical unit 정리와 transport 간 변환
 - 레거시 REST/socket fallback 유지와 제거 시점 관리
 
 ## 3. FE-C 주 담당
@@ -80,40 +82,45 @@
 
 ## 6. 진행도 재평가
 
-### FE-B 진행도: 55%
-
-이 수치는 "게임 UI가 어느 정도 있다"가 아니라 "새 이벤트 명세와 기존 계약의 차이를 흡수할 수 있는가" 기준이다.
+### FE-B 현재 단계
 
 완료된 것:
 
-- 게임 store 골격
-- 페이지/모달/턴 UI 기본 자산
-- socket 연결과 mock 기본 토대
+- 새 이벤트 계약용 타입/store/socket/mock 골격 반영
+- `GamePage.tsx`의 store 단일 상태 렌더 구조 1차 정리
+- `GameBoard.tsx` 내부 액션/동기화/거래 로직 분리 착수
 
 남은 것:
 
-- 새 타입 계약
-- patch/snapshot/revision store
-- prompt/ack 기반 입력 UX
-- 구 REST/구 이벤트 제거
-- mock 전환
-- roomId/gameId, money unit, tile/building enum mapper
+- `prompt/ack/error/pendingAction`의 실제 UI 연결
+- `game:prompt_response` 기반 사용자 응답 흐름 정리
+- 남아 있는 게임 REST fallback 추가 축소
+- `gameId` 중심 식별자 정리
+- money unit, tile/building enum 기준 문서와 코드의 최종 정렬
 
-### FE-C 진행도: 45%
+### FE-C 현재 단계
 
-완료된 것:
+핵심 남은 것:
 
-- 보드 배치와 기본 시각화
-- 말/타일/건물 렌더 뼈대
-
-남은 것:
-
-- store 단일 상태 렌더
-- event queue 기반 연출
-- `GameBoard.tsx` 로직 제거
+- 보드 표현/연출 레이어 정리
+- `eventQueue` 기반 이동/효과 재생
+- `GameBoard.tsx`의 로컬 게임 로직 추가 축소
 - 새 building/player state 시각 규칙 반영
 
-## 7. 작업 충돌 방지 규칙
+## 7. 현재 다음 우선순위
+
+중앙 docs와 현재 코드 상태 기준으로, FE-B의 다음 작업은 `prompt/ack` UI 연결이다.
+
+- `src/components/game/modals/*`
+  - `gameStore.prompt`를 실제 modal 열림 조건과 연결
+- `src/pages/GamePage.tsx`
+  - `pendingAction`, `lastAck`, `lastError`를 버튼/상태 문구/실패 메시지와 연결
+- `src/components/board/GameBoard.tsx`
+  - 기존 로컬 modal 분기를 `game:prompt` 소비 구조로 전환
+- `src/services/socket/game.handler.ts`
+  - `emitPromptResponse`가 실사용 UI 흐름에서 호출되도록 정리
+
+## 8. 작업 충돌 방지 규칙
 
 ### FE-B 작업 시
 
@@ -125,7 +132,7 @@
 - 새 socket 이벤트나 store 계약을 독자적으로 만들지 않는다.
 - 서버 권위 계산을 보드 내부에 다시 넣지 않는다.
 
-## 8. 최종 목표
+## 9. 최종 목표
 
 - FE-B: 새 이벤트 명세를 store와 socket 계층에서 안정적으로 흡수
 - FE-C: 그 상태를 보드에서 정확하고 자연스럽게 연출


### PR DESCRIPTION
## 📌 관련 이슈

> closes #이슈번호

---

## 📝 작업 내용

> 중앙 문서 저장소(`modoo-marble-team/docs`)의 `gamesocket.md`, `api.md`, `erd.md` 기준으로 로컬 게임 이행 문서를 최신화했습니다.

- `docs/game-delivery-roadmap.md`
  - 기준 문서를 중앙 docs 기준으로 재정의
  - 게임 영역의 canonical 계약이 `game:*` 소켓이라는 점 반영
  - `roomId` 보조 / `gameId` 중심 구조, money canonical unit 정리 필요성 반영
  - FE-B 다음 우선순위를 `prompt/ack/error/pendingAction` UI 연결로 갱신

- `docs/game-event-spec-migration-plan.md`
  - 중앙 docs 기준으로 이벤트 명세 전환 갭 분석 기준 수정
  - `game:error` 포함, `gameId` canonical, money unit 정리 기준 반영
  - 이미 반영된 1차 작업 상태와 현재 다음 실제 우선순위(`prompt/ack` UI 연결) 명시

- `docs/game-ownership.md`
  - FE-B / FE-C 분업 기준을 중앙 docs 기준으로 재정리
  - FE-B 현재 단계와 남은 작업을 `prompt/ack` UI 연결 중심으로 갱신
  - `GameBoard`와 `GamePage` 주변 현재 경계와 다음 작업 방향 명시

- `docs/game-ownership-corrected-table.md`
  - 요약표 기준을 중앙 docs에 맞게 수정
  - FE-B / FE-C 진행 상태를 퍼센트 대신 현재 단계 설명으로 변경
  - 현재 가장 큰 리스크와 최우선 작업을 최신 기준으로 갱신

---

## ✅ 체크리스트

- [x] 문서 기준 최신화 확인
- [x] 로컬 검증 통과
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

> 문서 변경만 있습니다.

---

## 🧪 검증

- `npm run lint`
- `npm run test`
- `npm run test:coverage`
- `npm run e2e`
- `npm run build`
