### PR TITLE
feat: Socket Mock Presence 및 방 입퇴장 실시간 동기화 구현

### DIFF
--- a/src/features/presence/mockData.ts
+++ b/src/features/presence/mockData.ts
@@ -26,6 +26,15 @@ const INITIAL_MOCK_ONLINE_USERS: OnlineUserPayload[] = [
 
 // 목 접속자 목록 저장소
 let mockOnlineUsersStore = [...INITIAL_MOCK_ONLINE_USERS]
+const mockOnlineUsersListeners = new Set<(users: OnlineUserPayload[]) => void>()
+
+// 저장소 최신 스냅샷을 구독자에게 전파
+function notifyMockOnlineUsersChanged() {
+  const snapshot = getMockOnlineUsersSnapshot()
+  mockOnlineUsersListeners.forEach((listener) => {
+    listener(snapshot)
+  })
+}
 
 // 현재 목 접속자 목록 스냅샷 조회
 export function getMockOnlineUsersSnapshot() {
@@ -35,23 +44,55 @@ export function getMockOnlineUsersSnapshot() {
 // 목 접속자 목록을 초기 상태로 복구
 export function resetMockOnlineUsers() {
   mockOnlineUsersStore = [...INITIAL_MOCK_ONLINE_USERS]
+  notifyMockOnlineUsersChanged()
 }
 
 // 특정 접속자 상태를 변경하고 최신 스냅샷을 반환
 export function setMockOnlineUserStatus(
   userId: string,
-  status: OnlineUserPayload['status']
+  status: OnlineUserPayload['status'],
+  nickname?: string
 ) {
+  let hasMatchedUser = false
+
   mockOnlineUsersStore = mockOnlineUsersStore.map((user) => {
     if (user.id !== userId) {
       return user
     }
 
+    hasMatchedUser = true
+
     return {
       ...user,
+      nickname: nickname ?? user.nickname,
       status,
     }
   })
 
+  // 기존 목록에 없는 사용자면 새로 추가
+  if (!hasMatchedUser) {
+    mockOnlineUsersStore = [
+      ...mockOnlineUsersStore,
+      {
+        id: userId,
+        nickname: nickname ?? `플레이어-${userId.slice(0, 4)}`,
+        status,
+      },
+    ]
+  }
+
+  notifyMockOnlineUsersChanged()
+
   return getMockOnlineUsersSnapshot()
+}
+
+// 접속자 저장소 변경을 구독하고 해제 함수를 반환
+export function subscribeMockOnlineUsersChange(
+  listener: (users: OnlineUserPayload[]) => void
+) {
+  mockOnlineUsersListeners.add(listener)
+
+  return () => {
+    mockOnlineUsersListeners.delete(listener)
+  }
 }

--- a/src/features/presence/onlineUsersSocket.test.ts
+++ b/src/features/presence/onlineUsersSocket.test.ts
@@ -10,6 +10,7 @@ interface LoadedOnlineUsersSocketModule {
   socket: MockSocket
   connectSocketWithAuthIfNeededMock: ReturnType<typeof vi.fn>
   getMockOnlineUsersSnapshotMock: ReturnType<typeof vi.fn>
+  subscribeMockOnlineUsersChangeMock: ReturnType<typeof vi.fn>
   listenerMock: ReturnType<typeof vi.fn>
   module: typeof import('./onlineUsersSocket')
 }
@@ -42,6 +43,12 @@ async function loadOnlineUsersSocketModule(
   const getMockOnlineUsersSnapshotMock = vi.fn(() =>
     mockUsers.map((user) => ({ ...user }))
   )
+  const subscribeMockOnlineUsersChangeMock = vi.fn(
+    (listener: (users: OnlineUserPayload[]) => void) => {
+      void listener
+      return vi.fn()
+    }
+  )
 
   vi.doMock('../../lib/socket', () => ({
     socket,
@@ -50,6 +57,7 @@ async function loadOnlineUsersSocketModule(
 
   vi.doMock('./mockData', () => ({
     getMockOnlineUsersSnapshot: getMockOnlineUsersSnapshotMock,
+    subscribeMockOnlineUsersChange: subscribeMockOnlineUsersChangeMock,
   }))
 
   const module = await import('./onlineUsersSocket')
@@ -58,6 +66,7 @@ async function loadOnlineUsersSocketModule(
     socket,
     connectSocketWithAuthIfNeededMock,
     getMockOnlineUsersSnapshotMock,
+    subscribeMockOnlineUsersChangeMock,
     listenerMock,
     module,
   }
@@ -111,16 +120,14 @@ describe('onlineUsersSocket', () => {
         status: 'lobby',
       },
     ]
-    const { module, listenerMock } = await loadOnlineUsersSocketModule(
-      true,
-      false,
-      users
-    )
+    const { module, listenerMock, subscribeMockOnlineUsersChangeMock } =
+      await loadOnlineUsersSocketModule(true, false, users)
 
     const stopBroadcast = module.startOnlineUsersMockBroadcast()
 
     // 시작 시 즉시 1회 브로드캐스트
     expect(listenerMock).toHaveBeenCalledTimes(1)
+    expect(subscribeMockOnlineUsersChangeMock).toHaveBeenCalledTimes(1)
 
     vi.advanceTimersByTime(5_000)
     expect(listenerMock).toHaveBeenCalledTimes(2)

--- a/src/features/presence/onlineUsersSocket.ts
+++ b/src/features/presence/onlineUsersSocket.ts
@@ -1,6 +1,9 @@
 import { connectSocketWithAuthIfNeeded, socket } from '../../lib/socket'
 import { IS_SOCKET_MOCK_ENABLED } from '../../config/env'
-import { getMockOnlineUsersSnapshot } from './mockData'
+import {
+  getMockOnlineUsersSnapshot,
+  subscribeMockOnlineUsersChange,
+} from './mockData'
 import type { OnlineUserPayload, OnlineUsersEventPayload } from './types'
 
 // 접속자 목록 소켓 이벤트 이름
@@ -39,11 +42,16 @@ export function emitMockOnlineUsersSnapshot() {
 export function startOnlineUsersMockBroadcast() {
   emitMockOnlineUsersSnapshot()
 
+  const unsubscribe = subscribeMockOnlineUsersChange((users) => {
+    emitOnlineUsersMock(users)
+  })
+
   const intervalId = setInterval(() => {
     emitMockOnlineUsersSnapshot()
   }, SOCKET_MOCK_INTERVAL_MS)
 
   return () => {
+    unsubscribe()
     clearInterval(intervalId)
   }
 }

--- a/src/pages/waiting-room/mockGateway.test.ts
+++ b/src/pages/waiting-room/mockGateway.test.ts
@@ -186,4 +186,36 @@ describe('mockGateway waiting-room action sequence', () => {
 
     expect(removedRoom).toBeUndefined()
   })
+
+  it('입장과 퇴장 시 접속자 목록 상태가 in_room -> lobby로 동기화된다', async () => {
+    const gateway = await loadMockGateway()
+    const presence = await import('../../features/presence/mockData')
+    const userId = 'presence-sync-user'
+    const nickname = '동기화테스터'
+
+    await gateway.mockJoinWaitingRoom({
+      roomId: 'room-5',
+      userId,
+      nickname,
+    })
+
+    const joinedUser = presence
+      .getMockOnlineUsersSnapshot()
+      .find((user) => user.id === userId)
+
+    expect(joinedUser).toBeTruthy()
+    expect(joinedUser?.status).toBe('in_room')
+
+    await gateway.mockLeaveWaitingRoom({
+      roomId: 'room-5',
+      userId,
+    })
+
+    const leftUser = presence
+      .getMockOnlineUsersSnapshot()
+      .find((user) => user.id === userId)
+
+    expect(leftUser).toBeTruthy()
+    expect(leftUser?.status).toBe('lobby')
+  })
 })

--- a/src/pages/waiting-room/mockGateway.ts
+++ b/src/pages/waiting-room/mockGateway.ts
@@ -1,5 +1,6 @@
 import { socket } from '../../lib/socket'
 import { ROOM_PASSWORD_PATTERN } from '../../constants/room'
+import { setMockOnlineUserStatus } from '../../features/presence/mockData'
 import { mockLobbyRooms } from '../lobby/mockData'
 import type { LobbyRoom, LobbyRoomStatus } from '../lobby/types'
 import type {
@@ -293,6 +294,16 @@ function createTalkChatPayload(
   }
 }
 
+// 대기방 참가자 상태를 접속자 저장소에 일괄 반영
+function syncRoomPlayersPresenceStatus(
+  room: MockRoom,
+  status: 'lobby' | 'in_room' | 'playing'
+) {
+  room.players.forEach((player) => {
+    setMockOnlineUserStatus(player.id, status, player.nickname)
+  })
+}
+
 interface MockJoinRoomParams {
   roomId: string
   userId: string
@@ -367,6 +378,11 @@ export async function mockJoinWaitingRoom({
 
   // 이미 입장한 사용자는 현재 스냅샷 그대로 반환
   if (existingPlayer) {
+    setMockOnlineUserStatus(
+      existingPlayer.id,
+      'in_room',
+      existingPlayer.nickname
+    )
     return toWaitingRoomSnapshot(room)
   }
 
@@ -384,6 +400,7 @@ export async function mockJoinWaitingRoom({
     is_ready: false,
     is_host: false,
   })
+  setMockOnlineUserStatus(userId, 'in_room', nickname)
 
   emitLobbyUpdated(room, 'status_changed')
   return toWaitingRoomSnapshot(room)
@@ -448,6 +465,7 @@ export async function mockCreateWaitingRoom({
   }
 
   roomsStore.set(createdRoom.id, createdRoom)
+  syncRoomPlayersPresenceStatus(createdRoom, 'in_room')
   emitLobbyUpdated(createdRoom, 'created')
 
   return {
@@ -478,6 +496,7 @@ export async function mockLeaveWaitingRoom({
   }
 
   const [leftPlayer] = room.players.splice(targetPlayerIndex, 1)
+  setMockOnlineUserStatus(leftPlayer.id, 'lobby', leftPlayer.nickname)
   let newHostId: string | undefined
 
   // 마지막 인원이 나가면 방을 삭제
@@ -585,6 +604,7 @@ export async function mockStartWaitingGame({
 
   room.status = 'playing'
   const gameStartPayload = createGameStartPayload(room)
+  syncRoomPlayersPresenceStatus(room, 'playing')
 
   emitLobbyUpdated(room, 'status_changed')
   setTimeout(() => {
@@ -690,7 +710,9 @@ export function mockDevAddWaitingRoomParticipant(roomId: string) {
     })
   }
 
-  room.players.push(createDevBotPlayer(room.id))
+  const createdBot = createDevBotPlayer(room.id)
+  room.players.push(createdBot)
+  setMockOnlineUserStatus(createdBot.id, 'in_room', createdBot.nickname)
   emitLobbyUpdated(room, 'status_changed')
 
   return toWaitingRoomSnapshot(room)
@@ -741,7 +763,10 @@ export function mockDevRemoveWaitingRoomParticipant(
     })
   }
 
-  room.players.splice(removablePlayerIndex, 1)
+  const [removedPlayer] = room.players.splice(removablePlayerIndex, 1)
+  if (removedPlayer) {
+    setMockOnlineUserStatus(removedPlayer.id, 'lobby', removedPlayer.nickname)
+  }
   emitLobbyUpdated(room, 'status_changed')
 
   return toWaitingRoomSnapshot(room)
@@ -833,6 +858,9 @@ export function mockDevResetWaitingRoom(
   currentNickname: string
 ) {
   const room = findRoomOrThrow(roomId)
+  const removedPlayers = room.players.filter(
+    (player) => player.id !== currentUserId
+  )
   const currentPlayer = room.players.find(
     (player) => player.id === currentUserId
   )
@@ -850,6 +878,10 @@ export function mockDevResetWaitingRoom(
       is_host: true,
     },
   ]
+  removedPlayers.forEach((player) => {
+    setMockOnlineUserStatus(player.id, 'lobby', player.nickname)
+  })
+  setMockOnlineUserStatus(currentUserId, 'in_room', normalizedNickname)
   room.chat_messages = []
 
   // 멀티 클라이언트에서도 방장 표시가 즉시 맞도록 host_changed를 함께 발행


### PR DESCRIPTION
## 📌 관련 이슈

> closes #277 

---

## 📝 작업 내용

- PR2 범위로 presence/방 입퇴장 실시간 동기화를 구현했습니다
- 접속자 mock 저장소에 변경 구독 경로를 추가했습니다
  - `src/features/presence/mockData.ts`
  - `subscribeMockOnlineUsersChange` 추가
  - `setMockOnlineUserStatus`를 upsert 방식으로 개선(없던 유저 자동 추가)
- mock 온라인 유저 브로드캐스트를 저장소 변경 이벤트와 연결했습니다
  - `src/features/presence/onlineUsersSocket.ts`
  - mock 저장소가 바뀌면 `online_users`를 즉시 emit
- 대기방 mock gateway에서 입퇴장/상태 전환 시 접속자 상태를 동기화했습니다
  - `src/pages/waiting-room/mockGateway.ts`
  - 방 생성/입장: `in_room`
  - 퇴장/DEV 제거: `lobby`
  - 게임 시작: `playing`
  - DEV reset 시 현재 사용자/제거 사용자 상태도 함께 반영
- 회귀 테스트를 추가/보강했습니다
  - `src/pages/waiting-room/mockGateway.test.ts`
    - 입장 후 `in_room`, 퇴장 후 `lobby` 동기화 검증
  - `src/features/presence/onlineUsersSocket.test.ts`
    - 저장소 구독 연동 경로 검증

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

- 해당 없음 (실시간 상태 동기화 로직/테스트 변경)

---

## 🧪 검증 내용

- `npm run lint` 통과
- `npm run test` 통과
- `npm run build` 통과
- 대상 테스트:
  - `npm run test -- src/pages/waiting-room/mockGateway.test.ts src/features/presence/onlineUsersSocket.test.ts`

---

## 📌 추가 메모

- 이번 PR은 PR2 범위(presence + room join/leave 동기화)까지 포함
- 준비/시작 규칙 세부 강화와 DM 정책 확장은 다음 PR에서 진행 예정
