### PR TITLE
fix: mock 모드 구매 REST 404 차단 및 구매 진행 로직 정리

### DIFF
--- a/src/components/board/gameBoardActionHandlers.ts
+++ b/src/components/board/gameBoardActionHandlers.ts
@@ -178,21 +178,10 @@ export function createGameBoardActionHandlers(
       return
     }
 
-    if (!roomId) {
-      setStatus(roomIdRequiredMessage)
-      return
-    }
-
     const active = curPlayerRef.current
     const activePlayerId = getPlayerIdByIndex(active)
     const activePlayerColor = getPlayerColorByIndex(active)
     const price = getPurchaseCost(tileId)
-
-    const actionResult = await gameApi.buyTile(roomId, { tile_index: tileId })
-    if (!actionResult.ok) {
-      setStatus(toBoardActionErrorMessage(actionResult.status))
-      return
-    }
 
     setBuyModal({ open: false, tileId: null })
     const bankrupt = applyMoney(active, -price, onDoneCallback)


### PR DESCRIPTION
## 📌 관련 이슈

> closes #301

---

## 📝 작업 내용

- `src/components/board/gameBoardActionHandlers.ts`의 `handleBuy`에서 **mock 모드일 때 REST `/api/game/:roomId/buy` 호출을 제거**했습니다.
- mock 모드에서는 로컬 상태 업데이트(자금 차감, 타일 소유 반영, 턴 전환)로 바로 진행되도록 정리했습니다.
- 이로 인해 로컬 개발 환경에서 발생하던 `POST /api/game/room-1/buy 404`로 인한 구매 진행 막힘을 해소했습니다.
- non-mock 경로(`emitGameAction('BUY_PROPERTY')`)는 기존대로 유지했습니다.

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [ ] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

> UI 변경 없음 (로직 수정)
