### PR TITLE
fix: 건물 업그레이드시에도 보유금 부족이 부족하면 팝업 뜨게 수정

### DIFF
--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -126,6 +126,7 @@ const INITIAL_INSUFFICIENT_FUNDS_MODAL_STATE: InsufficientFundsModalState = {
   open: false,
   buildingLevel: 0,
   onDoneCallback: undefined,
+  promptChoiceValue: null,
 }
 
 const DOTS: Record<number, [number, number][]> = {
@@ -1018,7 +1019,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
     }
 
     function handleInsufficientFundsConfirm() {
-      const { onDoneCallback } = insufficientFundsModal
+      const { onDoneCallback, promptChoiceValue } = insufficientFundsModal
       setInsufficientFundsModal(INITIAL_INSUFFICIENT_FUNDS_MODAL_STATE)
 
       if (useLocalPromptFallback) {
@@ -1026,7 +1027,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
         return
       }
 
-      submitPromptChoice(promptBuyPassChoiceValue)
+      submitPromptChoice(promptChoiceValue ?? null)
     }
 
     function handleDiceTimerConfirm() {
@@ -1253,6 +1254,9 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
         ? (tileOwners[buildModal.tileId]?.level ?? 0)
         : 0
       : promptCurrentLevel
+    const buildTargetLevel = useLocalPromptFallback
+      ? ((currentLevel + 1) as BuildingLevel)
+      : promptNextLevel
     const tollTile = useLocalPromptFallback
       ? tollModal.tileId !== null
         ? TILES[tollModal.tileId]
@@ -1316,6 +1320,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       dismissedBuyPromptId === activePrompt.id
     const buyModalVisible =
       buyModalOpen && !isBuyPromptDismissed && !insufficientFundsModal.open
+    const buildModalVisible = buildModalOpen && !insufficientFundsModal.open
     const activePlayerMoney = players[curPlayer]?.money ?? 0
     const buildCost = useLocalPromptFallback
       ? getUpgradeCost(buildTile?.price ?? 0, currentLevel as BuildingLevel)
@@ -1444,6 +1449,9 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
                 onDoneCallback: useLocalPromptFallback
                   ? buyModal.onDoneCallback
                   : undefined,
+                promptChoiceValue: useLocalPromptFallback
+                  ? null
+                  : promptBuyPassChoiceValue,
               })
               return
             }
@@ -1485,8 +1493,26 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
           onConfirm={handleInsufficientFundsConfirm}
         />
         <BuildModal
-          open={buildModalOpen}
+          open={buildModalVisible}
           onConfirm={() => {
+            if (activePlayerMoney < buildCost) {
+              if (useLocalPromptFallback) {
+                setBuildModal({ open: false, tileId: null })
+              }
+
+              setInsufficientFundsModal({
+                open: true,
+                buildingLevel: buildTargetLevel,
+                onDoneCallback: useLocalPromptFallback
+                  ? buildModal.onDoneCallback
+                  : undefined,
+                promptChoiceValue: useLocalPromptFallback
+                  ? null
+                  : promptBuildCancelChoiceValue,
+              })
+              return
+            }
+
             if (useLocalPromptFallback) {
               handleBuildConfirm(buildModal)
               return
@@ -1503,11 +1529,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
             submitPromptChoice(promptBuildCancelChoiceValue)
           }}
           cityName={promptTileName}
-          nextLevel={
-            useLocalPromptFallback
-              ? ((currentLevel + 1) as BuildingLevel)
-              : promptNextLevel
-          }
+          nextLevel={buildTargetLevel}
           cancelLabel={getPromptChoiceLabel(
             activePrompt,
             promptBuildCancelChoiceValue,

--- a/src/components/board/gameBoard.types.ts
+++ b/src/components/board/gameBoard.types.ts
@@ -39,6 +39,7 @@ export interface InsufficientFundsModalState {
   open: boolean
   buildingLevel: BuildingLevel
   onDoneCallback?: () => void
+  promptChoiceValue?: string | null
 }
 
 export interface CityAcquisitionModalState {


### PR DESCRIPTION
## 📌 관련 이슈

> closes #320


---

## 📝 작업 내용

> 건물 업그레이드시에도 보유금 부족이 부족하면 팝업 뜨게 수정 완료

---

## ✅ 체크리스트

- [ ] 로컬에서 정상 동작 확인
- [ ] 불필요한 console.log 제거
- [ ] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

> UI 변경이 있을 경우 첨부해주세요.
