### PR TITLE
Feat : non-mock 보드 액션을 game:action으로 전환

### DIFF
--- a/docs/game-delivery-roadmap.md
+++ b/docs/game-delivery-roadmap.md
@@ -144,6 +144,7 @@
 - `src/hooks/game/useGameState.ts`: 진입 시 `game:sync` 우선, REST bootstrap fallback 병행
 - `src/mocks/handlers/game.handler.ts`: `game:ack` + `game:patch(snapshot)` 기반 event-socket mock 추가
 - `src/pages/GamePage.tsx`: store 단일 소스 + `gameViewModel` mapper로 board 데이터 조립 + `prompt` 오버레이 응답, `pendingAction`/`lastAck`/`lastError` UI 연결
+- `src/components/board/gameBoardActionHandlers.ts`: BUY/SELL/END_TURN non-mock 경로를 `emitGameAction`으로 전환
 
 남은 핵심 축 — **명세 불일치 (코드 수정 전 반드시 선행)**:
 
@@ -166,7 +167,7 @@
 - `GamePage.tsx`의 `store.prompt`/`emitPromptResponse`/`pendingAction`/`lastAck`/`lastError` 연결은 완료
 - `store.prompt.type` → `modals/*` 및 `GameBoard.tsx` 분기 연결은 아직 없음 (Buy/Build/Toll 흐름은 여전히 로컬/REST 혼재)
 - `DiceTimerModal` → `game:prompt.timeoutSec` 연동 없음
-- `gameBoardActionHandlers.ts`: `gameApi.buyTile`, `gameApi.buildTile`, `gameApi.sellTile` REST 직접 호출 유지 → 격리 필요
+- `gameBoardActionHandlers.ts`: BUILD/sync는 여전히 REST 레거시 경로 유지 → 최종 정리 필요
 
 ### FE-C: 골격 완료(약 30%), 버그 수정 + 시각 레이어 수렴 단계
 
@@ -237,7 +238,7 @@
 - ~~`store.pendingAction`/`store.lastAck` 버튼 상태 및 상태 배지 연결~~ ✅ 완료
 - `store.prompt.type` → `modals/*`, `GameBoard.tsx` 분기 연결
 - `DiceTimerModal` → `game:prompt.timeoutSec` 기반으로 연결
-- `gameBoardActionHandlers.ts`: REST 직접 호출(`gameApi.buyTile` 등) → `emitGameAction` 전환
+- `gameBoardActionHandlers.ts`: BUILD/sync 레거시 호출 제거 및 prompt.type 기반 액션 확정
 
 ### 5-5. mock 검증 흐름 정비
 
@@ -288,7 +289,7 @@ FE-B `store.eventQueue`가 채워지는 구조는 완료. FE-C가 소비 쪽을 
 
 1. **FE-B 5-1**: 명세 불일치 수정 (`GamePromptResponse`, `GameAck`, `GamePatchEnvelope`, `emitGameSync`, `emitPromptResponse`, mock)
 2. **FE-C 6-1**: 버그 3개 수정 (`gameBoardStoreBridge`, `gameBoardTransactionUtils`, `gameBoardActionUtils`)
-3. **FE-B 5-4**: `store.prompt.type` 기반 modal 연결 + `DiceTimerModal` timeout 연결 + REST → `emitGameAction` 전환
+3. **FE-B 5-4**: `store.prompt.type` 기반 modal 연결 + `DiceTimerModal` timeout 연결 + `gameBoardActionHandlers` BUILD/sync 레거시 제거
 4. **FE-C 6-2**: `GameBoard.tsx` 서버 계산 제거, 시각 레이어 수렴
 5. **FE-C 6-4**: `store.eventQueue` 기반 이동/연출 구현
 6. **FE-B + FE-C**: `game:prompt` 흐름과 `DiceTimerModal` timeout 흐름 공동 검증

--- a/docs/game-event-spec-migration-plan.md
+++ b/docs/game-event-spec-migration-plan.md
@@ -74,22 +74,22 @@
 
 아래 표에서 **상태** 열 기준: ✅ 완료 / ⚠️ 명세 불일치 수정 필요 / ❌ 미구현
 
-| 파일                                                | 현재 상태         | 남은 수정 방향                                                                         | 담당                       |
-| --------------------------------------------------- | ----------------- | -------------------------------------------------------------------------------------- | -------------------------- |
-| `src/types/domain.ts`                               | ✅ 완료           | —                                                                                      | FE-B                       |
-| `src/stores/game.store.ts`                          | ✅ 완료           | —                                                                                      | FE-B                       |
-| `src/services/socket/game.handler.ts`               | ✅ 완료           | —                                                                                      | FE-B                       |
-| `src/hooks/game/useGameState.ts`                    | ✅ 완료           | —                                                                                      | FE-B                       |
-| `src/services/game/game.api.ts`                     | ⚠️ 레거시 격리 중 | deprecated 표시 완료. `gameBoardActionHandlers.ts` 호출부 → `emitGameAction` 전환 필요 | FE-B                       |
-| `src/hooks/game/useDiceRoll.ts`                     | ✅ 완료           | —                                                                                      | FE-B                       |
-| `src/pages/GamePage.tsx`                            | ✅ 2차 완료       | `prompt` 오버레이 응답, `pendingAction`/`lastAck`/`lastError` UI 연결 완료             | FE-B                       |
-| `src/components/board/GameBoard.tsx`                | ⚠️ 부분 정리      | `applyMoney`, `advanceTurn`, 통행료 계산, 파산 판정 제거. `store.prompt` 연결          | FE-C 주도 / FE-B 선행 필요 |
-| `src/components/game/modals/*`                      | ⚠️ 부분 완료      | `store.prompt.type` 기준 모달 열림 조건 연결. `DiceTimerModal` timeout 연동            | FE-B                       |
-| `src/mocks/handlers/game.handler.ts`                | ✅ 완료           | —                                                                                      | FE-B                       |
-| `src/components/board/gameBoardStoreBridge.ts`      | ❌ 버그           | `toStoreBuildingLevel` 상한 5→7                                                        | FE-C                       |
-| `src/components/board/gameBoardTransactionUtils.ts` | ❌ 버그           | `upgradeBoardTileOwner` 상한 5→7                                                       | FE-C                       |
-| `src/components/board/gameBoardActionUtils.ts`      | ❌ 버그           | `getBoardSellFallbackRefund` level 5, 6 케이스 추가                                    | FE-C                       |
-| `src/components/board/*` (렌더 레이어)              | ❌ 미구현         | `store.eventQueue` 소비 연출. `playerState` 시각화                                     | FE-C                       |
+| 파일                                                | 현재 상태         | 남은 수정 방향                                                                                                      | 담당                       |
+| --------------------------------------------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------- | -------------------------- |
+| `src/types/domain.ts`                               | ✅ 완료           | —                                                                                                                   | FE-B                       |
+| `src/stores/game.store.ts`                          | ✅ 완료           | —                                                                                                                   | FE-B                       |
+| `src/services/socket/game.handler.ts`               | ✅ 완료           | —                                                                                                                   | FE-B                       |
+| `src/hooks/game/useGameState.ts`                    | ✅ 완료           | —                                                                                                                   | FE-B                       |
+| `src/services/game/game.api.ts`                     | ⚠️ 레거시 격리 중 | deprecated 표시 완료. `gameBoardActionHandlers.ts`의 BUY/SELL/END_TURN non-mock 전환 완료, BUILD/sync는 레거시 유지 | FE-B                       |
+| `src/hooks/game/useDiceRoll.ts`                     | ✅ 완료           | —                                                                                                                   | FE-B                       |
+| `src/pages/GamePage.tsx`                            | ✅ 2차 완료       | `prompt` 오버레이 응답, `pendingAction`/`lastAck`/`lastError` UI 연결 완료                                          | FE-B                       |
+| `src/components/board/GameBoard.tsx`                | ⚠️ 부분 정리      | `applyMoney`, `advanceTurn`, 통행료 계산, 파산 판정 제거. `store.prompt` 연결                                       | FE-C 주도 / FE-B 선행 필요 |
+| `src/components/game/modals/*`                      | ⚠️ 부분 완료      | `store.prompt.type` 기준 모달 열림 조건 연결. `DiceTimerModal` timeout 연동                                         | FE-B                       |
+| `src/mocks/handlers/game.handler.ts`                | ✅ 완료           | —                                                                                                                   | FE-B                       |
+| `src/components/board/gameBoardStoreBridge.ts`      | ❌ 버그           | `toStoreBuildingLevel` 상한 5→7                                                                                     | FE-C                       |
+| `src/components/board/gameBoardTransactionUtils.ts` | ❌ 버그           | `upgradeBoardTileOwner` 상한 5→7                                                                                    | FE-C                       |
+| `src/components/board/gameBoardActionUtils.ts`      | ❌ 버그           | `getBoardSellFallbackRefund` level 5, 6 케이스 추가                                                                 | FE-C                       |
+| `src/components/board/*` (렌더 레이어)              | ❌ 미구현         | `store.eventQueue` 소비 연출. `playerState` 시각화                                                                  | FE-C                       |
 
 ### 2-1. `src/mocks/handlers/game.handler.ts` 명세 불일치 상세
 
@@ -286,7 +286,7 @@
 
 - `GamePage`: `store.prompt`/`lastError`/`pendingAction` UI 연결은 완료. `prompt.type`별 모달 분기 연결은 미완료
 - `store.eventQueue` → 소비 컴포넌트 없음
-- `gameBoardActionHandlers.ts` → REST 직접 호출 유지 (`emitGameAction` 전환 필요)
+- `gameBoardActionHandlers.ts` → BUY/SELL/END_TURN non-mock 전환 완료. BUILD/sync 레거시 호출 정리 필요
 
 ## 5-2. 다음 우선순위
 
@@ -295,7 +295,7 @@
 1. ~~`src/types/domain.ts`, `src/services/socket/game.handler.ts`: 명세 불일치 수정~~ ✅ 완료
 2. ~~`src/mocks/handlers/game.handler.ts`: 명세 불일치 수정~~ ✅ 완료
 3. `src/components/game/modals/*`, `src/components/board/GameBoard.tsx`: `store.prompt.type` → modal 연결, `DiceTimerModal` → `prompt.timeoutSec` 연결
-4. `src/components/board/gameBoardActionHandlers.ts`: REST 직접 호출 → `emitGameAction` 전환
+4. `src/components/board/gameBoardActionHandlers.ts`: BUILD/sync 레거시 호출 정리 및 prompt.type 기반 액션 확정
 
 **FE-C**
 

--- a/docs/game-ownership-corrected-table.md
+++ b/docs/game-ownership-corrected-table.md
@@ -18,17 +18,17 @@
 
 ## 진행도 요약
 
-| 파트 | 진행도  | 상태                                                                       |
-| ---- | ------- | -------------------------------------------------------------------------- |
-| FE-B | 진행 중 | `GamePage` prompt/ack/error/pendingAction 연결 완료, modal/board 연결 단계 |
-| FE-C | 진행 중 | 보드를 표현/연출 중심 레이어로 더 줄여야 하는 단계                         |
+| 파트 | 진행도  | 상태                                                                                                    |
+| ---- | ------- | ------------------------------------------------------------------------------------------------------- |
+| FE-B | 진행 중 | `GamePage` 연결 + `gameBoardActionHandlers` non-mock BUY/SELL/END_TURN 전환 완료, modal/board 연결 단계 |
+| FE-C | 진행 중 | 보드를 표현/연출 중심 레이어로 더 줄여야 하는 단계                                                      |
 
 ## FE-B 현재 최우선 작업
 
 - `src/components/game/modals/*`를 `gameStore.prompt`와 연결
 - `src/components/board/GameBoard.tsx`의 로컬 modal 분기를 `game:prompt` 소비 구조로 전환
 - `src/services/socket/game.handler.ts`의 `emitPromptResponse`를 실사용 UI 흐름과 연결
-- 남아 있는 게임 REST fallback을 compatibility layer로 더 명확히 격리
+- `src/components/board/gameBoardActionHandlers.ts`의 BUILD/sync 레거시 호출 정리
 
 ## FE-C 현재 최우선 작업
 
@@ -40,6 +40,7 @@
 ## 현재 가장 큰 리스크
 
 - `GamePage`는 `prompt`, `ack`, `pendingAction`을 소비하지만, `modals/*`/`GameBoard.tsx`는 아직 `prompt.type` 중심 소비 구조가 아니다.
+- `gameBoardActionHandlers`는 BUY/SELL/END_TURN만 non-mock 전환됐고 BUILD/sync는 레거시 경로가 남아 있다.
 - `GameBoard.tsx`가 여전히 일부 게임 엔진 성격 로직을 들고 있다.
 - 게임 REST fallback이 장기화되면 중앙 docs 기준과 실제 런타임이 다시 벌어질 수 있다.
 - `gameId`, money unit, tile/building enum 기준이 문서와 코드에서 완전히 수렴하지 않았다.

--- a/src/components/board/gameBoardActionHandlers.ts
+++ b/src/components/board/gameBoardActionHandlers.ts
@@ -1,5 +1,6 @@
 import type { Dispatch, MutableRefObject, SetStateAction } from 'react'
 import { gameApi } from '../../services/game/game.api'
+import { emitGameAction } from '../../services/socket/game.handler'
 import type { PlayerState, TileOwner, BuildingLevel } from './board.constants'
 import {
   getBoardSellFallbackRefund,
@@ -96,6 +97,23 @@ export function createGameBoardActionHandlers(
     advanceTurn,
   } = params
 
+  function emitSocketAction(
+    type: string,
+    payload?: Record<string, unknown>
+  ): boolean {
+    if (!roomId) {
+      setStatus(roomIdRequiredMessage)
+      return false
+    }
+
+    emitGameAction({
+      type,
+      roomId,
+      payload,
+    })
+    return true
+  }
+
   async function syncBoardStateFromServer() {
     if (!roomId) return false
 
@@ -148,6 +166,14 @@ export function createGameBoardActionHandlers(
     if (!sellTarget) return false
 
     const { tileId, owner } = sellTarget
+
+    if (!useGameSocketMock) {
+      return emitSocketAction('SELL_PROPERTY', {
+        tileId,
+        buildingLevel: owner.level,
+      })
+    }
+
     if (!roomId) return false
 
     const sellResult = await gameApi.sellTile(roomId, {
@@ -179,6 +205,20 @@ export function createGameBoardActionHandlers(
   async function handleBuy(buyModal: BuyModalState) {
     const { tileId, onDoneCallback } = buyModal
     if (tileId === null) return
+
+    if (!useGameSocketMock) {
+      const emitted = emitSocketAction('BUY_PROPERTY', {
+        tileId,
+      })
+      if (!emitted) {
+        return
+      }
+
+      setBuyModal({ open: false, tileId: null })
+      onDoneCallback?.()
+      return
+    }
+
     if (!roomId) {
       setStatus(roomIdRequiredMessage)
       return
@@ -215,6 +255,15 @@ export function createGameBoardActionHandlers(
 
   function handleBuyPass(buyModal: BuyModalState) {
     setBuyModal({ open: false, tileId: null })
+
+    if (!useGameSocketMock) {
+      const emitted = emitSocketAction('END_TURN')
+      if (emitted) {
+        buyModal.onDoneCallback?.()
+      }
+      return
+    }
+
     advanceTurn(buyModal.onDoneCallback)
   }
 
@@ -252,6 +301,15 @@ export function createGameBoardActionHandlers(
 
   function handleBuildCancel(buildModal: BuildModalState) {
     setBuildModal({ open: false, tileId: null })
+
+    if (!useGameSocketMock) {
+      const emitted = emitSocketAction('END_TURN')
+      if (emitted) {
+        buildModal.onDoneCallback?.()
+      }
+      return
+    }
+
     advanceTurn(buildModal.onDoneCallback)
   }
 
@@ -264,6 +322,14 @@ export function createGameBoardActionHandlers(
       ownerName: '',
       tollText: '',
     })
+
+    if (!useGameSocketMock) {
+      const emitted = emitSocketAction('END_TURN')
+      if (emitted) {
+        onDoneCallback?.()
+      }
+      return
+    }
 
     if (tileId !== null) {
       const owner = tileOwnersRef.current[tileId]


### PR DESCRIPTION
## 🔗 관련 이슈



---

## ✨ 작업 내용

- `gameBoardActionHandlers`의 non-mock 경로에서 보드 액션 일부를 REST 직접 호출 대신 소켓 액션으로 전환했습니다.
- 전환 범위
- `BUY_PROPERTY` -> `emitGameAction`
- `SELL_PROPERTY` -> `emitGameAction`
- `END_TURN` -> `emitGameAction`
- mock 경로는 기존 동작을 유지했습니다.
- `BUILD/sync`는 이번 PR에서 레거시 경로를 유지하고, 후속 이슈에서 정리하도록 범위를 제한했습니다.
- 작업 완료 후 문서 3종에 진행도/다음 작업을 최신화했습니다.
- `docs/game-event-spec-migration-plan.md`
- `docs/game-delivery-roadmap.md`
- `docs/game-ownership-corrected-table.md`

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련된 이슈 연결 완료

검증 내역
- [x] `npm run lint`
- [x] `npm run test`
- [x] `npm run build`
- [x] (pre-push) `npm run test:coverage`
- [x] (pre-push) `npm run e2e:ci`

---

## 📸 스크린샷 (선택)

- UI 변경 없음
