### PR TITLE
fix: non-mock 건설 확인 시 BUILD_PROPERTY 액션 전송 누락 수정

### DIFF
--- a/src/components/board/gameBoardActionHandlers.test.ts
+++ b/src/components/board/gameBoardActionHandlers.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createGameBoardActionHandlers } from './gameBoardActionHandlers'
+import { emitGameAction } from '../../services/socket/game.handler'
+import type { BuildModalState } from './gameBoard.types'
+
+vi.mock('../../services/socket/game.handler', () => ({
+  emitGameAction: vi.fn(),
+}))
+
+vi.mock('../../services/game/game.api', () => ({
+  gameApi: {
+    sellTile: vi.fn(),
+  },
+}))
+
+type SetState<T> = (value: T | ((prev: T) => T)) => void
+
+const createDefaultHandlers = (overrides?: {
+  roomId?: string | null
+  setStatus?: SetState<string>
+  setBuildModal?: SetState<BuildModalState>
+}) => {
+  const setStatus = overrides?.setStatus ?? vi.fn()
+  const setBuildModal = overrides?.setBuildModal ?? vi.fn()
+  const roomId =
+    overrides && 'roomId' in overrides ? overrides.roomId : 'room-1'
+
+  return createGameBoardActionHandlers({
+    roomId,
+    useGameSocketMock: false,
+    roomIdRequiredMessage: 'room id is required',
+    setStatus: setStatus as never,
+    setBuyModal: vi.fn() as never,
+    setBuildModal: setBuildModal as never,
+    setTollModal: vi.fn() as never,
+    curPlayerRef: { current: 0 },
+    tileOwnersRef: { current: {} },
+    getPlayerIdByIndex: () => 0,
+    getPlayerColorByIndex: () => '#000',
+    getPlayerIndexById: () => 0,
+    getPurchaseCost: () => 0,
+    getUpgradeCost: () => 0,
+    calcToll: () => 0,
+    getTilePrice: () => 0,
+    updateTileOwners: () => undefined,
+    applyMoney: () => false,
+    advanceTurn: () => undefined,
+  })
+}
+
+describe('createGameBoardActionHandlers - non mock build action', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('BUILD_PROPERTY 액션을 전송하고 모달을 닫는다', async () => {
+    const setBuildModal = vi.fn<SetState<BuildModalState>>()
+    const onDoneCallback = vi.fn()
+    const handlers = createDefaultHandlers({ setBuildModal })
+
+    await handlers.handleBuildConfirm({
+      open: true,
+      tileId: 7,
+      onDoneCallback,
+    })
+
+    expect(emitGameAction).toHaveBeenCalledWith({
+      type: 'BUILD_PROPERTY',
+      roomId: 'room-1',
+      payload: { tileId: 7 },
+    })
+    expect(setBuildModal).toHaveBeenCalledWith({ open: false, tileId: null })
+    expect(onDoneCallback).toHaveBeenCalledTimes(1)
+  })
+
+  it('roomId가 없으면 상태만 갱신하고 종료한다', async () => {
+    const setStatus = vi.fn<SetState<string>>()
+    const setBuildModal = vi.fn<SetState<BuildModalState>>()
+    const onDoneCallback = vi.fn()
+    const handlers = createDefaultHandlers({
+      roomId: null,
+      setStatus,
+      setBuildModal,
+    })
+
+    await handlers.handleBuildConfirm({
+      open: true,
+      tileId: 2,
+      onDoneCallback,
+    })
+
+    expect(emitGameAction).not.toHaveBeenCalled()
+    expect(setStatus).toHaveBeenCalledWith('room id is required')
+    expect(setBuildModal).not.toHaveBeenCalled()
+    expect(onDoneCallback).not.toHaveBeenCalled()
+  })
+
+  it('tileId가 없으면 아무 동작도 하지 않는다', async () => {
+    const setStatus = vi.fn<SetState<string>>()
+    const setBuildModal = vi.fn<SetState<BuildModalState>>()
+    const handlers = createDefaultHandlers({ setStatus, setBuildModal })
+
+    await handlers.handleBuildConfirm({
+      open: true,
+      tileId: null,
+    })
+
+    expect(emitGameAction).not.toHaveBeenCalled()
+    expect(setStatus).not.toHaveBeenCalled()
+    expect(setBuildModal).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/board/gameBoardActionHandlers.test.ts
+++ b/src/components/board/gameBoardActionHandlers.test.ts
@@ -22,8 +22,8 @@ const createDefaultHandlers = (overrides?: {
 }) => {
   const setStatus = overrides?.setStatus ?? vi.fn()
   const setBuildModal = overrides?.setBuildModal ?? vi.fn()
-  const roomId =
-    overrides && 'roomId' in overrides ? overrides.roomId : 'room-1'
+  const roomId: string | null =
+    overrides?.roomId === undefined ? 'room-1' : overrides.roomId
 
   return createGameBoardActionHandlers({
     roomId,

--- a/src/components/board/gameBoardActionHandlers.ts
+++ b/src/components/board/gameBoardActionHandlers.ts
@@ -243,6 +243,13 @@ export function createGameBoardActionHandlers(
     if (tileId === null) return
 
     if (!useGameSocketMock) {
+      const emitted = emitSocketAction('BUILD_PROPERTY', {
+        tileId,
+      })
+      if (!emitted) {
+        return
+      }
+
       setBuildModal({ open: false, tileId: null })
       onDoneCallback?.()
       return


### PR DESCRIPTION
## 📌 관련 이슈

> closes #313 

---

## 📝 작업 내용

- non-mock 모드에서 건설 확인(`handleBuildConfirm`) 시 서버 액션 전송이 누락되어 모달만 닫히던 문제를 수정했습니다.
- `BUILD_PROPERTY` 액션을 `emitGameAction` 경로로 전송하도록 반영했습니다.
- roomId가 없거나 tileId가 null인 경우에는 기존 방어 동작(조기 종료)을 유지했습니다.
- 회귀 방지를 위해 `gameBoardActionHandlers` 단위 테스트를 추가했습니다.
  - BUILD_PROPERTY 전송 + 모달 닫힘 + 콜백 호출
  - roomId 없음 시 액션 미전송 + 상태 메시지 처리
  - tileId null 시 no-op

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

- UI 변경 없음
