### PR TITLE
chore: Playwright 로컬 디버그 전용 뷰포트 설정 추가

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,12 @@
 import { defineConfig, devices } from '@playwright/test'
 
+// 로컬 디버그 실행(--debug/PW_LOCAL_DEBUG)에서만 큰 뷰포트를 사용
+const isLocalDebugRun =
+  !process.env.CI &&
+  (process.env.PWDEBUG === '1' ||
+    process.env.PWDEBUG === 'console' ||
+    process.env.PW_LOCAL_DEBUG === 'true')
+
 export default defineConfig({
   testDir: './e2e',
   fullyParallel: false,
@@ -14,7 +21,15 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      use: {
+        ...devices['Desktop Chrome'],
+        ...(isLocalDebugRun
+          ? {
+              viewport: { width: 1536, height: 960 },
+              launchOptions: { args: ['--window-size=1536,960'] },
+            }
+          : {}),
+      },
     },
   ],
   webServer: {


### PR DESCRIPTION
## 📌 관련 이슈

> closes #299 

---

## 📝 작업 내용

Playwright E2E를 `--debug`로 실행할 때 화면이 잘려 보이던 문제를 해결하기 위해  
로컬 디버그 전용 뷰포트 설정을 추가했습니다.

### 변경 파일
- `/Users/admin/Desktop/Blue_Marble-frontend/playwright.config.ts`

### 변경 사항
- `isLocalDebugRun` 분기 추가
  - 조건: `!CI && (PWDEBUG || PW_LOCAL_DEBUG=true)`
- 로컬 디버그에서만 큰 뷰포트/윈도우 크기 적용
  - `viewport: 1536x960`
  - `launchOptions.args: --window-size=1536,960`
- CI/일반 실행은 기존 `devices['Desktop Chrome']` 경로 유지 (동작 불변)

---

## ✅ 체크리스트

- [x] 로컬에서 설정 파싱 확인 (`npx playwright test --project=chromium --list`)
- [x] CI 실행 경로 영향 없음 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

<img width="1800" height="1169" alt="스크린샷 2026-03-05 오후 5 32 49" src="https://github.com/user-attachments/assets/6a1ad0ef-fcf9-4b48-b090-df581305c73c" />

