### PR TITLE
refactor: 아바타 렌더링 SSOT 통합 및 mock 프로필 이미지 비활성화

### DIFF
--- a/src/components/avatar/Avatar.tsx
+++ b/src/components/avatar/Avatar.tsx
@@ -1,0 +1,64 @@
+import { cn } from '../../lib/utils'
+import { getAvatarBackgroundColor, getAvatarText } from './avatarModel'
+
+// 공통 아바타 사이즈 variant
+type AvatarSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl'
+
+// 공통 아바타 렌더링 입력값 타입
+interface AvatarProps {
+  displayName?: string
+  imageUrl?: string | null
+  imageAlt?: string
+  backgroundColor?: string
+  colorSeed?: string
+  size?: AvatarSize
+  className?: string
+  textClassName?: string
+}
+
+const AVATAR_SIZE_CLASS_MAP: Record<AvatarSize, string> = {
+  xs: 'size-8 text-xs',
+  sm: 'size-9 text-xs',
+  md: 'size-10 text-sm',
+  lg: 'size-24 text-2xl',
+  xl: 'size-32 text-5xl',
+}
+
+// 화면 전반에서 재사용하는 공통 아바타 렌더러
+export function Avatar({
+  displayName,
+  imageUrl,
+  imageAlt,
+  backgroundColor,
+  colorSeed,
+  size = 'md',
+  className,
+  textClassName,
+}: AvatarProps) {
+  const fallbackText = getAvatarText(displayName)
+  const resolvedBackgroundColor =
+    backgroundColor ?? getAvatarBackgroundColor(colorSeed ?? displayName)
+
+  return (
+    <div
+      className={cn(
+        'relative flex shrink-0 items-center justify-center overflow-hidden rounded-full font-semibold text-ui-text-strong',
+        AVATAR_SIZE_CLASS_MAP[size],
+        className
+      )}
+      style={{ backgroundColor: resolvedBackgroundColor }}
+    >
+      {imageUrl ? (
+        <img
+          src={imageUrl}
+          alt={imageAlt ?? `${displayName ?? '사용자'} 프로필`}
+          className="size-full object-cover"
+        />
+      ) : (
+        <span className={cn('leading-none', textClassName)}>
+          {fallbackText}
+        </span>
+      )}
+    </div>
+  )
+}

--- a/src/components/avatar/avatarModel.ts
+++ b/src/components/avatar/avatarModel.ts
@@ -1,0 +1,37 @@
+// 아바타 fallback 배경색 후보군
+const AVATAR_FALLBACK_COLORS = [
+  '#f6c8a9',
+  '#7f8ea3',
+  '#dbc4f8',
+  '#8f7f77',
+  '#b5d9ff',
+  '#ffd8a6',
+]
+
+// 이름 첫 글자를 아바타 텍스트로 변환
+export function getAvatarText(displayName?: string): string {
+  const normalizedDisplayName = displayName?.trim() ?? ''
+
+  if (normalizedDisplayName.length === 0) {
+    return '?'
+  }
+
+  return normalizedDisplayName.slice(0, 1).toUpperCase()
+}
+
+// userId/닉네임 같은 seed 값으로 일관된 아바타 배경색 계산
+export function getAvatarBackgroundColor(seed?: string): string {
+  const normalizedSeed = seed?.trim() ?? ''
+
+  if (normalizedSeed.length === 0) {
+    return AVATAR_FALLBACK_COLORS[0]
+  }
+
+  const colorIndex =
+    normalizedSeed
+      .split('')
+      .reduce((sum, currentChar) => sum + currentChar.charCodeAt(0), 0) %
+    AVATAR_FALLBACK_COLORS.length
+
+  return AVATAR_FALLBACK_COLORS[colorIndex]
+}

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -7,6 +7,7 @@ interface HeaderProps {
   playerLabel?: string
   avatarText?: string
   avatarBackground?: string
+  avatarImageUrl?: string | null
   menuItems?: ProfileMenuItem[]
 }
 
@@ -15,6 +16,7 @@ function Header({
   playerLabel = '플레이어',
   avatarText = 'P',
   avatarBackground = '#fde68a',
+  avatarImageUrl = null,
   menuItems = [],
 }: HeaderProps) {
   return (
@@ -30,6 +32,7 @@ function Header({
         playerLabel={playerLabel}
         avatarText={avatarText}
         avatarBackground={avatarBackground}
+        avatarImageUrl={avatarImageUrl}
         menuItems={menuItems}
       />
     </header>

--- a/src/components/header/ProfileDropdown.tsx
+++ b/src/components/header/ProfileDropdown.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import { Avatar } from '../avatar/Avatar'
 import type { ProfileMenuItem } from './profileMenu'
 
 // 프로필 드롭다운 렌더링 입력값 타입
@@ -6,6 +7,7 @@ interface ProfileDropdownProps {
   playerLabel?: string
   avatarText?: string
   avatarBackground?: string
+  avatarImageUrl?: string | null
   menuItems?: ProfileMenuItem[]
 }
 
@@ -14,6 +16,7 @@ export function ProfileDropdown({
   playerLabel = '플레이어',
   avatarText = 'P',
   avatarBackground = '#fde68a',
+  avatarImageUrl = null,
   menuItems = [],
 }: ProfileDropdownProps) {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
@@ -21,12 +24,14 @@ export function ProfileDropdown({
 
   const hasMenuItems = menuItems.length > 0
   const avatar = (
-    <div
-      className="flex size-9 items-center justify-center rounded-full text-xs font-semibold text-ui-text-primary"
-      style={{ backgroundColor: avatarBackground }}
-    >
-      {avatarText}
-    </div>
+    <Avatar
+      size="sm"
+      displayName={avatarText}
+      imageUrl={avatarImageUrl}
+      imageAlt={`${playerLabel} 프로필`}
+      backgroundColor={avatarBackground}
+      className="text-ui-text-primary"
+    />
   )
 
   useEffect(() => {

--- a/src/components/header/profileMenu.ts
+++ b/src/components/header/profileMenu.ts
@@ -1,3 +1,8 @@
+import {
+  getAvatarBackgroundColor,
+  getAvatarText as getAvatarTextFromModel,
+} from '../avatar/avatarModel'
+
 // 프로필 드롭다운 메뉴 아이템 공통 타입
 export interface ProfileMenuItem {
   id: string
@@ -15,13 +20,12 @@ interface CreateProfileMenuItemsParams {
 
 // 닉네임 첫 글자를 아바타 텍스트로 만들고 비어 있으면 기본값 반환
 export function getAvatarText(nickname?: string): string {
-  const trimmedNickname = nickname?.trim() ?? ''
-  return trimmedNickname.length > 0 ? trimmedNickname.slice(0, 1) : 'P'
+  return getAvatarTextFromModel(nickname)
 }
 
-// 게스트 여부에 따라 아바타 배경 색상 반환
-export function getAvatarBackground(isGuest?: boolean): string {
-  return isGuest ? '#fde68a' : '#bfdbfe'
+// 사용자 식별값 기반으로 아바타 배경색 반환
+export function getAvatarBackground(userId?: string): string {
+  return getAvatarBackgroundColor(userId)
 }
 
 // 사용자 유형에 맞는 프로필 드롭다운 메뉴 목록 생성

--- a/src/features/auth/mock/myPage.ts
+++ b/src/features/auth/mock/myPage.ts
@@ -46,7 +46,7 @@ export async function mockGetMyPageProfile(
     profile: {
       id: session.userId,
       nickname: profileNickname,
-      profileImage: session.profileImage ?? kakaoUser.profileImage,
+      profileImage: null,
       stats: createMockMyPageStats(session.userId),
     },
   }

--- a/src/features/auth/mock/session.ts
+++ b/src/features/auth/mock/session.ts
@@ -31,7 +31,7 @@ export async function mockKakaoLogin() {
     accessToken: `mock-kakao-token-${kakaoUser.id}`,
     userId: kakaoUser.id,
     nickname: existingNickname,
-    profileImage: kakaoUser.profileImage,
+    profileImage: null,
     isGuest: false,
     needsNicknameSetup: !hasNickname,
     provider: 'kakao',

--- a/src/features/presence/components/DirectMessagePanel.tsx
+++ b/src/features/presence/components/DirectMessagePanel.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react'
 import { SendHorizontal, X } from 'lucide-react'
+import { Avatar } from '../../../components/avatar/Avatar'
 import { cn } from '../../../lib/utils'
 import type { DirectMessage, OnlineUser } from '../types'
 
@@ -44,12 +45,11 @@ export function DirectMessagePanel({
     <section className="fixed bottom-6 right-4 z-40 w-[340px] max-w-[calc(100vw-1rem)] overflow-hidden rounded-2xl border border-ui-border bg-ui-surface shadow-[0_18px_40px_rgba(15,23,42,0.2)] sm:right-6">
       <header className="flex h-14 items-center justify-between border-b border-ui-border px-4">
         <div className="flex min-w-0 items-center gap-3">
-          <div
-            className="flex size-8 shrink-0 items-center justify-center rounded-full text-xs font-semibold text-ui-text-strong"
-            style={{ backgroundColor: user.avatarBackground }}
-          >
-            {user.avatarText}
-          </div>
+          <Avatar
+            size="xs"
+            displayName={user.nickname}
+            backgroundColor={user.avatarBackground}
+          />
           <p className="truncate text-base font-semibold text-ui-text-primary">
             {user.nickname}
           </p>

--- a/src/features/presence/components/UserListPanel.tsx
+++ b/src/features/presence/components/UserListPanel.tsx
@@ -1,5 +1,6 @@
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { useMemo } from 'react'
+import { Avatar } from '../../../components/avatar/Avatar'
 import { cn } from '../../../lib/utils'
 import { ONLINE_USER_STATUS_DOT_CLASS_MAP } from '../status'
 import type { OnlineUser, OnlineUserStatus } from '../types'
@@ -175,12 +176,11 @@ export function UserListPanel({
               !isError &&
               sortedUsers.map((user) => (
                 <div key={user.id} className="relative">
-                  <div
-                    className="flex size-9 items-center justify-center rounded-full text-xs font-semibold text-ui-text-strong"
-                    style={{ backgroundColor: user.avatarBackground }}
-                  >
-                    {user.avatarText}
-                  </div>
+                  <Avatar
+                    size="sm"
+                    displayName={user.nickname}
+                    backgroundColor={user.avatarBackground}
+                  />
                   <span
                     className={cn(
                       'absolute -bottom-0.5 -right-0.5 size-2 rounded-full border-2 border-white',

--- a/src/features/presence/components/UserRow.tsx
+++ b/src/features/presence/components/UserRow.tsx
@@ -1,4 +1,5 @@
 import { MessageCircle } from 'lucide-react'
+import { Avatar } from '../../../components/avatar/Avatar'
 import { cn } from '../../../lib/utils'
 import {
   isDirectMessageAllowed,
@@ -32,12 +33,11 @@ export function UserRow({
   return (
     <div className="group flex items-center gap-3 px-4 py-2.5 hover:bg-ui-surface-muted">
       <div className="relative shrink-0">
-        <div
-          className="flex size-10 items-center justify-center rounded-full text-sm font-semibold text-ui-text-strong"
-          style={{ backgroundColor: user.avatarBackground }}
-        >
-          {user.avatarText}
-        </div>
+        <Avatar
+          size="md"
+          displayName={user.nickname}
+          backgroundColor={user.avatarBackground}
+        />
         <span
           className={cn(
             'absolute -bottom-0.5 -right-0.5 size-2.5 rounded-full border-2 border-white',

--- a/src/features/presence/onlineUsersModel.ts
+++ b/src/features/presence/onlineUsersModel.ts
@@ -1,36 +1,17 @@
 import type { OnlineUser, OnlineUserPayload } from './types'
-
-// userId 해시 기반 아바타 배경색 후보군
-const AVATAR_BACKGROUND_COLORS = [
-  '#f6c8a9',
-  '#7f8ea3',
-  '#dbc4f8',
-  '#8f7f77',
-  '#b5d9ff',
-  '#ffd8a6',
-]
+import {
+  getAvatarBackgroundColor,
+  getAvatarText,
+} from '../../components/avatar/avatarModel'
 
 // 닉네임 첫 글자를 아바타 텍스트로 변환
 export function getOnlineUserAvatarText(nickname: string) {
-  const trimmedNickname = nickname.trim()
-
-  // 빈 문자열 닉네임은 기본 문자 반환
-  if (trimmedNickname.length === 0) {
-    return '?'
-  }
-
-  return trimmedNickname.slice(0, 1).toUpperCase()
+  return getAvatarText(nickname)
 }
 
 // userId 문자열 해시로 일관된 아바타 배경색 선택
 export function getOnlineUserAvatarBackground(userId: string) {
-  const colorIndex =
-    userId
-      .split('')
-      .reduce((acc, character) => acc + character.charCodeAt(0), 0) %
-    AVATAR_BACKGROUND_COLORS.length
-
-  return AVATAR_BACKGROUND_COLORS[colorIndex]
+  return getAvatarBackgroundColor(userId)
 }
 
 // 접속자 payload를 UI 전용 접속자 모델로 매핑

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -1,10 +1,10 @@
-import { useMemo } from 'react'
 import { ArrowLeft, Gamepad2, Shield, Trophy } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import { useRequireActiveSession } from '../features/auth/hooks/useRequireActiveSession'
 import { useAuthStore } from '../features/auth/store'
 import { useMyPageProfileQuery } from '../features/auth/hooks/useMyPageProfileQuery'
-import { getAvatarText } from '../components/header/profileMenu'
+import { Avatar } from '../components/avatar/Avatar'
+import { getAvatarBackground } from '../components/header/profileMenu'
 
 // 전적 카드 렌더링 메타데이터
 const myPageStatsCardMeta = [
@@ -37,11 +37,6 @@ function MyPage() {
   const session = useAuthStore((state) => state.session)
   const isAllowedSession = useRequireActiveSession(session)
   const { data: profile, isLoading, isError } = useMyPageProfileQuery(session)
-
-  // 프로필 이미지가 없을 때 사용할 아바타 텍스트 계산
-  const fallbackAvatarText = useMemo(() => {
-    return getAvatarText(session?.nickname)
-  }, [session?.nickname])
 
   // 리다이렉트 조건에서는 화면을 렌더링하지 않음
   if (!isAllowedSession || !session) {
@@ -100,19 +95,15 @@ function MyPage() {
                 </p>
               ) : (
                 <div className="flex items-center gap-6">
-                  <div className="relative size-24 overflow-hidden rounded-full border border-ui-border bg-ui-brand-soft">
-                    {profile.profileImage ? (
-                      <img
-                        src={profile.profileImage}
-                        alt={`${profile.nickname} 프로필`}
-                        className="size-full object-cover"
-                      />
-                    ) : (
-                      <div className="flex size-full items-center justify-center text-2xl font-bold text-ui-brand">
-                        {fallbackAvatarText}
-                      </div>
-                    )}
-                  </div>
+                  <Avatar
+                    size="lg"
+                    displayName={profile.nickname}
+                    imageUrl={profile.profileImage}
+                    imageAlt={`${profile.nickname} 프로필`}
+                    backgroundColor={getAvatarBackground(session.userId)}
+                    className="border border-ui-border"
+                    textClassName="text-black"
+                  />
                   <h1 className="text-3xl font-extrabold tracking-tight text-ui-text-strong">
                     {profile.nickname}
                   </h1>

--- a/src/pages/lobby/LobbyPage.tsx
+++ b/src/pages/lobby/LobbyPage.tsx
@@ -107,7 +107,7 @@ function LobbyPage() {
   }
 
   const avatarText = getAvatarText(session.nickname)
-  const avatarBackground = getAvatarBackground(session.isGuest)
+  const avatarBackground = getAvatarBackground(session.userId)
   const headerMenuItems = createProfileMenuItems({
     isGuest: session.isGuest,
     onGoMyPage: handleGoMyPage,

--- a/src/pages/waiting-room/WaitingRoomPage.tsx
+++ b/src/pages/waiting-room/WaitingRoomPage.tsx
@@ -202,7 +202,7 @@ function WaitingRoomPage() {
     room?.title ?? selectedRoomTitle ?? DEFAULT_WAITING_ROOM_TITLE
   const roomIdLabel = formatRoomIdLabel(currentRoomId)
   const avatarText = getAvatarText(session.nickname)
-  const avatarBackground = getAvatarBackground(session.isGuest)
+  const avatarBackground = getAvatarBackground(session.userId)
   const headerMenuItems = createProfileMenuItems({
     isGuest: session.isGuest,
     onGoMyPage: handleGoMyPage,

--- a/src/pages/waiting-room/components/WaitingRoomHeader.tsx
+++ b/src/pages/waiting-room/components/WaitingRoomHeader.tsx
@@ -9,6 +9,7 @@ interface WaitingRoomHeaderProps {
   playerLabel: string
   avatarText: string
   avatarBackground: string
+  avatarImageUrl?: string | null
   menuItems: ProfileMenuItem[]
   onBackToLobby: () => void
 }
@@ -20,6 +21,7 @@ export function WaitingRoomHeader({
   playerLabel,
   avatarText,
   avatarBackground,
+  avatarImageUrl = null,
   menuItems,
   onBackToLobby,
 }: WaitingRoomHeaderProps) {
@@ -48,6 +50,7 @@ export function WaitingRoomHeader({
         playerLabel={playerLabel}
         avatarText={avatarText}
         avatarBackground={avatarBackground}
+        avatarImageUrl={avatarImageUrl}
         menuItems={menuItems}
       />
     </header>

--- a/src/pages/waiting-room/components/WaitingSeatCard.tsx
+++ b/src/pages/waiting-room/components/WaitingSeatCard.tsx
@@ -1,4 +1,5 @@
 import { CheckCircle2, Clock3, Crown, UserRound } from 'lucide-react'
+import { Avatar } from '../../../components/avatar/Avatar'
 import { cn } from '../../../lib/utils'
 import type { WaitingRoomSeat } from '../types'
 
@@ -25,11 +26,13 @@ export function WaitingSeatCard({ seat }: WaitingSeatCardProps) {
 
   return (
     <article className="relative flex h-full min-h-[260px] flex-col rounded-[34px] border border-ui-border bg-ui-surface px-7 py-7 shadow-[0_2px_10px_rgba(15,23,42,0.06)]">
-      <div
-        className="relative mx-auto mb-5 flex size-32 items-center justify-center rounded-full text-5xl font-extrabold text-white shadow-[inset_0_-5px_0_rgba(0,0,0,0.2)]"
-        style={{ backgroundColor: seat.avatarColor }}
-      >
-        {seat.nickname.slice(0, 1).toUpperCase()}
+      <div className="relative mx-auto mb-5">
+        <Avatar
+          size="xl"
+          displayName={seat.nickname}
+          backgroundColor={seat.avatarColor}
+          className="text-white shadow-[inset_0_-5px_0_rgba(0,0,0,0.2)]"
+        />
 
         {seat.isHost ? (
           <span className="absolute -left-2 top-2 inline-flex size-12 items-center justify-center rounded-full border-[3px] border-white bg-[#f7c600] text-white shadow-md">

--- a/src/pages/waiting-room/controller/state.ts
+++ b/src/pages/waiting-room/controller/state.ts
@@ -4,6 +4,7 @@ import type {
   WaitingRoomSeat,
   WaitingRoomSnapshot,
 } from '../types'
+import { getAvatarBackgroundColor } from '../../../components/avatar/avatarModel'
 
 // 대기방 액션 함수 공통 반환 타입
 export interface WaitingRoomActionResult {
@@ -16,26 +17,12 @@ export interface LeaveRoomSequenceParams {
   source: 'manual' | 'cleanup'
 }
 
-// 대기방 기본 정원과 좌석 색상 팔레트
+// 대기방 기본 정원
 const DEFAULT_WAITING_ROOM_MAX_PLAYERS = 4
-const AVATAR_COLORS = [
-  '#ef4444',
-  '#3b82f6',
-  '#f97316',
-  '#22c55e',
-  '#8b5cf6',
-  '#14b8a6',
-]
 
 // playerId 해시 기반으로 좌석 아바타 색상 선택
 function getAvatarColor(playerId: string) {
-  const colorIndex =
-    playerId
-      .split('')
-      .reduce((sum, currentChar) => sum + currentChar.charCodeAt(0), 0) %
-    AVATAR_COLORS.length
-
-  return AVATAR_COLORS[colorIndex]
+  return getAvatarBackgroundColor(playerId)
 }
 
 // 채팅 이벤트 payload에서 메시지 고유 ID 생성


### PR DESCRIPTION
## 📌 관련 이슈

> closes #331 

---

## 📝 작업 내용

- 공통 아바타 컴포넌트/모델 추가
  - `src/components/avatar/Avatar.tsx`
  - `src/components/avatar/avatarModel.ts`
- 헤더/드롭다운/대기방 헤더/마이페이지/접속자목록/DM/대기방 좌석 아바타 렌더링을 공통 `Avatar`로 통일
- 아바타 텍스트/배경색 계산 로직을 SSOT로 정리 (`avatarModel` 기반)
- mock 인증/마이페이지에서 프로필 이미지 사용 비활성화
  - 카카오 mock 로그인 세션 `profileImage: null`
  - 마이페이지 mock 응답 `profileImage: null`
- 마이페이지 fallback 아바타 텍스트 색상 조정 (검은색)

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 🧪 검증 내용

- `npm run lint` 통과
- `npm run test -- src/pages/lobby/LobbyPage.test.tsx src/pages/waiting-room/WaitingRoomPage.test.tsx` 통과

---

## 📸 스크린샷 (선택)

- 헤더/마이페이지/대기방/접속자 목록 아바타 스타일 통일 화면
- 마이페이지 프로필 이미지 미노출(fallback 아바타) 화면
