### PR TITLE
refactor: 소켓 ACK 에러를 code/message/detail 계약으로 정합화

### DIFF
--- a/src/contracts/socket/events.ts
+++ b/src/contracts/socket/events.ts
@@ -105,8 +105,9 @@ export interface SocketAckSuccess<T = Record<string, never>> {
 export interface SocketAckError {
   ok: false
   error: {
-    detail: string
     code: string
+    message: string
+    detail?: string
   }
 }
 

--- a/src/contracts/socket/schemas.test.ts
+++ b/src/contracts/socket/schemas.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { gameStartEventSchema, validateSocketEventPayload } from './schemas'
+
+describe('socket schema validator', () => {
+  it('유효한 payload는 success=true와 파싱 데이터를 반환한다', () => {
+    const result = validateSocketEventPayload(gameStartEventSchema, {
+      game_id: 'game-1',
+      room_id: 'room-1',
+    })
+
+    expect(result.success).toBe(true)
+
+    if (result.success) {
+      expect(result.data).toEqual({
+        game_id: 'game-1',
+        room_id: 'room-1',
+      })
+    }
+  })
+
+  it('유효하지 않은 payload는 code/message/detail 형식 에러를 반환한다', () => {
+    const result = validateSocketEventPayload(gameStartEventSchema, {
+      game_id: 'game-1',
+    })
+
+    expect(result.success).toBe(false)
+
+    if (!result.success) {
+      expect(result.error.code).toBe('INVALID_SOCKET_PAYLOAD')
+      expect(result.error.message).toBe('Socket payload validation failed')
+      expect(typeof result.error.detail).toBe('string')
+      expect(result.error.detail?.length).toBeGreaterThan(0)
+    }
+  })
+})

--- a/src/contracts/socket/schemas.ts
+++ b/src/contracts/socket/schemas.ts
@@ -100,12 +100,14 @@ export function validateSocketEventPayload<T>(
     }
   }
 
+  const issues = parsed.error.issues.map((issue) => issue.message).join(', ')
+
   return {
     success: false as const,
     error: {
-      detail: 'Socket payload validation failed',
       code: 'INVALID_SOCKET_PAYLOAD',
-      issues: parsed.error.issues.map((issue) => issue.message),
+      message: 'Socket payload validation failed',
+      detail: issues || undefined,
     },
   }
 }


### PR DESCRIPTION
## 📌 관련 이슈

> closes #306

---

## 📝 작업 내용

소켓 ACK 에러 타입과 소켓 payload 검증 에러 포맷을 공통 계약(`code`, `message`, `detail?`) 기준으로 정리했습니다.

### 변경 파일
- `/Users/admin/Desktop/Blue_Marble-frontend/src/contracts/socket/events.ts`
- `/Users/admin/Desktop/Blue_Marble-frontend/src/contracts/socket/schemas.ts`
- `/Users/admin/Desktop/Blue_Marble-frontend/src/contracts/socket/schemas.test.ts`

### 주요 변경 사항
1. `SocketAckError` 타입 정합화
- 기존: `error: { detail, code }`
- 변경: `error: { code, message, detail? }`

2. 소켓 payload validator 에러 형식 정합화
- 기존: `{ code, detail, issues[] }`
- 변경: `{ code, message, detail? }`
- `detail`에는 검증 이슈를 문자열로 요약해 전달

3. 테스트 추가
- `schemas.test.ts` 신규 추가
  - 유효 payload 성공 케이스
  - 유효하지 않은 payload 실패 케이스(`code/message/detail` 검증)

---

## ✅ 체크리스트

- [x] 기존 기능 동작 유지 확인
- [x] `npm run test` 통과
- [x] `npm run build` 통과
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

- N/A (계약/타입/테스트 정합화 작업)
