### PR TITLE
feat: game:prompt choice 규약 통일 및 GameBoard 응답 분기 정리

### DIFF
--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -17,9 +17,10 @@ import DiceTimerModal from '../game/modals/DiceTimerModal'
 import GameResultModal from '../game/modals/GameResultModal'
 import GoToIslandModal from '../game/modals/GoToIslandModal'
 import {
-  findPromptChoiceValue,
+  getPromptChoiceLabel,
   getPromptPayloadNumber,
   getPromptPayloadString,
+  resolvePromptChoiceValue,
   resolvePromptModalKind,
 } from '../game/modals/promptModalMapping'
 
@@ -333,47 +334,42 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
     ) as BuildingLevel
     const promptNextLevel = Math.min(promptCurrentLevel + 1, 7) as BuildingLevel
 
-    const promptBuyChoiceValue = findPromptChoiceValue(activePrompt, ['BUY'], 0)
-    const promptBuyPassChoiceValue = findPromptChoiceValue(activePrompt, [
-      'SKIP',
-      'PASS',
-      'CANCEL',
-      'NO',
-    ])
-    const promptBuildConfirmChoiceValue = findPromptChoiceValue(
+    const promptBuyChoiceValue = resolvePromptChoiceValue(
       activePrompt,
-      ['BUILD', 'UPGRADE', 'CONFIRM'],
-      0
+      'buyConfirm'
     )
-    const promptBuildCancelChoiceValue = findPromptChoiceValue(activePrompt, [
-      'SKIP',
-      'PASS',
-      'CANCEL',
-      'NO',
-    ])
-    const promptTollConfirmChoiceValue = findPromptChoiceValue(
+    const promptBuyPassChoiceValue = resolvePromptChoiceValue(
       activePrompt,
-      ['PAY_TOLL', 'PAY', 'CONFIRM', 'OK'],
-      0
+      'buyCancel'
     )
-    const promptTimerConfirmChoiceValue = findPromptChoiceValue(
+    const promptBuildConfirmChoiceValue = resolvePromptChoiceValue(
       activePrompt,
-      ['END_TURN', 'CONFIRM', 'OK', 'SKIP'],
-      0
+      'buildConfirm'
+    )
+    const promptBuildCancelChoiceValue = resolvePromptChoiceValue(
+      activePrompt,
+      'buildCancel'
+    )
+    const promptTollConfirmChoiceValue = resolvePromptChoiceValue(
+      activePrompt,
+      'tollConfirm'
+    )
+    const promptTimerConfirmChoiceValue = resolvePromptChoiceValue(
+      activePrompt,
+      'timerConfirm'
     )
 
-    const getPromptChoiceLabel = (
+    const submitPromptChoice = (
       choiceValue: string | null,
-      fallbackLabel: string
+      onSuccess?: () => void
     ) => {
-      if (!activePrompt || !choiceValue) {
-        return fallbackLabel
+      if (!choiceValue || !onPromptChoice || promptSubmittingChoice !== null) {
+        return false
       }
 
-      return (
-        activePrompt.choices?.find((choice) => choice.value === choiceValue)
-          ?.label ?? fallbackLabel
-      )
+      onPromptChoice(choiceValue)
+      onSuccess?.()
+      return true
     }
 
     useEffect(() => {
@@ -830,11 +826,8 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
     function handleDiceTimerConfirm() {
       if (
         isDiceTimerPromptOpen &&
-        promptTimerConfirmChoiceValue &&
-        onPromptChoice &&
-        promptSubmittingChoice === null
+        submitPromptChoice(promptTimerConfirmChoiceValue)
       ) {
-        onPromptChoice(promptTimerConfirmChoiceValue)
         return
       }
 
@@ -975,6 +968,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
     const diceTimerTitle = activePrompt?.title
     const diceTimerMessage = activePrompt?.message
     const diceTimerConfirmLabel = getPromptChoiceLabel(
+      activePrompt,
       promptTimerConfirmChoiceValue,
       '확인'
     )
@@ -1083,13 +1077,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
               return
             }
 
-            if (
-              promptBuyChoiceValue &&
-              onPromptChoice &&
-              promptSubmittingChoice === null
-            ) {
-              onPromptChoice(promptBuyChoiceValue)
-            }
+            submitPromptChoice(promptBuyChoiceValue)
           }}
           onPass={() => {
             if (useLocalPromptFallback) {
@@ -1097,22 +1085,18 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
               return
             }
 
-            const fallbackChoice =
-              promptBuyPassChoiceValue ??
-              findPromptChoiceValue(activePrompt, ['SKIP', 'PASS'], 1)
-            if (
-              fallbackChoice &&
-              onPromptChoice &&
-              promptSubmittingChoice === null
-            ) {
-              onPromptChoice(fallbackChoice)
-            }
+            submitPromptChoice(promptBuyPassChoiceValue)
           }}
           passLabel={getPromptChoiceLabel(
+            activePrompt,
             promptBuyPassChoiceValue,
             useLocalPromptFallback ? '패스' : '건너뛰기'
           )}
-          buyLabel={getPromptChoiceLabel(promptBuyChoiceValue, '구매하기')}
+          buyLabel={getPromptChoiceLabel(
+            activePrompt,
+            promptBuyChoiceValue,
+            '구매하기'
+          )}
           isSubmitting={
             promptSubmittingChoice !== null && !useLocalPromptFallback
           }
@@ -1127,13 +1111,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
               return
             }
 
-            if (
-              promptBuildConfirmChoiceValue &&
-              onPromptChoice &&
-              promptSubmittingChoice === null
-            ) {
-              onPromptChoice(promptBuildConfirmChoiceValue)
-            }
+            submitPromptChoice(promptBuildConfirmChoiceValue)
           }}
           onCancel={() => {
             if (useLocalPromptFallback) {
@@ -1141,16 +1119,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
               return
             }
 
-            const fallbackChoice =
-              promptBuildCancelChoiceValue ??
-              findPromptChoiceValue(activePrompt, ['SKIP', 'PASS', 'CANCEL'], 1)
-            if (
-              fallbackChoice &&
-              onPromptChoice &&
-              promptSubmittingChoice === null
-            ) {
-              onPromptChoice(fallbackChoice)
-            }
+            submitPromptChoice(promptBuildCancelChoiceValue)
           }}
           cityName={promptTileName}
           nextLevel={
@@ -1159,10 +1128,12 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
               : promptNextLevel
           }
           cancelLabel={getPromptChoiceLabel(
+            activePrompt,
             promptBuildCancelChoiceValue,
             '취소'
           )}
           confirmLabel={getPromptChoiceLabel(
+            activePrompt,
             promptBuildConfirmChoiceValue,
             '건설하기'
           )}
@@ -1180,18 +1151,13 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
               return
             }
 
-            if (
-              promptTollConfirmChoiceValue &&
-              onPromptChoice &&
-              promptSubmittingChoice === null
-            ) {
-              onPromptChoice(promptTollConfirmChoiceValue)
-            }
+            submitPromptChoice(promptTollConfirmChoiceValue)
           }}
           cityName={promptTileName || tollTile?.name || ''}
           ownerName={tollOwnerName}
           tollText={tollAmountText}
           confirmLabel={getPromptChoiceLabel(
+            activePrompt,
             promptTollConfirmChoiceValue,
             '확인하기'
           )}

--- a/src/components/game/modals/promptModalMapping.test.ts
+++ b/src/components/game/modals/promptModalMapping.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+import type { GamePrompt } from '../../../types/domain'
+import {
+  getPromptChoiceLabel,
+  resolvePromptChoiceValue,
+  resolvePromptModalKind,
+} from './promptModalMapping'
+
+const createPrompt = (overrides: Partial<GamePrompt> = {}): GamePrompt => ({
+  id: 'prompt-1',
+  type: 'UNKNOWN_PROMPT',
+  choices: [],
+  ...overrides,
+})
+
+describe('promptModalMapping', () => {
+  it('prompt type 토큰으로 buy 모달을 판별한다', () => {
+    const prompt = createPrompt({ type: 'BUY_OR_SKIP' })
+
+    expect(resolvePromptModalKind(prompt)).toBe('buy')
+  })
+
+  it('choice 토큰으로 build 모달을 판별한다', () => {
+    const prompt = createPrompt({
+      type: 'SERVER_PROMPT',
+      choices: [
+        { id: 'skip', label: '건너뛰기', value: 'SKIP' },
+        { id: 'upgrade', label: '건설', value: 'UPGRADE' },
+      ],
+    })
+
+    expect(resolvePromptModalKind(prompt)).toBe('build')
+  })
+
+  it('buyConfirm 규칙은 토큰 매칭을 우선 적용한다', () => {
+    const prompt = createPrompt({
+      type: 'BUY_OR_SKIP',
+      choices: [
+        { id: 'skip', label: '건너뛰기', value: 'SKIP' },
+        { id: 'buy', label: '구매하기', value: 'BUY' },
+      ],
+    })
+
+    expect(resolvePromptChoiceValue(prompt, 'buyConfirm')).toBe('BUY')
+  })
+
+  it('buyCancel 규칙은 매칭 실패 시 2번째 choice를 fallback으로 사용한다', () => {
+    const prompt = createPrompt({
+      type: 'BUY_OR_SKIP',
+      choices: [
+        { id: 'first', label: '첫번째', value: 'FIRST' },
+        { id: 'second', label: '두번째', value: 'SECOND' },
+      ],
+    })
+
+    expect(resolvePromptChoiceValue(prompt, 'buyCancel')).toBe('SECOND')
+  })
+
+  it('timerConfirm 규칙은 END_TURN 선택값을 반환한다', () => {
+    const prompt = createPrompt({
+      type: 'TURN_TIMEOUT',
+      timeoutSec: 15,
+      choices: [
+        { id: 'keep', label: '대기', value: 'WAIT' },
+        { id: 'end-turn', label: '턴 종료', value: 'END_TURN' },
+      ],
+    })
+
+    expect(resolvePromptChoiceValue(prompt, 'timerConfirm')).toBe('END_TURN')
+  })
+
+  it('선택값 label이 없으면 fallback label을 반환한다', () => {
+    const prompt = createPrompt({
+      choices: [{ id: 'buy', label: '구매하기', value: 'BUY' }],
+    })
+
+    expect(getPromptChoiceLabel(prompt, 'BUY', '기본값')).toBe('구매하기')
+    expect(getPromptChoiceLabel(prompt, 'PASS', '기본값')).toBe('기본값')
+  })
+})

--- a/src/components/game/modals/promptModalMapping.ts
+++ b/src/components/game/modals/promptModalMapping.ts
@@ -1,4 +1,4 @@
-import type { GamePrompt } from '../../../types/domain'
+import type { GamePrompt, GamePromptChoice } from '../../../types/domain'
 
 export type PromptModalKind =
   | 'buy'
@@ -6,6 +6,14 @@ export type PromptModalKind =
   | 'toll'
   | 'dice_timer'
   | 'unknown'
+
+export type PromptChoiceRuleKey =
+  | 'buyConfirm'
+  | 'buyCancel'
+  | 'buildConfirm'
+  | 'buildCancel'
+  | 'tollConfirm'
+  | 'timerConfirm'
 
 const BUY_TYPE_TOKENS = ['BUY_OR_SKIP', 'BUY_PROPERTY', 'BUY_PROMPT']
 const BUILD_TYPE_TOKENS = ['BUILD_OR_SKIP', 'UPGRADE_OR_SKIP', 'BUILD_PROMPT']
@@ -16,6 +24,38 @@ const DICE_TIMER_TYPE_TOKENS = [
   'TURN_TIMER',
   'ROLL_TIMEOUT',
 ]
+const PROMPT_CHOICE_RULES: Record<
+  PromptChoiceRuleKey,
+  {
+    preferredTokens: string[]
+    fallbackIndex?: number
+  }
+> = {
+  buyConfirm: {
+    preferredTokens: ['BUY', 'PURCHASE', 'CONFIRM', 'YES'],
+    fallbackIndex: 0,
+  },
+  buyCancel: {
+    preferredTokens: ['SKIP', 'PASS', 'CANCEL', 'NO'],
+    fallbackIndex: 1,
+  },
+  buildConfirm: {
+    preferredTokens: ['BUILD', 'UPGRADE', 'CONFIRM', 'YES'],
+    fallbackIndex: 0,
+  },
+  buildCancel: {
+    preferredTokens: ['SKIP', 'PASS', 'CANCEL', 'NO'],
+    fallbackIndex: 1,
+  },
+  tollConfirm: {
+    preferredTokens: ['PAY_TOLL', 'PAY', 'CONFIRM', 'OK'],
+    fallbackIndex: 0,
+  },
+  timerConfirm: {
+    preferredTokens: ['END_TURN', 'CONFIRM', 'OK', 'SKIP', 'PASS'],
+    fallbackIndex: 0,
+  },
+}
 
 const normalize = (value: unknown): string =>
   typeof value === 'string' ? value.trim().toUpperCase() : ''
@@ -27,20 +67,27 @@ const hasTypeToken = (prompt: GamePrompt, tokens: string[]) => {
 
 const getPromptChoices = (prompt: GamePrompt) => prompt.choices ?? []
 
+const hasMatchedChoiceToken = (choice: GamePromptChoice, token: string) => {
+  const normalizedToken = normalize(token)
+  if (!normalizedToken) {
+    return false
+  }
+
+  const valueToken = normalize(choice.value)
+  const idToken = normalize(choice.id)
+  const labelToken = normalize(choice.label)
+
+  return (
+    valueToken === normalizedToken ||
+    idToken === normalizedToken ||
+    labelToken.includes(normalizedToken)
+  )
+}
+
 const hasChoiceToken = (prompt: GamePrompt, tokens: string[]) =>
-  getPromptChoices(prompt).some((choice) => {
-    const valueToken = normalize(choice.value)
-    const idToken = normalize(choice.id)
-    const labelToken = normalize(choice.label)
-    return tokens.some((token) => {
-      const normalizedToken = normalize(token)
-      return (
-        valueToken === normalizedToken ||
-        idToken === normalizedToken ||
-        labelToken.includes(normalizedToken)
-      )
-    })
-  })
+  getPromptChoices(prompt).some((choice) =>
+    tokens.some((token) => hasMatchedChoiceToken(choice, token))
+  )
 
 export const resolvePromptModalKind = (
   prompt: GamePrompt | null | undefined
@@ -101,14 +148,7 @@ export const findPromptChoiceValue = (
   }
 
   const matchedChoice = choices.find((choice) =>
-    preferredTokens.some((token) => {
-      const normalizedToken = normalize(token)
-      return (
-        normalize(choice.value) === normalizedToken ||
-        normalize(choice.id) === normalizedToken ||
-        normalize(choice.label).includes(normalizedToken)
-      )
-    })
+    preferredTokens.some((token) => hasMatchedChoiceToken(choice, token))
   )
 
   if (matchedChoice) {
@@ -124,6 +164,30 @@ export const findPromptChoiceValue = (
   }
 
   return choices[0].value
+}
+
+export const resolvePromptChoiceValue = (
+  prompt: GamePrompt | null | undefined,
+  ruleKey: PromptChoiceRuleKey
+): string | null => {
+  const rule = PROMPT_CHOICE_RULES[ruleKey]
+
+  return findPromptChoiceValue(prompt, rule.preferredTokens, rule.fallbackIndex)
+}
+
+export const getPromptChoiceLabel = (
+  prompt: GamePrompt | null | undefined,
+  choiceValue: string | null,
+  fallbackLabel: string
+): string => {
+  if (!prompt || !choiceValue) {
+    return fallbackLabel
+  }
+
+  return (
+    getPromptChoices(prompt).find((choice) => choice.value === choiceValue)
+      ?.label ?? fallbackLabel
+  )
 }
 
 const getPayloadRecord = (


### PR DESCRIPTION
## 📌 관련 이슈

> closes #295

---

## 📝 작업 내용

- `src/components/game/modals/promptModalMapping.ts`
  - prompt choice 규약 키(`buyConfirm`, `buyCancel`, `buildConfirm`, `buildCancel`, `tollConfirm`, `timerConfirm`)를 추가하고, 토큰 우선 + fallback 인덱스 규칙을 공통화했습니다.
  - `resolvePromptChoiceValue`, `getPromptChoiceLabel` 공통 함수를 추가해 choice 해석/라벨 조회 로직을 일원화했습니다.
- `src/components/board/GameBoard.tsx`
  - 모달별 개별 `findPromptChoiceValue` 분기를 제거하고, 공통 규약 함수 기반으로 응답 choice를 선택하도록 변경했습니다.
  - `submitPromptChoice` 헬퍼로 `onPromptChoice` 호출 조건(`choice 존재`, `중복 제출 방지`)을 통합했습니다.
  - Buy/Build/Toll/Timer 모달 confirm/cancel 응답 경로를 동일한 규칙으로 정리했습니다.
- `src/components/game/modals/promptModalMapping.test.ts`
  - modal kind 판별, choice 규약 fallback, timer confirm, label fallback 케이스를 테스트로 추가했습니다.

검증:
- `npm run lint` 통과
- `npm run test -- --run` 통과
- `npm run build` 통과
- pre-push 검증(`test`, `test:coverage`, `e2e:ci`, `build`) 통과

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [ ] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

> UI 변경 없음 (prompt choice 해석/응답 분기 로직 정리)
