### PR TITLE
test: owner coverage 보강을 위한 waiting-room controller/DM 패널 테스트 추가

### DIFF
--- a/src/features/presence/components/DirectMessagePanel.test.tsx
+++ b/src/features/presence/components/DirectMessagePanel.test.tsx
@@ -1,0 +1,125 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { createOnlineUserFixture } from '../../../test/fixtures'
+import { DirectMessagePanel } from './DirectMessagePanel'
+import type { DirectMessage } from '../types'
+
+function createDirectMessage(
+  overrides: Partial<DirectMessage> = {}
+): DirectMessage {
+  return {
+    id: 'dm-1',
+    senderId: 'user-2',
+    senderNickname: '상대',
+    content: '기본 메시지',
+    sentAt: '2026-03-05T10:00:00.000Z',
+    ...overrides,
+  }
+}
+
+describe('DirectMessagePanel', () => {
+  it('메시지가 없으면 안내 문구를 표시한다', () => {
+    render(
+      <DirectMessagePanel
+        user={createOnlineUserFixture({
+          id: 'user-2',
+          nickname: '상대',
+        })}
+        currentUserId="user-1"
+        messages={[]}
+        onClose={vi.fn()}
+        onSendMessage={vi.fn()}
+      />
+    )
+
+    expect(
+      screen.getByText('메시지를 보내 대화를 시작하세요')
+    ).toBeInTheDocument()
+  })
+
+  it('메시지 목록을 sentAt 오름차순으로 정렬해 렌더링한다', () => {
+    const older = createDirectMessage({
+      id: 'dm-older',
+      content: '먼저 보낸 메시지',
+      sentAt: '2026-03-05T10:00:00.000Z',
+    })
+    const newer = createDirectMessage({
+      id: 'dm-newer',
+      content: '나중에 보낸 메시지',
+      sentAt: '2026-03-05T10:10:00.000Z',
+    })
+
+    const { container } = render(
+      <DirectMessagePanel
+        user={createOnlineUserFixture({
+          id: 'user-2',
+          nickname: '상대',
+        })}
+        currentUserId="user-1"
+        messages={[newer, older]}
+        onClose={vi.fn()}
+        onSendMessage={vi.fn()}
+      />
+    )
+
+    const panelText = container.textContent ?? ''
+    expect(panelText.indexOf('먼저 보낸 메시지')).toBeLessThan(
+      panelText.indexOf('나중에 보낸 메시지')
+    )
+  })
+
+  it('공백 입력은 전송하지 않고 유효 입력 전송 후 input을 비운다', async () => {
+    const user = userEvent.setup()
+    const onSendMessage = vi.fn()
+
+    render(
+      <DirectMessagePanel
+        user={createOnlineUserFixture({
+          id: 'user-2',
+          nickname: '상대',
+        })}
+        currentUserId="user-1"
+        messages={[]}
+        onClose={vi.fn()}
+        onSendMessage={onSendMessage}
+      />
+    )
+
+    const input = screen.getByPlaceholderText(
+      '메시지를 입력하세요...'
+    ) as HTMLInputElement
+    const sendButton = screen.getByRole('button', { name: 'DM 전송' })
+
+    await user.type(input, '   ')
+    expect(sendButton).toBeDisabled()
+
+    await user.clear(input)
+    await user.type(input, ' 안녕하세요 ')
+    await user.click(sendButton)
+
+    expect(onSendMessage).toHaveBeenCalledWith('안녕하세요')
+    expect(input.value).toBe('')
+  })
+
+  it('닫기 버튼 클릭 시 onClose를 호출한다', async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+
+    render(
+      <DirectMessagePanel
+        user={createOnlineUserFixture({
+          id: 'user-2',
+          nickname: '상대',
+        })}
+        currentUserId="user-1"
+        messages={[]}
+        onClose={onClose}
+        onSendMessage={vi.fn()}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'DM 닫기' }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/pages/waiting-room/controller/actions.test.ts
+++ b/src/pages/waiting-room/controller/actions.test.ts
@@ -1,0 +1,224 @@
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createAuthSessionFixture } from '../../../test/fixtures'
+import { useWaitingRoomActions } from './actions'
+import type { WaitingRoomSnapshot } from '../types'
+import type { WaitingRoomActionResult } from './state'
+
+const {
+  leaveWaitingRoomMock,
+  startWaitingGameMock,
+  toggleWaitingReadyMock,
+  getWaitingRoomErrorMessageMock,
+  leaveWaitingRoomSocketMock,
+  sendWaitingRoomChatMock,
+} = vi.hoisted(() => ({
+  leaveWaitingRoomMock: vi.fn(),
+  startWaitingGameMock: vi.fn(),
+  toggleWaitingReadyMock: vi.fn(),
+  getWaitingRoomErrorMessageMock: vi.fn(),
+  leaveWaitingRoomSocketMock: vi.fn(),
+  sendWaitingRoomChatMock: vi.fn(),
+}))
+
+vi.mock('../api', () => ({
+  leaveWaitingRoom: leaveWaitingRoomMock,
+  startWaitingGame: startWaitingGameMock,
+  toggleWaitingReady: toggleWaitingReadyMock,
+  getWaitingRoomErrorMessage: getWaitingRoomErrorMessageMock,
+}))
+
+vi.mock('../socket', () => ({
+  leaveWaitingRoomSocket: leaveWaitingRoomSocketMock,
+  sendWaitingRoomChat: sendWaitingRoomChatMock,
+}))
+
+function createRoomSnapshot(): WaitingRoomSnapshot {
+  return {
+    roomId: 'room-5',
+    title: '즐거운 게임 한판!',
+    status: 'waiting',
+    maxPlayers: 4,
+    isPrivate: false,
+    players: [
+      { id: 'user-1', nickname: '테스터', isReady: false, isHost: true },
+      { id: 'user-2', nickname: '상대', isReady: false, isHost: false },
+    ],
+    chatMessages: [],
+  }
+}
+
+function createActionsHookParams(overrides: Record<string, unknown> = {}) {
+  const session = createAuthSessionFixture({
+    userId: 'user-1',
+    nickname: '테스터',
+  })
+  const room = createRoomSnapshot()
+
+  return {
+    roomId: room.roomId,
+    room,
+    session,
+    canToggleReady: true,
+    canStartGame: true,
+    isReadyPending: false,
+    isStartPending: false,
+    hasEnteredRoomRef: { current: true },
+    hasLeftRoomRef: { current: false },
+    shouldSkipNextCleanupLeaveRef: { current: false },
+    leaveInFlightRef: {
+      current: null as Promise<WaitingRoomActionResult> | null,
+    },
+    sessionRef: { current: session },
+    roomIdRef: { current: room.roomId },
+    roomRef: { current: room },
+    setRoom: vi.fn(),
+    setIsReadyPending: vi.fn(),
+    setIsStartPending: vi.fn(),
+    setIsLeavePending: vi.fn(),
+    ...overrides,
+  }
+}
+
+describe('useWaitingRoomActions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getWaitingRoomErrorMessageMock.mockReturnValue('요청에 실패했습니다.')
+  })
+
+  it('sendChatMessage는 세션/방 정보가 있을 때만 소켓 전송을 호출한다', () => {
+    const params = createActionsHookParams()
+    const { result } = renderHook(() => useWaitingRoomActions(params))
+
+    act(() => {
+      result.current.sendChatMessage('안녕하세요')
+    })
+
+    expect(sendWaitingRoomChatMock).toHaveBeenCalledWith({
+      roomId: 'room-5',
+      senderId: 'user-1',
+      senderNickname: '테스터',
+      message: '안녕하세요',
+    })
+  })
+
+  it('leaveRoom 수동 호출 성공 시 leave API와 leave 소켓 이벤트를 순차 실행한다', async () => {
+    leaveWaitingRoomMock.mockResolvedValue({ success: true })
+    const params = createActionsHookParams()
+    const { result } = renderHook(() => useWaitingRoomActions(params))
+
+    let response: WaitingRoomActionResult | undefined
+    await act(async () => {
+      response = await result.current.leaveRoom()
+    })
+
+    expect(response).toEqual({ ok: true })
+    expect(params.setIsLeavePending).toHaveBeenNthCalledWith(1, true)
+    expect(leaveWaitingRoomMock).toHaveBeenCalledWith({
+      roomId: 'room-5',
+      userId: 'user-1',
+    })
+    expect(leaveWaitingRoomSocketMock).toHaveBeenCalledWith({
+      roomId: 'room-5',
+    })
+    expect(params.setIsLeavePending).toHaveBeenLastCalledWith(false)
+    expect(params.hasLeftRoomRef.current).toBe(true)
+  })
+
+  it('leaveRoom 중복 호출 시 진행 중 Promise를 재사용한다', async () => {
+    let resolveLeave: (() => void) | undefined
+    leaveWaitingRoomMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveLeave = () => resolve()
+        })
+    )
+
+    const params = createActionsHookParams()
+    const { result } = renderHook(() => useWaitingRoomActions(params))
+
+    let firstPromise!: Promise<WaitingRoomActionResult>
+    let secondPromise!: Promise<WaitingRoomActionResult>
+
+    act(() => {
+      firstPromise = result.current.leaveRoom()
+      secondPromise = result.current.leaveRoom()
+    })
+
+    expect(leaveWaitingRoomMock).toHaveBeenCalledTimes(1)
+
+    if (resolveLeave) {
+      resolveLeave()
+    }
+    let firstResult: WaitingRoomActionResult | undefined
+    let secondResult: WaitingRoomActionResult | undefined
+
+    await act(async () => {
+      firstResult = await firstPromise
+      secondResult = await secondPromise
+    })
+
+    expect(firstResult).toEqual({ ok: true })
+    expect(secondResult).toEqual({ ok: true })
+  })
+
+  it('cleanup에서 skip 플래그가 켜져 있으면 퇴장 시퀀스를 실행하지 않는다', () => {
+    const params = createActionsHookParams({
+      shouldSkipNextCleanupLeaveRef: { current: true },
+    })
+
+    const { unmount } = renderHook(() => useWaitingRoomActions(params))
+    unmount()
+
+    expect(leaveWaitingRoomMock).not.toHaveBeenCalled()
+    expect(params.shouldSkipNextCleanupLeaveRef.current).toBe(false)
+  })
+
+  it('handleToggleReady 성공 시 setRoom updater로 내 준비 상태를 갱신한다', async () => {
+    toggleWaitingReadyMock.mockResolvedValue({ isReady: true })
+    const params = createActionsHookParams({
+      canStartGame: false,
+    })
+    const { result } = renderHook(() => useWaitingRoomActions(params))
+
+    let response: WaitingRoomActionResult | undefined
+    await act(async () => {
+      response = await result.current.handleToggleReady()
+    })
+
+    expect(response).toEqual({ ok: true })
+    expect(toggleWaitingReadyMock).toHaveBeenCalledWith({
+      roomId: 'room-5',
+      userId: 'user-1',
+    })
+
+    const updater = params.setRoom.mock.calls[0]?.[0] as
+      | ((snapshot: WaitingRoomSnapshot | null) => WaitingRoomSnapshot | null)
+      | undefined
+    expect(typeof updater).toBe('function')
+
+    const updatedRoom = updater?.(createRoomSnapshot())
+    const me = updatedRoom?.players.find((player) => player.id === 'user-1')
+    expect(me?.isReady).toBe(true)
+  })
+
+  it('handleStartGame 실패 시 파싱된 에러 메시지를 반환한다', async () => {
+    startWaitingGameMock.mockRejectedValue(new Error('failed'))
+    getWaitingRoomErrorMessageMock.mockReturnValue('게임 시작 실패')
+
+    const params = createActionsHookParams()
+    const { result } = renderHook(() => useWaitingRoomActions(params))
+
+    let response: WaitingRoomActionResult | undefined
+    await act(async () => {
+      response = await result.current.handleStartGame()
+    })
+
+    expect(response).toEqual({
+      ok: false,
+      message: '게임 시작 실패',
+    })
+    expect(params.setIsStartPending).toHaveBeenNthCalledWith(1, true)
+    expect(params.setIsStartPending).toHaveBeenLastCalledWith(false)
+  })
+})

--- a/src/pages/waiting-room/controller/lifecycle.test.ts
+++ b/src/pages/waiting-room/controller/lifecycle.test.ts
@@ -1,0 +1,148 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createAuthSessionFixture } from '../../../test/fixtures'
+import { useWaitingRoomLifecycle } from './lifecycle'
+import type { WaitingRoomSnapshot } from '../types'
+
+const {
+  joinWaitingRoomMock,
+  getWaitingRoomErrorMessageMock,
+  enterWaitingRoomSocketMock,
+} = vi.hoisted(() => ({
+  joinWaitingRoomMock: vi.fn(),
+  getWaitingRoomErrorMessageMock: vi.fn(),
+  enterWaitingRoomSocketMock: vi.fn(),
+}))
+
+vi.mock('../api', () => ({
+  joinWaitingRoom: joinWaitingRoomMock,
+  getWaitingRoomErrorMessage: getWaitingRoomErrorMessageMock,
+}))
+
+vi.mock('../socket', () => ({
+  enterWaitingRoomSocket: enterWaitingRoomSocketMock,
+}))
+
+function createPreJoinedSnapshot(): WaitingRoomSnapshot {
+  return {
+    roomId: 'room-5',
+    title: '즐거운 게임 한판!',
+    status: 'waiting',
+    maxPlayers: 4,
+    isPrivate: false,
+    players: [
+      { id: 'user-1', nickname: '테스터', isReady: false, isHost: true },
+    ],
+    chatMessages: [],
+  }
+}
+
+function createLifecycleParams(overrides: Record<string, unknown> = {}) {
+  const session = createAuthSessionFixture({
+    userId: 'user-1',
+    nickname: '테스터',
+  })
+
+  return {
+    roomId: 'room-5',
+    session,
+    fallbackRoomTitle: 'fallback',
+    preJoinedSnapshot: null,
+    hasEnteredRoomRef: { current: false },
+    hasLeftRoomRef: { current: false },
+    hasInitializedPreJoinRef: { current: false },
+    setRoom: vi.fn(),
+    setChatMessages: vi.fn(),
+    setIsRoomLoading: vi.fn(),
+    setRoomErrorMessage: vi.fn(),
+    ...overrides,
+  }
+}
+
+describe('useWaitingRoomLifecycle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getWaitingRoomErrorMessageMock.mockReturnValue(
+      '대기방 입장에 실패했습니다.'
+    )
+  })
+
+  it('roomId가 없으면 방 상태를 초기화한다', () => {
+    const params = createLifecycleParams({
+      roomId: '',
+      hasEnteredRoomRef: { current: true },
+      hasLeftRoomRef: { current: true },
+      hasInitializedPreJoinRef: { current: true },
+    })
+
+    renderHook(() => useWaitingRoomLifecycle(params))
+
+    expect(params.setRoom).toHaveBeenCalledWith(null)
+    expect(params.setChatMessages).toHaveBeenCalledWith([])
+    expect(params.setIsRoomLoading).toHaveBeenCalledWith(false)
+    expect(params.setRoomErrorMessage).toHaveBeenCalledWith(null)
+    expect(params.hasEnteredRoomRef.current).toBe(false)
+    expect(params.hasLeftRoomRef.current).toBe(false)
+    expect(params.hasInitializedPreJoinRef.current).toBe(false)
+  })
+
+  it('preJoinedSnapshot이 있으면 join API 없이 즉시 상태를 반영한다', () => {
+    const preJoinedSnapshot = createPreJoinedSnapshot()
+    const params = createLifecycleParams({
+      preJoinedSnapshot,
+    })
+
+    renderHook(() => useWaitingRoomLifecycle(params))
+
+    expect(joinWaitingRoomMock).not.toHaveBeenCalled()
+    expect(params.setRoom).toHaveBeenCalledWith(preJoinedSnapshot)
+    expect(params.setChatMessages).toHaveBeenCalledWith(
+      preJoinedSnapshot.chatMessages
+    )
+    expect(enterWaitingRoomSocketMock).toHaveBeenCalledWith({
+      roomId: 'room-5',
+    })
+    expect(params.hasEnteredRoomRef.current).toBe(true)
+    expect(params.hasInitializedPreJoinRef.current).toBe(true)
+  })
+
+  it('join 성공 시 스냅샷 반영과 enter_room 소켓 전송을 수행한다', async () => {
+    const joinedSnapshot = createPreJoinedSnapshot()
+    joinWaitingRoomMock.mockResolvedValue(joinedSnapshot)
+    const params = createLifecycleParams()
+
+    renderHook(() => useWaitingRoomLifecycle(params))
+
+    await waitFor(() => {
+      expect(joinWaitingRoomMock).toHaveBeenCalledWith({
+        roomId: 'room-5',
+        userId: 'user-1',
+        nickname: '테스터',
+        fallbackTitle: 'fallback',
+      })
+    })
+
+    expect(params.setRoom).toHaveBeenCalledWith(joinedSnapshot)
+    expect(params.setChatMessages).toHaveBeenCalledWith(
+      joinedSnapshot.chatMessages
+    )
+    expect(enterWaitingRoomSocketMock).toHaveBeenCalledWith({
+      roomId: 'room-5',
+    })
+    expect(params.setIsRoomLoading).toHaveBeenCalledWith(true)
+    expect(params.setIsRoomLoading).toHaveBeenLastCalledWith(false)
+  })
+
+  it('join 실패 시 파싱된 오류 메시지를 roomError로 설정한다', async () => {
+    joinWaitingRoomMock.mockRejectedValue(new Error('join failed'))
+    getWaitingRoomErrorMessageMock.mockReturnValue('입장 실패')
+    const params = createLifecycleParams()
+
+    renderHook(() => useWaitingRoomLifecycle(params))
+
+    await waitFor(() => {
+      expect(params.setRoomErrorMessage).toHaveBeenCalledWith('입장 실패')
+    })
+    expect(params.setIsRoomLoading).toHaveBeenLastCalledWith(false)
+  })
+})

--- a/src/pages/waiting-room/controller/socketSync.test.ts
+++ b/src/pages/waiting-room/controller/socketSync.test.ts
@@ -1,0 +1,217 @@
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Dispatch, SetStateAction } from 'react'
+import { createAuthSessionFixture } from '../../../test/fixtures'
+import { useWaitingRoomSocketSync } from './socketSync'
+import type {
+  ChatEventPayload,
+  GameStartEventPayload,
+  HostChangedEventPayload,
+  PlayerReadyEventPayload,
+  WaitingRoomSnapshot,
+} from '../types'
+
+const { subscribeWaitingRoomSocketEventsMock, unsubscribeMock } = vi.hoisted(
+  () => ({
+    subscribeWaitingRoomSocketEventsMock: vi.fn(),
+    unsubscribeMock: vi.fn(),
+  })
+)
+
+vi.mock('../socket', () => ({
+  subscribeWaitingRoomSocketEvents: subscribeWaitingRoomSocketEventsMock,
+}))
+
+function createRoomSnapshot(): WaitingRoomSnapshot {
+  return {
+    roomId: 'room-5',
+    title: '즐거운 게임 한판!',
+    status: 'waiting',
+    maxPlayers: 4,
+    isPrivate: false,
+    players: [
+      { id: 'user-1', nickname: '테스터', isReady: false, isHost: true },
+      { id: 'user-2', nickname: '상대', isReady: false, isHost: false },
+    ],
+    chatMessages: [],
+  }
+}
+
+interface SocketSyncHookParams {
+  roomId: string
+  session: ReturnType<typeof createAuthSessionFixture> | null
+  activeRoomId?: string
+  onGameStart: (payload: GameStartEventPayload) => void
+  setRoom: Dispatch<SetStateAction<WaitingRoomSnapshot | null>>
+  setChatMessages: Dispatch<SetStateAction<WaitingRoomSnapshot['chatMessages']>>
+  setRoomMock: ReturnType<typeof vi.fn>
+  setChatMessagesMock: ReturnType<typeof vi.fn>
+}
+
+function createBaseParams(): SocketSyncHookParams {
+  const setRoomMock = vi.fn()
+  const setChatMessagesMock = vi.fn()
+
+  return {
+    roomId: 'room-5',
+    session: createAuthSessionFixture({
+      userId: 'user-1',
+      nickname: '테스터',
+    }),
+    activeRoomId: 'room-5',
+    onGameStart: vi.fn(),
+    setRoom: setRoomMock as unknown as Dispatch<
+      SetStateAction<WaitingRoomSnapshot | null>
+    >,
+    setChatMessages: setChatMessagesMock as unknown as Dispatch<
+      SetStateAction<WaitingRoomSnapshot['chatMessages']>
+    >,
+    setRoomMock,
+    setChatMessagesMock,
+  }
+}
+
+describe('useWaitingRoomSocketSync', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    subscribeWaitingRoomSocketEventsMock.mockReturnValue(unsubscribeMock)
+  })
+
+  it('핵심 입력값(roomId/session/activeRoomId)이 없으면 구독을 생략한다', () => {
+    const params = createBaseParams()
+    params.activeRoomId = undefined
+
+    renderHook(() => useWaitingRoomSocketSync(params))
+
+    expect(subscribeWaitingRoomSocketEventsMock).not.toHaveBeenCalled()
+  })
+
+  it('onChat은 현재 방 이벤트만 반영하고 중복 메시지를 무시한다', () => {
+    const params = createBaseParams()
+    renderHook(() => useWaitingRoomSocketSync(params))
+
+    const handlers = subscribeWaitingRoomSocketEventsMock.mock
+      .calls[0]?.[0] as {
+      onChat: (payload: ChatEventPayload) => void
+    }
+
+    act(() => {
+      handlers.onChat({
+        room_id: 'room-other',
+        sender_id: 'user-2',
+        sender_nickname: '상대',
+        message: '다른 방 메시지',
+        sent_at: '2026-03-05T01:00:00.000Z',
+      })
+    })
+    expect(params.setChatMessagesMock).not.toHaveBeenCalled()
+
+    act(() => {
+      handlers.onChat({
+        room_id: 'room-5',
+        sender_id: 'user-2',
+        sender_nickname: '상대',
+        message: '중복 테스트',
+        sent_at: '2026-03-05T01:00:00.000Z',
+      })
+    })
+
+    const updater = params.setChatMessagesMock.mock.calls[0]?.[0] as
+      | ((
+          messages: WaitingRoomSnapshot['chatMessages']
+        ) => WaitingRoomSnapshot['chatMessages'])
+      | undefined
+    expect(typeof updater).toBe('function')
+
+    const duplicatedMessages = [
+      {
+        id: 'room-5-user-2-2026-03-05T01:00:00.000Z',
+        senderId: 'user-2',
+        senderNickname: '상대',
+        content: '중복 테스트',
+        timestamp: '2026-03-05T01:00:00.000Z',
+        type: 'talk' as const,
+      },
+    ]
+    const deduped = updater?.(duplicatedMessages)
+    expect(deduped).toBe(duplicatedMessages)
+  })
+
+  it('onPlayerReady와 onHostChanged는 room updater를 통해 플레이어 상태를 갱신한다', () => {
+    const params = createBaseParams()
+    renderHook(() => useWaitingRoomSocketSync(params))
+
+    const handlers = subscribeWaitingRoomSocketEventsMock.mock
+      .calls[0]?.[0] as {
+      onPlayerReady: (payload: PlayerReadyEventPayload) => void
+      onHostChanged: (payload: HostChangedEventPayload) => void
+    }
+
+    act(() => {
+      handlers.onPlayerReady({
+        player_id: 'user-2',
+        is_ready: true,
+        all_ready: true,
+      })
+    })
+
+    const readyUpdater = params.setRoomMock.mock.calls[0]?.[0] as
+      | ((room: WaitingRoomSnapshot | null) => WaitingRoomSnapshot | null)
+      | undefined
+    const afterReady = readyUpdater?.(createRoomSnapshot())
+    expect(
+      afterReady?.players.find((player) => player.id === 'user-2')?.isReady
+    ).toBe(true)
+
+    act(() => {
+      handlers.onHostChanged({
+        new_host_id: 'user-2',
+        new_host_nickname: '상대',
+      })
+    })
+
+    const hostUpdater = params.setRoomMock.mock.calls[1]?.[0] as
+      | ((room: WaitingRoomSnapshot | null) => WaitingRoomSnapshot | null)
+      | undefined
+    const afterHostChanged = hostUpdater?.(createRoomSnapshot())
+    expect(
+      afterHostChanged?.players.find((player) => player.id === 'user-2')?.isHost
+    ).toBe(true)
+    expect(
+      afterHostChanged?.players.find((player) => player.id === 'user-2')
+        ?.isReady
+    ).toBe(false)
+  })
+
+  it('onGameStart는 현재 방 이벤트만 전달하고 cleanup에서 unsubscribe를 호출한다', () => {
+    const params = createBaseParams()
+    const { unmount } = renderHook(() => useWaitingRoomSocketSync(params))
+
+    const handlers = subscribeWaitingRoomSocketEventsMock.mock
+      .calls[0]?.[0] as {
+      onGameStart: (payload: GameStartEventPayload) => void
+    }
+
+    act(() => {
+      handlers.onGameStart({
+        game_id: 'game-1',
+        room_id: 'room-other',
+      })
+    })
+    expect(params.onGameStart).not.toHaveBeenCalled()
+
+    act(() => {
+      handlers.onGameStart({
+        game_id: 'game-2',
+        room_id: 'room-5',
+      })
+    })
+    expect(params.onGameStart).toHaveBeenCalledWith({
+      game_id: 'game-2',
+      room_id: 'room-5',
+    })
+
+    unmount()
+    expect(unsubscribeMock).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## 📌 관련 이슈

> closes #292 

---

## 📝 작업 내용

owner coverage 보강을 위해 대기방 controller 훅과 DM 패널 UI 테스트를 추가했습니다.  
프로덕션 코드 변경 없이 테스트 코드만 추가/보완했습니다.

### 추가/보완된 테스트
- `src/pages/waiting-room/controller/actions.test.ts`
  - ready/start/leave/chat 액션 흐름 검증
- `src/pages/waiting-room/controller/lifecycle.test.ts`
  - room join lifecycle(성공/실패/사전입장 스냅샷) 검증
- `src/pages/waiting-room/controller/socketSync.test.ts`
  - 소켓 이벤트 반영 및 cleanup(unsubscribe) 검증
- `src/features/presence/components/DirectMessagePanel.test.tsx`
  - DM 입력/전송/초기화/닫기 UI 상호작용 검증

### 반영 포인트
- 테스트 더블 타입 정리(`Dispatch<SetStateAction<...>>`)로 TS 빌드 안정화
- 기존 시나리오 회귀 방지 범위 확대

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] `npm run build` 통과
- [x] `npm run test` 통과
- [x] `npm run test:coverage:owner` 통과
- [x] 프로덕션 코드 변경 없음 확인
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

<img width="1912" height="1242" alt="스크린샷 2026-03-05 오후 5 11 14" src="https://github.com/user-attachments/assets/c1c7c98e-970d-4625-b79e-11dabd07aef9" />

