### PR TITLE
fix: DM 실시간 소켓 계약 정합화 (message_id/client_message_id)

### DIFF
--- a/src/pages/waiting-room/api.test.ts
+++ b/src/pages/waiting-room/api.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { getWaitingRoomErrorMessage, isJoinPasswordMismatchError } from './api'
+import {
+  getWaitingRoomErrorMessage,
+  isJoinPasswordMismatchError,
+  parseJoinWaitingRoomPayload,
+  WaitingRoomContractError,
+} from './api'
 import { WaitingRoomMockError } from './mockGateway'
 
 // axios 에러 형태를 테스트에서 간단히 재현
@@ -72,5 +77,65 @@ describe('waiting-room api error mapping', () => {
     expect(
       getWaitingRoomErrorMessage(error, '대기방 정보를 불러오지 못했습니다.')
     ).toBe('대기방 정보를 불러오지 못했습니다.')
+  })
+})
+
+describe('waiting-room join response contract', () => {
+  it('필수 필드가 모두 있으면 join payload 파싱에 성공한다', () => {
+    const parsedPayload = parseJoinWaitingRoomPayload({
+      room_id: 'room-1',
+      title: '즐거운 게임 한판!',
+      status: 'waiting',
+      max_players: 4,
+      is_private: false,
+      players: [
+        {
+          id: 'u-1',
+          nickname: '고름EE',
+          is_ready: false,
+          is_host: true,
+        },
+      ],
+      chat_messages: [
+        {
+          id: 'chat-1',
+          sender_id: 'u-1',
+          sender_nickname: '고름EE',
+          message: '안녕하세요',
+          sent_at: '2026-03-06T10:00:00.000Z',
+          type: 'talk',
+        },
+      ],
+    })
+
+    expect(parsedPayload.room_id).toBe('room-1')
+    expect(parsedPayload.chat_messages).toHaveLength(1)
+  })
+
+  it('chat_messages 필드가 누락되면 계약 오류를 던진다', () => {
+    expect(() =>
+      parseJoinWaitingRoomPayload({
+        room_id: 'room-1',
+        title: '즐거운 게임 한판!',
+        status: 'waiting',
+        max_players: 4,
+        is_private: false,
+        players: [],
+      })
+    ).toThrow(WaitingRoomContractError)
+  })
+
+  it('status 값이 계약 외 값이면 계약 오류를 던진다', () => {
+    expect(() =>
+      parseJoinWaitingRoomPayload({
+        room_id: 'room-1',
+        title: '즐거운 게임 한판!',
+        status: 'closed',
+        max_players: 4,
+        is_private: false,
+        players: [],
+        chat_messages: [],
+      })
+    ).toThrow(WaitingRoomContractError)
   })
 })

--- a/src/pages/waiting-room/api.ts
+++ b/src/pages/waiting-room/api.ts
@@ -24,6 +24,7 @@ import type {
 const DEFAULT_WAITING_ROOM_TITLE = '즐거운 게임 한판!'
 const DEFAULT_WAITING_ROOM_MAX_PLAYERS = 4
 const USE_WAITING_ROOM_MOCK = IS_SOCKET_MOCK_ENABLED
+const WAITING_ROOM_STATUS_VALUES = new Set(['waiting', 'playing'])
 // 비밀번호 불일치로 간주할 서버 에러 코드 집합
 const JOIN_PASSWORD_MISMATCH_ERROR_CODES = new Set([
   'ROOM_PASSWORD_MISMATCH',
@@ -72,6 +73,147 @@ interface StartWaitingGameParams {
   userId: string
 }
 
+type UnknownRecord = Record<string, unknown>
+
+// 입장 응답 계약 미일치 시 공통으로 던지는 오류 타입
+export class WaitingRoomContractError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'WaitingRoomContractError'
+  }
+}
+
+// object인지 확인하고 안전한 Record로 변환
+function toRecord(value: unknown): UnknownRecord | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null
+  }
+
+  return value as UnknownRecord
+}
+
+// 계약 오류 메시지를 필드 경로 기준으로 통일
+function createFieldContractError(fieldPath: string) {
+  return new WaitingRoomContractError(
+    `ROOM_JOIN_INVALID_RESPONSE: ${fieldPath} 필드가 올바르지 않습니다.`
+  )
+}
+
+// 필수 문자열 필드를 검증해 반환
+function readRequiredString(record: UnknownRecord, fieldName: string) {
+  const fieldValue = record[fieldName]
+  if (typeof fieldValue !== 'string' || fieldValue.trim().length === 0) {
+    throw createFieldContractError(fieldName)
+  }
+
+  return fieldValue
+}
+
+// 필수 number 필드를 검증해 반환
+function readRequiredNumber(record: UnknownRecord, fieldName: string) {
+  const fieldValue = record[fieldName]
+  if (typeof fieldValue !== 'number' || Number.isNaN(fieldValue)) {
+    throw createFieldContractError(fieldName)
+  }
+
+  return fieldValue
+}
+
+// 필수 boolean 필드를 검증해 반환
+function readRequiredBoolean(record: UnknownRecord, fieldName: string) {
+  const fieldValue = record[fieldName]
+  if (typeof fieldValue !== 'boolean') {
+    throw createFieldContractError(fieldName)
+  }
+
+  return fieldValue
+}
+
+// 필수 배열 필드를 검증해 반환
+function readRequiredArray(record: UnknownRecord, fieldName: string) {
+  const fieldValue = record[fieldName]
+  if (!Array.isArray(fieldValue)) {
+    throw createFieldContractError(fieldName)
+  }
+
+  return fieldValue
+}
+
+// 입장 응답 players[] 원소를 계약 기준으로 정규화
+function parseJoinPlayerPayload(
+  item: unknown,
+  index: number
+): WaitingRoomPlayerPayload {
+  const playerRecord = toRecord(item)
+  if (!playerRecord) {
+    throw createFieldContractError(`players[${index}]`)
+  }
+
+  return {
+    id: readRequiredString(playerRecord, `id`),
+    nickname: readRequiredString(playerRecord, `nickname`),
+    is_ready: readRequiredBoolean(playerRecord, `is_ready`),
+    is_host: readRequiredBoolean(playerRecord, `is_host`),
+  }
+}
+
+// 입장 응답 chat_messages[] 원소를 계약 기준으로 정규화
+function parseJoinChatPayload(
+  item: unknown,
+  index: number
+): WaitingRoomChatPayload {
+  const chatRecord = toRecord(item)
+  if (!chatRecord) {
+    throw createFieldContractError(`chat_messages[${index}]`)
+  }
+
+  const messageType = readRequiredString(chatRecord, `type`)
+  if (messageType !== 'talk') {
+    throw createFieldContractError(`chat_messages[${index}].type`)
+  }
+
+  return {
+    id: readRequiredString(chatRecord, 'id'),
+    sender_id: readRequiredString(chatRecord, 'sender_id'),
+    sender_nickname: readRequiredString(chatRecord, 'sender_nickname'),
+    message: readRequiredString(chatRecord, 'message'),
+    sent_at: readRequiredString(chatRecord, 'sent_at'),
+    type: messageType,
+  }
+}
+
+// ROOM-002(join) 응답을 최신 계약 기준으로 strict 검증
+export function parseJoinWaitingRoomPayload(
+  payload: unknown
+): JoinWaitingRoomResponsePayload {
+  const payloadRecord = toRecord(payload)
+  if (!payloadRecord) {
+    throw new WaitingRoomContractError(
+      'ROOM_JOIN_INVALID_RESPONSE: join 응답이 object 형태가 아닙니다.'
+    )
+  }
+
+  const status = readRequiredString(payloadRecord, 'status')
+  if (!WAITING_ROOM_STATUS_VALUES.has(status)) {
+    throw createFieldContractError('status')
+  }
+  const normalizedStatus = status as JoinWaitingRoomResponsePayload['status']
+
+  return {
+    room_id: readRequiredString(payloadRecord, 'room_id'),
+    title: readRequiredString(payloadRecord, 'title'),
+    status: normalizedStatus,
+    max_players: readRequiredNumber(payloadRecord, 'max_players'),
+    is_private: readRequiredBoolean(payloadRecord, 'is_private'),
+    players: readRequiredArray(payloadRecord, 'players').map(
+      parseJoinPlayerPayload
+    ),
+    chat_messages: readRequiredArray(payloadRecord, 'chat_messages').map(
+      parseJoinChatPayload
+    ),
+  }
+}
+
 // 플레이어 payload를 화면 모델로 매핑
 function mapRoomPlayer(payload: WaitingRoomPlayerPayload) {
   return {
@@ -94,19 +236,18 @@ function mapChatMessage(payload: WaitingRoomChatPayload) {
   }
 }
 
-// 입장 응답 payload를 대기방 스냅샷으로 변환
+// 계약 검증된 입장 응답 payload를 대기방 스냅샷으로 변환
 function mapJoinResponse(
-  payload: JoinWaitingRoomResponsePayload,
-  fallbackTitle?: string
+  payload: JoinWaitingRoomResponsePayload
 ): WaitingRoomSnapshot {
   return {
     roomId: payload.room_id,
-    title: payload.title || fallbackTitle || DEFAULT_WAITING_ROOM_TITLE,
-    status: payload.status ?? 'waiting',
-    maxPlayers: payload.max_players ?? DEFAULT_WAITING_ROOM_MAX_PLAYERS,
-    isPrivate: payload.is_private ?? false,
+    title: payload.title,
+    status: payload.status,
+    maxPlayers: payload.max_players,
+    isPrivate: payload.is_private,
     players: payload.players.map(mapRoomPlayer),
-    chatMessages: (payload.chat_messages ?? []).map(mapChatMessage),
+    chatMessages: payload.chat_messages.map(mapChatMessage),
   }
 }
 
@@ -168,13 +309,9 @@ export async function createWaitingRoom({
 }
 
 // 대기방 입장 API 호출 또는 목 게이트웨이 호출
-export async function joinWaitingRoom({
-  roomId,
-  userId,
-  nickname,
-  fallbackTitle,
-  password,
-}: JoinWaitingRoomParams) {
+export async function joinWaitingRoom(params: JoinWaitingRoomParams) {
+  const { roomId, userId, nickname, password } = params
+
   if (USE_WAITING_ROOM_MOCK) {
     return mockJoinWaitingRoom({
       roomId,
@@ -185,12 +322,13 @@ export async function joinWaitingRoom({
   }
 
   const requestBody = password ? { password } : undefined
-  const { data } = await apiClient.post<JoinWaitingRoomResponsePayload>(
+  const { data } = await apiClient.post<unknown>(
     `/rooms/${roomId}/join`,
     requestBody
   )
 
-  return mapJoinResponse(data, fallbackTitle)
+  const joinPayload = parseJoinWaitingRoomPayload(data)
+  return mapJoinResponse(joinPayload)
 }
 
 // 대기방 퇴장 API 호출 또는 목 게이트웨이 호출


### PR DESCRIPTION
## 📌 관련 이슈

> closes #327

---

## 📝 작업 내용

- DM 소켓 payload 계약을 최신 합의안에 맞춰 정렬했습니다.
- `dm_send` payload에 `client_message_id`(optional) 반영
- `dm_receive` payload에 `message_id`(required) 반영
- DM 수신 처리에서 `message_id` 기준 중복 삽입 방지 로직 적용
- 중복 수신 시 unread 카운트가 증가하지 않도록 보정
- DEV 제어 패널 mock DM payload에도 `message_id` 반영
- 관련 단위 테스트 보강 및 기존 테스트 기대값 정합화

### 변경 파일(핵심)

- `src/contracts/socket/events.ts`
- `src/contracts/socket/schemas.ts`
- `src/features/presence/types.ts`
- `src/features/presence/directMessageSocket.ts`
- `src/features/presence/useDirectMessageController.ts`
- `src/features/presence/components/DevPresenceControlPanel.tsx`
- `src/pages/waiting-room/components/DevControlPanel.tsx`
- `src/features/presence/directMessageSocket.test.ts`
- `src/features/presence/useDirectMessageController.test.tsx`

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료
- [x] `npm run lint` 통과
- [x] `npm run test -- --run` 통과

---

## 📸 스크린샷 (선택)

- UI 변경 없음 (소켓 계약/상태 처리 로직 정합화 중심)