### PR TITLE
feat: DM 소켓 계약 반영 (message_id dedupe + client_message_id 송신)

### DIFF
--- a/src/contracts/socket/events.ts
+++ b/src/contracts/socket/events.ts
@@ -41,9 +41,11 @@ export interface OnlineUsersEventPayload {
 export interface DirectMessageSendEventPayload {
   receiver_id: string
   message: string
+  client_message_id?: string
 }
 
 export interface DirectMessageReceiveEventPayload {
+  message_id: string
   sender_id: string
   sender_nickname: string
   message: string

--- a/src/contracts/socket/schemas.ts
+++ b/src/contracts/socket/schemas.ts
@@ -17,9 +17,11 @@ export const onlineUsersEventSchema = z.object({
 export const directMessageSendEventSchema = z.object({
   receiver_id: z.string().min(1),
   message: z.string().trim().min(1),
+  client_message_id: z.string().min(1).optional(),
 })
 
 export const directMessageReceiveEventSchema = z.object({
+  message_id: z.string().min(1),
   sender_id: z.string().min(1),
   sender_nickname: z.string().min(1),
   message: z.string().trim().min(1),

--- a/src/features/presence/components/DevPresenceControlPanel.tsx
+++ b/src/features/presence/components/DevPresenceControlPanel.tsx
@@ -95,6 +95,7 @@ export function DevPresenceControlPanel({
     }
 
     emitDirectMessageReceiveMockForDev({
+      message_id: `dev-dm-${Date.now()}`,
       sender_id: selectedUser.id,
       sender_nickname: selectedUser.nickname,
       message: normalizedMessage,

--- a/src/features/presence/directMessageSocket.test.ts
+++ b/src/features/presence/directMessageSocket.test.ts
@@ -99,6 +99,22 @@ describe('directMessageSocket', () => {
     })
   })
 
+  it('real 모드에서 clientMessageId를 전달하면 client_message_id를 함께 emit한다', async () => {
+    const { module, socket } = await loadDirectMessageSocketModule(false, true)
+
+    module.sendDirectMessage({
+      receiverId: 'user-2',
+      message: '테스트',
+      clientMessageId: 'client-msg-1',
+    })
+
+    expect(socket.emit).toHaveBeenCalledWith('dm_send', {
+      receiver_id: 'user-2',
+      message: '테스트',
+      client_message_id: 'client-msg-1',
+    })
+  })
+
   it('공백 메시지는 real/mock 모드 모두 전송하지 않는다', async () => {
     const { module: realModule, socket: realSocket } =
       await loadDirectMessageSocketModule(false)
@@ -137,6 +153,7 @@ describe('directMessageSocket', () => {
     const { module, socket } = await loadDirectMessageSocketModule(true)
     const onReceive = vi.fn()
     const payload: DirectMessageReceiveSocketPayload = {
+      message_id: 'dm-1',
       sender_id: 'user-2',
       sender_nickname: '상대',
       message: '수신 테스트',
@@ -160,6 +177,7 @@ describe('directMessageSocket', () => {
       onReceive,
     })
     module.emitDirectMessageReceiveMockForDev({
+      message_id: 'dm-1',
       sender_id: 'user-2',
       sender_nickname: '상대',
       message: '수신 테스트',

--- a/src/features/presence/directMessageSocket.ts
+++ b/src/features/presence/directMessageSocket.ts
@@ -17,6 +17,7 @@ const USE_SOCKET_MOCK = IS_SOCKET_MOCK_ENABLED
 interface SendDirectMessageParams {
   receiverId: string
   message: string
+  clientMessageId?: string
 }
 
 // DM 수신 구독 함수 입력값 타입
@@ -84,6 +85,7 @@ export function subscribeDirectMessageSocketEvents({
 export function sendDirectMessage({
   receiverId,
   message,
+  clientMessageId,
 }: SendDirectMessageParams) {
   const normalizedMessage = message.trim()
 
@@ -102,6 +104,7 @@ export function sendDirectMessage({
   const payload: DirectMessageSendSocketPayload = {
     receiver_id: receiverId,
     message: normalizedMessage,
+    ...(clientMessageId ? { client_message_id: clientMessageId } : {}),
   }
 
   socket.emit(DIRECT_MESSAGE_EVENT_NAMES.send, payload)

--- a/src/features/presence/types.ts
+++ b/src/features/presence/types.ts
@@ -32,10 +32,12 @@ export interface DirectMessage {
 export interface DirectMessageSendSocketPayload {
   receiver_id: string
   message: string
+  client_message_id?: string
 }
 
 // DM 수신 소켓 payload 타입
 export interface DirectMessageReceiveSocketPayload {
+  message_id: string
   sender_id: string
   sender_nickname: string
   message: string

--- a/src/features/presence/useDirectMessageController.test.tsx
+++ b/src/features/presence/useDirectMessageController.test.tsx
@@ -19,6 +19,7 @@ const {
   directMessageReceiveHandlerRef: {
     current: null as
       | ((payload: {
+          message_id: string
           sender_id: string
           sender_nickname: string
           message: string
@@ -121,6 +122,7 @@ describe('useDirectMessageController', () => {
     expect(sendDirectMessageSocketMock).toHaveBeenCalledWith({
       receiverId: 'user-2',
       message: '안녕하세요',
+      clientMessageId: expect.any(String),
     })
     expect(result.current.directMessagesByUserId['user-2']).toHaveLength(1)
   })
@@ -210,6 +212,7 @@ describe('useDirectMessageController', () => {
 
     act(() => {
       directMessageReceiveHandlerRef.current?.({
+        message_id: 'dm-1',
         sender_id: 'user-2',
         sender_nickname: '상대',
         message: '첫 메시지',
@@ -245,6 +248,7 @@ describe('useDirectMessageController', () => {
 
     act(() => {
       directMessageReceiveHandlerRef.current?.({
+        message_id: 'dm-2',
         sender_id: 'user-2',
         sender_nickname: '상대',
         message: '열린 창 메시지',
@@ -279,6 +283,7 @@ describe('useDirectMessageController', () => {
 
     act(() => {
       directMessageReceiveHandlerRef.current?.({
+        message_id: 'dm-3',
         sender_id: 'user-3',
         sender_nickname: '상대B',
         message: '다른 사용자 메시지',
@@ -290,5 +295,37 @@ describe('useDirectMessageController', () => {
       result.current.unreadDirectMessageCountByUserId['user-2']
     ).toBeUndefined()
     expect(result.current.unreadDirectMessageCountByUserId['user-3']).toBe(1)
+  })
+
+  it('동일 message_id 수신은 중복 삽입하지 않는다', () => {
+    const user = createOnlineUserFixture({
+      id: 'user-2',
+      nickname: '상대',
+      status: 'lobby',
+    })
+
+    const { result } = renderDirectMessageControllerHook({
+      users: [user],
+    })
+
+    act(() => {
+      directMessageReceiveHandlerRef.current?.({
+        message_id: 'dm-duplicate',
+        sender_id: 'user-2',
+        sender_nickname: '상대',
+        message: '중복 메시지',
+        sent_at: '2026-03-03T10:03:00.000Z',
+      })
+      directMessageReceiveHandlerRef.current?.({
+        message_id: 'dm-duplicate',
+        sender_id: 'user-2',
+        sender_nickname: '상대',
+        message: '중복 메시지',
+        sent_at: '2026-03-03T10:03:00.000Z',
+      })
+    })
+
+    expect(result.current.directMessagesByUserId['user-2']).toHaveLength(1)
+    expect(result.current.unreadDirectMessageCountByUserId['user-2']).toBe(1)
   })
 })

--- a/src/features/presence/useDirectMessageController.ts
+++ b/src/features/presence/useDirectMessageController.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import type { AuthSession } from '../auth/types'
 import {
   sendDirectMessage as sendDirectMessageSocket,
@@ -18,6 +18,18 @@ interface UseDirectMessageControllerParams {
   onBlockedByPlaying?: () => void
 }
 
+// DM 송신/수신 메시지의 클라이언트 식별자 생성
+function createDirectMessageId() {
+  if (
+    typeof crypto !== 'undefined' &&
+    typeof crypto.randomUUID === 'function'
+  ) {
+    return crypto.randomUUID()
+  }
+
+  return `dm-${Date.now()}-${Math.random().toString(16).slice(2)}`
+}
+
 // DM 상태/구독/전송 로직을 공통으로 관리
 export function useDirectMessageController({
   session,
@@ -34,6 +46,12 @@ export function useDirectMessageController({
   ] = useState<Record<string, number>>({})
 
   const openedDirectMessageUserId = dmTargetUser?.id
+  const directMessagesByUserIdRef = useRef<Record<string, DirectMessage[]>>({})
+
+  // 최신 DM 목록 상태를 ref에 동기화해 수신 이벤트 중복 판정에 사용
+  useEffect(() => {
+    directMessagesByUserIdRef.current = directMessagesByUserId
+  }, [directMessagesByUserId])
 
   // DM 수신 이벤트를 구독해 대화 목록과 unread 카운트를 갱신
   useEffect(() => {
@@ -44,30 +62,30 @@ export function useDirectMessageController({
     const unsubscribe = subscribeDirectMessageSocketEvents({
       onReceive: (payload: DirectMessageReceiveSocketPayload) => {
         const receivedMessage: DirectMessage = {
-          id: `${payload.sender_id}-${payload.sent_at}`,
+          id: payload.message_id,
           senderId: payload.sender_id,
           senderNickname: payload.sender_nickname,
           content: payload.message,
           sentAt: payload.sent_at,
         }
 
-        setDirectMessagesByUserId((previousMessagesByUserId) => {
-          const previousMessages =
-            previousMessagesByUserId[payload.sender_id] ?? []
-          const hasSameMessage = previousMessages.some(
-            (message) => message.id === receivedMessage.id
-          )
+        const previousMessages =
+          directMessagesByUserIdRef.current[payload.sender_id] ?? []
+        const hasSameMessage = previousMessages.some(
+          (message) => message.id === receivedMessage.id
+        )
 
-          // 동일 메시지 ID는 중복 삽입을 방지
-          if (hasSameMessage) {
-            return previousMessagesByUserId
-          }
+        // 동일 message_id는 목록/카운트 모두 갱신하지 않음
+        if (hasSameMessage) {
+          return
+        }
 
-          return {
-            ...previousMessagesByUserId,
-            [payload.sender_id]: [...previousMessages, receivedMessage],
-          }
-        })
+        const nextMessagesByUserId = {
+          ...directMessagesByUserIdRef.current,
+          [payload.sender_id]: [...previousMessages, receivedMessage],
+        }
+        directMessagesByUserIdRef.current = nextMessagesByUserId
+        setDirectMessagesByUserId(nextMessagesByUserId)
 
         // 현재 열려 있는 사용자 메시지는 unread 카운트에서 제외
         if (payload.sender_id === openedDirectMessageUserId) {
@@ -154,8 +172,9 @@ export function useDirectMessageController({
       }
 
       const targetUserId = dmTargetUser.id
+      const clientMessageId = createDirectMessageId()
       const nextDirectMessage: DirectMessage = {
-        id: `${targetUserId}-${Date.now()}`,
+        id: clientMessageId,
         senderId: session.userId,
         senderNickname: session.nickname,
         content: message,
@@ -174,6 +193,7 @@ export function useDirectMessageController({
       sendDirectMessageSocket({
         receiverId: dmTargetUser.id,
         message,
+        clientMessageId,
       })
     },
     [dmTargetUser, onBlockedByPlaying, session]

--- a/src/pages/waiting-room/components/DevControlPanel.tsx
+++ b/src/pages/waiting-room/components/DevControlPanel.tsx
@@ -183,6 +183,7 @@ export function DevControlPanel({
     }
 
     emitDirectMessageReceiveMockForDev({
+      message_id: `dev-dm-${Date.now()}`,
       sender_id: selectedPresenceUser.id,
       sender_nickname: selectedPresenceUser.nickname,
       message: normalizedMessage,


### PR DESCRIPTION
## 📌 관련 이슈

> closes #325 

---

## 📝 작업 내용

- DM 소켓 계약을 최신 명세로 정합화했습니다.
- `dm_receive` payload에 `message_id`를 필수 반영했습니다.
- `dm_send` payload에 `client_message_id`(optional) 지원을 추가했습니다.
- DM 중복 삽입 방지 기준을 기존 조합 키에서 `message_id` 기준으로 변경했습니다.
- DEV 컨트롤 패널에서 주입하는 DM payload도 `message_id`를 포함하도록 맞췄습니다.
- 소켓 계약 타입/스키마(`contracts/socket`)도 동일하게 동기화했습니다.

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

- UI 변경 없음 (소켓 계약/상태 처리 변경)

---

## 🔍 검증 결과

- `npm run lint` 통과
- `npm run test` 통과 (25 files, 128 tests)
- `npm run build` 통과

---

## 📂 주요 변경 파일

- `/Users/admin/Desktop/Blue_Marble-frontend/src/features/presence/types.ts`
- `/Users/admin/Desktop/Blue_Marble-frontend/src/features/presence/directMessageSocket.ts`
- `/Users/admin/Desktop/Blue_Marble-frontend/src/features/presence/useDirectMessageController.ts`
- `/Users/admin/Desktop/Blue_Marble-frontend/src/features/presence/components/DevPresenceControlPanel.tsx`
- `/Users/admin/Desktop/Blue_Marble-frontend/src/pages/waiting-room/components/DevControlPanel.tsx`
- `/Users/admin/Desktop/Blue_Marble-frontend/src/contracts/socket/events.ts`
- `/Users/admin/Desktop/Blue_Marble-frontend/src/contracts/socket/schemas.ts`
- `/Users/admin/Desktop/Blue_Marble-frontend/src/features/presence/directMessageSocket.test.ts`
- `/Users/admin/Desktop/Blue_Marble-frontend/src/features/presence/useDirectMessageController.test.tsx`

---

## 📌 추가 메모

- DM 정책은 문서 확정안대로 무영속(실시간 전용) 유지
- 영속 저장/읽음 API(`GET /dm/rooms` 등)는 2차 범위로 분리 예정