### PR TITLE
feat: Socket Mock 채팅/DM 정책 검증 및 실시간 경계 보강

### DIFF
--- a/docs/socket-mock-server.md
+++ b/docs/socket-mock-server.md
@@ -19,6 +19,7 @@ npm run socket:mock
 - `enter_room`, `leave_room` 검증 및 상태 갱신
 - `send_chat` 룸 브로드캐스트
 - `dm_send` -> `dm_receive` 전달
+- DM 정책: 송신자/수신자 중 `playing` 상태가 있으면 차단
 - `toggle_ready` 준비 상태 토글 + `player_ready` 브로드캐스트
 - `start_game` 시작 조건 검증 + `game_start` 브로드캐스트
 - 방장 퇴장 시 `host_changed` 브로드캐스트
@@ -48,3 +49,4 @@ npm run socket:mock
 - `HOST_CANNOT_TOGGLE_READY`
 - `ONLY_HOST_CAN_START`
 - `READY_CONDITION_NOT_MET`
+- `DM_BLOCKED_WHILE_PLAYING`

--- a/mock-socket-server/index.ts
+++ b/mock-socket-server/index.ts
@@ -9,6 +9,8 @@ import {
   type GameStartEventPayload,
   type HostChangedEventPayload,
   type PlayerReadyEventPayload,
+  isDirectMessageBlockedByStatus,
+  isWaitingRoomStartConditionMet,
   type SocketAck,
 } from '../src/contracts/socket'
 import {
@@ -174,16 +176,7 @@ function getOrCreateRoom(roomId: string) {
 }
 
 function canStartGame(room: MockRoom) {
-  if (room.players.length < 2) {
-    return false
-  }
-
-  const nonHostPlayers = room.players.filter((player) => !player.isHost)
-  if (nonHostPlayers.length === 0) {
-    return false
-  }
-
-  return nonHostPlayers.every((player) => player.isReady)
+  return isWaitingRoomStartConditionMet(room.players)
 }
 
 function emitHostChanged(io: Server, room: MockRoom, nextHost: MockRoomPlayer) {
@@ -607,6 +600,26 @@ function configureSocketHandlers(io: Server, socket: Socket) {
       const receiverSocketId = socketIdByUserId.get(validated.data.receiver_id)
       if (!receiverSocketId) {
         ackError(ack, '상대 사용자가 오프라인입니다.', 'RECEIVER_NOT_FOUND')
+        return
+      }
+
+      const receiver = connectedUsersBySocketId.get(receiverSocketId)
+      if (!receiver) {
+        ackError(
+          ack,
+          '상대 사용자 연결을 찾을 수 없습니다.',
+          'RECEIVER_NOT_FOUND'
+        )
+        return
+      }
+
+      // 게임 중 사용자와의 DM은 송수신 모두 차단
+      if (isDirectMessageBlockedByStatus(sender.status, receiver.status)) {
+        ackError(
+          ack,
+          '게임 중인 사용자와는 DM을 보낼 수 없습니다.',
+          'DM_BLOCKED_WHILE_PLAYING'
+        )
         return
       }
 

--- a/src/contracts/socket/index.ts
+++ b/src/contracts/socket/index.ts
@@ -1,2 +1,3 @@
 export * from './events'
+export * from './policies'
 export * from './schemas'

--- a/src/contracts/socket/policies.test.ts
+++ b/src/contracts/socket/policies.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isDirectMessageBlockedByStatus,
+  isWaitingRoomStartConditionMet,
+} from './policies'
+
+describe('socket contract policies', () => {
+  it('DM 정책은 송신자/수신자 중 한 명이라도 playing이면 차단한다', () => {
+    expect(isDirectMessageBlockedByStatus('playing', 'lobby')).toBe(true)
+    expect(isDirectMessageBlockedByStatus('in_room', 'playing')).toBe(true)
+    expect(isDirectMessageBlockedByStatus('lobby', 'in_room')).toBe(false)
+  })
+
+  it('대기방 시작 조건은 최소 2명 + non-host 전원 준비 완료를 만족해야 한다', () => {
+    expect(
+      isWaitingRoomStartConditionMet([{ isHost: true, isReady: false }])
+    ).toBe(false)
+
+    expect(
+      isWaitingRoomStartConditionMet([
+        { isHost: true, isReady: false },
+        { isHost: false, isReady: false },
+      ])
+    ).toBe(false)
+
+    expect(
+      isWaitingRoomStartConditionMet([
+        { isHost: true, isReady: false },
+        { isHost: false, isReady: true },
+      ])
+    ).toBe(true)
+  })
+})

--- a/src/contracts/socket/policies.ts
+++ b/src/contracts/socket/policies.ts
@@ -1,0 +1,30 @@
+import type { ContractUserStatus } from './events'
+
+// DM 정책: 송신자/수신자 중 한 명이라도 게임 중이면 차단
+export function isDirectMessageBlockedByStatus(
+  senderStatus: ContractUserStatus,
+  receiverStatus: ContractUserStatus
+) {
+  return senderStatus === 'playing' || receiverStatus === 'playing'
+}
+
+interface WaitingRoomStartPlayer {
+  isHost: boolean
+  isReady: boolean
+}
+
+// 대기방 시작 조건: 최소 2명 + non-host 전원 준비 완료
+export function isWaitingRoomStartConditionMet(
+  players: WaitingRoomStartPlayer[]
+) {
+  if (players.length < 2) {
+    return false
+  }
+
+  const nonHostPlayers = players.filter((player) => !player.isHost)
+  if (nonHostPlayers.length === 0) {
+    return false
+  }
+
+  return nonHostPlayers.every((player) => player.isReady)
+}


### PR DESCRIPTION
## 📌 관련 이슈

> closes #283 

---

## 📝 작업 내용

- PR4 범위로 채팅/DM 정책을 계약 기반으로 보강했습니다
- 소켓 정책 함수를 분리하고 단위 테스트를 추가했습니다
  - `src/contracts/socket/policies.ts`
  - `src/contracts/socket/policies.test.ts`
  - `src/contracts/socket/index.ts` export 반영
- mock socket 서버에 DM 정책을 적용했습니다
  - `mock-socket-server/index.ts`
  - 송신자/수신자 중 하나라도 `playing` 상태면 DM 차단
  - 차단 시 `DM_BLOCKED_WHILE_PLAYING` 에러 반환
- 기존 대기방 시작 조건도 공통 정책 함수(`isWaitingRoomStartConditionMet`)를 사용하도록 정리했습니다
- 문서를 업데이트했습니다
  - `docs/socket-mock-server.md`
  - DM 정책 및 신규 에러 코드 명시

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

- 해당 없음 (소켓 정책/서버/문서 변경)

---

## 🧪 검증 내용

- `npm run lint` 통과
- `npm run test` 통과
- `npm run build` 통과
- 추가 단위 테스트:
  - `src/contracts/socket/policies.test.ts`

---

## 📌 추가 메모

- 이번 PR은 게임 본플레이(`game:*`) 로직이 아니라 채팅/DM 경계 정책만 포함합니다
- 게임 로직 구현은 팀원 파트와 분리하여 진행합니다
