### PR TITLE
feat: Socket Mock 대기방 준비/시작 규칙 검증 및 에러 코드 정합화

### DIFF
--- a/docs/socket-mock-server.md
+++ b/docs/socket-mock-server.md
@@ -19,6 +19,9 @@ npm run socket:mock
 - `enter_room`, `leave_room` 검증 및 상태 갱신
 - `send_chat` 룸 브로드캐스트
 - `dm_send` -> `dm_receive` 전달
+- `toggle_ready` 준비 상태 토글 + `player_ready` 브로드캐스트
+- `start_game` 시작 조건 검증 + `game_start` 브로드캐스트
+- 방장 퇴장 시 `host_changed` 브로드캐스트
 
 ## 3. 계약 위치
 
@@ -28,4 +31,20 @@ npm run socket:mock
 ## 4. 주의사항
 
 - 현재 서버는 개발용 mock이며 영속 저장소를 사용하지 않습니다
-- PR1 범위 기준으로 최소 동작/검증만 포함합니다
+- 현재 문서는 PR3 범위(입퇴장 + 준비/시작 규칙) 기준입니다
+
+## 5. 대기방 규칙/에러 코드
+
+- 시작 조건: 최소 2명 + non-host 전원 준비 완료
+- host만 시작 가능, host는 ready 토글 불가
+
+대표 에러 코드:
+
+- `ROOM_NOT_FOUND`
+- `ROOM_FULL`
+- `ROOM_ALREADY_PLAYING`
+- `ALREADY_LEFT_ROOM`
+- `PLAYER_NOT_IN_ROOM`
+- `HOST_CANNOT_TOGGLE_READY`
+- `ONLY_HOST_CAN_START`
+- `READY_CONDITION_NOT_MET`

--- a/mock-socket-server/index.ts
+++ b/mock-socket-server/index.ts
@@ -6,6 +6,9 @@ import { Server, type Socket } from 'socket.io'
 import {
   SOCKET_EVENTS,
   type ContractOnlineUser,
+  type GameStartEventPayload,
+  type HostChangedEventPayload,
+  type PlayerReadyEventPayload,
   type SocketAck,
 } from '../src/contracts/socket'
 import {
@@ -13,9 +16,14 @@ import {
   directMessageReceiveEventSchema,
   directMessageSendEventSchema,
   enterRoomEventSchema,
+  gameStartEventSchema,
+  hostChangedEventSchema,
   leaveRoomEventSchema,
   onlineUsersEventSchema,
+  playerReadyEventSchema,
   sendChatEventSchema,
+  startGameEventSchema,
+  toggleReadyEventSchema,
   validateSocketEventPayload,
 } from '../src/contracts/socket'
 
@@ -27,14 +35,35 @@ interface HandshakeAuth {
 type AckHandler<T = Record<string, never>> = (response: SocketAck<T>) => void
 
 const DEFAULT_PORT = 3000
+const DEFAULT_ROOM_MAX_PLAYERS = 4
 const STATUS_IN_ROOM: ContractOnlineUser['status'] = 'in_room'
 const STATUS_LOBBY: ContractOnlineUser['status'] = 'lobby'
+const STATUS_PLAYING: ContractOnlineUser['status'] = 'playing'
+
+interface MockRoomPlayer {
+  id: string
+  nickname: string
+  socketId: string
+  isReady: boolean
+  isHost: boolean
+}
+
+interface MockRoom {
+  id: string
+  status: 'waiting' | 'playing'
+  maxPlayers: number
+  players: MockRoomPlayer[]
+}
 
 // 연결된 사용자 목록을 소켓 ID 기준으로 저장
 const connectedUsersBySocketId = new Map<string, ContractOnlineUser>()
 
 // DM 송신 시 대상 소켓을 찾기 위해 userId -> socketId 인덱스를 유지
 const socketIdByUserId = new Map<string, string>()
+
+// 대기방 참가자 추적을 위해 roomId -> room 상태 저장
+const roomsById = new Map<string, MockRoom>()
+const roomIdByUserId = new Map<string, string>()
 
 function resolveHandshakeAuth(socket: Socket): HandshakeAuth {
   if (
@@ -104,10 +133,15 @@ function broadcastOnlineUsers(io: Server) {
   io.emit(SOCKET_EVENTS.onlineUsers, validated.data)
 }
 
-function updateUserStatus(
-  socketId: string,
+function setConnectedUserStatus(
+  userId: string,
   status: ContractOnlineUser['status']
 ) {
+  const socketId = socketIdByUserId.get(userId)
+  if (!socketId) {
+    return
+  }
+
   const currentUser = connectedUsersBySocketId.get(socketId)
   if (!currentUser) {
     return
@@ -119,32 +153,257 @@ function updateUserStatus(
   })
 }
 
+function getConnectedUser(socketId: string) {
+  return connectedUsersBySocketId.get(socketId)
+}
+
+function getOrCreateRoom(roomId: string) {
+  const existingRoom = roomsById.get(roomId)
+  if (existingRoom) {
+    return existingRoom
+  }
+
+  const createdRoom: MockRoom = {
+    id: roomId,
+    status: 'waiting',
+    maxPlayers: DEFAULT_ROOM_MAX_PLAYERS,
+    players: [],
+  }
+  roomsById.set(roomId, createdRoom)
+  return createdRoom
+}
+
+function canStartGame(room: MockRoom) {
+  if (room.players.length < 2) {
+    return false
+  }
+
+  const nonHostPlayers = room.players.filter((player) => !player.isHost)
+  if (nonHostPlayers.length === 0) {
+    return false
+  }
+
+  return nonHostPlayers.every((player) => player.isReady)
+}
+
+function emitHostChanged(io: Server, room: MockRoom, nextHost: MockRoomPlayer) {
+  const payload: HostChangedEventPayload = {
+    new_host_id: nextHost.id,
+    new_host_nickname: nextHost.nickname,
+  }
+
+  const validated = validateSocketEventPayload(hostChangedEventSchema, payload)
+  if (!validated.success) {
+    return
+  }
+
+  io.to(room.id).emit(SOCKET_EVENTS.hostChanged, validated.data)
+}
+
+function emitPlayerReady(io: Server, room: MockRoom, player: MockRoomPlayer) {
+  const payload: PlayerReadyEventPayload = {
+    player_id: player.id,
+    is_ready: player.isReady,
+    all_ready: canStartGame(room),
+  }
+
+  const validated = validateSocketEventPayload(playerReadyEventSchema, payload)
+  if (!validated.success) {
+    return
+  }
+
+  io.to(room.id).emit(SOCKET_EVENTS.playerReady, validated.data)
+}
+
+function removeUserFromRoom(io: Server, roomId: string, userId: string) {
+  const room = roomsById.get(roomId)
+  if (!room) {
+    return {
+      ok: false as const,
+      code: 'ROOM_NOT_FOUND',
+      detail: '존재하지 않는 방입니다.',
+    }
+  }
+
+  const playerIndex = room.players.findIndex((player) => player.id === userId)
+  if (playerIndex === -1) {
+    return {
+      ok: false as const,
+      code: 'ALREADY_LEFT_ROOM',
+      detail: '이미 방에서 나간 상태입니다.',
+    }
+  }
+
+  const [leftPlayer] = room.players.splice(playerIndex, 1)
+  roomIdByUserId.delete(userId)
+  setConnectedUserStatus(userId, STATUS_LOBBY)
+
+  if (room.players.length === 0) {
+    roomsById.delete(room.id)
+    return {
+      ok: true as const,
+      leftPlayer,
+    }
+  }
+
+  if (leftPlayer.isHost) {
+    const [nextHost] = room.players
+    nextHost.isHost = true
+    nextHost.isReady = false
+    emitHostChanged(io, room, nextHost)
+  }
+
+  return {
+    ok: true as const,
+    leftPlayer,
+  }
+}
+
+function emitGameStart(io: Server, room: MockRoom) {
+  const payload: GameStartEventPayload = {
+    game_id: `game-${room.id}-${Date.now()}`,
+    room_id: room.id,
+  }
+
+  const validated = validateSocketEventPayload(gameStartEventSchema, payload)
+  if (!validated.success) {
+    return null
+  }
+
+  io.to(room.id).emit(SOCKET_EVENTS.gameStart, validated.data)
+  return validated.data
+}
+
 function configureSocketHandlers(io: Server, socket: Socket) {
-  socket.on(SOCKET_EVENTS.enterRoom, (payload: unknown, ack?: AckHandler) => {
-    const validated = validateSocketEventPayload(enterRoomEventSchema, payload)
-    if (!validated.success) {
-      ackError(ack, validated.error.detail, validated.error.code)
-      return
+  socket.on(
+    SOCKET_EVENTS.enterRoom,
+    (
+      payload: unknown,
+      ack?: AckHandler<{ room_id: string; is_host: boolean }>
+    ) => {
+      const validated = validateSocketEventPayload(
+        enterRoomEventSchema,
+        payload
+      )
+      if (!validated.success) {
+        ackError(ack, validated.error.detail, validated.error.code)
+        return
+      }
+
+      const connectedUser = getConnectedUser(socket.id)
+      if (!connectedUser) {
+        ackError(ack, '사용자 연결을 찾을 수 없습니다.', 'USER_NOT_CONNECTED')
+        return
+      }
+
+      const previousRoomId = roomIdByUserId.get(connectedUser.id)
+      if (previousRoomId && previousRoomId !== validated.data.room_id) {
+        const leaveResult = removeUserFromRoom(
+          io,
+          previousRoomId,
+          connectedUser.id
+        )
+        if (!leaveResult.ok) {
+          ackError(ack, leaveResult.detail, leaveResult.code)
+          return
+        }
+        socket.leave(previousRoomId)
+      }
+
+      const room = getOrCreateRoom(validated.data.room_id)
+      const existingPlayer = room.players.find(
+        (player) => player.id === connectedUser.id
+      )
+
+      if (existingPlayer) {
+        existingPlayer.socketId = socket.id
+        existingPlayer.nickname = connectedUser.nickname
+        roomIdByUserId.set(connectedUser.id, room.id)
+        socket.join(room.id)
+        setConnectedUserStatus(connectedUser.id, STATUS_IN_ROOM)
+        broadcastOnlineUsers(io)
+        ackSuccess(ack, {
+          room_id: room.id,
+          is_host: existingPlayer.isHost,
+        })
+        return
+      }
+
+      if (room.status === 'playing') {
+        ackError(ack, '이미 게임이 시작된 방입니다.', 'ROOM_ALREADY_PLAYING')
+        return
+      }
+
+      if (room.players.length >= room.maxPlayers) {
+        ackError(ack, '방 인원이 가득 찼습니다.', 'ROOM_FULL')
+        return
+      }
+
+      const isHost = room.players.length === 0
+      room.players.push({
+        id: connectedUser.id,
+        nickname: connectedUser.nickname,
+        socketId: socket.id,
+        isReady: false,
+        isHost,
+      })
+
+      roomIdByUserId.set(connectedUser.id, room.id)
+      socket.join(room.id)
+      setConnectedUserStatus(connectedUser.id, STATUS_IN_ROOM)
+      broadcastOnlineUsers(io)
+      ackSuccess(ack, {
+        room_id: room.id,
+        is_host: isHost,
+      })
     }
+  )
 
-    socket.join(validated.data.room_id)
-    updateUserStatus(socket.id, STATUS_IN_ROOM)
-    broadcastOnlineUsers(io)
-    ackSuccess(ack, {})
-  })
+  socket.on(
+    SOCKET_EVENTS.leaveRoom,
+    (
+      payload: unknown,
+      ack?: AckHandler<{ room_id: string; left: boolean }>
+    ) => {
+      const validated = validateSocketEventPayload(
+        leaveRoomEventSchema,
+        payload
+      )
+      if (!validated.success) {
+        ackError(ack, validated.error.detail, validated.error.code)
+        return
+      }
 
-  socket.on(SOCKET_EVENTS.leaveRoom, (payload: unknown, ack?: AckHandler) => {
-    const validated = validateSocketEventPayload(leaveRoomEventSchema, payload)
-    if (!validated.success) {
-      ackError(ack, validated.error.detail, validated.error.code)
-      return
+      const connectedUser = getConnectedUser(socket.id)
+      if (!connectedUser) {
+        ackError(ack, '사용자 연결을 찾을 수 없습니다.', 'USER_NOT_CONNECTED')
+        return
+      }
+
+      const joinedRoomId = roomIdByUserId.get(connectedUser.id)
+      if (joinedRoomId !== validated.data.room_id) {
+        ackError(ack, '이미 방에서 나간 상태입니다.', 'ALREADY_LEFT_ROOM')
+        return
+      }
+
+      const leaveResult = removeUserFromRoom(
+        io,
+        validated.data.room_id,
+        connectedUser.id
+      )
+      if (!leaveResult.ok) {
+        ackError(ack, leaveResult.detail, leaveResult.code)
+        return
+      }
+
+      socket.leave(validated.data.room_id)
+      broadcastOnlineUsers(io)
+      ackSuccess(ack, {
+        room_id: validated.data.room_id,
+        left: true,
+      })
     }
-
-    socket.leave(validated.data.room_id)
-    updateUserStatus(socket.id, STATUS_LOBBY)
-    broadcastOnlineUsers(io)
-    ackSuccess(ack, {})
-  })
+  )
 
   socket.on(SOCKET_EVENTS.sendChat, (payload: unknown, ack?: AckHandler) => {
     const validated = validateSocketEventPayload(sendChatEventSchema, payload)
@@ -155,7 +414,18 @@ function configureSocketHandlers(io: Server, socket: Socket) {
 
     const sender = connectedUsersBySocketId.get(socket.id)
     if (!sender) {
-      ackError(ack, 'Sender is not connected', 'SENDER_NOT_FOUND')
+      ackError(ack, '사용자 연결을 찾을 수 없습니다.', 'USER_NOT_CONNECTED')
+      return
+    }
+
+    const senderRoomId = roomIdByUserId.get(sender.id)
+    if (!senderRoomId || senderRoomId !== validated.data.room_id) {
+      ackError(ack, '방 참가자를 찾을 수 없습니다.', 'PLAYER_NOT_IN_ROOM')
+      return
+    }
+
+    if (!roomsById.has(validated.data.room_id)) {
+      ackError(ack, '존재하지 않는 방입니다.', 'ROOM_NOT_FOUND')
       return
     }
 
@@ -181,6 +451,142 @@ function configureSocketHandlers(io: Server, socket: Socket) {
   })
 
   socket.on(
+    SOCKET_EVENTS.toggleReady,
+    (
+      payload: unknown,
+      ack?: AckHandler<{ is_ready: boolean; all_ready: boolean }>
+    ) => {
+      const validated = validateSocketEventPayload(
+        toggleReadyEventSchema,
+        payload
+      )
+      if (!validated.success) {
+        ackError(ack, validated.error.detail, validated.error.code)
+        return
+      }
+
+      const connectedUser = getConnectedUser(socket.id)
+      if (!connectedUser) {
+        ackError(ack, '사용자 연결을 찾을 수 없습니다.', 'USER_NOT_CONNECTED')
+        return
+      }
+
+      const room = roomsById.get(validated.data.room_id)
+      if (!room) {
+        ackError(ack, '존재하지 않는 방입니다.', 'ROOM_NOT_FOUND')
+        return
+      }
+
+      const player = room.players.find(
+        (target) => target.id === connectedUser.id
+      )
+      if (!player) {
+        ackError(ack, '방 참가자를 찾을 수 없습니다.', 'PLAYER_NOT_IN_ROOM')
+        return
+      }
+
+      if (player.isHost) {
+        ackError(
+          ack,
+          '방장은 준비 상태를 변경할 수 없습니다.',
+          'HOST_CANNOT_TOGGLE_READY'
+        )
+        return
+      }
+
+      if (room.status === 'playing') {
+        ackError(ack, '이미 게임이 시작된 방입니다.', 'ROOM_ALREADY_PLAYING')
+        return
+      }
+
+      player.isReady = !player.isReady
+      emitPlayerReady(io, room, player)
+      ackSuccess(ack, {
+        is_ready: player.isReady,
+        all_ready: canStartGame(room),
+      })
+    }
+  )
+
+  socket.on(
+    SOCKET_EVENTS.startGame,
+    (
+      payload: unknown,
+      ack?: AckHandler<{ game_id: string; room_id: string }>
+    ) => {
+      const validated = validateSocketEventPayload(
+        startGameEventSchema,
+        payload
+      )
+      if (!validated.success) {
+        ackError(ack, validated.error.detail, validated.error.code)
+        return
+      }
+
+      const connectedUser = getConnectedUser(socket.id)
+      if (!connectedUser) {
+        ackError(ack, '사용자 연결을 찾을 수 없습니다.', 'USER_NOT_CONNECTED')
+        return
+      }
+
+      const room = roomsById.get(validated.data.room_id)
+      if (!room) {
+        ackError(ack, '존재하지 않는 방입니다.', 'ROOM_NOT_FOUND')
+        return
+      }
+
+      const player = room.players.find(
+        (target) => target.id === connectedUser.id
+      )
+      if (!player) {
+        ackError(ack, '방 참가자를 찾을 수 없습니다.', 'PLAYER_NOT_IN_ROOM')
+        return
+      }
+
+      if (!player.isHost) {
+        ackError(
+          ack,
+          '방장만 게임을 시작할 수 있습니다.',
+          'ONLY_HOST_CAN_START'
+        )
+        return
+      }
+
+      if (room.status === 'playing') {
+        ackError(ack, '이미 게임이 시작된 방입니다.', 'ROOM_ALREADY_PLAYING')
+        return
+      }
+
+      if (!canStartGame(room)) {
+        ackError(
+          ack,
+          '최소 2명 + 전원 준비 완료 조건이 필요합니다.',
+          'READY_CONDITION_NOT_MET'
+        )
+        return
+      }
+
+      room.status = 'playing'
+      room.players.forEach((roomPlayer) => {
+        setConnectedUserStatus(roomPlayer.id, STATUS_PLAYING)
+      })
+      broadcastOnlineUsers(io)
+
+      const gameStartPayload = emitGameStart(io, room)
+      if (!gameStartPayload) {
+        ackError(
+          ack,
+          '게임 시작 이벤트 생성에 실패했습니다.',
+          'GAME_START_FAILED'
+        )
+        return
+      }
+
+      ackSuccess(ack, gameStartPayload)
+    }
+  )
+
+  socket.on(
     SOCKET_EVENTS.directMessageSend,
     (payload: unknown, ack?: AckHandler<{ delivered: boolean }>) => {
       const validated = validateSocketEventPayload(
@@ -194,13 +600,13 @@ function configureSocketHandlers(io: Server, socket: Socket) {
 
       const sender = connectedUsersBySocketId.get(socket.id)
       if (!sender) {
-        ackError(ack, 'Sender is not connected', 'SENDER_NOT_FOUND')
+        ackError(ack, '사용자 연결을 찾을 수 없습니다.', 'USER_NOT_CONNECTED')
         return
       }
 
       const receiverSocketId = socketIdByUserId.get(validated.data.receiver_id)
       if (!receiverSocketId) {
-        ackError(ack, 'Receiver is not connected', 'RECEIVER_NOT_FOUND')
+        ackError(ack, '상대 사용자가 오프라인입니다.', 'RECEIVER_NOT_FOUND')
         return
       }
 
@@ -270,19 +676,57 @@ function bootstrapSocketMockServer() {
 
   io.on('connection', (socket) => {
     const connectedUser = createConnectedUser(socket)
+    const previousSocketId = socketIdByUserId.get(connectedUser.id)
+
+    // 동일 userId 재연결 시 이전 소켓 엔트리를 정리
+    if (previousSocketId && previousSocketId !== socket.id) {
+      connectedUsersBySocketId.delete(previousSocketId)
+    }
+
     connectedUsersBySocketId.set(socket.id, connectedUser)
     socketIdByUserId.set(connectedUser.id, socket.id)
+
+    const joinedRoomId = roomIdByUserId.get(connectedUser.id)
+    if (joinedRoomId) {
+      const joinedRoom = roomsById.get(joinedRoomId)
+      const joinedPlayer = joinedRoom?.players.find(
+        (player) => player.id === connectedUser.id
+      )
+
+      if (joinedRoom && joinedPlayer) {
+        joinedPlayer.socketId = socket.id
+        socket.join(joinedRoom.id)
+        setConnectedUserStatus(
+          connectedUser.id,
+          joinedRoom.status === 'playing' ? STATUS_PLAYING : STATUS_IN_ROOM
+        )
+      }
+    }
+
     broadcastOnlineUsers(io)
     configureSocketHandlers(io, socket)
 
     socket.on('disconnect', () => {
       const disconnectedUser = connectedUsersBySocketId.get(socket.id)
-      connectedUsersBySocketId.delete(socket.id)
-
-      if (disconnectedUser) {
-        socketIdByUserId.delete(disconnectedUser.id)
+      if (!disconnectedUser) {
+        broadcastOnlineUsers(io)
+        return
       }
 
+      // 이미 같은 userId가 다른 소켓으로 재연결된 경우 현재 소켓만 정리
+      if (socketIdByUserId.get(disconnectedUser.id) !== socket.id) {
+        connectedUsersBySocketId.delete(socket.id)
+        broadcastOnlineUsers(io)
+        return
+      }
+
+      const joinedRoomId = roomIdByUserId.get(disconnectedUser.id)
+      if (joinedRoomId) {
+        removeUserFromRoom(io, joinedRoomId, disconnectedUser.id)
+      }
+
+      socketIdByUserId.delete(disconnectedUser.id)
+      connectedUsersBySocketId.delete(socket.id)
       broadcastOnlineUsers(io)
     })
   })

--- a/src/contracts/socket/events.ts
+++ b/src/contracts/socket/events.ts
@@ -4,6 +4,8 @@ export const SOCKET_EVENTS = {
   enterRoom: 'enter_room',
   leaveRoom: 'leave_room',
   sendChat: 'send_chat',
+  toggleReady: 'toggle_ready',
+  startGame: 'start_game',
   chat: 'chat',
   playerReady: 'player_ready',
   hostChanged: 'host_changed',
@@ -62,12 +64,31 @@ export interface SendChatEventPayload {
   message: string
 }
 
+export interface ToggleReadyEventPayload {
+  room_id: string
+}
+
+export interface StartGameEventPayload {
+  room_id: string
+}
+
 export interface ChatEventPayload {
   room_id: string
   sender_id: string
   sender_nickname: string
   message: string
   sent_at: string
+}
+
+export interface PlayerReadyEventPayload {
+  player_id: string
+  is_ready: boolean
+  all_ready: boolean
+}
+
+export interface HostChangedEventPayload {
+  new_host_id: string
+  new_host_nickname: string
 }
 
 export interface GameStartEventPayload {

--- a/src/contracts/socket/schemas.ts
+++ b/src/contracts/socket/schemas.ts
@@ -39,12 +39,31 @@ export const sendChatEventSchema = z.object({
   message: z.string().trim().min(1),
 })
 
+export const toggleReadyEventSchema = z.object({
+  room_id: z.string().min(1),
+})
+
+export const startGameEventSchema = z.object({
+  room_id: z.string().min(1),
+})
+
 export const chatEventSchema = z.object({
   room_id: z.string().min(1),
   sender_id: z.string().min(1),
   sender_nickname: z.string().min(1),
   message: z.string().trim().min(1),
   sent_at: z.string().datetime(),
+})
+
+export const playerReadyEventSchema = z.object({
+  player_id: z.string().min(1),
+  is_ready: z.boolean(),
+  all_ready: z.boolean(),
+})
+
+export const hostChangedEventSchema = z.object({
+  new_host_id: z.string().min(1),
+  new_host_nickname: z.string().min(1),
 })
 
 export const gameStartEventSchema = z.object({
@@ -57,7 +76,11 @@ export const eventPayloadSchemas = {
   [SOCKET_EVENTS.enterRoom]: enterRoomEventSchema,
   [SOCKET_EVENTS.leaveRoom]: leaveRoomEventSchema,
   [SOCKET_EVENTS.sendChat]: sendChatEventSchema,
+  [SOCKET_EVENTS.toggleReady]: toggleReadyEventSchema,
+  [SOCKET_EVENTS.startGame]: startGameEventSchema,
   [SOCKET_EVENTS.chat]: chatEventSchema,
+  [SOCKET_EVENTS.playerReady]: playerReadyEventSchema,
+  [SOCKET_EVENTS.hostChanged]: hostChangedEventSchema,
   [SOCKET_EVENTS.directMessageSend]: directMessageSendEventSchema,
   [SOCKET_EVENTS.directMessageReceive]: directMessageReceiveEventSchema,
   [SOCKET_EVENTS.gameStart]: gameStartEventSchema,


### PR DESCRIPTION
## 📌 관련 이슈

> closes #280 

---

## 📝 작업 내용

- PR3 범위로 대기방 준비/시작 규칙을 socket mock 서버에 반영했습니다
- 소켓 계약 타입/스키마를 확장했습니다
  - `src/contracts/socket/events.ts`
  - `src/contracts/socket/schemas.ts`
  - 추가 이벤트: `toggle_ready`, `start_game`
  - 추가 payload: `player_ready`, `host_changed`
- mock socket 서버에 대기방 상태 저장소/규칙 검증 로직을 추가했습니다
  - `mock-socket-server/index.ts`
  - room 상태 추적: `roomsById`, `roomIdByUserId`
  - 입장/퇴장/재연결 처리 정합화
  - 방장 이관 시 `host_changed` emit
  - 준비 토글 시 `player_ready` emit
  - 시작 시 `game_start` emit + 접속자 상태 `playing` 반영
- 명세 기반 에러 코드 분기를 서버(mock)에서 강제했습니다
  - `ROOM_NOT_FOUND`
  - `ROOM_FULL`
  - `ROOM_ALREADY_PLAYING`
  - `ALREADY_LEFT_ROOM`
  - `PLAYER_NOT_IN_ROOM`
  - `HOST_CANNOT_TOGGLE_READY`
  - `ONLY_HOST_CAN_START`
  - `READY_CONDITION_NOT_MET`
- 문서 업데이트
  - `docs/socket-mock-server.md`
  - 준비/시작 규칙과 에러 코드 목록 추가

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

- 해당 없음 (소켓 규칙/계약 레이어 변경)

---

## 🧪 검증 내용

- `npm run lint` 통과
- `npm run test` 통과
- `npm run build` 통과
- `npm run socket:mock` 실행 및 `/health` 응답 확인

---

## 📌 추가 메모

- 이번 PR은 대기방 규칙(ready/start)과 에러 코드 정합화까지 포함
- DM 정책 강화 및 `game:*` 네임스페이스 확장은 다음 PR에서 진행 예정
