### PR TITLE
fix:  타이머가 끝나고 다른 플레이어 턴 넘기면 다시 타이머가 차게 수정

### DIFF
--- a/src/components/board/gameBoardStoreBridge.test.ts
+++ b/src/components/board/gameBoardStoreBridge.test.ts
@@ -81,12 +81,16 @@ describe('gameBoardStoreBridge', () => {
   })
 
   it('현재 턴과 파산 상태를 store에 반영한다', () => {
+    const beforeTurnTimerKey = useGameStore.getState().turnTimerKey
+
     syncMockStoreCurrentTurn(1)
     syncMockStoreBankrupt(0)
 
-    const { currentTurn, currentPlayerId, players } = useGameStore.getState()
+    const { currentTurn, currentPlayerId, players, turnTimerKey } =
+      useGameStore.getState()
     expect(currentTurn).toBe('p2')
     expect(currentPlayerId).toBe('p2')
+    expect(turnTimerKey).toBeGreaterThan(beforeTurnTimerKey)
     expect(players[0]?.is_bankrupt).toBe(true)
   })
 

--- a/src/components/board/gameBoardStoreBridge.ts
+++ b/src/components/board/gameBoardStoreBridge.ts
@@ -32,10 +32,15 @@ export function syncMockStorePlayers(nextPlayers: PlayerState[]) {
 }
 
 export function syncMockStoreCurrentTurn(playerIdx: number) {
-  const { players: storePlayers, setCurrentTurn } = useGameStore.getState()
+  const {
+    players: storePlayers,
+    setCurrentTurn,
+    setGameState,
+  } = useGameStore.getState()
   const nextTurnPlayer = storePlayers[playerIdx]
   if (nextTurnPlayer) {
     setCurrentTurn(nextTurnPlayer.id)
+    setGameState({ turnTimerKey: Date.now() })
   }
 }
 

--- a/src/components/game/controls/RollButton.tsx
+++ b/src/components/game/controls/RollButton.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 
 interface RollControlProps {
   timeLeft: number
@@ -13,6 +13,19 @@ const RollControl: React.FC<RollControlProps> = ({
 }) => {
   const dashArray = 251 // Approx circumference for r=40
   const dashOffset = dashArray * (1 - timeLeft / 30)
+  const previousTimeLeftRef = useRef<number | null>(null)
+  const [shouldAnimate, setShouldAnimate] = useState(false)
+
+  useEffect(() => {
+    const previous = previousTimeLeftRef.current
+    if (previous === null) {
+      setShouldAnimate(false)
+    } else {
+      setShouldAnimate(timeLeft < previous)
+    }
+
+    previousTimeLeftRef.current = timeLeft
+  }, [timeLeft])
 
   return (
     <div className="flex items-center gap-6">
@@ -39,7 +52,9 @@ const RollControl: React.FC<RollControlProps> = ({
               strokeDasharray={`${dashArray}`}
               strokeDashoffset={dashOffset}
               strokeLinecap="round"
-              className="transition-all duration-1000 linear"
+              className={
+                shouldAnimate ? 'transition-all duration-1000 linear' : ''
+              }
             />
           </svg>
         </div>


### PR DESCRIPTION
## 📌 관련 이슈

> closes #324


---

## 📝 작업 내용

> 타이머가 끝나고 다른 플레이어 턴 넘기면 다시 타이머가 차게 수정 완료 

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

> UI 변경이 있을 경우 첨부해주세요.
