### PR TITLE
Feat : GamePage prompt/ack/error/pendingAction UI 연결

### DIFF
--- a/docs/game-delivery-roadmap.md
+++ b/docs/game-delivery-roadmap.md
@@ -143,7 +143,7 @@
 - `src/services/socket/game.handler.ts`: `game:ack`, `game:patch`, `game:prompt`, `game:error` 구독. `emitGameAction`, `emitGameSync`, `emitPromptResponse` emit. 구 이벤트 리스너 제거
 - `src/hooks/game/useGameState.ts`: 진입 시 `game:sync` 우선, REST bootstrap fallback 병행
 - `src/mocks/handlers/game.handler.ts`: `game:ack` + `game:patch(snapshot)` 기반 event-socket mock 추가
-- `src/pages/GamePage.tsx`: store 단일 소스 + `gameViewModel` mapper로 board 데이터 조립
+- `src/pages/GamePage.tsx`: store 단일 소스 + `gameViewModel` mapper로 board 데이터 조립 + `prompt` 오버레이 응답, `pendingAction`/`lastAck`/`lastError` UI 연결
 
 남은 핵심 축 — **명세 불일치 (코드 수정 전 반드시 선행)**:
 
@@ -163,9 +163,9 @@
 
 남은 핵심 축 — UI 연결:
 
-- `store.prompt` → 모달/오버레이 열림 조건 연결 없음 (BuyModal 등은 여전히 REST 직접 호출)
-- `emitPromptResponse` → 실제 사용자 응답 흐름 연결 없음
-- `store.pendingAction`, `store.lastAck`, `store.lastError` → 버튼 비활성화/에러 UI 연결 없음
+- `GamePage.tsx`의 `store.prompt`/`emitPromptResponse`/`pendingAction`/`lastAck`/`lastError` 연결은 완료
+- `store.prompt.type` → `modals/*` 및 `GameBoard.tsx` 분기 연결은 아직 없음 (Buy/Build/Toll 흐름은 여전히 로컬/REST 혼재)
+- `DiceTimerModal` → `game:prompt.timeoutSec` 연동 없음
 - `gameBoardActionHandlers.ts`: `gameApi.buyTile`, `gameApi.buildTile`, `gameApi.sellTile` REST 직접 호출 유지 → 격리 필요
 
 ### FE-C: 골격 완료(약 30%), 버그 수정 + 시각 레이어 수렴 단계
@@ -231,10 +231,11 @@
 
 현재 FE-B의 다음 최우선 작업이다.
 
-- `store.prompt` → 모달/오버레이 열림 조건 연결 (`GameBoard.tsx`, `GamePage.tsx`)
-- `emitPromptResponse` → 실제 사용자 확인/거절 응답 흐름 연결
-- 즉시 실패는 `game:ack.ok=false` → `store.lastError` → 에러 UI 표시
-- `store.pendingAction` → 버튼 비활성화/로딩 연결
+- ~~`GamePage.tsx`에서 `store.prompt` 오버레이 열림 조건 연결~~ ✅ 완료
+- ~~`GamePage.tsx`에서 `emitPromptResponse` 사용자 응답 흐름 연결~~ ✅ 완료
+- ~~`game:ack.ok=false` → `store.lastError` → 에러 UI 표시 연결~~ ✅ 완료
+- ~~`store.pendingAction`/`store.lastAck` 버튼 상태 및 상태 배지 연결~~ ✅ 완료
+- `store.prompt.type` → `modals/*`, `GameBoard.tsx` 분기 연결
 - `DiceTimerModal` → `game:prompt.timeoutSec` 기반으로 연결
 - `gameBoardActionHandlers.ts`: REST 직접 호출(`gameApi.buyTile` 등) → `emitGameAction` 전환
 
@@ -287,7 +288,7 @@ FE-B `store.eventQueue`가 채워지는 구조는 완료. FE-C가 소비 쪽을 
 
 1. **FE-B 5-1**: 명세 불일치 수정 (`GamePromptResponse`, `GameAck`, `GamePatchEnvelope`, `emitGameSync`, `emitPromptResponse`, mock)
 2. **FE-C 6-1**: 버그 3개 수정 (`gameBoardStoreBridge`, `gameBoardTransactionUtils`, `gameBoardActionUtils`)
-3. **FE-B 5-4**: `store.prompt` / `store.lastError` / `store.pendingAction` → UI 연결. REST → `emitGameAction` 전환
+3. **FE-B 5-4**: `store.prompt.type` 기반 modal 연결 + `DiceTimerModal` timeout 연결 + REST → `emitGameAction` 전환
 4. **FE-C 6-2**: `GameBoard.tsx` 서버 계산 제거, 시각 레이어 수렴
 5. **FE-C 6-4**: `store.eventQueue` 기반 이동/연출 구현
 6. **FE-B + FE-C**: `game:prompt` 흐름과 `DiceTimerModal` timeout 흐름 공동 검증

--- a/docs/game-event-spec-migration-plan.md
+++ b/docs/game-event-spec-migration-plan.md
@@ -82,9 +82,9 @@
 | `src/hooks/game/useGameState.ts`                    | ✅ 완료           | —                                                                                      | FE-B                       |
 | `src/services/game/game.api.ts`                     | ⚠️ 레거시 격리 중 | deprecated 표시 완료. `gameBoardActionHandlers.ts` 호출부 → `emitGameAction` 전환 필요 | FE-B                       |
 | `src/hooks/game/useDiceRoll.ts`                     | ✅ 완료           | —                                                                                      | FE-B                       |
-| `src/pages/GamePage.tsx`                            | ✅ 1차 완료       | `store.prompt`, `store.lastError`, `store.pendingAction` UI 연결 필요                  | FE-B                       |
+| `src/pages/GamePage.tsx`                            | ✅ 2차 완료       | `prompt` 오버레이 응답, `pendingAction`/`lastAck`/`lastError` UI 연결 완료             | FE-B                       |
 | `src/components/board/GameBoard.tsx`                | ⚠️ 부분 정리      | `applyMoney`, `advanceTurn`, 통행료 계산, 파산 판정 제거. `store.prompt` 연결          | FE-C 주도 / FE-B 선행 필요 |
-| `src/components/game/modals/*`                      | ❌ prompt 미연결  | `store.prompt.type` 기준 모달 열림 조건 연결. `emitPromptResponse` 연결                | FE-B                       |
+| `src/components/game/modals/*`                      | ⚠️ 부분 완료      | `store.prompt.type` 기준 모달 열림 조건 연결. `DiceTimerModal` timeout 연동            | FE-B                       |
 | `src/mocks/handlers/game.handler.ts`                | ✅ 완료           | —                                                                                      | FE-B                       |
 | `src/components/board/gameBoardStoreBridge.ts`      | ❌ 버그           | `toStoreBuildingLevel` 상한 5→7                                                        | FE-C                       |
 | `src/components/board/gameBoardTransactionUtils.ts` | ❌ 버그           | `upgradeBoardTileOwner` 상한 5→7                                                       | FE-C                       |
@@ -268,7 +268,7 @@
 - `src/stores/game.store.ts`: `replaceFromSnapshot`, `applyPatchEnvelope`(revision guard + set/inc/push/remove), `setPendingAction`, `resolveAck`, `setPrompt`, `clearPrompt`, `enqueueEvents`, `consumeNextEvent`, `setLastError`, `resetGame` 전부 구현
 - `src/services/socket/game.handler.ts`: `game:ack`, `game:patch`, `game:prompt`, `game:error` 구독. `emitGameAction`, `emitGameSync`, `emitPromptResponse` 구현
 - `src/hooks/game/useGameState.ts`: `game:sync` 우선, REST bootstrap fallback 병행
-- `src/pages/GamePage.tsx`: store 단일 소스, `gameViewModel` mapper로 board 데이터 조립
+- `src/pages/GamePage.tsx`: store 단일 소스, `gameViewModel` mapper로 board 데이터 조립 + `prompt` 오버레이 응답, `pendingAction`/`lastAck`/`lastError` UI 연결
 
 ### 명세 불일치 (수정 완료 — 2026-03-05)
 
@@ -284,9 +284,7 @@
 
 ### 구조 미구현 (FE-B 2단계)
 
-- `store.prompt` → 모달 연결 없음
-- `store.lastError` → 에러 UI 연결 없음
-- `store.pendingAction` → 버튼 상태 연결 없음
+- `GamePage`: `store.prompt`/`lastError`/`pendingAction` UI 연결은 완료. `prompt.type`별 모달 분기 연결은 미완료
 - `store.eventQueue` → 소비 컴포넌트 없음
 - `gameBoardActionHandlers.ts` → REST 직접 호출 유지 (`emitGameAction` 전환 필요)
 
@@ -296,7 +294,7 @@
 
 1. ~~`src/types/domain.ts`, `src/services/socket/game.handler.ts`: 명세 불일치 수정~~ ✅ 완료
 2. ~~`src/mocks/handlers/game.handler.ts`: 명세 불일치 수정~~ ✅ 완료
-3. `src/components/game/modals/*`, `src/pages/GamePage.tsx`, `src/components/board/GameBoard.tsx`: `store.prompt` → modal 연결. `store.lastError` → 에러 UI. `store.pendingAction` → 버튼 상태
+3. `src/components/game/modals/*`, `src/components/board/GameBoard.tsx`: `store.prompt.type` → modal 연결, `DiceTimerModal` → `prompt.timeoutSec` 연결
 4. `src/components/board/gameBoardActionHandlers.ts`: REST 직접 호출 → `emitGameAction` 전환
 
 **FE-C**
@@ -315,3 +313,9 @@
 - 기존 roomId/REST/원 단위 계약을 안전하게 유지하기 위한 호환 변경인지
 
 둘을 섞을 때는 반드시 mapper/adapter 계층을 명시적으로 둔다.
+
+### 6-1. 작업 종료 시 문서 업데이트 규칙 (2026-03-05 추가)
+
+- 모든 작업은 완료 시점에 문서를 함께 갱신한다.
+- 문서에는 반드시 `진행도(무엇이 완료됐는지)`와 `다음 작업(무엇을 이어서 할지)`를 함께 기록한다.
+- 기본 갱신 대상은 `docs/game-event-spec-migration-plan.md`, `docs/game-delivery-roadmap.md`, `docs/game-ownership-corrected-table.md`다.

--- a/docs/game-ownership-corrected-table.md
+++ b/docs/game-ownership-corrected-table.md
@@ -18,15 +18,14 @@
 
 ## 진행도 요약
 
-| 파트 | 진행도  | 상태                                                        |
-| ---- | ------- | ----------------------------------------------------------- |
-| FE-B | 진행 중 | 타입/store/socket/mock 골격 정리 후 prompt/ack UI 연결 단계 |
-| FE-C | 진행 중 | 보드를 표현/연출 중심 레이어로 더 줄여야 하는 단계          |
+| 파트 | 진행도  | 상태                                                                       |
+| ---- | ------- | -------------------------------------------------------------------------- |
+| FE-B | 진행 중 | `GamePage` prompt/ack/error/pendingAction 연결 완료, modal/board 연결 단계 |
+| FE-C | 진행 중 | 보드를 표현/연출 중심 레이어로 더 줄여야 하는 단계                         |
 
 ## FE-B 현재 최우선 작업
 
 - `src/components/game/modals/*`를 `gameStore.prompt`와 연결
-- `src/pages/GamePage.tsx`에서 `pendingAction`, `lastAck`, `lastError`를 실제 UI 상태와 연결
 - `src/components/board/GameBoard.tsx`의 로컬 modal 분기를 `game:prompt` 소비 구조로 전환
 - `src/services/socket/game.handler.ts`의 `emitPromptResponse`를 실사용 UI 흐름과 연결
 - 남아 있는 게임 REST fallback을 compatibility layer로 더 명확히 격리
@@ -40,10 +39,16 @@
 
 ## 현재 가장 큰 리스크
 
-- `prompt`, `ack`, `pendingAction`이 store에는 있지만 실제 UI 소비가 아직 불완전하다.
+- `GamePage`는 `prompt`, `ack`, `pendingAction`을 소비하지만, `modals/*`/`GameBoard.tsx`는 아직 `prompt.type` 중심 소비 구조가 아니다.
 - `GameBoard.tsx`가 여전히 일부 게임 엔진 성격 로직을 들고 있다.
 - 게임 REST fallback이 장기화되면 중앙 docs 기준과 실제 런타임이 다시 벌어질 수 있다.
 - `gameId`, money unit, tile/building enum 기준이 문서와 코드에서 완전히 수렴하지 않았다.
+
+## 작업 운영 규칙 (2026-03-05 추가)
+
+- 작업 종료 시점마다 문서를 같이 갱신한다.
+- 문서에는 반드시 `진행도`와 `다음 작업`을 같이 적는다.
+- 기본 갱신 파일: `docs/game-event-spec-migration-plan.md`, `docs/game-delivery-roadmap.md`, `docs/game-ownership-corrected-table.md`
 
 ## 완료 판단 기준
 

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { Settings } from 'lucide-react'
 import { useLocation, useParams } from 'react-router-dom'
 import BoardGame, { BoardGameHandle } from '../components/board/GameBoard'
@@ -13,8 +13,9 @@ import { useGameState } from '../hooks/game/useGameState'
 import { useGameTimer } from '../hooks/game/useGameTimer'
 import { useTurn } from '../hooks/game/useTurn'
 import { socket } from '../lib/socket'
+import { emitPromptResponse } from '../services/socket/game.handler'
 import { useGameStore } from '../stores/game.store'
-import type { ChatMessage } from '../types/domain'
+import type { ChatMessage, GamePromptChoice } from '../types/domain'
 import {
   findBoardCurrentPlayerIndex,
   mapStorePlayersToBoardPlayers,
@@ -33,6 +34,13 @@ const DEFAULT_MOCK_PLAYER_ID = 'mock-player-1'
 const DEFAULT_MOCK_NICKNAME = '플레이어 1'
 const DEFAULT_GUEST_ID = 'guest-local'
 const MOCK_LOCAL_PLAYER_INDEX = 0
+const FALLBACK_PROMPT_CHOICES: GamePromptChoice[] = [
+  {
+    id: 'confirm',
+    label: 'Confirm',
+    value: 'confirm',
+  },
+]
 
 function mapGameChatEventToMessage(payload: ChatEventPayload): ChatMessage {
   return {
@@ -63,7 +71,17 @@ const GamePage: React.FC = () => {
     turnTimerKey,
     players: storePlayers,
     tiles: storeTiles,
+    prompt,
+    pendingAction,
+    lastAck,
+    lastError,
+    gameId: storeGameId,
+    clearPrompt,
+    setLastError,
   } = useGameStore()
+  const [promptSubmittingChoice, setPromptSubmittingChoice] = useState<
+    string | null
+  >(null)
   const [timeLeft] = useGameTimer({
     initialTime: turnTimeoutSec,
     resetSignal: turnTimerKey,
@@ -102,6 +120,38 @@ const GamePage: React.FC = () => {
     : normalizedCurrentTurn === null
       ? true
       : isMyTurnFromStore
+  const isPromptTargetedToCurrentUser =
+    prompt?.playerId == null ||
+    (currentUserId != null && String(prompt.playerId) === String(currentUserId))
+  const isPromptVisible = Boolean(prompt && isPromptTargetedToCurrentUser)
+  const promptChoices = useMemo(
+    () =>
+      prompt?.choices && prompt.choices.length > 0
+        ? prompt.choices
+        : FALLBACK_PROMPT_CHOICES,
+    [prompt]
+  )
+  const isActionPending = pendingAction !== null
+
+  useEffect(() => {
+    if (!prompt) {
+      setPromptSubmittingChoice(null)
+      return
+    }
+
+    if (lastAck?.promptId === prompt.id) {
+      clearPrompt(prompt.id)
+      setPromptSubmittingChoice(null)
+    }
+  }, [clearPrompt, lastAck?.promptId, prompt])
+
+  useEffect(() => {
+    if (!lastError) {
+      return
+    }
+
+    setPromptSubmittingChoice(null)
+  }, [lastError])
 
   useEffect(() => {
     if (!activeRoomId) {
@@ -166,6 +216,21 @@ const GamePage: React.FC = () => {
     roomChatSenderOptions.find(
       (senderOption) => senderOption.id !== currentUserIdForChat
     )?.id ?? roomChatSenderOptions[0]?.id
+  const handlePromptChoice = (choice: string) => {
+    if (!prompt || promptSubmittingChoice !== null) {
+      return
+    }
+
+    setPromptSubmittingChoice(choice)
+    emitPromptResponse({
+      gameId: storeGameId ?? gameId ?? null,
+      promptId: prompt.id,
+      choice,
+    })
+  }
+  const dismissLastError = () => {
+    setLastError(null)
+  }
 
   return (
     <div className="relative flex h-screen w-full items-center justify-center bg-[#F2EBD8] px-6 font-['Inter']">
@@ -173,6 +238,38 @@ const GamePage: React.FC = () => {
         <button className="flex h-10 w-10 items-center justify-center rounded-xl border border-[#E2E8F0] bg-white/80 text-[#45556C] shadow-sm transition-colors hover:bg-white">
           <Settings size={20} />
         </button>
+      </div>
+      <div className="absolute right-6 top-6 z-20 flex w-[340px] flex-col gap-2">
+        {isActionPending && (
+          <div className="rounded-xl border border-[#BFDBFE] bg-[#EFF6FF] px-3 py-2 text-xs font-semibold text-[#1D4ED8]">
+            Pending action: {pendingAction.type}
+          </div>
+        )}
+        {lastAck && (
+          <div
+            className={`rounded-xl border px-3 py-2 text-xs font-semibold ${
+              lastAck.ok
+                ? 'border-[#BBF7D0] bg-[#F0FDF4] text-[#166534]'
+                : 'border-[#FECACA] bg-[#FEF2F2] text-[#B91C1C]'
+            }`}
+          >
+            {lastAck.ok ? 'Action acknowledged' : 'Action rejected'} (
+            {lastAck.type ?? 'UNKNOWN'})
+          </div>
+        )}
+        {lastError && (
+          <div className="rounded-xl border border-[#FECACA] bg-[#FEF2F2] px-3 py-2 text-xs text-[#991B1B]">
+            <div className="font-semibold">{lastError.code}</div>
+            <div className="mt-1">{lastError.message}</div>
+            <button
+              type="button"
+              onClick={dismissLastError}
+              className="mt-2 rounded-lg border border-[#FCA5A5] bg-white px-2 py-1 text-[11px] font-semibold text-[#B91C1C] transition-colors hover:bg-[#FEE2E2]"
+            >
+              Dismiss
+            </button>
+          </div>
+        )}
       </div>
 
       <div
@@ -239,11 +336,54 @@ const GamePage: React.FC = () => {
         {!isCurrentPlayerSkipped && !isCurrentPlayerBankrupt && (
           <RollButton
             timeLeft={timeLeft}
-            isMyTurn={isMyTurn}
+            isMyTurn={isMyTurn && !isActionPending && !isPromptVisible}
             onRoll={() => diceRoll(activeRoomId)}
           />
         )}
       </div>
+
+      {isPromptVisible && prompt && (
+        <div className="fixed inset-0 z-30 flex items-center justify-center bg-black/45 px-4">
+          <div className="w-full max-w-xl rounded-3xl bg-white p-6 shadow-2xl">
+            <h2 className="text-2xl font-black text-[#1F2A44]">
+              {prompt.title ?? prompt.type ?? 'Prompt'}
+            </h2>
+            {prompt.message && (
+              <p className="mt-2 text-sm font-semibold text-[#5A6D8A]">
+                {prompt.message}
+              </p>
+            )}
+            {typeof prompt.timeoutSec === 'number' && (
+              <p className="mt-1 text-xs font-semibold text-[#64748B]">
+                Timeout: {prompt.timeoutSec}s
+              </p>
+            )}
+            <div className="mt-4 flex flex-col gap-2">
+              {promptChoices.map((choice) => (
+                <button
+                  key={choice.id}
+                  type="button"
+                  disabled={promptSubmittingChoice !== null}
+                  onClick={() => handlePromptChoice(choice.value)}
+                  className="w-full rounded-xl border border-[#D0D7E2] px-4 py-3 text-left text-sm font-bold text-[#334155] transition-colors hover:bg-[#F8FAFC] disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {choice.label}
+                  {choice.description ? (
+                    <span className="mt-1 block text-xs font-medium text-[#64748B]">
+                      {choice.description}
+                    </span>
+                  ) : null}
+                </button>
+              ))}
+            </div>
+            {promptSubmittingChoice && (
+              <p className="mt-3 text-xs font-semibold text-[#1D4ED8]">
+                Sending response...
+              </p>
+            )}
+          </div>
+        </div>
+      )}
 
       <DevRoomChatControlPanel
         roomId={activeRoomId ?? ''}


### PR DESCRIPTION
## 🔗 관련 이슈

> closes #261 

---

## ✨ 작업 내용

- `src/pages/GamePage.tsx`
- `store.prompt` 기반 오버레이 표시 및 선택 응답(`emitPromptResponse`) 연결
- `lastAck.promptId` 기준 prompt 정리(`clearPrompt`) 처리
- `pendingAction`/`lastAck`/`lastError` 상태 UI 배지 연결
- `lastError` dismiss 처리 추가
- `pendingAction` 또는 prompt 활성 시 Roll 버튼 비활성화 처리

- 문서 진행도 및 다음 작업 갱신
- `docs/game-event-spec-migration-plan.md`
- `docs/game-delivery-roadmap.md`
- `docs/game-ownership-corrected-table.md`
- 이번 작업 반영(완료/미완료 재분류, 다음 우선순위 갱신)
- 작업 종료 시 문서 업데이트 규칙(진행도 + 다음 작업 기록) 추가

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [ ] 관련된 이슈 연결 완료

추가 검증 내역:
- [x] `npm run lint`
- [x] `npm run test`
- [x] `npm run test:coverage`
- [x] `npm run e2e:ci`
- [x] `npm run build`

---

## 📸 스크린샷 (선택)

> UI 변경이 있을 경우 첨부해주세요.
