### PR TITLE
refactor: 홈/채팅/접속자 목록 UI 디테일 일관성 개선

### DIFF
--- a/src/features/presence/components/DirectMessagePanel.tsx
+++ b/src/features/presence/components/DirectMessagePanel.tsx
@@ -78,7 +78,7 @@ export function DirectMessagePanel({
 
       <div
         ref={messageListRef}
-        className="h-[320px] overflow-y-auto bg-ui-surface px-4 py-3"
+        className="ui-scrollbar h-[320px] overflow-y-auto bg-ui-surface px-4 py-3"
       >
         {sortedMessages.length === 0 ? (
           <p className="flex h-full items-center justify-center text-sm font-medium text-ui-text-subtle">

--- a/src/features/presence/components/DirectMessagePanel.tsx
+++ b/src/features/presence/components/DirectMessagePanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { SendHorizontal, X } from 'lucide-react'
 import { Avatar } from '../../../components/avatar/Avatar'
 import { cn } from '../../../lib/utils'
@@ -31,12 +31,23 @@ export function DirectMessagePanel({
   onSendMessage,
 }: DirectMessagePanelProps) {
   const [inputMessage, setInputMessage] = useState('')
+  const messageListRef = useRef<HTMLDivElement | null>(null)
 
   // 메시지 목록을 전송 시각 기준으로 오름차순 정렬
   const sortedMessages = useMemo(() => {
     return [...messages].sort((firstMessage, secondMessage) => {
       return firstMessage.sentAt.localeCompare(secondMessage.sentAt)
     })
+  }, [messages])
+
+  // 새 DM 메시지가 추가되면 스크롤을 최신 메시지로 이동
+  useEffect(() => {
+    const messageListElement = messageListRef.current
+    if (!messageListElement) {
+      return
+    }
+
+    messageListElement.scrollTop = messageListElement.scrollHeight
   }, [messages])
 
   const canSend = inputMessage.trim().length > 0
@@ -65,7 +76,10 @@ export function DirectMessagePanel({
         </button>
       </header>
 
-      <div className="h-[320px] overflow-y-auto bg-ui-surface px-4 py-3">
+      <div
+        ref={messageListRef}
+        className="h-[320px] overflow-y-auto bg-ui-surface px-4 py-3"
+      >
         {sortedMessages.length === 0 ? (
           <p className="flex h-full items-center justify-center text-sm font-medium text-ui-text-subtle">
             메시지를 보내 대화를 시작하세요

--- a/src/features/presence/components/UserListPanel.tsx
+++ b/src/features/presence/components/UserListPanel.tsx
@@ -115,7 +115,7 @@ export function UserListPanel({
             </button>
           </div>
 
-          <div className="flex-1 overflow-y-auto">
+          <div className="ui-scrollbar flex-1 overflow-y-auto">
             {isLoading &&
               Array.from({ length: 4 }).map((_, index) => (
                 <div
@@ -154,7 +154,7 @@ export function UserListPanel({
       ) : (
         <div
           className={cn(
-            'flex min-h-[120px] items-center gap-2 overflow-x-auto p-3 xl:flex-col xl:items-center xl:justify-start xl:overflow-visible',
+            'ui-scrollbar flex min-h-[120px] items-center gap-2 overflow-x-auto p-3 xl:flex-col xl:items-center xl:justify-start xl:overflow-visible',
             panelHeightClass
           )}
         >

--- a/src/features/presence/components/UserListPanel.tsx
+++ b/src/features/presence/components/UserListPanel.tsx
@@ -183,12 +183,12 @@ export function UserListPanel({
                   />
                   <span
                     className={cn(
-                      'absolute -bottom-0.5 -right-0.5 size-2 rounded-full border-2 border-white',
+                      'absolute -bottom-0.5 -right-0.5 size-2.5 rounded-full border-2 border-white',
                       ONLINE_USER_STATUS_DOT_CLASS_MAP[user.status]
                     )}
                   />
                   {(unreadDirectMessageCountByUserId[user.id] ?? 0) > 0 ? (
-                    <span className="absolute -left-1 -top-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full border-2 border-white bg-ui-danger px-1 text-[10px] font-bold leading-none text-white">
+                    <span className="absolute -left-1 -top-1 inline-flex h-4 min-w-4 select-none items-center justify-center rounded-full border border-white bg-ui-danger px-1 text-[9px] font-semibold leading-none tracking-tight text-white">
                       {formatUnreadBadgeCount(
                         unreadDirectMessageCountByUserId[user.id] ?? 0
                       )}

--- a/src/features/presence/components/UserRow.tsx
+++ b/src/features/presence/components/UserRow.tsx
@@ -45,7 +45,7 @@ export function UserRow({
           )}
         />
         {unreadDirectMessageCount > 0 ? (
-          <span className="absolute -left-1 -top-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full border-2 border-white bg-ui-danger px-1 text-[10px] font-bold leading-none text-white">
+          <span className="absolute -left-1 -top-1 inline-flex h-4 min-w-4 select-none items-center justify-center rounded-full border border-white bg-ui-danger px-1 text-[9px] font-semibold leading-none tracking-tight text-white">
             {formatUnreadBadgeCount(unreadDirectMessageCount)}
           </span>
         ) : null}

--- a/src/features/room-chat/RoomChat.tsx
+++ b/src/features/room-chat/RoomChat.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { MessageSquare } from 'lucide-react'
 import type { ChatMessage } from '../../types/domain'
 import { cn } from '../../lib/utils'
@@ -25,7 +25,18 @@ export default function RoomChat({
   inputPlaceholder = '메시지...',
 }: RoomChatProps) {
   const [input, setInput] = useState('')
+  const messagesContainerRef = useRef<HTMLDivElement | null>(null)
   const canSend = input.trim().length > 0
+
+  // 새 메시지가 추가되면 스크롤을 최신 메시지 위치로 이동
+  useEffect(() => {
+    const containerElement = messagesContainerRef.current
+    if (!containerElement) {
+      return
+    }
+
+    containerElement.scrollTop = containerElement.scrollHeight
+  }, [messages])
 
   // 채팅 입력 submit 처리
   function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
@@ -59,7 +70,10 @@ export default function RoomChat({
           </div>
         </header>
 
-        <div className="min-h-0 flex-1 space-y-3 overflow-y-auto bg-ui-surface px-3 py-3">
+        <div
+          ref={messagesContainerRef}
+          className="min-h-0 flex-1 space-y-3 overflow-y-auto bg-ui-surface px-3 py-3"
+        >
           {messages.map((message) => {
             const isMine = message.sender_id === currentUserId
 

--- a/src/features/room-chat/RoomChat.tsx
+++ b/src/features/room-chat/RoomChat.tsx
@@ -42,15 +42,15 @@ export default function RoomChat({
   }
 
   return (
-    <div className={cn('flex h-full w-full flex-col gap-3', className)}>
+    <div className={cn('flex h-full min-h-0 w-full flex-col gap-3', className)}>
       {notice ? (
-        <div className="flex items-center justify-start rounded-xl border border-ui-border bg-ui-brand-soft px-3 py-2">
+        <div className="shrink-0 rounded-xl border border-ui-border bg-ui-brand-soft px-3 py-2">
           <span className="text-xs font-semibold text-ui-brand">{notice}</span>
         </div>
       ) : null}
 
-      <section className="flex flex-1 flex-col overflow-hidden rounded-2xl border border-ui-border bg-ui-surface shadow-sm">
-        <header className="flex items-center justify-between border-b border-ui-border bg-ui-surface px-4 py-3">
+      <section className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-ui-border bg-ui-surface shadow-sm">
+        <header className="shrink-0 border-b border-ui-border bg-ui-surface px-4 py-3">
           <div className="flex items-center gap-2">
             <MessageSquare className="size-4 text-ui-brand" />
             <span className="text-base font-semibold text-ui-text-strong">
@@ -59,7 +59,7 @@ export default function RoomChat({
           </div>
         </header>
 
-        <div className="flex-1 space-y-3 overflow-y-auto bg-ui-surface px-3 py-3">
+        <div className="min-h-0 flex-1 space-y-3 overflow-y-auto bg-ui-surface px-3 py-3">
           {messages.map((message) => {
             const isMine = message.sender_id === currentUserId
 
@@ -94,9 +94,9 @@ export default function RoomChat({
 
         <form
           onSubmit={handleSubmit}
-          className="flex gap-2 border-t border-ui-border bg-ui-surface p-3"
+          className="shrink-0 flex items-center gap-2 border-t border-ui-border bg-ui-surface p-3"
         >
-          <div className="flex h-10 flex-1 items-center rounded-xl border border-ui-border bg-ui-surface-muted px-3 focus-within:border-ui-brand focus-within:ring-2 focus-within:ring-ui-brand/20">
+          <div className="flex h-10 w-full items-center rounded-xl border border-ui-border bg-ui-surface-muted px-3 focus-within:border-ui-brand focus-within:ring-2 focus-within:ring-ui-brand/20">
             <input
               type="text"
               value={input}
@@ -110,7 +110,7 @@ export default function RoomChat({
             type="submit"
             disabled={!canSend}
             className={cn(
-              'flex h-10 w-10 items-center justify-center rounded-xl text-white transition-colors',
+              'flex h-10 w-10 shrink-0 items-center justify-center rounded-xl text-white transition-colors',
               canSend
                 ? 'bg-ui-brand hover:bg-ui-brand-strong'
                 : 'bg-ui-disabled-bg text-ui-disabled-text'

--- a/src/features/room-chat/RoomChat.tsx
+++ b/src/features/room-chat/RoomChat.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { MessageSquare } from 'lucide-react'
 import type { ChatMessage } from '../../types/domain'
 import { cn } from '../../lib/utils'
 
@@ -24,6 +25,7 @@ export default function RoomChat({
   inputPlaceholder = '메시지...',
 }: RoomChatProps) {
   const [input, setInput] = useState('')
+  const canSend = input.trim().length > 0
 
   // 채팅 입력 submit 처리
   function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
@@ -40,26 +42,24 @@ export default function RoomChat({
   }
 
   return (
-    <div className={cn('flex h-full w-[320px] flex-col gap-4', className)}>
+    <div className={cn('flex h-full w-full flex-col gap-3', className)}>
       {notice ? (
-        <div className="flex items-center justify-start rounded-lg border border-white/10 bg-[#314158]/90 p-3 shadow-md">
-          <span className="text-xs leading-none font-bold text-white">
-            {notice}
-          </span>
+        <div className="flex items-center justify-start rounded-xl border border-ui-border bg-ui-brand-soft px-3 py-2">
+          <span className="text-xs font-semibold text-ui-brand">{notice}</span>
         </div>
       ) : null}
 
-      <section className="flex flex-1 flex-col overflow-hidden rounded-2xl border border-white/50 bg-white/90 shadow-xl">
-        <header className="flex items-center justify-between border-b border-[#0F172B] bg-[#F8FAFC] p-3">
+      <section className="flex flex-1 flex-col overflow-hidden rounded-2xl border border-ui-border bg-ui-surface shadow-sm">
+        <header className="flex items-center justify-between border-b border-ui-border bg-ui-surface px-4 py-3">
           <div className="flex items-center gap-2">
-            <span className="text-sm text-[#90A1B9]">💬</span>
-            <span className="text-xs font-black tracking-widest text-[#45556C]">
+            <MessageSquare className="size-4 text-ui-brand" />
+            <span className="text-base font-semibold text-ui-text-strong">
               {title}
             </span>
           </div>
         </header>
 
-        <div className="flex-1 space-y-3 overflow-y-auto bg-[#F8FAFC]/30 p-3">
+        <div className="flex-1 space-y-3 overflow-y-auto bg-ui-surface px-3 py-3">
           {messages.map((message) => {
             const isMine = message.sender_id === currentUserId
 
@@ -72,17 +72,17 @@ export default function RoomChat({
                 )}
               >
                 <div className="mb-0.5 px-0.5">
-                  <span className="text-[9px] font-bold text-[#90A1B9]">
+                  <span className="text-[11px] font-medium text-ui-text-subtle">
                     {message.sender_nickname}
                   </span>
                 </div>
 
                 <div
                   className={cn(
-                    'max-w-[85%] px-3 py-2 text-xs leading-snug font-medium shadow-sm',
+                    'max-w-[85%] px-3 py-2 text-sm leading-snug font-medium shadow-sm',
                     isMine
-                      ? 'rounded-[16px_0_16px_16px] bg-[#2B7FFF] text-white'
-                      : 'rounded-[0_16px_16px_16px] border border-[#E2E8F0] bg-white text-[#314158]'
+                      ? 'rounded-[16px_0_16px_16px] bg-ui-brand text-white'
+                      : 'rounded-[0_16px_16px_16px] border border-ui-border bg-ui-surface-soft text-ui-text-primary'
                   )}
                 >
                   {message.content}
@@ -94,21 +94,27 @@ export default function RoomChat({
 
         <form
           onSubmit={handleSubmit}
-          className="flex gap-2 border-t border-[#0F172B] bg-white p-3"
+          className="flex gap-2 border-t border-ui-border bg-ui-surface p-3"
         >
-          <div className="ring-[#2B7FFF]/30 flex flex-1 items-center rounded-lg bg-[#F1F5F9] px-3 py-1.5 focus-within:ring-1">
+          <div className="flex h-10 flex-1 items-center rounded-xl border border-ui-border bg-ui-surface-muted px-3 focus-within:border-ui-brand focus-within:ring-2 focus-within:ring-ui-brand/20">
             <input
               type="text"
               value={input}
               onChange={(event) => setInput(event.target.value)}
               placeholder={inputPlaceholder}
-              className="w-full bg-transparent text-xs font-medium text-[#314158] placeholder:text-[#90A1B9] outline-none"
+              className="w-full bg-transparent text-sm font-medium text-ui-text-primary placeholder:text-ui-text-subtle outline-none"
             />
           </div>
 
           <button
             type="submit"
-            className="flex h-8 w-8 items-center justify-center rounded-lg bg-[#2B7FFF] text-white shadow-md transition-transform hover:scale-105 active:scale-95"
+            disabled={!canSend}
+            className={cn(
+              'flex h-10 w-10 items-center justify-center rounded-xl text-white transition-colors',
+              canSend
+                ? 'bg-ui-brand hover:bg-ui-brand-strong'
+                : 'bg-ui-disabled-bg text-ui-disabled-text'
+            )}
           >
             <span className="text-sm">➤</span>
           </button>

--- a/src/features/room-chat/RoomChat.tsx
+++ b/src/features/room-chat/RoomChat.tsx
@@ -72,7 +72,7 @@ export default function RoomChat({
 
         <div
           ref={messagesContainerRef}
-          className="min-h-0 flex-1 space-y-3 overflow-y-auto bg-ui-surface px-3 py-3"
+          className="ui-scrollbar min-h-0 flex-1 space-y-3 overflow-y-auto bg-ui-surface px-3 py-3"
         >
           {messages.map((message) => {
             const isMine = message.sender_id === currentUserId

--- a/src/index.css
+++ b/src/index.css
@@ -39,4 +39,12 @@
   #root {
     @apply min-h-screen;
   }
+
+  button:enabled {
+    @apply cursor-pointer;
+  }
+
+  button:disabled {
+    @apply cursor-not-allowed;
+  }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -48,3 +48,31 @@
     @apply cursor-not-allowed;
   }
 }
+
+@layer utilities {
+  .ui-scrollbar {
+    scrollbar-width: thin;
+    scrollbar-color: var(--color-ui-border) transparent;
+  }
+
+  .ui-scrollbar::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+
+  .ui-scrollbar::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  .ui-scrollbar::-webkit-scrollbar-thumb {
+    border: 2px solid transparent;
+    border-radius: 9999px;
+    background: var(--color-ui-border);
+    background-clip: padding-box;
+  }
+
+  .ui-scrollbar:hover::-webkit-scrollbar-thumb {
+    background: var(--color-ui-text-subtle);
+    background-clip: padding-box;
+  }
+}

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -277,7 +277,7 @@ const GamePage: React.FC = () => {
       </div>
 
       <div className="mx-auto flex h-full w-full items-center justify-between gap-8 pb-12 pt-4">
-        <div className="flex h-[80%] w-[320px] shrink-0 flex-col">
+        <div className="flex h-[80%] min-h-0 w-[320px] shrink-0 flex-col">
           <RoomChat
             title={GAME_CHAT_TITLE}
             messages={messages}

--- a/src/pages/lobby/CreateRoomModal.tsx
+++ b/src/pages/lobby/CreateRoomModal.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { Lock, X } from 'lucide-react'
+import { Plus, Lock, X } from 'lucide-react'
 import {
   ROOM_PASSWORD_LENGTH,
   ROOM_PASSWORD_PATTERN,
@@ -84,7 +84,7 @@ export function CreateRoomModal({
         role="dialog"
         aria-modal="true"
         aria-label="방 만들기"
-        className="relative z-10 w-full max-w-[450px] overflow-hidden rounded-[32px] border border-ui-border bg-ui-surface shadow-[0_24px_60px_rgba(15,23,42,0.2)]"
+        className="relative z-10 w-full max-w-[430px] rounded-[32px] border border-ui-border bg-ui-surface px-7 pb-7 pt-8 shadow-[0_24px_60px_rgba(15,23,42,0.2)]"
       >
         <button
           type="button"
@@ -92,24 +92,28 @@ export function CreateRoomModal({
           onClick={handleClose}
           disabled={!canClose}
           className={cn(
-            'absolute right-5 top-5 inline-flex size-9 items-center justify-center rounded-full text-white/80 transition-colors',
-            canClose ? 'hover:bg-white/15 hover:text-white' : 'opacity-60'
+            'absolute right-5 top-5 inline-flex size-9 items-center justify-center rounded-full border border-ui-border bg-white text-ui-text-muted transition-colors',
+            canClose
+              ? 'hover:bg-ui-surface-soft hover:text-ui-text-strong'
+              : 'cursor-not-allowed opacity-60'
           )}
         >
           <X className="size-5" />
         </button>
 
-        <header className="bg-[linear-gradient(104deg,#3f8df7_0%,#334ce9_52%,#5633ea_100%)] px-7 pb-8 pt-7 text-center">
-          <h2 className="text-[2.2rem] font-extrabold tracking-tight text-white">
-            방 만들기
-          </h2>
-          <p className="mt-1 text-base font-semibold text-white/75">
-            친구들을 초대하고 게임을 즐기세요!
-          </p>
-        </header>
+        <div className="mx-auto mb-4 flex size-[62px] items-center justify-center rounded-full bg-ui-surface-soft text-ui-text-subtle">
+          <Plus className="size-8" />
+        </div>
+
+        <h2 className="text-center text-[2.1rem] font-extrabold tracking-tight text-ui-text-strong">
+          방 만들기
+        </h2>
+        <p className="mt-1 text-center text-lg font-semibold text-ui-text-muted">
+          친구들을 초대하고 게임을 즐기세요!
+        </p>
 
         <form
-          className="px-7 pb-8 pt-7"
+          className="mt-6"
           onSubmit={(event) => {
             event.preventDefault()
 
@@ -203,10 +207,10 @@ export function CreateRoomModal({
             type="submit"
             disabled={isSubmitDisabled}
             className={cn(
-              'mt-6 h-14 w-full rounded-2xl text-[1.35rem] font-extrabold transition-colors',
+              'mt-6 h-12 w-full rounded-2xl text-lg font-bold transition-colors',
               isSubmitDisabled
                 ? 'cursor-not-allowed bg-ui-disabled-bg text-ui-disabled-text'
-                : 'bg-ui-brand text-white shadow-[0_10px_20px_rgba(37,99,235,0.25)] hover:bg-ui-brand-strong'
+                : 'bg-ui-brand text-white hover:bg-ui-brand-strong'
             )}
           >
             {isSubmitting ? '생성 중...' : '방 만들기 완료'}

--- a/src/pages/lobby/PrivateRoomJoinModal.tsx
+++ b/src/pages/lobby/PrivateRoomJoinModal.tsx
@@ -113,7 +113,6 @@ export function PrivateRoomJoinModal({
             maxLength={ROOM_PASSWORD_LENGTH}
             value={password}
             onFocus={() => setIsPasswordInputFocused(true)}
-            onBlur={() => setIsPasswordInputFocused(false)}
             onChange={(event) => {
               const nextValue = event.target.value
                 .replace(/\D/g, '')

--- a/src/pages/waiting-room/components/WaitingRoomActionPanel.tsx
+++ b/src/pages/waiting-room/components/WaitingRoomActionPanel.tsx
@@ -28,7 +28,7 @@ export function WaitingRoomActionPanel({
   const readyButtonLabel = isReady ? '준비 취소' : '준비하기'
 
   return (
-    <div className="mt-4">
+    <div className="mt-4 shrink-0">
       {isHost ? (
         <button
           type="button"

--- a/src/pages/waiting-room/components/WaitingRoomChatBox.tsx
+++ b/src/pages/waiting-room/components/WaitingRoomChatBox.tsx
@@ -30,7 +30,7 @@ export function WaitingRoomChatBox({
 
   return (
     <RoomChat
-      className="flex-1 w-full"
+      className="min-h-0 flex-1 w-full"
       title="실시간 채팅"
       currentUserId={currentUserId}
       inputPlaceholder="메시지 입력..."

--- a/src/pages/waiting-room/components/WaitingRoomSidePanel.tsx
+++ b/src/pages/waiting-room/components/WaitingRoomSidePanel.tsx
@@ -32,7 +32,7 @@ export function WaitingRoomSidePanel({
   onSendMessage,
 }: WaitingRoomSidePanelProps) {
   return (
-    <aside className="flex h-full min-h-[320px] flex-col rounded-3xl border border-ui-border bg-ui-surface p-3">
+    <aside className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden rounded-3xl border border-ui-border bg-ui-surface p-3">
       <WaitingRoomChatBox
         messages={messages}
         currentUserId={currentUserId}

--- a/src/pages/waiting-room/components/WaitingSeatCard.tsx
+++ b/src/pages/waiting-room/components/WaitingSeatCard.tsx
@@ -26,29 +26,31 @@ export function WaitingSeatCard({ seat }: WaitingSeatCardProps) {
 
   return (
     <article className="relative flex h-full min-h-[260px] flex-col rounded-[34px] border border-ui-border bg-ui-surface px-7 py-7 shadow-[0_2px_10px_rgba(15,23,42,0.06)]">
-      <div className="relative mx-auto mb-5">
-        <Avatar
-          size="xl"
-          displayName={seat.nickname}
-          backgroundColor={seat.avatarColor}
-          className="text-white shadow-[inset_0_-5px_0_rgba(0,0,0,0.2)]"
-        />
+      <div className="flex flex-1 flex-col items-center justify-center">
+        <div className="relative mb-5">
+          <Avatar
+            size="xl"
+            displayName={seat.nickname}
+            backgroundColor={seat.avatarColor}
+            className="text-white shadow-[inset_0_-5px_0_rgba(0,0,0,0.2)]"
+          />
 
-        {seat.isHost ? (
-          <span className="absolute -left-2 top-2 inline-flex size-12 items-center justify-center rounded-full border-[3px] border-white bg-[#f7c600] text-white shadow-md">
-            <Crown className="size-6 fill-white" />
-          </span>
-        ) : null}
+          {seat.isHost ? (
+            <span className="absolute -left-2 top-2 inline-flex size-12 items-center justify-center rounded-full border-[3px] border-white bg-[#f7c600] text-white shadow-md">
+              <Crown className="size-6 fill-white" />
+            </span>
+          ) : null}
+        </div>
+
+        <p className="truncate text-center text-[2.25rem] font-extrabold tracking-tight text-ui-text-strong">
+          {seat.nickname}
+          {seat.isMe ? (
+            <span className="ml-2 rounded-lg bg-ui-surface-soft px-2 py-0.5 text-xl font-semibold text-ui-text-subtle">
+              나
+            </span>
+          ) : null}
+        </p>
       </div>
-
-      <p className="truncate text-center text-[3rem] font-extrabold tracking-tight text-ui-text-strong">
-        {seat.nickname}
-        {seat.isMe ? (
-          <span className="ml-2 rounded-lg bg-ui-surface-soft px-2 py-0.5 text-xl font-semibold text-ui-text-subtle">
-            나
-          </span>
-        ) : null}
-      </p>
 
       <div className="mt-auto flex justify-end">
         <span


### PR DESCRIPTION
## 📌 관련 이슈

> closes #335

---

## 📝 작업 내용

> 홈/채팅/접속자 목록/대기방 UI의 자잘한 불일치와 레이아웃 흔들림을 정리해 전체 사용감을 안정적으로 맞췄습니다.

- 공통 `RoomChat` 스타일을 프로젝트 UI 토큰 기준으로 정리
- 신규 메시지 수신 시 채팅/DM 패널이 자동으로 최신 메시지로 스크롤되도록 개선
- 채팅이 길어져도 패널 높이가 늘어나며 버튼 영역을 밀어내지 않도록 레이아웃 보정
- 접속자 목록과 채팅 영역에 얇은 스크롤바 스타일을 공통 적용
- 접속자 unread 배지 크기/위치를 UI 비율에 맞게 조정
- 대기방 유저 카드의 아바타/닉네임 정렬을 보정
- 전역 버튼 커서 상태(`pointer`, `not-allowed`) 규칙 추가
- 비밀번호 입력 blur 시 helper text 흔들림 제거
- 방 만들기 모달 스타일을 비밀방 입장 모달 톤과 맞춰 일관성 정리

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

<img width="1912" height="1242" alt="스크린샷 2026-03-09 오후 4 14 15" src="https://github.com/user-attachments/assets/ec648470-947a-480b-801f-b3333f94b4f6" />

