### PR TITLE
feat: 접속자 목록 정렬 규칙과 목 접속자 초기 동기화 개선

### DIFF
--- a/e2e/chat-flow-direct-message.spec.ts
+++ b/e2e/chat-flow-direct-message.spec.ts
@@ -13,6 +13,8 @@ test.describe('로비 1:1 DM 채팅 플로우', () => {
       .locator('button[aria-label$=" 채팅"]:not(:disabled)')
       .first()
     await expect(openDmButton).toBeVisible()
+    const dmTargetButtonLabel = await openDmButton.getAttribute('aria-label')
+    const dmTargetNickname = dmTargetButtonLabel?.replace(/ 채팅$/, '').trim()
     await openDmButton.click()
 
     const dmPanel = page
@@ -26,6 +28,11 @@ test.describe('로비 1:1 DM 채팅 플로우', () => {
     await expect(page.getByText('안녕 DM')).toBeVisible()
 
     await ensureDevPresencePanelOpen(page)
+    if (dmTargetNickname) {
+      await page
+        .getByLabel('제어 유저')
+        .selectOption({ label: dmTargetNickname })
+    }
     await page.getByLabel('수신 DM').fill('수신 테스트 DM')
     await page.getByRole('button', { name: '선택 유저로 DM 수신' }).click()
 

--- a/e2e/chat-flow-direct-message.spec.ts
+++ b/e2e/chat-flow-direct-message.spec.ts
@@ -9,14 +9,16 @@ test.describe('로비 1:1 DM 채팅 플로우', () => {
     await resetSessionAndOpenHome(page)
     await loginAsGuest(page)
 
-    const openDmButton = page.getByRole('button', { name: '마블왕 채팅' })
+    const openDmButton = page
+      .locator('button[aria-label$=" 채팅"]:not(:disabled)')
+      .first()
+    await expect(openDmButton).toBeVisible()
     await openDmButton.click()
 
     const dmPanel = page
       .locator('section')
       .filter({ has: page.getByRole('button', { name: 'DM 닫기' }) })
     await expect(dmPanel).toBeVisible()
-    await expect(dmPanel.getByText('마블왕')).toBeVisible()
 
     await page.getByPlaceholder('메시지를 입력하세요...').fill('안녕 DM')
     await page.getByRole('button', { name: 'DM 전송' }).click()

--- a/src/features/presence/components/UserListPanel.test.tsx
+++ b/src/features/presence/components/UserListPanel.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { createOnlineUserFixture } from '../../../test/fixtures'
+import { UserListPanel } from './UserListPanel'
+
+describe('UserListPanel', () => {
+  it('접속자 목록은 나 우선 -> 상태 우선 -> 같은 상태 닉네임순으로 정렬된다', () => {
+    render(
+      <UserListPanel
+        users={[
+          createOnlineUserFixture({
+            id: 'u-playing',
+            nickname: '마블러',
+            status: 'playing',
+          }),
+          createOnlineUserFixture({
+            id: 'u-in-room-b',
+            nickname: '도라',
+            status: 'in_room',
+          }),
+          createOnlineUserFixture({
+            id: 'u-lobby-b',
+            nickname: '나래',
+            status: 'lobby',
+          }),
+          createOnlineUserFixture({
+            id: 'u-lobby-a',
+            nickname: '가람',
+            status: 'lobby',
+          }),
+          createOnlineUserFixture({
+            id: 'u-me',
+            nickname: '내닉네임',
+            status: 'playing',
+          }),
+          createOnlineUserFixture({
+            id: 'u-in-room-a',
+            nickname: '다온',
+            status: 'in_room',
+          }),
+        ]}
+        isLoading={false}
+        isError={false}
+        isOpen
+        currentUserId="u-me"
+        onToggle={vi.fn()}
+        onOpenDirectMessage={vi.fn()}
+      />
+    )
+
+    const chatButtons = screen.getAllByRole('button', { name: / 채팅$/ })
+    const sortedButtonNames = chatButtons.map((button) => {
+      return button.getAttribute('aria-label')
+    })
+
+    expect(sortedButtonNames).toEqual([
+      '내닉네임 채팅',
+      '가람 채팅',
+      '나래 채팅',
+      '다온 채팅',
+      '도라 채팅',
+      '마블러 채팅',
+    ])
+  })
+})

--- a/src/features/presence/components/UserListPanel.tsx
+++ b/src/features/presence/components/UserListPanel.tsx
@@ -1,7 +1,8 @@
 import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { useMemo } from 'react'
 import { cn } from '../../../lib/utils'
 import { ONLINE_USER_STATUS_DOT_CLASS_MAP } from '../status'
-import type { OnlineUser } from '../types'
+import type { OnlineUser, OnlineUserStatus } from '../types'
 import { formatUnreadBadgeCount } from '../unreadBadge'
 import { UserRow } from './UserRow'
 
@@ -19,6 +20,13 @@ interface UserListPanelProps {
   disableWidthTransition?: boolean
 }
 
+// 접속자 상태 정렬 우선순위(낮을수록 위)
+const ONLINE_USER_STATUS_PRIORITY: Record<OnlineUserStatus, number> = {
+  lobby: 0,
+  in_room: 1,
+  playing: 2,
+}
+
 // 접속자 목록 패널의 열림/닫힘 UI와 목록 상태 렌더링
 export function UserListPanel({
   users,
@@ -33,11 +41,46 @@ export function UserListPanel({
   disableWidthTransition = false,
 }: UserListPanelProps) {
   const panelHeightClass =
-    heightMode === 'full' ? 'h-full' : 'xl:min-h-[calc(100vh-7rem)]'
-  const panelContainerHeightClass = heightMode === 'full' ? 'h-full' : undefined
+    heightMode === 'full'
+      ? 'h-full'
+      : 'h-[calc(100dvh-6rem)] sm:h-[calc(100dvh-7rem)]'
+  const panelContainerHeightClass =
+    heightMode === 'full'
+      ? 'h-full'
+      : 'h-[calc(100dvh-6rem)] sm:h-[calc(100dvh-7rem)]'
   const widthTransitionClass = disableWidthTransition
     ? undefined
     : 'transition-[width] duration-300'
+  const sortedUsers = useMemo(() => {
+    return [...users].sort((firstUser, secondUser) => {
+      // 1) 현재 사용자 최우선
+      if (currentUserId && firstUser.id === currentUserId) {
+        return -1
+      }
+      if (currentUserId && secondUser.id === currentUserId) {
+        return 1
+      }
+
+      // 2) 상태 우선순위(lobby -> in_room -> playing)
+      const statusPriorityDiff =
+        ONLINE_USER_STATUS_PRIORITY[firstUser.status] -
+        ONLINE_USER_STATUS_PRIORITY[secondUser.status]
+      if (statusPriorityDiff !== 0) {
+        return statusPriorityDiff
+      }
+
+      // 3) 같은 상태는 닉네임 가나다순
+      const nicknameCompare = firstUser.nickname.localeCompare(
+        secondUser.nickname,
+        'ko-KR'
+      )
+      if (nicknameCompare !== 0) {
+        return nicknameCompare
+      }
+
+      return firstUser.id.localeCompare(secondUser.id)
+    })
+  }, [currentUserId, users])
 
   return (
     <aside
@@ -58,7 +101,7 @@ export function UserListPanel({
                 접속자 목록
               </h2>
               <span className="rounded-full bg-ui-brand-soft px-2 py-0.5 text-xs font-semibold text-ui-brand">
-                {users.length}명
+                {sortedUsers.length}명
               </span>
             </div>
             <button
@@ -94,7 +137,7 @@ export function UserListPanel({
 
             {!isLoading &&
               !isError &&
-              users.map((user) => (
+              sortedUsers.map((user) => (
                 <UserRow
                   key={user.id}
                   user={user}
@@ -124,13 +167,13 @@ export function UserListPanel({
           </button>
 
           <span className="rounded-full bg-ui-brand-soft px-2 py-0.5 text-xs font-semibold text-ui-brand">
-            {users.length}
+            {sortedUsers.length}
           </span>
 
           <div className="flex items-center gap-2 xl:mt-2 xl:flex-col">
             {!isLoading &&
               !isError &&
-              users.map((user) => (
+              sortedUsers.map((user) => (
                 <div key={user.id} className="relative">
                   <div
                     className="flex size-9 items-center justify-center rounded-full text-xs font-semibold text-ui-text-strong"

--- a/src/features/presence/mockData.test.ts
+++ b/src/features/presence/mockData.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createSeededRoomPlayers } from '../../pages/waiting-room/mockSeed'
+
+type PresenceMockDataModule = typeof import('./mockData')
+type WaitingRoomMockGatewayModule =
+  typeof import('../../pages/waiting-room/mockGateway')
+
+interface LoadedMockModules {
+  presence: PresenceMockDataModule
+  gateway: WaitingRoomMockGatewayModule
+}
+
+// 테스트 간 목 저장소 오염을 막기 위해 매번 새 모듈 인스턴스로 로드
+async function loadMockModules(): Promise<LoadedMockModules> {
+  vi.resetModules()
+
+  const [presence, gateway] = await Promise.all([
+    import('./mockData'),
+    import('../../pages/waiting-room/mockGateway'),
+  ])
+
+  return {
+    presence,
+    gateway,
+  }
+}
+
+describe('presence mockData SSOT', () => {
+  it('초기 접속자 시드는 대기방 목 스토어 플레이어 상태와 동일 규칙으로 생성된다', async () => {
+    const { presence, gateway } = await loadMockModules()
+    const users = presence.getMockOnlineUsersSnapshot()
+    const rooms = gateway.getMockLobbyRooms()
+    const uniqueNicknames = new Set(users.map((user) => user.nickname))
+
+    // 접속자 목록 시드 닉네임은 모두 서로 다른 값이어야 한다
+    expect(uniqueNicknames.size).toBe(users.length)
+
+    rooms.forEach((room) => {
+      const expectedStatus = room.status === 'playing' ? 'playing' : 'in_room'
+      const seededPlayers = createSeededRoomPlayers(
+        room.id,
+        room.currentPlayers
+      )
+
+      for (let index = 1; index <= room.currentPlayers; index += 1) {
+        const expectedUserId = `${room.id}-user-${index}`
+        const matchedUser = users.find((user) => user.id === expectedUserId)
+        const expectedNickname = seededPlayers[index - 1]?.nickname
+
+        expect(matchedUser).toBeTruthy()
+        expect(matchedUser?.nickname).toBe(expectedNickname)
+        expect(matchedUser?.status).toBe(expectedStatus)
+      }
+    })
+  })
+})

--- a/src/features/presence/mockData.ts
+++ b/src/features/presence/mockData.ts
@@ -1,28 +1,9 @@
 import type { OnlineUserPayload } from './types'
+import { createInitialSeededOnlineUsers } from '../../pages/waiting-room/mockSeed'
 
-// 접속자 목록 UI 개발용 초기 목 데이터
-const INITIAL_MOCK_ONLINE_USERS: OnlineUserPayload[] = [
-  {
-    id: 'user-1',
-    nickname: '마블왕',
-    status: 'lobby',
-  },
-  {
-    id: 'user-2',
-    nickname: '주사위마스터',
-    status: 'playing',
-  },
-  {
-    id: 'user-3',
-    nickname: '행운의여신',
-    status: 'in_room',
-  },
-  {
-    id: 'user-4',
-    nickname: '부동산왕',
-    status: 'playing',
-  },
-]
+// 대기방 시드와 동일한 규칙으로 접속자 초기 데이터를 생성
+const INITIAL_MOCK_ONLINE_USERS: OnlineUserPayload[] =
+  createInitialSeededOnlineUsers()
 
 // 목 접속자 목록 저장소
 let mockOnlineUsersStore = [...INITIAL_MOCK_ONLINE_USERS]

--- a/src/pages/lobby/LobbyPage.tsx
+++ b/src/pages/lobby/LobbyPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import toast from 'react-hot-toast'
 import { useNavigate } from 'react-router-dom'
 import Header from '../../components/header/Header'
@@ -14,6 +14,7 @@ import { DirectMessagePanel } from '../../features/presence/components/DirectMes
 import { DevPresenceControlPanel } from '../../features/presence/components/DevPresenceControlPanel'
 import { useOnlineUsersSocket } from '../../features/presence/useOnlineUsersSocket'
 import { useDirectMessageController } from '../../features/presence/useDirectMessageController'
+import { setMockOnlineUserStatus } from '../../features/presence/mockData'
 import type { LobbyRoomFilter } from './api'
 import { useLobbyRoomsQuery } from './hooks'
 import { LobbyControls } from './LobbyControls'
@@ -21,6 +22,7 @@ import { RoomGrid } from './RoomGrid'
 import { PrivateRoomJoinModal } from './PrivateRoomJoinModal'
 import { CreateRoomModal } from './CreateRoomModal'
 import { useLobbyRoomActions } from './useLobbyRoomActions'
+import { IS_SOCKET_MOCK_ENABLED } from '../../config/env'
 
 // 로비 화면 상태 관리와 방/접속자/DM 상호작용 통합 처리
 function LobbyPage() {
@@ -79,6 +81,15 @@ function LobbyPage() {
       toast.error('게임중인 유저에게는 DM을 보낼 수 없습니다.')
     },
   })
+
+  // 목 모드에서는 로비 진입 시 현재 사용자를 접속자 목록에 즉시 반영
+  useEffect(() => {
+    if (!IS_SOCKET_MOCK_ENABLED || !session) {
+      return
+    }
+
+    setMockOnlineUserStatus(session.userId, 'lobby', session.nickname)
+  }, [session])
 
   function handleLogout() {
     clearSession()

--- a/src/pages/waiting-room/mockGateway.test.ts
+++ b/src/pages/waiting-room/mockGateway.test.ts
@@ -54,6 +54,11 @@ describe('mockGateway DEV control', () => {
 
   it('방 초기화는 현재 사용자만 남기고 채팅/상태를 초기화한다', async () => {
     const gateway = await loadMockGateway()
+    const beforeResetSnapshot = gateway.mockDevGetWaitingRoomSnapshot('room-5')
+    const currentUserNickname =
+      beforeResetSnapshot.players.find(
+        (player) => player.id === 'room-5-user-2'
+      )?.nickname ?? ''
 
     gateway.mockSendWaitingRoomChat({
       roomId: 'room-5',
@@ -73,7 +78,7 @@ describe('mockGateway DEV control', () => {
     expect(resetSnapshot.players).toHaveLength(1)
     expect(resetSnapshot.players[0]).toEqual({
       id: 'room-5-user-2',
-      nickname: '플레이어2',
+      nickname: currentUserNickname,
       isReady: false,
       isHost: true,
     })

--- a/src/pages/waiting-room/mockGateway.ts
+++ b/src/pages/waiting-room/mockGateway.ts
@@ -3,6 +3,7 @@ import { ROOM_PASSWORD_PATTERN } from '../../constants/room'
 import { setMockOnlineUserStatus } from '../../features/presence/mockData'
 import { mockLobbyRooms } from '../lobby/mockData'
 import type { LobbyRoom, LobbyRoomStatus } from '../lobby/types'
+import { createSeededRoomPlayers } from './mockSeed'
 import type {
   ChatEventPayload,
   GameStartEventPayload,
@@ -82,10 +83,10 @@ function wait(delayMs: number) {
 
 // 초기 방 플레이어 목록을 1번 플레이어 방장으로 생성
 function createRoomPlayers(roomId: string, count: number): MockRoomPlayer[] {
-  return Array.from({ length: count }, (_, index) => {
+  return createSeededRoomPlayers(roomId, count).map((player, index) => {
     return {
-      id: `${roomId}-user-${index + 1}`,
-      nickname: `플레이어${index + 1}`,
+      id: player.id,
+      nickname: player.nickname,
       is_ready: false,
       is_host: index === 0,
     }
@@ -300,7 +301,7 @@ function syncRoomPlayersPresenceStatus(
   status: 'lobby' | 'in_room' | 'playing'
 ) {
   room.players.forEach((player) => {
-    setMockOnlineUserStatus(player.id, status, player.nickname)
+    setMockOnlineUserStatus(player.id, status)
   })
 }
 
@@ -378,11 +379,7 @@ export async function mockJoinWaitingRoom({
 
   // 이미 입장한 사용자는 현재 스냅샷 그대로 반환
   if (existingPlayer) {
-    setMockOnlineUserStatus(
-      existingPlayer.id,
-      'in_room',
-      existingPlayer.nickname
-    )
+    setMockOnlineUserStatus(existingPlayer.id, 'in_room')
     return toWaitingRoomSnapshot(room)
   }
 
@@ -496,7 +493,7 @@ export async function mockLeaveWaitingRoom({
   }
 
   const [leftPlayer] = room.players.splice(targetPlayerIndex, 1)
-  setMockOnlineUserStatus(leftPlayer.id, 'lobby', leftPlayer.nickname)
+  setMockOnlineUserStatus(leftPlayer.id, 'lobby')
   let newHostId: string | undefined
 
   // 마지막 인원이 나가면 방을 삭제
@@ -765,7 +762,7 @@ export function mockDevRemoveWaitingRoomParticipant(
 
   const [removedPlayer] = room.players.splice(removablePlayerIndex, 1)
   if (removedPlayer) {
-    setMockOnlineUserStatus(removedPlayer.id, 'lobby', removedPlayer.nickname)
+    setMockOnlineUserStatus(removedPlayer.id, 'lobby')
   }
   emitLobbyUpdated(room, 'status_changed')
 
@@ -879,7 +876,7 @@ export function mockDevResetWaitingRoom(
     },
   ]
   removedPlayers.forEach((player) => {
-    setMockOnlineUserStatus(player.id, 'lobby', player.nickname)
+    setMockOnlineUserStatus(player.id, 'lobby')
   })
   setMockOnlineUserStatus(currentUserId, 'in_room', normalizedNickname)
   room.chat_messages = []

--- a/src/pages/waiting-room/mockSeed.ts
+++ b/src/pages/waiting-room/mockSeed.ts
@@ -1,0 +1,102 @@
+import type {
+  OnlineUserPayload,
+  OnlineUserStatus,
+} from '../../features/presence/types'
+import { mockLobbyRooms } from '../lobby/mockData'
+import type { LobbyRoom, LobbyRoomStatus } from '../lobby/types'
+
+// 목 시드 플레이어의 공통 기본 정보 타입
+interface SeededRoomPlayer {
+  id: string
+  nickname: string
+}
+
+// 닉네임 조합용 게임 느낌 단어 사전
+const NICKNAME_PREFIXES = [
+  '주사위',
+  '마블',
+  '럭키',
+  '코인',
+  '랜드',
+  '턴킬',
+  '부스터',
+  '스피드',
+  '탑티어',
+  '골드',
+]
+
+const NICKNAME_SUFFIXES = [
+  '헌터',
+  '장인',
+  '마스터',
+  '러너',
+  '요정',
+  '킹',
+  '퀸',
+  '고수',
+  '전략가',
+  '챔프',
+]
+
+// roomId/index 조합을 숫자 시드로 변환
+function createNicknameSeed(roomId: string, index: number) {
+  return `${roomId}-${index + 1}`.split('').reduce((hash, char) => {
+    return (hash * 31 + char.charCodeAt(0)) >>> 0
+  }, 7)
+}
+
+// 동일 입력이면 항상 같은 닉네임이 나오도록 결정적 생성
+function createSeededNickname(roomId: string, index: number) {
+  const seed = createNicknameSeed(roomId, index)
+  const roomNumber = Number.parseInt(roomId.replace('room-', ''), 10) || 0
+  const prefix = NICKNAME_PREFIXES[seed % NICKNAME_PREFIXES.length]
+  const suffix =
+    NICKNAME_SUFFIXES[Math.floor(seed / 3) % NICKNAME_SUFFIXES.length]
+  // room 번호 + 좌석 번호를 합쳐 닉네임 충돌을 방지
+  const tagNumber = roomNumber * 10 + (index + 1)
+
+  return `${prefix}${suffix}${tagNumber}`
+}
+
+// 방 시드 상태를 접속자 상태 값으로 변환
+function mapLobbyStatusToOnlineStatus(
+  status: LobbyRoomStatus
+): OnlineUserStatus {
+  if (status === 'playing') {
+    return 'playing'
+  }
+
+  return 'in_room'
+}
+
+// roomId + 인원 수 규칙으로 초기 시드 플레이어 목록을 생성
+export function createSeededRoomPlayers(roomId: string, count: number) {
+  return Array.from({ length: count }, (_, index): SeededRoomPlayer => {
+    return {
+      id: `${roomId}-user-${index + 1}`,
+      nickname: createSeededNickname(roomId, index),
+    }
+  })
+}
+
+// 로비 방 시드 배열을 접속자 초기 스냅샷으로 변환
+export function createSeededOnlineUsersFromLobbyRooms(
+  rooms: LobbyRoom[]
+): OnlineUserPayload[] {
+  return rooms.flatMap((room) => {
+    const status = mapLobbyStatusToOnlineStatus(room.status)
+
+    return createSeededRoomPlayers(room.id, room.currentPlayers).map(
+      (player) => ({
+        id: player.id,
+        nickname: player.nickname,
+        status,
+      })
+    )
+  })
+}
+
+// 프로젝트 기본 로비 시드를 기준으로 접속자 초기 스냅샷 생성
+export function createInitialSeededOnlineUsers() {
+  return createSeededOnlineUsersFromLobbyRooms(mockLobbyRooms)
+}


### PR DESCRIPTION
## 📌 관련 이슈

> closes #329

---

## 📝 작업 내용

접속자 목록 UX와 목 동기화 품질을 함께 개선했습니다.

- 접속자 목록 정렬 규칙 고정
  - 나 자신 맨 위
  - 상태 우선순위: `lobby -> in_room -> playing`
  - 같은 상태 내 닉네임 가나다순(`ko-KR`)
- 목 모드 로비 첫 진입 시 현재 사용자 즉시 반영
  - 로비 진입 직후 `setMockOnlineUserStatus(userId, 'lobby', nickname)` 반영
- 접속자/대기방 SSOT 정합 개선
  - 공용 시드 모듈(`mockSeed`)로 초기 닉네임/ID 생성 규칙 통합
  - 접속자 상태 변경 시 불필요한 닉네임 덮어쓰기 제거
- 접속자 패널 높이 보정
  - 뷰포트 기준(`dvh`) 높이 계산으로 화면 오버플로우 완화
  - 내부 스크롤 유지

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

- 로비 접속자 목록
  - 본인 최상단 표시
  - 상태/닉네임 정렬 규칙 반영
- 접속자 패널
  - 화면 높이 맞춤 + 내부 스크롤 확인

---

### 테스트 결과

- `npm run lint` ✅
- `npm run test -- --run` ✅ (27 files, 133 tests)
- `npm run e2e -- e2e/chat-flow-direct-message.spec.ts` ✅

---

### 변경 파일

- `/Users/admin/Desktop/Blue_Marble-frontend/src/features/presence/components/UserListPanel.tsx`
- `/Users/admin/Desktop/Blue_Marble-frontend/src/pages/lobby/LobbyPage.tsx`
- `/Users/admin/Desktop/Blue_Marble-frontend/src/pages/waiting-room/mockSeed.ts`
- `/Users/admin/Desktop/Blue_Marble-frontend/src/features/presence/mockData.ts`
- `/Users/admin/Desktop/Blue_Marble-frontend/src/pages/waiting-room/mockGateway.ts`
- `/Users/admin/Desktop/Blue_Marble-frontend/src/features/presence/components/UserListPanel.test.tsx`
- `/Users/admin/Desktop/Blue_Marble-frontend/src/features/presence/mockData.test.ts`
- `/Users/admin/Desktop/Blue_Marble-frontend/src/pages/waiting-room/mockGateway.test.ts`
- `/Users/admin/Desktop/Blue_Marble-frontend/e2e/chat-flow-direct-message.spec.ts`