### PR TITLE
fix: 상대 인수 하기에서 보유금 보다 많으면 보유금 부족 팝업 창 띄우기 + svg 수정

### DIFF
--- a/src/components/board/BoardTile.tsx
+++ b/src/components/board/BoardTile.tsx
@@ -273,9 +273,12 @@ const BoardTile: React.FC<BoardTileProps> = ({
                   fontWeight: 800,
                   color: '#374151',
                   textAlign: 'center',
-                  lineHeight: 1.2,
-                  marginTop: 6,
-                  marginBottom: 2,
+                  lineHeight: '14px',
+                  height: 14,
+                  marginTop: 2,
+                  marginBottom: 0,
+                  display: 'flex',
+                  alignItems: 'center',
                 }}
               >
                 {tile.name}
@@ -295,7 +298,16 @@ const BoardTile: React.FC<BoardTileProps> = ({
 
             {isProperty && (
               <>
-                <div style={{ flex: 1, display: 'flex', alignItems: 'center' }}>
+                <div
+                  style={{
+                    flex: 1,
+                    minHeight: 34,
+                    width: '100%',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                >
                   {hasBuilding && (
                     <BuildingBadge
                       level={buildingLevel}
@@ -389,11 +401,27 @@ const BoardTile: React.FC<BoardTileProps> = ({
           >
             {isProperty && (
               <>
-                <span style={{ fontSize: 9, fontWeight: 800, marginBottom: 2 }}>
+                <span
+                  style={{
+                    fontSize: 9,
+                    fontWeight: 800,
+                    lineHeight: '14px',
+                    height: 14,
+                    marginBottom: 0,
+                    display: 'flex',
+                    alignItems: 'center',
+                  }}
+                >
                   {tile.name}
                 </span>
                 <div
-                  style={{ height: 30, display: 'flex', alignItems: 'center' }}
+                  style={{
+                    height: 30,
+                    width: '100%',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
                 >
                   {hasBuilding && (
                     <BuildingBadge

--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -1153,11 +1153,42 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
 
     function handleCityAcquisitionConfirm() {
       if (!useLocalPromptFallback) {
+        const activePlayerIdx = curPlayerRef.current
+        const activePlayerMoney =
+          playersRef.current[activePlayerIdx]?.money ?? 0
+        const requiredAcquisitionCost =
+          promptAcquisitionCost ??
+          (promptTileId != null ? (TILES[promptTileId]?.price ?? 0) : 0)
+
+        if (activePlayerMoney < requiredAcquisitionCost) {
+          setInsufficientFundsModal({
+            open: true,
+            buildingLevel: promptCurrentLevel,
+            promptChoiceValue: promptAcquisitionCancelChoiceValue,
+          })
+          return
+        }
+
         submitPromptChoice(promptAcquisitionConfirmChoiceValue)
         return
       }
 
-      const { tileId, acquisitionCost, onDoneCallback } = cityAcquisitionModal
+      const { tileId, acquisitionCost, currentLevel, onDoneCallback } =
+        cityAcquisitionModal
+      const activePlayerIdx = curPlayerRef.current
+      const activePlayerMoney = playersRef.current[activePlayerIdx]?.money ?? 0
+
+      if (activePlayerMoney < acquisitionCost) {
+        setCityAcquisitionModal(INITIAL_CITY_ACQUISITION_MODAL_STATE)
+        setInsufficientFundsModal({
+          open: true,
+          buildingLevel: currentLevel,
+          onDoneCallback,
+          promptChoiceValue: null,
+        })
+        return
+      }
+
       setCityAcquisitionModal(INITIAL_CITY_ACQUISITION_MODAL_STATE)
 
       if (tileId === null) {
@@ -1171,7 +1202,6 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
         return
       }
 
-      const activePlayerIdx = curPlayerRef.current
       const activePlayerId = getPlayerIdByIndex(activePlayerIdx)
       const activePlayerColor = getPlayerColorByIndex(activePlayerIdx)
       const ownerPlayerIdx = getPlayerIndexById(owner.ownerId)
@@ -1438,7 +1468,8 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
     const acquisitionModalOpenRaw = useLocalPromptFallback
       ? cityAcquisitionModal.open
       : isAcquisitionPromptOpen
-    const acquisitionModalOpen = acquisitionModalOpenRaw && !tollModalOpen
+    const acquisitionModalOpen =
+      acquisitionModalOpenRaw && !tollModalOpen && !insufficientFundsModal.open
     const acquisitionOwnerName = useLocalPromptFallback
       ? cityAcquisitionModal.ownerName
       : promptOwnerName


### PR DESCRIPTION
## 📌 관련 이슈

> closes #341

---

## 📝 작업 내용

> 상대 인수 하기에서 보유금 보다 많으면 보유금 부족 팝업 창 띄우기 + svg 수정 완료

---

## ✅ 체크리스트

- [ ] 로컬에서 정상 동작 확인
- [ ] 불필요한 console.log 제거
- [ ] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

> UI 변경이 있을 경우 첨부해주세요.
