### PR TITLE
chore: owner coverage 제외 대상 정리 및 테스트 문서 반영

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -38,6 +38,7 @@ npm run build
 - 게임 E2E는 `npm run e2e:game`으로 분리 실행한다
 - 내 파트 전용 커버리지는 `npm run test:coverage:owner`로 측정한다
   - 범위: `lobby`, `waiting-room`, `presence`, `room-chat`
+  - 제외: DEV 전용 제어 패널, `types.ts`, test/d.ts 파일
   - 리포트 경로: `coverage-owner/index.html`
 
 ## 2.1 게이트 정책

--- a/vitest.owner.config.ts
+++ b/vitest.owner.config.ts
@@ -32,7 +32,14 @@ export default defineConfig({
         'src/features/presence/**/*.{ts,tsx}',
         'src/features/room-chat/**/*.{ts,tsx}',
       ],
-      exclude: ['**/*.test.ts', '**/*.test.tsx', '**/*.d.ts'],
+      exclude: [
+        '**/*.test.ts',
+        '**/*.test.tsx',
+        '**/*.d.ts',
+        '**/types.ts',
+        'src/pages/waiting-room/components/DevControlPanel.tsx',
+        'src/features/room-chat/DevRoomChatControlPanel.tsx',
+      ],
     },
   },
 })


### PR DESCRIPTION
## 📌 관련 이슈

> closes #290 

---

## 📝 작업 내용

- owner coverage 지표 왜곡을 줄이기 위해 제외 대상을 정리했습니다
  - `vitest.owner.config.ts`
  - 제외 추가:
    - `**/types.ts`
    - `src/pages/waiting-room/components/DevControlPanel.tsx`
    - `src/features/room-chat/DevRoomChatControlPanel.tsx`
- 테스트 정책 문서에 owner coverage 제외 기준을 반영했습니다
  - `docs/testing.md`
  - DEV 전용 제어 패널 및 타입 파일 제외 원칙 명시

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

- 해당 없음 (테스트 설정/문서 변경)

---

## 🧪 검증 내용

- `npm run test:coverage:owner` 통과
- 적용 후 owner coverage:
  - Statements: 71.11%
  - Branches: 60.43%
  - Functions: 74.67%
  - Lines: 70.72%

---

## 📌 추가 메모

- 본 PR은 coverage 대상 정리(chore) 목적이며, 로직 테스트 추가/보강은 별도 PR에서 진행 예정입니다.
