### PR TITLE
refactor: useGameState REST bootstrap fallback 제거 및 game:sync knownRevision 적용

### DIFF
--- a/src/hooks/game/useGameState.ts
+++ b/src/hooks/game/useGameState.ts
@@ -1,7 +1,6 @@
 import { useEffect, useRef } from 'react'
 import { IS_SOCKET_MOCK_ENABLED } from '../../config/env'
 import { connectSocketWithAuthIfNeeded, socket } from '../../lib/socket'
-import { gameApi } from '../../services/game/game.api'
 import {
   emitGameSync,
   setupGameHandlers,
@@ -11,7 +10,6 @@ import { useGameStore } from '../../stores/game.store'
 const USE_GAME_SOCKET_MOCK = IS_SOCKET_MOCK_ENABLED
 
 export const useGameState = (roomId: string | null) => {
-  const { setGameState, players } = useGameStore()
   const syncedRoomIdRef = useRef<string | null>(null)
 
   useEffect(() => {
@@ -28,48 +26,26 @@ export const useGameState = (roomId: string | null) => {
       connectSocketWithAuthIfNeeded()
     }
 
-    const syncGameState = async () => {
+    const syncGameState = () => {
       const roomChanged = syncedRoomIdRef.current !== roomId
+      const { players, revision } = useGameStore.getState()
 
       // 같은 방에서 이미 상태를 들고 있으면 초기 동기화를 반복하지 않는다.
       if (!roomChanged && players.length > 0) return
 
-      emitGameSync({ roomId })
-
-      // mock/socket rollout 전까지는 REST snapshot을 bootstrap fallback으로 유지한다.
-      const result = await gameApi.getState(roomId, {
-        reset: USE_GAME_SOCKET_MOCK && roomChanged,
-      })
-      if (!result.ok) return
-
-      const payload = result.data as {
-        players?: unknown[]
-        tiles?: unknown[]
-        messages?: unknown[]
-        current_turn?: string | null
-        currentTurn?: string | null
-        round?: number
-        timeout_sec?: number
-        timeoutSec?: number
-      }
-
-      setGameState({
-        players: (payload.players as never[]) ?? [],
-        tiles: (payload.tiles as never[]) ?? [],
-        messages: (payload.messages as never[]) ?? [],
-        currentTurn: payload.current_turn ?? payload.currentTurn ?? null,
-        round: payload.round ?? 1,
-        turnTimeoutSec: payload.timeout_sec ?? payload.timeoutSec ?? 30,
+      emitGameSync({
+        roomId,
+        knownRevision: roomChanged ? 0 : revision,
       })
       syncedRoomIdRef.current = roomId
     }
 
-    void syncGameState()
+    syncGameState()
 
     return () => {
       teardownHandlers()
     }
-  }, [roomId, setGameState, players.length])
+  }, [roomId])
 
   return {}
 }

--- a/src/mocks/handlers/game.handler.ts
+++ b/src/mocks/handlers/game.handler.ts
@@ -478,7 +478,15 @@ const handleEndTurnAction = (
   ])
 }
 
-export const mockEmitGameSync = ({ roomId, gameId }: MockGameSyncPayload) => {
+export const mockEmitGameSync = ({
+  roomId,
+  gameId,
+  knownRevision,
+}: MockGameSyncPayload) => {
+  if (knownRevision === 0) {
+    resetMockGameState()
+  }
+
   setTimeout(() => {
     emitSnapshotPatch(roomId, gameId)
   }, 0)


### PR DESCRIPTION
## 📌 관련 이슈

> closes #314

---

## 📝 작업 내용

- `useGameState`의 초기 동기화 경로에서 REST bootstrap(`gameApi.getState`) 호출을 제거했습니다.
- 초기/재진입 동기화를 `game:sync` 단일 경로로 정리하고, `knownRevision`을 함께 전송하도록 변경했습니다.
  - 방이 바뀐 경우: `knownRevision = 0`
  - 같은 방 재동기화인 경우: 현재 store `revision` 사용
- `useGameState` effect 재실행 범위를 `roomId` 변경 시점으로 제한해, 패치마다 핸들러가 재등록될 수 있는 리스크를 제거했습니다.
- mock 환경에서 기존 reset 동작이 유지되도록 `mockEmitGameSync`에 `knownRevision === 0` 분기를 추가해 `resetMockGameState()`를 수행하도록 보완했습니다.

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

- UI 변경 없음
