### PR TITLE
fix: FE-B 명세 불일치 수정 + mock BuildingLevel 상한 버그

### DIFF
--- a/docs/game-event-spec-migration-plan.md
+++ b/docs/game-event-spec-migration-plan.md
@@ -74,22 +74,22 @@
 
 아래 표에서 **상태** 열 기준: ✅ 완료 / ⚠️ 명세 불일치 수정 필요 / ❌ 미구현
 
-| 파일                                                | 현재 상태                 | 남은 수정 방향                                                                                                       | 담당                       |
-| --------------------------------------------------- | ------------------------- | -------------------------------------------------------------------------------------------------------------------- | -------------------------- |
-| `src/types/domain.ts`                               | ⚠️ 골격 완료, 불일치 있음 | `GamePromptResponse.value`→`choice`. `GameAck` error 구조 중첩화. `GamePatchEnvelope`에 `turn`, `gameId` 추가        | FE-B                       |
-| `src/stores/game.store.ts`                          | ✅ 완료                   | —                                                                                                                    | FE-B                       |
-| `src/services/socket/game.handler.ts`               | ⚠️ 골격 완료, 불일치 있음 | `emitGameSync` payload에 `knownRevision` 추가, `reset` 제거. `emitPromptResponse`: `value`→`choice`, `playerId` 제거 | FE-B                       |
-| `src/hooks/game/useGameState.ts`                    | ✅ 완료                   | —                                                                                                                    | FE-B                       |
-| `src/services/game/game.api.ts`                     | ⚠️ 레거시 격리 중         | deprecated 표시 완료. `gameBoardActionHandlers.ts` 호출부 → `emitGameAction` 전환 필요                               | FE-B                       |
-| `src/hooks/game/useDiceRoll.ts`                     | ✅ 완료                   | —                                                                                                                    | FE-B                       |
-| `src/pages/GamePage.tsx`                            | ✅ 1차 완료               | `store.prompt`, `store.lastError`, `store.pendingAction` UI 연결 필요                                                | FE-B                       |
-| `src/components/board/GameBoard.tsx`                | ⚠️ 부분 정리              | `applyMoney`, `advanceTurn`, 통행료 계산, 파산 판정 제거. `store.prompt` 연결                                        | FE-C 주도 / FE-B 선행 필요 |
-| `src/components/game/modals/*`                      | ❌ prompt 미연결          | `store.prompt.type` 기준 모달 열림 조건 연결. `emitPromptResponse` 연결                                              | FE-B                       |
-| `src/mocks/handlers/game.handler.ts`                | ⚠️ 명세 불일치 다수       | 아래 2-1 참조                                                                                                        | FE-B                       |
-| `src/components/board/gameBoardStoreBridge.ts`      | ❌ 버그                   | `toStoreBuildingLevel` 상한 5→7                                                                                      | FE-C                       |
-| `src/components/board/gameBoardTransactionUtils.ts` | ❌ 버그                   | `upgradeBoardTileOwner` 상한 5→7                                                                                     | FE-C                       |
-| `src/components/board/gameBoardActionUtils.ts`      | ❌ 버그                   | `getBoardSellFallbackRefund` level 5, 6 케이스 추가                                                                  | FE-C                       |
-| `src/components/board/*` (렌더 레이어)              | ❌ 미구현                 | `store.eventQueue` 소비 연출. `playerState` 시각화                                                                   | FE-C                       |
+| 파일                                                | 현재 상태         | 남은 수정 방향                                                                         | 담당                       |
+| --------------------------------------------------- | ----------------- | -------------------------------------------------------------------------------------- | -------------------------- |
+| `src/types/domain.ts`                               | ✅ 완료           | —                                                                                      | FE-B                       |
+| `src/stores/game.store.ts`                          | ✅ 완료           | —                                                                                      | FE-B                       |
+| `src/services/socket/game.handler.ts`               | ✅ 완료           | —                                                                                      | FE-B                       |
+| `src/hooks/game/useGameState.ts`                    | ✅ 완료           | —                                                                                      | FE-B                       |
+| `src/services/game/game.api.ts`                     | ⚠️ 레거시 격리 중 | deprecated 표시 완료. `gameBoardActionHandlers.ts` 호출부 → `emitGameAction` 전환 필요 | FE-B                       |
+| `src/hooks/game/useDiceRoll.ts`                     | ✅ 완료           | —                                                                                      | FE-B                       |
+| `src/pages/GamePage.tsx`                            | ✅ 1차 완료       | `store.prompt`, `store.lastError`, `store.pendingAction` UI 연결 필요                  | FE-B                       |
+| `src/components/board/GameBoard.tsx`                | ⚠️ 부분 정리      | `applyMoney`, `advanceTurn`, 통행료 계산, 파산 판정 제거. `store.prompt` 연결          | FE-C 주도 / FE-B 선행 필요 |
+| `src/components/game/modals/*`                      | ❌ prompt 미연결  | `store.prompt.type` 기준 모달 열림 조건 연결. `emitPromptResponse` 연결                | FE-B                       |
+| `src/mocks/handlers/game.handler.ts`                | ✅ 완료           | —                                                                                      | FE-B                       |
+| `src/components/board/gameBoardStoreBridge.ts`      | ❌ 버그           | `toStoreBuildingLevel` 상한 5→7                                                        | FE-C                       |
+| `src/components/board/gameBoardTransactionUtils.ts` | ❌ 버그           | `upgradeBoardTileOwner` 상한 5→7                                                       | FE-C                       |
+| `src/components/board/gameBoardActionUtils.ts`      | ❌ 버그           | `getBoardSellFallbackRefund` level 5, 6 케이스 추가                                    | FE-C                       |
+| `src/components/board/*` (렌더 레이어)              | ❌ 미구현         | `store.eventQueue` 소비 연출. `playerState` 시각화                                     | FE-C                       |
 
 ### 2-1. `src/mocks/handlers/game.handler.ts` 명세 불일치 상세
 
@@ -270,36 +270,19 @@
 - `src/hooks/game/useGameState.ts`: `game:sync` 우선, REST bootstrap fallback 병행
 - `src/pages/GamePage.tsx`: store 단일 소스, `gameViewModel` mapper로 board 데이터 조립
 
-### 명세 불일치 (수정 미완료)
+### 명세 불일치 (수정 완료 — 2026-03-05)
 
-아래 항목은 코드가 존재하지만 `gamesocket.md` 명세와 불일치 상태다.
+- `src/types/domain.ts`: `GamePromptResponse.choice`, `GameAck.error: { code, message }`, `GamePatchEnvelope.gameId/turn` ✅
+- `src/services/socket/game.handler.ts`: `emitGameSync` knownRevision 추가, `emitPromptResponse` choice 전환 ✅
+- `src/mocks/handlers/game.handler.ts`: `END_TURN` 핸들러 추가, `BUILD_PROPERTY` 제거, ServerEventType 명세 정렬, payload camelCase, `BuildingLevel` 상한 7 ✅
 
-**`src/types/domain.ts`**
-
-- `GamePromptResponse.value` → `choice` 로 변경 필요
-- `GameAck.errorCode` + `GameAck.message` 플랫 구조 → `GameAck.error: { code, message }` 중첩 구조
-- `GamePatchEnvelope`: `turn?: number`, `gameId?: GameId` 누락
-
-**`src/services/socket/game.handler.ts`**
-
-- `emitGameSync` payload: `knownRevision` 누락. 스펙 외 `reset` 포함
-- `emitPromptResponse`: `value` → `choice`. `playerId` 제거
-
-**`src/mocks/handlers/game.handler.ts`**
-
-- `BUILD_PROPERTY` 액션: 명세에 없음 → 제거
-- `END_TURN` 액션: 명세에 있지만 핸들러 없음 → 추가
-- `ServerEventType` 전체 명칭 불일치 (위 2-1 표 참조)
-- action payload snake_case → camelCase
-- `BuildingLevel` 상한 5 → 7
-
-### 버그 (수정 미완료)
+### 버그 (수정 미완료 — FE-C 담당)
 
 - `src/components/board/gameBoardStoreBridge.ts:6`: `toStoreBuildingLevel` 상한 5 (→ 7 필요)
 - `src/components/board/gameBoardTransactionUtils.ts`: `upgradeBoardTileOwner` 상한 5 (→ 7 필요)
 - `src/components/board/gameBoardActionUtils.ts`: `getBoardSellFallbackRefund` level 5, 6 누락
 
-### 구조 미구현
+### 구조 미구현 (FE-B 2단계)
 
 - `store.prompt` → 모달 연결 없음
 - `store.lastError` → 에러 UI 연결 없음
@@ -311,8 +294,8 @@
 
 **FE-B**
 
-1. `src/types/domain.ts`, `src/services/socket/game.handler.ts`: 명세 불일치 수정 (위 5-1 참조)
-2. `src/mocks/handlers/game.handler.ts`: 명세 불일치 수정 (위 2-1 표 기준)
+1. ~~`src/types/domain.ts`, `src/services/socket/game.handler.ts`: 명세 불일치 수정~~ ✅ 완료
+2. ~~`src/mocks/handlers/game.handler.ts`: 명세 불일치 수정~~ ✅ 완료
 3. `src/components/game/modals/*`, `src/pages/GamePage.tsx`, `src/components/board/GameBoard.tsx`: `store.prompt` → modal 연결. `store.lastError` → 에러 UI. `store.pendingAction` → 버튼 상태
 4. `src/components/board/gameBoardActionHandlers.ts`: REST 직접 호출 → `emitGameAction` 전환
 

--- a/src/hooks/game/useGameState.ts
+++ b/src/hooks/game/useGameState.ts
@@ -34,10 +34,7 @@ export const useGameState = (roomId: string | null) => {
       // 같은 방에서 이미 상태를 들고 있으면 초기 동기화를 반복하지 않는다.
       if (!roomChanged && players.length > 0) return
 
-      emitGameSync({
-        roomId,
-        reset: USE_GAME_SOCKET_MOCK && roomChanged,
-      })
+      emitGameSync({ roomId })
 
       // mock/socket rollout 전까지는 REST snapshot을 bootstrap fallback으로 유지한다.
       const result = await gameApi.getState(roomId, {

--- a/src/mocks/handlers/game.handler.ts
+++ b/src/mocks/handlers/game.handler.ts
@@ -54,7 +54,7 @@ type MockGameActionPayload = {
 type MockGameSyncPayload = {
   roomId?: string | null
   gameId?: string | null
-  reset?: boolean
+  knownRevision?: number
 }
 
 const clonePlayers = () => structuredClone(mockPlayers)
@@ -152,11 +152,6 @@ const emitGamePatch = (
   payload: GamePatchEnvelope & { snapshot?: GameSnapshot }
 ) => {
   emitSocketEvent('game:patch', payload)
-}
-
-const emitGamePrompt = (prompt: GamePrompt) => {
-  mockGameState.prompt = prompt
-  emitSocketEvent('game:prompt', prompt)
 }
 
 const emitGameError = (error: GameError) => {
@@ -263,8 +258,10 @@ const handleRollDiceAction = (
       actionId: action.actionId,
       type: action.type,
       ok: false,
-      message: '현재 턴 플레이어를 찾을 수 없습니다.',
-      errorCode: 'PLAYER_NOT_FOUND',
+      error: {
+        code: 'PLAYER_NOT_FOUND',
+        message: '현재 턴 플레이어를 찾을 수 없습니다.',
+      },
     })
     return
   }
@@ -294,7 +291,7 @@ const handleRollDiceAction = (
 
   emitSnapshotPatch(action.roomId, action.gameId, [
     {
-      type: 'ROLL_DICE',
+      type: 'DICE_ROLLED',
       playerId: currentPlayer.id,
       payload: {
         dice: [dice1, dice2],
@@ -302,7 +299,7 @@ const handleRollDiceAction = (
       },
     },
     {
-      type: 'MOVE_PLAYER',
+      type: 'PLAYER_MOVED',
       playerId: currentPlayer.id,
       tileIndex: toIndex,
       amount: passGo ? MOCK_PASS_GO_SALARY : undefined,
@@ -319,7 +316,7 @@ const handleBuyPropertyAction = (
   action: Required<Pick<MockGameActionPayload, 'type' | 'actionId'>> &
     Pick<MockGameActionPayload, 'roomId' | 'gameId' | 'payload'>
 ) => {
-  const tileIndex = Number(action.payload?.tile_index)
+  const tileIndex = Number(action.payload?.tileId)
   const player = getCurrentPlayer()
   const tile = getTileByIndex(tileIndex)
 
@@ -328,8 +325,10 @@ const handleBuyPropertyAction = (
       actionId: action.actionId,
       type: action.type,
       ok: false,
-      message: '구매할 수 없는 타일입니다.',
-      errorCode: 'TILE_NOT_OWNABLE',
+      error: {
+        code: 'TILE_NOT_OWNABLE',
+        message: '구매할 수 없는 타일입니다.',
+      },
     })
     return
   }
@@ -339,8 +338,7 @@ const handleBuyPropertyAction = (
       actionId: action.actionId,
       type: action.type,
       ok: false,
-      message: '이미 소유된 타일입니다.',
-      errorCode: 'TILE_ALREADY_OWNED',
+      error: { code: 'TILE_ALREADY_OWNED', message: '이미 소유된 타일입니다.' },
     })
     return
   }
@@ -351,8 +349,10 @@ const handleBuyPropertyAction = (
       actionId: action.actionId,
       type: action.type,
       ok: false,
-      message: '보유 금액이 부족합니다.',
-      errorCode: 'INSUFFICIENT_BALANCE',
+      error: {
+        code: 'INSUFFICIENT_BALANCE',
+        message: '보유 금액이 부족합니다.',
+      },
     })
     return
   }
@@ -373,84 +373,10 @@ const handleBuyPropertyAction = (
 
   emitSnapshotPatch(action.roomId, action.gameId, [
     {
-      type: 'BUY_PROPERTY',
+      type: 'BOUGHT_PROPERTY',
       playerId: player.id,
       tileIndex,
       amount: price,
-    },
-  ])
-}
-
-const handleBuildPropertyAction = (
-  action: Required<Pick<MockGameActionPayload, 'type' | 'actionId'>> &
-    Pick<MockGameActionPayload, 'roomId' | 'gameId' | 'payload'>
-) => {
-  const tileIndex = Number(action.payload?.tile_index)
-  const player = getCurrentPlayer()
-  const tile = getTileByIndex(tileIndex)
-
-  if (!player || !isOwnableTile(tile)) {
-    emitGameAck({
-      actionId: action.actionId,
-      type: action.type,
-      ok: false,
-      message: '건설할 수 없는 타일입니다.',
-      errorCode: 'TILE_NOT_BUILDABLE',
-    })
-    return
-  }
-
-  if (String(tile.owner_id) !== String(player.id)) {
-    emitGameAck({
-      actionId: action.actionId,
-      type: action.type,
-      ok: false,
-      message: '본인 소유 타일만 건설할 수 있습니다.',
-      errorCode: 'FORBIDDEN_BUILD',
-    })
-    return
-  }
-
-  if (tile.building >= 5) {
-    emitGameAck({
-      actionId: action.actionId,
-      type: action.type,
-      ok: false,
-      message: '최대 단계까지 건설했습니다.',
-      errorCode: 'MAX_BUILDING_LEVEL',
-    })
-    return
-  }
-
-  if (player.balance < MOCK_BUILD_COST) {
-    emitGameAck({
-      actionId: action.actionId,
-      type: action.type,
-      ok: false,
-      message: '건설 비용이 부족합니다.',
-      errorCode: 'INSUFFICIENT_BALANCE',
-    })
-    return
-  }
-
-  player.balance -= MOCK_BUILD_COST
-  tile.building = (tile.building + 1) as BuildingLevel
-  const revision = nextRevision()
-
-  emitGameAck({
-    actionId: action.actionId,
-    type: action.type,
-    ok: true,
-    revision,
-  })
-
-  emitSnapshotPatch(action.roomId, action.gameId, [
-    {
-      type: 'BUILD_PROPERTY',
-      playerId: player.id,
-      tileIndex,
-      amount: MOCK_BUILD_COST,
-      payload: { buildingLevel: tile.building },
     },
   ])
 }
@@ -459,9 +385,11 @@ const handleSellPropertyAction = (
   action: Required<Pick<MockGameActionPayload, 'type' | 'actionId'>> &
     Pick<MockGameActionPayload, 'roomId' | 'gameId' | 'payload'>
 ) => {
-  const tileIndex = Number(action.payload?.tile_index)
-  const level =
-    typeof action.payload?.level === 'number' ? action.payload.level : undefined
+  const tileIndex = Number(action.payload?.tileId)
+  const buildingLevel =
+    typeof action.payload?.buildingLevel === 'number'
+      ? action.payload.buildingLevel
+      : undefined
   const player = getCurrentPlayer()
   const tile = getTileByIndex(tileIndex)
 
@@ -470,8 +398,10 @@ const handleSellPropertyAction = (
       actionId: action.actionId,
       type: action.type,
       ok: false,
-      message: '매각할 수 없는 타일입니다.',
-      errorCode: 'TILE_NOT_SELLABLE',
+      error: {
+        code: 'TILE_NOT_SELLABLE',
+        message: '매각할 수 없는 타일입니다.',
+      },
     })
     return
   }
@@ -481,13 +411,18 @@ const handleSellPropertyAction = (
       actionId: action.actionId,
       type: action.type,
       ok: false,
-      message: '본인 소유 타일만 매각할 수 있습니다.',
-      errorCode: 'FORBIDDEN_SELL',
+      error: {
+        code: 'FORBIDDEN_SELL',
+        message: '본인 소유 타일만 매각할 수 있습니다.',
+      },
     })
     return
   }
 
-  const { refund, nextBuilding, releaseOwnership } = getSellRefund(tile, level)
+  const { refund, nextBuilding, releaseOwnership } = getSellRefund(
+    tile,
+    buildingLevel
+  )
   player.balance += refund
   tile.building = nextBuilding
 
@@ -508,7 +443,7 @@ const handleSellPropertyAction = (
 
   emitSnapshotPatch(action.roomId, action.gameId, [
     {
-      type: 'SELL_PROPERTY',
+      type: 'SOLD_PROPERTY',
       playerId: player.id,
       tileIndex,
       amount: refund,
@@ -520,15 +455,30 @@ const handleSellPropertyAction = (
   ])
 }
 
-export const mockEmitGameSync = ({
-  roomId,
-  gameId,
-  reset,
-}: MockGameSyncPayload) => {
-  if (reset) {
-    resetMockGameState()
-  }
+const handleEndTurnAction = (
+  action: Required<Pick<MockGameActionPayload, 'type' | 'actionId'>> &
+    Pick<MockGameActionPayload, 'roomId' | 'gameId'>
+) => {
+  advanceMockTurn()
+  mockGameState.phase = 'rolling'
+  const revision = nextRevision()
 
+  emitGameAck({
+    actionId: action.actionId,
+    type: action.type,
+    ok: true,
+    revision,
+  })
+
+  emitSnapshotPatch(action.roomId, action.gameId, [
+    {
+      type: 'TURN_ENDED',
+      playerId: mockGameState.currentTurn,
+    },
+  ])
+}
+
+export const mockEmitGameSync = ({ roomId, gameId }: MockGameSyncPayload) => {
   setTimeout(() => {
     emitSnapshotPatch(roomId, gameId)
   }, 0)
@@ -557,24 +507,12 @@ export const mockEmitGameAction = ({
       case 'BUY_PROPERTY':
         handleBuyPropertyAction(action)
         break
-      case 'BUILD_PROPERTY':
-        handleBuildPropertyAction(action)
-        break
       case 'SELL_PROPERTY':
         handleSellPropertyAction(action)
         break
-      case 'REQUEST_BUY_PROPERTY_PROMPT': {
-        emitGamePrompt({
-          id: `prompt-buy-${Date.now()}`,
-          type: 'buy',
-          playerId: mockGameState.currentTurn,
-          title: '도시 구매',
-          message: '이 도시를 구매하시겠습니까?',
-          timeoutSec: MOCK_TURN_TIMEOUT_SEC,
-          payload,
-        })
+      case 'END_TURN':
+        handleEndTurnAction(action)
         break
-      }
       default:
         emitGameError({
           code: 'UNSUPPORTED_GAME_ACTION',
@@ -585,8 +523,10 @@ export const mockEmitGameAction = ({
           actionId,
           type,
           ok: false,
-          message: '지원하지 않는 게임 액션입니다.',
-          errorCode: 'UNSUPPORTED_GAME_ACTION',
+          error: {
+            code: 'UNSUPPORTED_GAME_ACTION',
+            message: '지원하지 않는 게임 액션입니다.',
+          },
         })
     }
   }, 0)
@@ -617,8 +557,7 @@ export const mockEmitPromptResponse = (response: GamePromptResponse) => {
   emitSnapshotPatch(undefined, undefined, [
     {
       type: 'PROMPT_RESPONSE',
-      playerId: response.playerId,
-      payload: { value: response.value },
+      payload: { choice: response.choice },
     },
   ])
 }

--- a/src/mocks/handlers/game.handler.ts
+++ b/src/mocks/handlers/game.handler.ts
@@ -694,7 +694,7 @@ export const gameHandlers = [
       )
     }
 
-    if (tile.building >= 5) {
+    if (tile.building >= 7) {
       return buildErrorResponse(
         '\uCD5C\uB300 \uB2E8\uACC4\uAE4C\uC9C0 \uAC74\uC124\uD588\uC2B5\uB2C8\uB2E4.',
         409

--- a/src/services/socket/game.handler.ts
+++ b/src/services/socket/game.handler.ts
@@ -40,7 +40,7 @@ type GameActionPayload = {
 type GameSyncPayload = {
   roomId?: RoomId | null
   gameId?: GameId | null
-  reset?: boolean
+  knownRevision?: number
 }
 
 type PromptResponsePayload = GamePromptResponse & {
@@ -170,45 +170,43 @@ export const emitGameAction = ({
   return actionId
 }
 
-export const emitGameSync = ({ roomId, gameId, reset }: GameSyncPayload) => {
+export const emitGameSync = ({
+  roomId,
+  gameId,
+  knownRevision,
+}: GameSyncPayload) => {
   if (USE_GAME_SOCKET_MOCK) {
     mockEmitGameSync({
       roomId,
       gameId,
-      reset,
+      knownRevision,
     })
     return
   }
 
   socket.emit('game:sync', {
-    roomId,
     gameId,
-    reset,
+    knownRevision,
   })
 }
 
 export const emitPromptResponse = ({
   promptId,
-  playerId,
-  value,
-  roomId,
+  choice,
   gameId,
 }: PromptResponsePayload) => {
   if (USE_GAME_SOCKET_MOCK) {
     mockEmitPromptResponse({
       promptId,
-      playerId,
-      value,
+      choice,
     })
     return
   }
 
   socket.emit('game:prompt_response', {
-    promptId,
-    playerId,
-    value,
-    roomId,
     gameId,
+    promptId,
+    choice,
   })
 }
 
@@ -216,19 +214,6 @@ export const emitPromptResponse = ({
 export const emitRollDice = (payload: { room_id: string }) => {
   emitGameAction({
     type: 'ROLL_DICE',
-    roomId: payload.room_id,
-  })
-}
-
-// Deprecated compatibility wrapper until board prompt flow is migrated.
-export const emitConfirmPenalty = (payload: {
-  room_id: string
-  player_id: string
-}) => {
-  emitPromptResponse({
-    promptId: 'legacy-penalty-confirm',
-    playerId: payload.player_id,
-    value: 'confirm',
     roomId: payload.room_id,
   })
 }

--- a/src/stores/game.store.test.ts
+++ b/src/stores/game.store.test.ts
@@ -187,8 +187,7 @@ describe('game store partial updates', () => {
     store.resolveAck({
       actionId: 'action-1',
       ok: false,
-      errorCode: 'GAME_ACTION_REJECTED',
-      message: 'rejected',
+      error: { code: 'GAME_ACTION_REJECTED', message: 'rejected' },
     })
     store.setPrompt(prompt)
     store.clearPrompt('other-prompt')

--- a/src/stores/game.store.ts
+++ b/src/stores/game.store.ts
@@ -376,8 +376,8 @@ export const useGameStore = create<GameStoreState>()(
         draft.lastError = ack.ok
           ? null
           : {
-              code: ack.errorCode ?? 'GAME_ACTION_REJECTED',
-              message: ack.message ?? '게임 액션이 거부되었습니다.',
+              code: ack.error?.code ?? 'GAME_ACTION_REJECTED',
+              message: ack.error?.message ?? '게임 액션이 거부되었습니다.',
               actionId: ack.actionId,
             }
 

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -130,8 +130,7 @@ export interface GamePrompt {
 
 export interface GamePromptResponse {
   promptId: string
-  playerId?: PlayerId | null
-  value: string
+  choice: string
 }
 
 export interface GameAck {
@@ -140,8 +139,7 @@ export interface GameAck {
   ok: boolean
   revision?: number
   promptId?: string | null
-  message?: string
-  errorCode?: string
+  error?: { code: string; message: string }
   payload?: Record<string, unknown>
 }
 
@@ -218,7 +216,9 @@ export interface GameSnapshot {
 }
 
 export interface GamePatchEnvelope {
+  gameId?: GameId
   revision: number
+  turn?: number
   patch: GamePatchOperation[]
   events?: ServerEvent[]
 }


### PR DESCRIPTION
## 📌 관련 이슈

> closes #이슈번호

---

## 📝 작업 내용

> gamesocket.md 명세 기준으로 FE-B 담당 파일의 불일치 항목 전체 수정.

src/types/domain.ts

GamePromptResponse.value → choice 필드로 변경
GameAck error 구조: errorCode + message 플랫 → error: { code, message } 중첩
GamePatchEnvelope에 gameId?: GameId, turn?: number 추가
src/stores/game.store.ts

resolveAck: ack.error?.code, ack.error?.message 중첩 구조 반영
src/services/socket/game.handler.ts

emitGameSync: knownRevision 파라미터 추가, 명세 외 reset 제거
emitPromptResponse: value → choice 전환, playerId 제거
emitConfirmPenalty deprecated wrapper 제거 (PR #268에서 호출부 이미 제거됨)
src/mocks/handlers/game.handler.ts

END_TURN 액션 핸들러 추가
BUILD_PROPERTY, REQUEST_BUY_PROPERTY_PROMPT 액션 제거 (명세 외)
ServerEventType 명세 정렬: ROLL_DICE→DICE_ROLLED, MOVE_PLAYER→PLAYER_MOVED, BUY_PROPERTY→BOUGHT_PROPERTY, SELL_PROPERTY→SOLD_PROPERTY
action payload camelCase: tile_index→tileId, level→buildingLevel
BuildingLevel 상한 5 → 7 (레거시 REST /build 핸들러 포함)
mockEmitPromptResponse: response.choice 사용
docs/game-event-spec-migration-plan.md

섹션 2 상태표: 완료 항목 ✅ 반영
섹션 5-1: 명세 불일치 완료 처리, FE-B 2단계 미구현 항목 명시

---

## ✅ 체크리스트

- [ ] 로컬에서 정상 동작 확인
- [ ] 불필요한 console.log 제거
- [ ] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

> UI 변경이 있을 경우 첨부해주세요.
