### PR TITLE
Feat :gameStore.prompt 기반 보드 모달 통합 및 DiceTimer timeout 연동

### DIFF
--- a/docs/game-delivery-roadmap.md
+++ b/docs/game-delivery-roadmap.md
@@ -165,8 +165,8 @@
 남은 핵심 축 — UI 연결:
 
 - `GamePage.tsx`의 `store.prompt`/`emitPromptResponse`/`pendingAction`/`lastAck`/`lastError` 연결은 완료
-- `store.prompt.type` → `modals/*` 및 `GameBoard.tsx` 분기 연결은 아직 없음 (Buy/Build/Toll 흐름은 여전히 로컬/REST 혼재)
-- `DiceTimerModal` → `game:prompt.timeoutSec` 연동 없음
+- `store.prompt.type` → `modals/*` 및 `GameBoard.tsx` 분기 연결 완료 (non-mock 기준 Buy/Build/Toll/Timer 모달)
+- `DiceTimerModal` → `game:prompt.timeoutSec` 연동 완료
 - `gameBoardActionHandlers.ts`: BUILD/sync는 여전히 REST 레거시 경로 유지 → 최종 정리 필요
 
 ### FE-C: 골격 완료(약 30%), 버그 수정 + 시각 레이어 수렴 단계
@@ -190,7 +190,7 @@
 - `GameBoard.tsx` 내부에 `rollDice`, `applyMoney`, `advanceTurn`, 통행료 계산, 파산 판정 로직 잔존 → 제거
 - `store.eventQueue` 소비 컴포넌트 없음 (enqueue는 되지만 아무 연출도 없음)
 - `store.playerState`(`island`, `locked`) 기반 섬/잠금 상태 시각화 없음
-- `DiceTimerModal`: `game:prompt` timeout과 연결 없이 `GameBoard.tsx` 내부 독자 타이머만 사용
+- `DiceTimerModal`: `game:prompt.timeoutSec` 연동 완료. 다만 mock 로컬 fallback 타이머 분기는 유지
 
 ## 5. FE-B 우선 작업
 
@@ -236,8 +236,8 @@
 - ~~`GamePage.tsx`에서 `emitPromptResponse` 사용자 응답 흐름 연결~~ ✅ 완료
 - ~~`game:ack.ok=false` → `store.lastError` → 에러 UI 표시 연결~~ ✅ 완료
 - ~~`store.pendingAction`/`store.lastAck` 버튼 상태 및 상태 배지 연결~~ ✅ 완료
-- `store.prompt.type` → `modals/*`, `GameBoard.tsx` 분기 연결
-- `DiceTimerModal` → `game:prompt.timeoutSec` 기반으로 연결
+- ~~`store.prompt.type` → `modals/*`, `GameBoard.tsx` 분기 연결~~ ✅ 완료 (non-mock)
+- ~~`DiceTimerModal` → `game:prompt.timeoutSec` 기반으로 연결~~ ✅ 완료
 - `gameBoardActionHandlers.ts`: BUILD/sync 레거시 호출 제거 및 prompt.type 기반 액션 확정
 
 ### 5-5. mock 검증 흐름 정비
@@ -283,13 +283,13 @@ FE-B `store.eventQueue`가 채워지는 구조는 완료. FE-C가 소비 쪽을 
 
 - `playerState`(`island`, `locked`) 기반 섬 감금/잠금 상태 표시 추가
 - `stateDuration` 기반 잔여 턴 표시
-- `DiceTimerModal` → `game:prompt.timeoutSec` 기반 타이머로 교체 (FE-B와 협업)
+- `DiceTimerModal` → `game:prompt.timeoutSec` 기반 타이머 연결 완료. FE-C는 시각 연출/애니메이션만 후속 반영
 
 ## 7. 권장 실행 순서
 
 1. **FE-B 5-1**: 명세 불일치 수정 (`GamePromptResponse`, `GameAck`, `GamePatchEnvelope`, `emitGameSync`, `emitPromptResponse`, mock)
 2. **FE-C 6-1**: 버그 3개 수정 (`gameBoardStoreBridge`, `gameBoardTransactionUtils`, `gameBoardActionUtils`)
-3. **FE-B 5-4**: `store.prompt.type` 기반 modal 연결 + `DiceTimerModal` timeout 연결 + `gameBoardActionHandlers` BUILD/sync 레거시 제거
+3. **FE-B 5-4**: `gameBoardActionHandlers` BUILD/sync 레거시 제거 + prompt.type 액션 확정
 4. **FE-C 6-2**: `GameBoard.tsx` 서버 계산 제거, 시각 레이어 수렴
 5. **FE-C 6-4**: `store.eventQueue` 기반 이동/연출 구현
 6. **FE-B + FE-C**: `game:prompt` 흐름과 `DiceTimerModal` timeout 흐름 공동 검증
@@ -315,5 +315,5 @@ FE-B `store.eventQueue`가 채워지는 구조는 완료. FE-C가 소비 쪽을 
 지금 당장 해야 할 일은 **명세 불일치 수정**이다.
 코드 구조를 아무리 잘 만들어도 payload 필드명(`choice` vs `value`)이나 에러 구조(`error.code` vs `errorCode`)가 백엔드와 다르면 실서버 연동에서 즉시 깨진다.
 FE-B는 5-1 불일치 수정을 먼저, FE-C는 6-1 버그 3개 수정을 먼저 진행한다.
-그 다음 단계가 `store.prompt` UI 연결, `GameBoard.tsx` 시각 레이어 수렴이다.
+그 다음 단계는 `gameBoardActionHandlers`의 BUILD/sync 레거시 제거와 `GameBoard.tsx` 시각 레이어 수렴이다.
 `roomId`, money unit, 현재 보드 view model은 갑자기 제거하지 않고 compatibility layer로 안전하게 이행한다.

--- a/docs/game-event-spec-migration-plan.md
+++ b/docs/game-event-spec-migration-plan.md
@@ -74,22 +74,22 @@
 
 아래 표에서 **상태** 열 기준: ✅ 완료 / ⚠️ 명세 불일치 수정 필요 / ❌ 미구현
 
-| 파일                                                | 현재 상태         | 남은 수정 방향                                                                                                      | 담당                       |
-| --------------------------------------------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------- | -------------------------- |
-| `src/types/domain.ts`                               | ✅ 완료           | —                                                                                                                   | FE-B                       |
-| `src/stores/game.store.ts`                          | ✅ 완료           | —                                                                                                                   | FE-B                       |
-| `src/services/socket/game.handler.ts`               | ✅ 완료           | —                                                                                                                   | FE-B                       |
-| `src/hooks/game/useGameState.ts`                    | ✅ 완료           | —                                                                                                                   | FE-B                       |
-| `src/services/game/game.api.ts`                     | ⚠️ 레거시 격리 중 | deprecated 표시 완료. `gameBoardActionHandlers.ts`의 BUY/SELL/END_TURN non-mock 전환 완료, BUILD/sync는 레거시 유지 | FE-B                       |
-| `src/hooks/game/useDiceRoll.ts`                     | ✅ 완료           | —                                                                                                                   | FE-B                       |
-| `src/pages/GamePage.tsx`                            | ✅ 2차 완료       | `prompt` 오버레이 응답, `pendingAction`/`lastAck`/`lastError` UI 연결 완료                                          | FE-B                       |
-| `src/components/board/GameBoard.tsx`                | ⚠️ 부분 정리      | `applyMoney`, `advanceTurn`, 통행료 계산, 파산 판정 제거. `store.prompt` 연결                                       | FE-C 주도 / FE-B 선행 필요 |
-| `src/components/game/modals/*`                      | ⚠️ 부분 완료      | `store.prompt.type` 기준 모달 열림 조건 연결. `DiceTimerModal` timeout 연동                                         | FE-B                       |
-| `src/mocks/handlers/game.handler.ts`                | ✅ 완료           | —                                                                                                                   | FE-B                       |
-| `src/components/board/gameBoardStoreBridge.ts`      | ❌ 버그           | `toStoreBuildingLevel` 상한 5→7                                                                                     | FE-C                       |
-| `src/components/board/gameBoardTransactionUtils.ts` | ❌ 버그           | `upgradeBoardTileOwner` 상한 5→7                                                                                    | FE-C                       |
-| `src/components/board/gameBoardActionUtils.ts`      | ❌ 버그           | `getBoardSellFallbackRefund` level 5, 6 케이스 추가                                                                 | FE-C                       |
-| `src/components/board/*` (렌더 레이어)              | ❌ 미구현         | `store.eventQueue` 소비 연출. `playerState` 시각화                                                                  | FE-C                       |
+| 파일                                                | 현재 상태         | 남은 수정 방향                                                                                                         | 담당                       |
+| --------------------------------------------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------- | -------------------------- |
+| `src/types/domain.ts`                               | ✅ 완료           | —                                                                                                                      | FE-B                       |
+| `src/stores/game.store.ts`                          | ✅ 완료           | —                                                                                                                      | FE-B                       |
+| `src/services/socket/game.handler.ts`               | ✅ 완료           | —                                                                                                                      | FE-B                       |
+| `src/hooks/game/useGameState.ts`                    | ✅ 완료           | —                                                                                                                      | FE-B                       |
+| `src/services/game/game.api.ts`                     | ⚠️ 레거시 격리 중 | deprecated 표시 완료. `gameBoardActionHandlers.ts`의 BUY/SELL/END_TURN non-mock 전환 완료, BUILD/sync는 레거시 유지    | FE-B                       |
+| `src/hooks/game/useDiceRoll.ts`                     | ✅ 완료           | —                                                                                                                      | FE-B                       |
+| `src/pages/GamePage.tsx`                            | ✅ 3차 완료       | `prompt` 오버레이 응답 + `prompt.type` board-modal 분기 연결 완료. 미매핑 prompt는 오버레이 fallback 유지              | FE-B                       |
+| `src/components/board/GameBoard.tsx`                | ⚠️ 부분 정리      | non-mock에서 `store.prompt` 기반 Buy/Build/Toll/Timer 모달 연결 완료. `applyMoney`, `advanceTurn`, 파산 판정 제거 필요 | FE-C 주도 / FE-B 선행 필요 |
+| `src/components/game/modals/*`                      | ✅ 3차 완료       | `store.prompt.type` 기준 모달 열림 조건/응답 연결 완료. `DiceTimerModal` timeout 연동 완료                             | FE-B                       |
+| `src/mocks/handlers/game.handler.ts`                | ✅ 완료           | —                                                                                                                      | FE-B                       |
+| `src/components/board/gameBoardStoreBridge.ts`      | ❌ 버그           | `toStoreBuildingLevel` 상한 5→7                                                                                        | FE-C                       |
+| `src/components/board/gameBoardTransactionUtils.ts` | ❌ 버그           | `upgradeBoardTileOwner` 상한 5→7                                                                                       | FE-C                       |
+| `src/components/board/gameBoardActionUtils.ts`      | ❌ 버그           | `getBoardSellFallbackRefund` level 5, 6 케이스 추가                                                                    | FE-C                       |
+| `src/components/board/*` (렌더 레이어)              | ❌ 미구현         | `store.eventQueue` 소비 연출. `playerState` 시각화                                                                     | FE-C                       |
 
 ### 2-1. `src/mocks/handlers/game.handler.ts` 명세 불일치 상세
 
@@ -284,7 +284,7 @@
 
 ### 구조 미구현 (FE-B 2단계)
 
-- `GamePage`: `store.prompt`/`lastError`/`pendingAction` UI 연결은 완료. `prompt.type`별 모달 분기 연결은 미완료
+- `GamePage` + `GameBoard`: `prompt.type` → Buy/Build/Toll/Timer 모달 매핑, `emitPromptResponse` 응답 경로 연결 완료
 - `store.eventQueue` → 소비 컴포넌트 없음
 - `gameBoardActionHandlers.ts` → BUY/SELL/END_TURN non-mock 전환 완료. BUILD/sync 레거시 호출 정리 필요
 
@@ -294,7 +294,7 @@
 
 1. ~~`src/types/domain.ts`, `src/services/socket/game.handler.ts`: 명세 불일치 수정~~ ✅ 완료
 2. ~~`src/mocks/handlers/game.handler.ts`: 명세 불일치 수정~~ ✅ 완료
-3. `src/components/game/modals/*`, `src/components/board/GameBoard.tsx`: `store.prompt.type` → modal 연결, `DiceTimerModal` → `prompt.timeoutSec` 연결
+3. ~~`src/components/game/modals/*`, `src/components/board/GameBoard.tsx`: `store.prompt.type` → modal 연결, `DiceTimerModal` → `prompt.timeoutSec` 연결~~ ✅ 완료
 4. `src/components/board/gameBoardActionHandlers.ts`: BUILD/sync 레거시 호출 정리 및 prompt.type 기반 액션 확정
 
 **FE-C**

--- a/docs/game-ownership-corrected-table.md
+++ b/docs/game-ownership-corrected-table.md
@@ -18,17 +18,16 @@
 
 ## 진행도 요약
 
-| 파트 | 진행도  | 상태                                                                                                    |
-| ---- | ------- | ------------------------------------------------------------------------------------------------------- |
-| FE-B | 진행 중 | `GamePage` 연결 + `gameBoardActionHandlers` non-mock BUY/SELL/END_TURN 전환 완료, modal/board 연결 단계 |
-| FE-C | 진행 중 | 보드를 표현/연출 중심 레이어로 더 줄여야 하는 단계                                                      |
+| 파트 | 진행도  | 상태                                                                                                                                 |
+| ---- | ------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| FE-B | 진행 중 | `GamePage`/`GameBoard` prompt modal 연결 완료 + `gameBoardActionHandlers` non-mock BUY/SELL/END_TURN 전환 완료, BUILD/sync 정리 단계 |
+| FE-C | 진행 중 | 보드를 표현/연출 중심 레이어로 더 줄여야 하는 단계                                                                                   |
 
 ## FE-B 현재 최우선 작업
 
-- `src/components/game/modals/*`를 `gameStore.prompt`와 연결
-- `src/components/board/GameBoard.tsx`의 로컬 modal 분기를 `game:prompt` 소비 구조로 전환
-- `src/services/socket/game.handler.ts`의 `emitPromptResponse`를 실사용 UI 흐름과 연결
 - `src/components/board/gameBoardActionHandlers.ts`의 BUILD/sync 레거시 호출 정리
+- prompt.type별 choice 표준(BUY/SKIP, BUILD/SKIP, PAY_TOLL, END_TURN)을 문서/목업과 최종 고정
+- 미매핑 prompt의 fallback 표면(오버레이) 유지 범위 확정
 
 ## FE-C 현재 최우선 작업
 
@@ -39,7 +38,7 @@
 
 ## 현재 가장 큰 리스크
 
-- `GamePage`는 `prompt`, `ack`, `pendingAction`을 소비하지만, `modals/*`/`GameBoard.tsx`는 아직 `prompt.type` 중심 소비 구조가 아니다.
+- `GamePage` + `GameBoard`는 `prompt.type` 중심 소비 구조로 전환됐지만, mock 로컬 fallback과 실서버 경로가 이원화돼 있다.
 - `gameBoardActionHandlers`는 BUY/SELL/END_TURN만 non-mock 전환됐고 BUILD/sync는 레거시 경로가 남아 있다.
 - `GameBoard.tsx`가 여전히 일부 게임 엔진 성격 로직을 들고 있다.
 - 게임 REST fallback이 장기화되면 중앙 docs 기준과 실제 런타임이 다시 벌어질 수 있다.

--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -16,6 +16,12 @@ import BankruptModal from '../game/modals/BankruptModal'
 import DiceTimerModal from '../game/modals/DiceTimerModal'
 import GameResultModal from '../game/modals/GameResultModal'
 import GoToIslandModal from '../game/modals/GoToIslandModal'
+import {
+  findPromptChoiceValue,
+  getPromptPayloadNumber,
+  getPromptPayloadString,
+  resolvePromptModalKind,
+} from '../game/modals/promptModalMapping'
 
 import {
   TILES,
@@ -54,6 +60,7 @@ import type {
 import '../../styles/board.css'
 import { IS_SOCKET_MOCK_ENABLED } from '../../config/env'
 import { formatWon } from '../../lib/utils'
+import type { GamePrompt } from '../../types/domain'
 
 function getUpgradeCost(price: number, currentLevel: BuildingLevel): number {
   if (currentLevel === 0) return price * 0.5
@@ -170,6 +177,9 @@ interface GameBoardProps {
   roomId?: string | null
   players: PlayerState[]
   curPlayer: number
+  activePrompt?: GamePrompt | null
+  promptSubmittingChoice?: string | null
+  onPromptChoice?: (choice: string) => void
   tiles?: Array<{
     index: number
     owner_id?: string | number | null
@@ -234,6 +244,9 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       roomId = null,
       players,
       curPlayer,
+      activePrompt = null,
+      promptSubmittingChoice = null,
+      onPromptChoice,
       tiles = [],
       onPlayersChange,
       onCurPlayerChange,
@@ -244,6 +257,9 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
   ) => {
     const [localTimeLeft, setLocalTimeLeft] = useState(DICE_TIMEOUT)
     const [showTimerModal, setShowTimerModal] = useState(false)
+    const [promptTimerLeftSec, setPromptTimerLeftSec] = useState<number | null>(
+      null
+    )
     const [dice1, setDice1] = useState(1)
     const [dice2, setDice2] = useState(1)
     const [rolling, setRolling] = useState(false)
@@ -267,6 +283,98 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
     const tileOwners =
       optimisticTileOwners === null ? derivedTileOwners : optimisticTileOwners
     const tileOwnersRef = useRef<Record<number, TileOwner>>(tileOwners)
+    const promptModalKind = resolvePromptModalKind(activePrompt)
+    const isBuyPromptOpen = promptModalKind === 'buy'
+    const isBuildPromptOpen = promptModalKind === 'build'
+    const isTollPromptOpen = promptModalKind === 'toll'
+    const isDiceTimerPromptOpen = promptModalKind === 'dice_timer'
+
+    const promptTileId = getPromptPayloadNumber(activePrompt, [
+      'tileId',
+      'targetTileId',
+      'toTileId',
+    ])
+    const promptTile = promptTileId != null ? TILES[promptTileId] : null
+    const promptOwnerId = getPromptPayloadNumber(activePrompt, [
+      'ownerId',
+      'toPlayerId',
+    ])
+    const promptOwnerNameFromPayload = getPromptPayloadString(activePrompt, [
+      'ownerName',
+      'ownerNickname',
+    ])
+    const promptOwnerName =
+      promptOwnerNameFromPayload ??
+      (promptOwnerId != null
+        ? players.find((player) => Number(player.id) === promptOwnerId)?.name
+        : null) ??
+      DEFAULT_OPPONENT_NAME
+    const promptAmount = getPromptPayloadNumber(activePrompt, [
+      'amount',
+      'toll',
+      'tollAmount',
+      'price',
+    ])
+    const promptTileName =
+      getPromptPayloadString(activePrompt, ['tileName', 'cityName']) ??
+      promptTile?.name ??
+      ''
+    const promptCurrentLevelFromPayload = getPromptPayloadNumber(activePrompt, [
+      'buildingLevel',
+      'currentLevel',
+    ])
+    const promptCurrentLevel = Math.min(
+      7,
+      Math.max(
+        0,
+        promptCurrentLevelFromPayload ??
+          (promptTileId != null ? (tileOwners[promptTileId]?.level ?? 0) : 0)
+      )
+    ) as BuildingLevel
+    const promptNextLevel = Math.min(promptCurrentLevel + 1, 7) as BuildingLevel
+
+    const promptBuyChoiceValue = findPromptChoiceValue(activePrompt, ['BUY'], 0)
+    const promptBuyPassChoiceValue = findPromptChoiceValue(activePrompt, [
+      'SKIP',
+      'PASS',
+      'CANCEL',
+      'NO',
+    ])
+    const promptBuildConfirmChoiceValue = findPromptChoiceValue(
+      activePrompt,
+      ['BUILD', 'UPGRADE', 'CONFIRM'],
+      0
+    )
+    const promptBuildCancelChoiceValue = findPromptChoiceValue(activePrompt, [
+      'SKIP',
+      'PASS',
+      'CANCEL',
+      'NO',
+    ])
+    const promptTollConfirmChoiceValue = findPromptChoiceValue(
+      activePrompt,
+      ['PAY_TOLL', 'PAY', 'CONFIRM', 'OK'],
+      0
+    )
+    const promptTimerConfirmChoiceValue = findPromptChoiceValue(
+      activePrompt,
+      ['END_TURN', 'CONFIRM', 'OK', 'SKIP'],
+      0
+    )
+
+    const getPromptChoiceLabel = (
+      choiceValue: string | null,
+      fallbackLabel: string
+    ) => {
+      if (!activePrompt || !choiceValue) {
+        return fallbackLabel
+      }
+
+      return (
+        activePrompt.choices?.find((choice) => choice.value === choiceValue)
+          ?.label ?? fallbackLabel
+      )
+    }
 
     useEffect(() => {
       setOptimisticTileOwners(null)
@@ -277,6 +385,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
     useEffect(() => {
       setLocalTimeLeft(DICE_TIMEOUT)
       setShowTimerModal(false)
+      setPromptTimerLeftSec(null)
 
       // Close all other modals when turn changes
       setBuyModal({ open: false, tileId: null })
@@ -308,7 +417,9 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       const timer = setInterval(() => {
         setLocalTimeLeft((prev) => {
           if (prev <= 1) {
-            setShowTimerModal(true)
+            if (USE_GAME_SOCKET_MOCK && !isDiceTimerPromptOpen) {
+              setShowTimerModal(true)
+            }
             clearInterval(timer) // Stop once triggered
             return 0
           }
@@ -317,7 +428,46 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       }, 1000)
 
       return () => clearInterval(timer)
-    }, [curPlayer, rolling])
+    }, [curPlayer, rolling, isDiceTimerPromptOpen])
+
+    useEffect(() => {
+      if (!isDiceTimerPromptOpen || !activePrompt) {
+        setPromptTimerLeftSec(null)
+        return
+      }
+
+      const initialTimeoutSec =
+        typeof activePrompt.timeoutSec === 'number' &&
+        activePrompt.timeoutSec > 0
+          ? Math.ceil(activePrompt.timeoutSec)
+          : DICE_TIMEOUT
+
+      setPromptTimerLeftSec(initialTimeoutSec)
+    }, [activePrompt, isDiceTimerPromptOpen])
+
+    useEffect(() => {
+      if (
+        !isDiceTimerPromptOpen ||
+        promptTimerLeftSec === null ||
+        promptTimerLeftSec <= 0
+      ) {
+        return
+      }
+
+      const timer = window.setTimeout(() => {
+        setPromptTimerLeftSec((prev) => {
+          if (prev === null || prev <= 0) {
+            return 0
+          }
+
+          return prev - 1
+        })
+      }, 1000)
+
+      return () => {
+        window.clearTimeout(timer)
+      }
+    }, [isDiceTimerPromptOpen, promptTimerLeftSec])
 
     function getPlayerIdByIndex(playerIdx: number): number {
       const rawId = playersRef.current[playerIdx]?.id ?? playerIdx
@@ -699,6 +849,16 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
     }
 
     function handleDiceTimerConfirm() {
+      if (
+        isDiceTimerPromptOpen &&
+        promptTimerConfirmChoiceValue &&
+        onPromptChoice &&
+        promptSubmittingChoice === null
+      ) {
+        onPromptChoice(promptTimerConfirmChoiceValue)
+        return
+      }
+
       setShowTimerModal(false)
       // Clear all other possible modals
       setBuyModal({ open: false, tileId: null })
@@ -729,6 +889,12 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       }
 
       if (tile.type === 'PROPERTY') {
+        if (!USE_GAME_SOCKET_MOCK) {
+          setStatus('서버 선택 요청을 기다리는 중...')
+          onDone?.()
+          return
+        }
+
         if (!owner) {
           setBuyModal({ open: true, tileId, onDoneCallback: onDone })
         } else if (owner.ownerId !== getPlayerIdByIndex(playerIdx)) {
@@ -778,14 +944,61 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
     const SS = STRAIGHT_SIZE
     const GAP = GRID_GAP
 
-    const buyTile = buyModal.tileId !== null ? TILES[buyModal.tileId] : null
-    const buildTile =
-      buildModal.tileId !== null ? TILES[buildModal.tileId] : null
-    const currentLevel =
-      buildModal.tileId !== null
+    const useLocalPromptFallback = USE_GAME_SOCKET_MOCK
+    const buyTile = useLocalPromptFallback
+      ? buyModal.tileId !== null
+        ? TILES[buyModal.tileId]
+        : null
+      : promptTile
+    const buyModalOpen = useLocalPromptFallback
+      ? buyModal.open
+      : isBuyPromptOpen
+    const buildTile = useLocalPromptFallback
+      ? buildModal.tileId !== null
+        ? TILES[buildModal.tileId]
+        : null
+      : promptTile
+    const buildModalOpen = useLocalPromptFallback
+      ? buildModal.open
+      : isBuildPromptOpen
+    const currentLevel = useLocalPromptFallback
+      ? buildModal.tileId !== null
         ? (tileOwners[buildModal.tileId]?.level ?? 0)
         : 0
-    const tollTile = tollModal.tileId !== null ? TILES[tollModal.tileId] : null
+      : promptCurrentLevel
+    const tollTile = useLocalPromptFallback
+      ? tollModal.tileId !== null
+        ? TILES[tollModal.tileId]
+        : null
+      : promptTile
+    const tollModalOpen = useLocalPromptFallback
+      ? tollModal.open
+      : isTollPromptOpen
+    const tollOwnerName = useLocalPromptFallback
+      ? tollModal.ownerName
+      : promptOwnerName
+    const tollAmountText = useLocalPromptFallback
+      ? tollModal.tollText
+      : formatWon(promptAmount ?? 0)
+    const buyCost = useLocalPromptFallback
+      ? (buyTile?.price ?? 0)
+      : (getPromptPayloadNumber(activePrompt, ['price', 'purchaseCost']) ??
+        buyTile?.price ??
+        0)
+    const buildCost = useLocalPromptFallback
+      ? getUpgradeCost(buildTile?.price ?? 0, currentLevel as BuildingLevel)
+      : (getPromptPayloadNumber(activePrompt, ['buildCost', 'cost', 'price']) ??
+        getUpgradeCost(buildTile?.price ?? 0, currentLevel as BuildingLevel))
+    const nextTollCost = useLocalPromptFallback
+      ? calcToll(buildTile?.price ?? 0, (currentLevel + 1) as BuildingLevel)
+      : (getPromptPayloadNumber(activePrompt, ['nextToll', 'toll', 'amount']) ??
+        calcToll(buildTile?.price ?? 0, (currentLevel + 1) as BuildingLevel))
+    const diceTimerTitle = activePrompt?.title
+    const diceTimerMessage = activePrompt?.message
+    const diceTimerConfirmLabel = getPromptChoiceLabel(
+      promptTimerConfirmChoiceValue,
+      '확인'
+    )
 
     return (
       <div className="board-page">
@@ -884,31 +1097,128 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
         </div>
 
         <BuyModal
-          open={buyModal.open}
-          onBuy={() => handleBuy(buyModal)}
-          onPass={() => handleBuyPass(buyModal)}
-          cityName={buyTile?.name ?? ''}
-          purchaseCostText={formatWon(buyTile?.price ?? 0)}
+          open={buyModalOpen}
+          onBuy={() => {
+            if (useLocalPromptFallback) {
+              handleBuy(buyModal)
+              return
+            }
+
+            if (
+              promptBuyChoiceValue &&
+              onPromptChoice &&
+              promptSubmittingChoice === null
+            ) {
+              onPromptChoice(promptBuyChoiceValue)
+            }
+          }}
+          onPass={() => {
+            if (useLocalPromptFallback) {
+              handleBuyPass(buyModal)
+              return
+            }
+
+            const fallbackChoice =
+              promptBuyPassChoiceValue ??
+              findPromptChoiceValue(activePrompt, ['SKIP', 'PASS'], 1)
+            if (
+              fallbackChoice &&
+              onPromptChoice &&
+              promptSubmittingChoice === null
+            ) {
+              onPromptChoice(fallbackChoice)
+            }
+          }}
+          passLabel={getPromptChoiceLabel(
+            promptBuyPassChoiceValue,
+            useLocalPromptFallback ? '패스' : '건너뛰기'
+          )}
+          buyLabel={getPromptChoiceLabel(promptBuyChoiceValue, '구매하기')}
+          isSubmitting={
+            promptSubmittingChoice !== null && !useLocalPromptFallback
+          }
+          cityName={promptTileName}
+          purchaseCostText={formatWon(buyCost)}
         />
         <BuildModal
-          open={buildModal.open}
-          onConfirm={() => handleBuildConfirm(buildModal)}
-          onCancel={() => handleBuildCancel(buildModal)}
-          cityName={buildTile?.name ?? ''}
-          nextLevel={(currentLevel + 1) as BuildingLevel}
-          buildCostText={formatWon(
-            getUpgradeCost(buildTile?.price ?? 0, currentLevel as BuildingLevel)
+          open={buildModalOpen}
+          onConfirm={() => {
+            if (useLocalPromptFallback) {
+              handleBuildConfirm(buildModal)
+              return
+            }
+
+            if (
+              promptBuildConfirmChoiceValue &&
+              onPromptChoice &&
+              promptSubmittingChoice === null
+            ) {
+              onPromptChoice(promptBuildConfirmChoiceValue)
+            }
+          }}
+          onCancel={() => {
+            if (useLocalPromptFallback) {
+              handleBuildCancel(buildModal)
+              return
+            }
+
+            const fallbackChoice =
+              promptBuildCancelChoiceValue ??
+              findPromptChoiceValue(activePrompt, ['SKIP', 'PASS', 'CANCEL'], 1)
+            if (
+              fallbackChoice &&
+              onPromptChoice &&
+              promptSubmittingChoice === null
+            ) {
+              onPromptChoice(fallbackChoice)
+            }
+          }}
+          cityName={promptTileName}
+          nextLevel={
+            useLocalPromptFallback
+              ? ((currentLevel + 1) as BuildingLevel)
+              : promptNextLevel
+          }
+          cancelLabel={getPromptChoiceLabel(
+            promptBuildCancelChoiceValue,
+            '취소'
           )}
-          nextTollText={formatWon(
-            calcToll(buildTile?.price ?? 0, (currentLevel + 1) as BuildingLevel)
+          confirmLabel={getPromptChoiceLabel(
+            promptBuildConfirmChoiceValue,
+            '건설하기'
           )}
+          isSubmitting={
+            promptSubmittingChoice !== null && !useLocalPromptFallback
+          }
+          buildCostText={formatWon(buildCost)}
+          nextTollText={formatWon(nextTollCost)}
         />
         <TollModal
-          open={tollModal.open}
-          onConfirm={() => handleTollConfirm(tollModal)}
-          cityName={tollTile?.name ?? ''}
-          ownerName={tollModal.ownerName}
-          tollText={tollModal.tollText}
+          open={tollModalOpen}
+          onConfirm={() => {
+            if (useLocalPromptFallback) {
+              handleTollConfirm(tollModal)
+              return
+            }
+
+            if (
+              promptTollConfirmChoiceValue &&
+              onPromptChoice &&
+              promptSubmittingChoice === null
+            ) {
+              onPromptChoice(promptTollConfirmChoiceValue)
+            }
+          }}
+          cityName={promptTileName || tollTile?.name || ''}
+          ownerName={tollOwnerName}
+          tollText={tollAmountText}
+          confirmLabel={getPromptChoiceLabel(
+            promptTollConfirmChoiceValue,
+            '확인하기'
+          )}
+          isSubmitting={
+            promptSubmittingChoice !== null && !useLocalPromptFallback
+          }
         />
         <CardModal
           open={cardModal.open}
@@ -937,7 +1247,21 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
           onConfirm={handleBankruptConfirm}
         />
         <DiceTimerModal
-          open={showTimerModal}
+          open={showTimerModal || isDiceTimerPromptOpen}
+          title={diceTimerTitle}
+          description={diceTimerMessage}
+          timeLeftSec={
+            isDiceTimerPromptOpen
+              ? (promptTimerLeftSec ??
+                (typeof activePrompt?.timeoutSec === 'number'
+                  ? activePrompt.timeoutSec
+                  : DICE_TIMEOUT))
+              : null
+          }
+          confirmLabel={diceTimerConfirmLabel}
+          isSubmitting={
+            promptSubmittingChoice !== null && isDiceTimerPromptOpen
+          }
           onConfirm={handleDiceTimerConfirm}
         />
         <GameResultModal

--- a/src/components/game/modals/BuildModal.tsx
+++ b/src/components/game/modals/BuildModal.tsx
@@ -15,6 +15,7 @@ interface BuildModalProps {
   cancelLabel?: string
   confirmLabel?: string
   canBuild?: boolean
+  isSubmitting?: boolean
   onCancel?: () => void
   onConfirm?: () => void
 }
@@ -36,6 +37,7 @@ const BuildModal: React.FC<BuildModalProps> = ({
   cancelLabel = DEFAULT_CANCEL_LABEL,
   confirmLabel = DEFAULT_CONFIRM_LABEL,
   canBuild = true,
+  isSubmitting = false,
   onCancel,
   onConfirm,
 }) => {
@@ -86,7 +88,8 @@ const BuildModal: React.FC<BuildModalProps> = ({
           <button
             type="button"
             onClick={onCancel}
-            className="h-15 w-full max-w-42 rounded-[22px] bg-[#E6EBF3] text-[24px] font-black tracking-tight text-[#5E708D] transition-colors hover:bg-[#DDE4EE]"
+            disabled={isSubmitting}
+            className="h-15 w-full max-w-42 rounded-[22px] bg-[#E6EBF3] text-[24px] font-black tracking-tight text-[#5E708D] transition-colors hover:bg-[#DDE4EE] disabled:cursor-not-allowed disabled:opacity-50"
           >
             {cancelLabel}
           </button>
@@ -94,8 +97,8 @@ const BuildModal: React.FC<BuildModalProps> = ({
           <button
             type="button"
             onClick={onConfirm}
-            disabled={!canBuild}
-            className="h-15 w-full max-w-56 rounded-[22px] bg-[#245FE5] text-[24px] font-black tracking-tight text-white shadow-lg transition-colors hover:bg-[#1F56D1] disabled:opacity-40"
+            disabled={isSubmitting || !canBuild}
+            className="h-15 w-full max-w-56 rounded-[22px] bg-[#245FE5] text-[24px] font-black tracking-tight text-white shadow-lg transition-colors hover:bg-[#1F56D1] disabled:cursor-not-allowed disabled:opacity-40"
           >
             {confirmLabel}
           </button>

--- a/src/components/game/modals/BuyModal.tsx
+++ b/src/components/game/modals/BuyModal.tsx
@@ -8,12 +8,17 @@ interface BuyModalProps {
   purchaseCostText?: string
   isUpgrade?: boolean
   currentLevel?: number
+  passLabel?: string
+  buyLabel?: string
+  isSubmitting?: boolean
   onPass?: () => void
   onBuy?: () => void
 }
 
 const DEFAULT_CITY_NAME = '대구'
 const DEFAULT_PURCHASE_COST_TEXT = '6칸'
+const DEFAULT_PASS_LABEL = '패스'
+const DEFAULT_BUY_LABEL = '구매하기'
 
 const BuyModal: React.FC<BuyModalProps> = ({
   open,
@@ -21,6 +26,9 @@ const BuyModal: React.FC<BuyModalProps> = ({
   purchaseCostText = DEFAULT_PURCHASE_COST_TEXT,
   isUpgrade = false,
   currentLevel = 0,
+  passLabel = DEFAULT_PASS_LABEL,
+  buyLabel = DEFAULT_BUY_LABEL,
+  isSubmitting = false,
   onPass,
   onBuy,
 }) => {
@@ -65,18 +73,19 @@ const BuyModal: React.FC<BuyModalProps> = ({
           <button
             type="button"
             onClick={onPass}
-            className="h-18.5 w-39.5 rounded-[22px] bg-[#E6EBF3] text-[34px] font-black tracking-tight text-[#5E708D] transition-colors hover:bg-[#DDE4EE]"
+            disabled={isSubmitting}
+            className="h-18.5 w-39.5 rounded-[22px] bg-[#E6EBF3] text-[34px] font-black tracking-tight text-[#5E708D] transition-colors hover:bg-[#DDE4EE] disabled:cursor-not-allowed disabled:opacity-50"
           >
-            패스
+            {passLabel}
           </button>
 
           <button
             type="button"
             onClick={onBuy}
-            disabled={isUpgrade && !canUpgrade}
-            className="h-18.5 w-46.5 rounded-[22px] bg-[#245FE5] text-[34px] font-black tracking-tight text-white shadow-lg transition-colors hover:bg-[#1F56D1] disabled:opacity-40"
+            disabled={isSubmitting || (isUpgrade && !canUpgrade)}
+            className="h-18.5 w-46.5 rounded-[22px] bg-[#245FE5] text-[34px] font-black tracking-tight text-white shadow-lg transition-colors hover:bg-[#1F56D1] disabled:cursor-not-allowed disabled:opacity-40"
           >
-            {isUpgrade ? '업그레이드' : '구매하기'}
+            {isUpgrade ? '업그레이드' : buyLabel}
           </button>
         </div>
       </div>

--- a/src/components/game/modals/DiceTimerModal.tsx
+++ b/src/components/game/modals/DiceTimerModal.tsx
@@ -4,7 +4,9 @@ interface DiceTimerModalProps {
   open: boolean
   title?: string
   description?: string
+  timeLeftSec?: number | null
   confirmLabel?: string
+  isSubmitting?: boolean
   onConfirm?: () => void
 }
 
@@ -45,7 +47,9 @@ const DiceTimerModal: React.FC<DiceTimerModalProps> = ({
   open,
   title = DEFAULT_TITLE,
   description = DEFAULT_DESCRIPTION,
+  timeLeftSec = null,
   confirmLabel = DEFAULT_CONFIRM_LABEL,
+  isSubmitting = false,
   onConfirm,
 }) => {
   if (!open) {
@@ -66,11 +70,17 @@ const DiceTimerModal: React.FC<DiceTimerModalProps> = ({
         <p className="mb-10 mt-5 text-center text-[22px] font-bold leading-[1.35] text-[#5A6D8A]">
           {description}
         </p>
+        {typeof timeLeftSec === 'number' && (
+          <p className="mb-8 text-center text-[18px] font-extrabold text-[#245FE5]">
+            남은 시간: {Math.max(0, Math.ceil(timeLeftSec))}초
+          </p>
+        )}
 
         <button
           type="button"
           onClick={onConfirm}
-          className="mx-auto flex h-15 w-full max-w-102 items-center justify-center rounded-[22px] bg-[#245FE5] text-[24px] font-black tracking-tight text-white shadow-[0_12px_24px_rgba(36,95,229,0.3)] transition-colors hover:bg-[#1F56D1]"
+          disabled={isSubmitting}
+          className="mx-auto flex h-15 w-full max-w-102 items-center justify-center rounded-[22px] bg-[#245FE5] text-[24px] font-black tracking-tight text-white shadow-[0_12px_24px_rgba(36,95,229,0.3)] transition-colors hover:bg-[#1F56D1] disabled:cursor-not-allowed disabled:opacity-50"
         >
           {confirmLabel}
         </button>

--- a/src/components/game/modals/TollModal.tsx
+++ b/src/components/game/modals/TollModal.tsx
@@ -6,6 +6,7 @@ interface TollModalProps {
   ownerName?: string
   tollText?: string
   confirmLabel?: string
+  isSubmitting?: boolean
   onConfirm?: () => void
 }
 
@@ -20,6 +21,7 @@ const TollModal: React.FC<TollModalProps> = ({
   ownerName = DEFAULT_OWNER_NAME,
   tollText = DEFAULT_TOLL_TEXT,
   confirmLabel = DEFAULT_CONFIRM_LABEL,
+  isSubmitting = false,
   onConfirm,
 }) => {
   if (!open) {
@@ -55,7 +57,8 @@ const TollModal: React.FC<TollModalProps> = ({
         <button
           type="button"
           onClick={onConfirm}
-          className="mx-auto flex h-15 w-full max-w-102 items-center justify-center rounded-[22px] bg-[#245FE5] text-[26px] font-black tracking-tight text-white shadow-lg transition-colors hover:bg-[#1F56D1]"
+          disabled={isSubmitting}
+          className="mx-auto flex h-15 w-full max-w-102 items-center justify-center rounded-[22px] bg-[#245FE5] text-[26px] font-black tracking-tight text-white shadow-lg transition-colors hover:bg-[#1F56D1] disabled:cursor-not-allowed disabled:opacity-50"
         >
           {confirmLabel}
         </button>

--- a/src/components/game/modals/promptModalMapping.ts
+++ b/src/components/game/modals/promptModalMapping.ts
@@ -1,0 +1,173 @@
+import type { GamePrompt } from '../../../types/domain'
+
+export type PromptModalKind =
+  | 'buy'
+  | 'build'
+  | 'toll'
+  | 'dice_timer'
+  | 'unknown'
+
+const BUY_TYPE_TOKENS = ['BUY_OR_SKIP', 'BUY_PROPERTY', 'BUY_PROMPT']
+const BUILD_TYPE_TOKENS = ['BUILD_OR_SKIP', 'UPGRADE_OR_SKIP', 'BUILD_PROMPT']
+const TOLL_TYPE_TOKENS = ['PAY_TOLL', 'TOLL_CONFIRM', 'PAY_TOLL_CONFIRM']
+const DICE_TIMER_TYPE_TOKENS = [
+  'DICE_TIMEOUT',
+  'TURN_TIMEOUT',
+  'TURN_TIMER',
+  'ROLL_TIMEOUT',
+]
+
+const normalize = (value: unknown): string =>
+  typeof value === 'string' ? value.trim().toUpperCase() : ''
+
+const hasTypeToken = (prompt: GamePrompt, tokens: string[]) => {
+  const promptType = normalize(prompt.type)
+  return tokens.some((token) => promptType.includes(token))
+}
+
+const getPromptChoices = (prompt: GamePrompt) => prompt.choices ?? []
+
+const hasChoiceToken = (prompt: GamePrompt, tokens: string[]) =>
+  getPromptChoices(prompt).some((choice) => {
+    const valueToken = normalize(choice.value)
+    const idToken = normalize(choice.id)
+    const labelToken = normalize(choice.label)
+    return tokens.some((token) => {
+      const normalizedToken = normalize(token)
+      return (
+        valueToken === normalizedToken ||
+        idToken === normalizedToken ||
+        labelToken.includes(normalizedToken)
+      )
+    })
+  })
+
+export const resolvePromptModalKind = (
+  prompt: GamePrompt | null | undefined
+): PromptModalKind => {
+  if (!prompt) {
+    return 'unknown'
+  }
+
+  if (
+    hasTypeToken(prompt, BUY_TYPE_TOKENS) ||
+    (hasChoiceToken(prompt, ['BUY']) &&
+      hasChoiceToken(prompt, ['SKIP', 'PASS']))
+  ) {
+    return 'buy'
+  }
+
+  if (
+    hasTypeToken(prompt, BUILD_TYPE_TOKENS) ||
+    hasChoiceToken(prompt, ['BUILD', 'UPGRADE'])
+  ) {
+    return 'build'
+  }
+
+  if (
+    hasTypeToken(prompt, TOLL_TYPE_TOKENS) ||
+    hasChoiceToken(prompt, ['PAY_TOLL', 'PAY'])
+  ) {
+    return 'toll'
+  }
+
+  if (
+    hasTypeToken(prompt, DICE_TIMER_TYPE_TOKENS) ||
+    (typeof prompt.timeoutSec === 'number' &&
+      hasChoiceToken(prompt, ['END_TURN']))
+  ) {
+    return 'dice_timer'
+  }
+
+  return 'unknown'
+}
+
+export const isPromptHandledByBoardModal = (
+  prompt: GamePrompt | null | undefined
+) => resolvePromptModalKind(prompt) !== 'unknown'
+
+export const findPromptChoiceValue = (
+  prompt: GamePrompt | null | undefined,
+  preferredTokens: string[],
+  fallbackIndex?: number
+): string | null => {
+  if (!prompt) {
+    return null
+  }
+
+  const choices = getPromptChoices(prompt)
+  if (choices.length === 0) {
+    return null
+  }
+
+  const matchedChoice = choices.find((choice) =>
+    preferredTokens.some((token) => {
+      const normalizedToken = normalize(token)
+      return (
+        normalize(choice.value) === normalizedToken ||
+        normalize(choice.id) === normalizedToken ||
+        normalize(choice.label).includes(normalizedToken)
+      )
+    })
+  )
+
+  if (matchedChoice) {
+    return matchedChoice.value
+  }
+
+  if (
+    typeof fallbackIndex === 'number' &&
+    fallbackIndex >= 0 &&
+    fallbackIndex < choices.length
+  ) {
+    return choices[fallbackIndex].value
+  }
+
+  return choices[0].value
+}
+
+const getPayloadRecord = (
+  prompt: GamePrompt | null | undefined
+): Record<string, unknown> => {
+  if (!prompt?.payload || typeof prompt.payload !== 'object') {
+    return {}
+  }
+
+  return prompt.payload
+}
+
+export const getPromptPayloadNumber = (
+  prompt: GamePrompt | null | undefined,
+  keys: string[]
+): number | null => {
+  const payload = getPayloadRecord(prompt)
+  for (const key of keys) {
+    const rawValue = payload[key]
+    if (typeof rawValue === 'number' && Number.isFinite(rawValue)) {
+      return rawValue
+    }
+    if (typeof rawValue === 'string' && rawValue.trim() !== '') {
+      const parsed = Number.parseInt(rawValue, 10)
+      if (!Number.isNaN(parsed)) {
+        return parsed
+      }
+    }
+  }
+
+  return null
+}
+
+export const getPromptPayloadString = (
+  prompt: GamePrompt | null | undefined,
+  keys: string[]
+): string | null => {
+  const payload = getPayloadRecord(prompt)
+  for (const key of keys) {
+    const rawValue = payload[key]
+    if (typeof rawValue === 'string' && rawValue.trim() !== '') {
+      return rawValue
+    }
+  }
+
+  return null
+}

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -3,6 +3,7 @@ import { Settings } from 'lucide-react'
 import { useLocation, useParams } from 'react-router-dom'
 import BoardGame, { BoardGameHandle } from '../components/board/GameBoard'
 import RollButton from '../components/game/controls/RollButton'
+import { isPromptHandledByBoardModal } from '../components/game/modals/promptModalMapping'
 import PlayerPanel from '../components/game/panels/PlayerPanel'
 import { IS_SOCKET_MOCK_ENABLED } from '../config/env'
 import { useAuthStore } from '../features/auth/store'
@@ -124,6 +125,9 @@ const GamePage: React.FC = () => {
     prompt?.playerId == null ||
     (currentUserId != null && String(prompt.playerId) === String(currentUserId))
   const isPromptVisible = Boolean(prompt && isPromptTargetedToCurrentUser)
+  const isBoardHandledPrompt = isPromptHandledByBoardModal(prompt)
+  const activeBoardPrompt =
+    isPromptVisible && isBoardHandledPrompt ? prompt : null
   const promptChoices = useMemo(
     () =>
       prompt?.choices && prompt.choices.length > 0
@@ -297,6 +301,9 @@ const GamePage: React.FC = () => {
               players={boardPlayers}
               curPlayer={boardCurPlayer}
               tiles={normalizedTilesForBoard}
+              activePrompt={activeBoardPrompt}
+              promptSubmittingChoice={promptSubmittingChoice}
+              onPromptChoice={handlePromptChoice}
             />
           </div>
         </div>
@@ -342,7 +349,7 @@ const GamePage: React.FC = () => {
         )}
       </div>
 
-      {isPromptVisible && prompt && (
+      {isPromptVisible && prompt && !isBoardHandledPrompt && (
         <div className="fixed inset-0 z-30 flex items-center justify-center bg-black/45 px-4">
           <div className="w-full max-w-xl rounded-3xl bg-white p-6 shadow-2xl">
             <h2 className="text-2xl font-black text-[#1F2A44]">


### PR DESCRIPTION
## 📌 관련 이슈

> closes #286

---

## 📝 작업 내용

- `GamePage`에서 `prompt.type`이 보드 모달 대상일 때 오버레이 대신 `GameBoard`로 prompt를 전달하도록 분기 추가
- `GameBoard`에서 non-mock 기준 `BUY/BUILD/TOLL/DICE_TIMER` 모달을 `gameStore.prompt` 단일 기준으로 노출/응답 처리
- 모달 액션 응답을 `onPromptChoice -> emitPromptResponse({ promptId, choice })` 경로로 통합
- `DiceTimerModal`을 `prompt.timeoutSec` 기반 카운트다운으로 연결
- `promptModalMapping` 헬퍼 추가(`prompt.type`/choices/payload 기반 모달 매핑, choice 추출)
- 모달 컴포넌트(`Buy/Build/Toll/DiceTimer`)에 submitting 상태/동적 라벨 props 반영
- mock 로컬 fallback 경로는 유지하고, non-mock에서 로컬 PROPERTY 분기 진입은 차단
- 문서 3종 진행도/다음 작업 갱신
  - `docs/game-event-spec-migration-plan.md`
  - `docs/game-delivery-roadmap.md`
  - `docs/game-ownership-corrected-table.md`

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

> UI 구조 변경은 prompt 표면 연결(오버레이/모달 분기) 중심이며, 별도 스크린샷은 생략했습니다.
