### PR TITLE
docs: 중앙 docs 기준 게임 문서 정합성 갱신

### DIFF
--- a/docs/game-delivery-roadmap.md
+++ b/docs/game-delivery-roadmap.md
@@ -120,201 +120,118 @@
 ### 타입 갭
 
 - `src/types/domain.ts`
-  현재 `Player.id`, `currentTurn` 등이 문자열 중심이고, `BuildingLevel`은 `0..5`만 지원한다.
-  새 명세 기준으로는 숫자 기반 ID, `revision`, `phase`, `playerState`, `BuildingLevel 0..7`, `TileType` 재정의가 필요하다.
-  동시에 `roomId <-> gameId`, `원 <-> 만단위`, `city <-> PROPERTY`를 잇는 compatibility layer도 필요하다.
+  `BuildingLevel 0..7`, `GamePatchEnvelope`, `GameAck`, `GamePromptResponse.choice` 등 핵심 타입은 반영됐다.
+  현재 남은 갭은 식별자/필드 canonical 정렬(`roomId <-> gameId`, prompt/snapshot 필드명)과 money unit 고정이다.
+  `city <-> PROPERTY` 같은 렌더 호환은 mapper/adapter 계층으로 유지한다.
 
 ### 목업 갭
 
 - `src/mocks/handlers/game.handler.ts`
-  현재 mock은 REST 액션과 구 소켓 이벤트를 함께 흉내 낸다.
-  새 명세 기준 검증을 하려면 `game:ack`, `game:patch`, `game:prompt`를 내보내는 형태로 다시 써야 한다.
+  event-socket 기준(`game:ack`, `game:patch`, `game:prompt`)은 반영됐고, 레거시 REST 핸들러는 fallback 검증용으로만 남아 있다.
+  잔여 과제는 중앙 docs 대비 필드 canonical(`gameId`, prompt/snapshot 스키마) 정렬이다.
 
-## 4. 진행도 재평가 (2026-03-05 기준)
+## 4. 진행도 재평가 (2026-03-10 기준)
 
-새 이벤트 명세 **이행 진행도** 기준 현황이다.
+새 이벤트 명세 **이행 진행도** 기준 최신 현황이다.
 
-### FE-B: 골격 완료(약 65%), 명세 불일치 수정 + UI 연결 단계
-
-완료된 축:
-
-- `src/types/domain.ts`: `BuildingLevel 0..7`, `GamePhase`, `PlayerStateType`, `GameSnapshot`, `GamePatchEnvelope`, `GamePatchOperation`, `GameAck`, `GameError`, `GamePrompt`, `GamePromptResponse`, `ServerEvent`, `GameState` 정의 완료
-- `src/stores/game.store.ts`: `replaceFromSnapshot`, `applyPatchEnvelope`(revision guard + set/inc/push/remove), `setPendingAction`, `resolveAck`, `setPrompt`, `clearPrompt`, `enqueueEvents`, `consumeNextEvent`, `setLastError` 구현 완료
-- `src/services/socket/game.handler.ts`: `game:ack`, `game:patch`, `game:prompt`, `game:error` 구독. `emitGameAction`, `emitGameSync`, `emitPromptResponse` emit. 구 이벤트 리스너 제거
-- `src/hooks/game/useGameState.ts`: 진입 시 `game:sync` 우선, REST bootstrap fallback 병행
-- `src/mocks/handlers/game.handler.ts`: `game:ack` + `game:patch(snapshot)` 기반 event-socket mock 추가
-- `src/pages/GamePage.tsx`: store 단일 소스 + `gameViewModel` mapper로 board 데이터 조립 + `prompt` 오버레이 응답, `pendingAction`/`lastAck`/`lastError` UI 연결
-- `src/components/board/gameBoardActionHandlers.ts`: BUY/SELL/END_TURN non-mock 경로를 `emitGameAction`으로 전환
-- `src/components/board/gameBoardActionHandlers.ts`: mock BUY/BUILD 성공 시 턴 고정 버그 수정(자동 턴 전환 보장)
-
-남은 핵심 축 — **명세 불일치 (코드 수정 전 반드시 선행)**:
-
-아래 항목은 `gamesocket.md` / `api.md` 기준과 실제 코드 사이에 불일치가 확인된 항목이다.
-
-| 파일                                                       | 불일치 내용                                                                   | 수정 방향                                                                              |
-| ---------------------------------------------------------- | ----------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| `src/types/domain.ts` `GamePromptResponse`                 | `value: string`                                                               | `choice: string` 으로 변경                                                             |
-| `src/types/domain.ts` `GameAck`                            | `errorCode`, `message` 플랫 구조                                              | `error?: { code: string; message: string }` 중첩 구조로 변경                           |
-| `src/types/domain.ts` `GamePatchEnvelope`                  | `turn`, `gameId` 필드 누락                                                    | `turn?: number`, `gameId?: GameId` 추가                                                |
-| `src/services/socket/game.handler.ts` `emitGameSync`       | `knownRevision` 누락, 스펙 외 `reset` 포함                                    | payload에 `knownRevision: number` 추가                                                 |
-| `src/services/socket/game.handler.ts` `emitPromptResponse` | `value` 필드 사용, `playerId` 포함                                            | `choice` 필드 사용, `playerId` 제거                                                    |
-| `src/mocks/handlers/game.handler.ts`                       | `BUILD_PROPERTY` ActionType은 명세에 없음                                     | 제거. `END_TURN` 핸들러 추가 필요                                                      |
-| `src/mocks/handlers/game.handler.ts`                       | `BuildingLevel` 상한을 5로 제한 (`>= 5` 차단)                                 | 7로 변경                                                                               |
-| `src/mocks/handlers/game.handler.ts` ServerEvent type      | `ROLL_DICE`, `MOVE_PLAYER`, `BUY_PROPERTY`, `SELL_PROPERTY`, `BUILD_PROPERTY` | `DICE_ROLLED`, `PLAYER_MOVED`, `BOUGHT_PROPERTY`, `SOLD_PROPERTY`. `TURNED_ENDED` 추가 |
-| `src/mocks/handlers/game.handler.ts` action payload        | snake_case (`tile_index`, `level`)                                            | camelCase (`tileId`, `buildingLevel`)                                                  |
-
-남은 핵심 축 — UI 연결:
-
-- `GamePage.tsx`의 `store.prompt`/`emitPromptResponse`/`pendingAction`/`lastAck`/`lastError` 연결은 완료
-- `store.prompt.type` → `modals/*` 및 `GameBoard.tsx` 분기 연결 완료 (non-mock 기준 Buy/Build/Toll/Timer 모달)
-- `DiceTimerModal` → `game:prompt.timeoutSec` 연동 완료
-- `gameBoardActionHandlers.ts`: BUILD/sync는 여전히 REST 레거시 경로 유지 → 최종 정리 필요
-
-### FE-C: 골격 완료(약 30%), 버그 수정 + 시각 레이어 수렴 단계
+### FE-B: 계약/상태 골격 완료, 런타임 정합성 마무리 단계
 
 완료된 축:
 
-- 보드 배치, 타일 렌더, 말 렌더, 건물 시각화 기본 구조 존재
-- `GameBoard.tsx`: `BuildingLevel 0..7` 대응 (`LEVEL_LABEL`, `calcToll`, `getUpgradeCost`, `toBoardBuildingLevel`) 완료
-- `gameViewModel.ts`: `mapStorePlayersToBoardPlayers`, `findBoardCurrentPlayerIndex`, `mapStoreTilesToBoardTiles` mapper 구현
+- `src/types/domain.ts`: `BuildingLevel 0..7`, `GamePhase`, `GameSnapshot`, `GamePatchEnvelope`, `GameAck`, `GamePrompt`, `GamePromptResponse` 등 핵심 타입 반영 완료
+- `src/stores/game.store.ts`: snapshot 교체, patch(revision guard), ack/prompt/pendingAction/eventQueue 처리 완료
+- `src/services/socket/game.handler.ts`: `game:ack`/`game:patch`/`game:prompt`/`game:error` 구독 + `emitGameAction`/`emitGameSync`/`emitPromptResponse` 송신 완료
+- `src/hooks/game/useGameState.ts`: `game:sync` 중심 진입 동기화로 정리 (REST bootstrap 경로 제거)
+- `src/mocks/handlers/game.handler.ts`: `game:ack` + `game:patch(snapshot)` 기반 mock 계약 정렬
+- `src/pages/GamePage.tsx`: prompt/ack/error/pendingAction UI 연결 완료
+- `src/components/board/gameBoardActionHandlers.ts`: non-mock 경로에서 BUY/BUILD/SELL/END_TURN를 `emitGameAction`으로 송신
 
-남은 핵심 축 — **버그 (즉시 수정 필요)**:
+남은 핵심 축 — **중앙 docs 대비 런타임 정합성**:
 
-| 파일                                                                        | 버그 내용                                                 | 수정 방향                                                          |
-| --------------------------------------------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------ |
-| `src/components/board/gameBoardStoreBridge.ts:6`                            | `toStoreBuildingLevel` 상한 5로 고정 (`Math.min(..., 5)`) | `Math.min(..., 7)` 로 변경                                         |
-| `src/components/board/gameBoardTransactionUtils.ts` `upgradeBoardTileOwner` | level 상한 5로 고정 (`Math.min(..., 5)`)                  | `Math.min(..., 7)` 로 변경                                         |
-| `src/components/board/gameBoardActionUtils.ts` `getBoardSellFallbackRefund` | loop에서 level 5, 6 케이스 누락                           | level 5(`basePrice * 1.0`), level 6(`basePrice * 2.0`) 케이스 추가 |
+| 영역             | 현재 상태                           | 정리 방향                                                                                            |
+| ---------------- | ----------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| 식별자 canonical | 일부 송신 호출이 `roomId` 중심      | `game:action`/`game:sync`/`game:prompt_response`를 `gameId` canonical로 고정                         |
+| ActionType(건설) | FE는 `BUILD_PROPERTY` 송신          | 중앙 `gamesocket.md`(`ROLL_DICE`,`BUY_PROPERTY`,`SELL_PROPERTY`,`END_TURN`) 기준으로 BE 합의 후 통일 |
+| Prompt 스키마    | FE는 `prompt.id`, `timeoutSec` 사용 | 중앙 문서(`promptId`, `payload.timeoutMs`)와 어댑터 또는 계약 통일                                   |
+| Snapshot 스키마  | FE 타입과 중앙 예시 필드가 다름     | BE 응답 고정 또는 FE 어댑터 계층에서 단일 canonical 스냅샷 확정                                      |
+| 이벤트 표기      | 문서 내 오타 이력 존재              | `TURN_ENDED` 표기로 통일                                                                             |
 
-남은 핵심 축 — 구조:
+### FE-C: 헬퍼 버그 수정 완료, 보드 엔진 제거/연출 분리 단계
 
-- `GameBoard.tsx` 내부에 `rollDice`, `applyMoney`, `advanceTurn`, 통행료 계산, 파산 판정 로직 잔존 → 제거
-- `store.eventQueue` 소비 컴포넌트 없음 (enqueue는 되지만 아무 연출도 없음)
-- `store.playerState`(`island`, `locked`) 기반 섬/잠금 상태 시각화 없음
-- `DiceTimerModal`: `game:prompt.timeoutSec` 연동 완료. 다만 mock 로컬 fallback 타이머 분기는 유지
+완료된 축:
+
+- `gameBoardStoreBridge.ts`, `gameBoardTransactionUtils.ts`, `gameBoardActionUtils.ts`의 `BuildingLevel 0..7` 관련 버그 수정 반영
+
+남은 핵심 축:
+
+- `GameBoard.tsx` 내부 `applyMoney`/`advanceTurn`/파산 판정/로컬 턴 전환 등 로컬 엔진 성격 로직 제거
+- `store.eventQueue` 소비 레이어 구현(이동/연출 분리)
+- `playerState`(`island`, `locked`)와 `stateDuration` 시각화 보강
 
 ## 5. FE-B 우선 작업
 
-### 5-1. 명세 불일치 수정 (선행 필수)
+### 5-1. BE 계약 고정(선행)
 
-아래 항목은 `gamesocket.md` / `api.md` 와 현재 코드 간 직접 불일치다. 이 항목을 먼저 맞춰야 이후 UI 연결 작업이 올바른 계약 위에서 진행된다.
+다음 항목은 FE 단독으로 확정할 수 없으므로 BE와 계약을 먼저 고정한다.
 
-**`src/types/domain.ts`**
+- `gameId` canonical 사용 범위 (`roomId` 임시 허용 여부/종료 시점)
+- ActionType에서 건설 처리 방식 (`BUILD_PROPERTY` 유지 vs `BUY_PROPERTY` 통합)
+- prompt 필드명 (`id`/`promptId`, `timeoutSec`/`timeoutMs`) 및 ack 매칭 규칙
+- snapshot/player/tile 필드 최종 스키마
+- money canonical unit 확정
 
-- `GamePromptResponse`: `value: string` → `choice: string`
-- `GameAck`: `{ errorCode?: string; message?: string }` → `{ error?: { code: string; message: string } }`
-- `GamePatchEnvelope`: `turn?: number`, `gameId?: GameId` 필드 추가
+### 5-2. FE 정리 항목
 
-**`src/services/socket/game.handler.ts`**
+- `emitGameAction`/`emitGameSync`/`emitPromptResponse` 호출부를 `gameId` 기준으로 정리
+- `GameBoard` prompt 소비 경로의 로컬 fallback 분기 축소
+- `src/services/game/game.api.ts`는 레거시 fallback 유틸로만 격리 유지(직접 호출 금지)
 
-- `emitGameSync` payload: `knownRevision: number` 추가. 스펙 외 `reset` 필드 제거
-- `emitPromptResponse`: `value` → `choice`, `playerId` 제거 (`gamesocket.md` `game:prompt_response` 명세 기준)
+### 5-3. mock 검증 흐름 유지
 
-**`src/mocks/handlers/game.handler.ts`**
-
-- `BUILD_PROPERTY` ActionType 제거 (명세에 없음). `END_TURN` 핸들러 추가
-- `BuildingLevel` 상한 5 → 7 (`if (tile.building >= 5)` → `if (tile.building >= 7)`)
-- ServerEvent `type` 명칭 전체 수정: `ROLL_DICE`→`DICE_ROLLED`, `MOVE_PLAYER`→`PLAYER_MOVED`, `BUY_PROPERTY`→`BOUGHT_PROPERTY`, `SELL_PROPERTY`→`SOLD_PROPERTY`. `TURNED_ENDED` 추가
-- action payload 필드명 camelCase로 통일: `tile_index`→`tileId`, `level`→`buildingLevel`
-
-### 5-2. 타입과 store 계약 재정의 (완료)
-
-- `src/types/domain.ts`: 신규 명세 타입 도입 완료
-- `src/stores/game.store.ts`: snapshot/patch/ack/prompt/eventQueue 수용 구조 완료
-- 5-1 명세 불일치 항목만 추가 수정 필요
-
-### 5-3. 소켓 계층 전환 (완료)
-
-- `src/services/socket/game.handler.ts`: 구 이벤트 구독 제거, 새 이벤트 구독 완료
-- `emitGameAction`, `emitGameSync`, `emitPromptResponse` 완료
-- 5-1 명세 불일치 항목(`emitGameSync`, `emitPromptResponse` payload)만 추가 수정 필요
-
-### 5-4. prompt/ack 기반 입력 UX 연결
-
-현재 FE-B의 다음 최우선 작업이다.
-
-- ~~`GamePage.tsx`에서 `store.prompt` 오버레이 열림 조건 연결~~ ✅ 완료
-- ~~`GamePage.tsx`에서 `emitPromptResponse` 사용자 응답 흐름 연결~~ ✅ 완료
-- ~~`game:ack.ok=false` → `store.lastError` → 에러 UI 표시 연결~~ ✅ 완료
-- ~~`store.pendingAction`/`store.lastAck` 버튼 상태 및 상태 배지 연결~~ ✅ 완료
-- ~~`store.prompt.type` → `modals/*`, `GameBoard.tsx` 분기 연결~~ ✅ 완료 (non-mock)
-- ~~`DiceTimerModal` → `game:prompt.timeoutSec` 기반으로 연결~~ ✅ 완료
-- `gameBoardActionHandlers.ts`: BUILD/sync 레거시 호출 제거 및 prompt.type 기반 액션 확정
-
-### 5-5. mock 검증 흐름 정비
-
-5-1 수정 후 mock이 명세와 동일한 계약을 따르는지 검증한다.
-
-- 한 턴 검증 시나리오: `sync → action(ROLL_DICE) → ack → patch(snapshot+DICE_ROLLED+PLAYER_MOVED) → prompt(BUY_OR_SKIP) → prompt_response → ack → patch`
-- `END_TURN` 흐름: `action(END_TURN) → ack → patch(TURNED_ENDED)`
-- 레거시 REST fallback 시나리오는 최소 범위로 유지
+- 한 턴 검증 시나리오: `sync → action(ROLL_DICE) → ack → patch(snapshot + events) → prompt → prompt_response → ack → patch`
+- `END_TURN` 흐름: `action(END_TURN) → ack → patch(TURN_ENDED)`
 
 ## 6. FE-C 우선 작업
 
-### 6-1. 버그 수정 (선행 필수)
+### 6-1. 보드 presentational 전환
 
-아래 3개 버그는 `GameBoard.tsx`에서 `BuildingLevel 0..7`을 반영했으나 helper 파일들이 동기화되지 않아 발생한 회귀다.
+- `GameBoard.tsx`에서 서버 권위 계산(돈/턴/파산/소유권 진실 소스) 제거
+- 보드는 store 기반 렌더 + 입력 surface(prompt/버튼) + 연출만 담당
 
-- `src/components/board/gameBoardStoreBridge.ts:6`: `Math.min(Math.max(level, 0), 5)` → `Math.min(Math.max(level, 0), 7)`
-- `src/components/board/gameBoardTransactionUtils.ts` `upgradeBoardTileOwner`: `Math.min(existing.level + 1, 5)` → `Math.min(existing.level + 1, 7)`
-- `src/components/board/gameBoardActionUtils.ts` `getBoardSellFallbackRefund`: loop에 `currentLevel === 5`(`basePrice * 1.0`), `currentLevel === 6`(`basePrice * 2.0`) 케이스 추가 (`GameBoard.tsx` `getUpgradeCost`와 동일한 비율 기준)
+### 6-2. 이벤트 기반 연출
 
-### 6-2. 보드 presentational 전환
+- `store.eventQueue`를 소비하는 훅/컴포넌트 구현
+- `DICE_ROLLED`/`PLAYER_MOVED`/`LANDED`/`PAID_TOLL`/`CHANCE_RESOLVED`/`TURN_ENDED` 연출 분기 정리
 
-FE-B의 5-4 작업이 선행되어야 한다.
+### 6-3. 시각 규격 보강
 
-- `GameBoard.tsx`에서 `applyMoney`, `advanceTurn`, 통행료 계산, 파산 판정 로직 제거
-- 보드 컴포넌트는 store에서 넘어온 상태만 렌더하도록 정리
-- `emitConfirmPenalty` deprecated 호출 → `emitGameAction` 직접 호출로 교체
-
-### 6-3. store 단일 렌더 구조 (1차 완료, 잔여 있음)
-
-- `gameViewModel.ts` mapper 완료: `mapStorePlayersToBoardPlayers`, `mapStoreTilesToBoardTiles`
-- 잔여: `GameBoard.tsx` 내부 `onPlayersChange`, `onTileOwnersChange`, `syncMockStore*` write-back 경로 제거
-
-### 6-4. 이벤트 기반 연출
-
-FE-B `store.eventQueue`가 채워지는 구조는 완료. FE-C가 소비 쪽을 만들어야 한다.
-
-- `store.eventQueue`를 소비하는 훅 또는 컴포넌트 구현
-- `ServerEventType` 기준 연출 분기: `DICE_ROLLED`(주사위 표시), `PLAYER_MOVED`(말 이동), `LANDED`(도착), `PAID_TOLL`(통행료), `CHANCE_RESOLVED`(찬스), `TURNED_ENDED`(턴 종료)
-- 이벤트 연출 중 상태 기준은 store snapshot/patch가 유지하도록 분리
-
-### 6-5. 시각 규격 재반영
-
-- `playerState`(`island`, `locked`) 기반 섬 감금/잠금 상태 표시 추가
-- `stateDuration` 기반 잔여 턴 표시
-- `DiceTimerModal` → `game:prompt.timeoutSec` 기반 타이머 연결 완료. FE-C는 시각 연출/애니메이션만 후속 반영
+- `playerState`(`island`, `locked`) 표시
+- `stateDuration`(잔여 턴) 표시
 
 ## 7. 권장 실행 순서
 
-1. **FE-B 5-1**: 명세 불일치 수정 (`GamePromptResponse`, `GameAck`, `GamePatchEnvelope`, `emitGameSync`, `emitPromptResponse`, mock)
-2. **FE-C 6-1**: 버그 3개 수정 (`gameBoardStoreBridge`, `gameBoardTransactionUtils`, `gameBoardActionUtils`)
-3. **FE-B 5-4**: `gameBoardActionHandlers` BUILD/sync 레거시 제거 + prompt.type 액션 확정
-4. **FE-C 6-2**: `GameBoard.tsx` 서버 계산 제거, 시각 레이어 수렴
-5. **FE-C 6-4**: `store.eventQueue` 기반 이동/연출 구현
-6. **FE-B + FE-C**: `game:prompt` 흐름과 `DiceTimerModal` timeout 흐름 공동 검증
+1. **FE-B + BE**: `gameId`/ActionType/prompt/snapshot/money 계약 고정
+2. **FE-B**: 호출부 canonical(`gameId`) 정리 + 문서/타입 동기화
+3. **FE-C**: `GameBoard.tsx` 로컬 엔진 제거 및 presentational 수렴
+4. **FE-C**: `eventQueue` 기반 이동/연출 구현
+5. **FE-B + FE-C**: prompt 흐름 + 타이머 + 턴 종료(`TURN_ENDED`) 통합 검증
 
 ## 8. 완료 조건
 
 ### FE-B 완료 조건
 
-- `gamesocket.md` / `api.md` 기준 모든 payload 필드명과 구조가 일치한다.
-- 구 REST 액션 의존이 제거되거나 보조 수단으로만 남는다.
-- patch/snapshot/revision 처리와 prompt 응답이 안정적으로 동작한다.
-- mock이 실제 명세(`ActionType`, `ServerEventType`, payload camelCase)와 동일한 계약을 따른다.
+- `gamesocket.md` / `api.md` 기준 payload 필드명/구조가 일치한다.
+- `game:*` 소켓 경로가 기본이며, 레거시 fallback은 의도적으로만 남아 있다.
+- prompt 응답, ack 매칭, revision 기반 patch 적용이 안정적으로 동작한다.
 
 ### FE-C 완료 조건
 
-- `gameBoardStoreBridge`, `gameBoardTransactionUtils`, `gameBoardActionUtils`의 `BuildingLevel` 버그가 수정된다.
-- 보드가 store 기준 단일 상태만 읽는다.
-- `store.eventQueue` 소비 기반 이동/연출이 동작한다.
-- `playerState`(`island`, `locked`) 기반 상태 시각화가 반영된다.
+- 보드가 store 기준 단일 상태만 렌더한다.
+- `eventQueue` 소비 기반 이동/연출이 동작한다.
+- `playerState`/`stateDuration` 시각화가 반영된다.
 
 ## 9. 결론
 
-지금 당장 해야 할 일은 **명세 불일치 수정**이다.
-코드 구조를 아무리 잘 만들어도 payload 필드명(`choice` vs `value`)이나 에러 구조(`error.code` vs `errorCode`)가 백엔드와 다르면 실서버 연동에서 즉시 깨진다.
-FE-B는 5-1 불일치 수정을 먼저, FE-C는 6-1 버그 3개 수정을 먼저 진행한다.
-그 다음 단계는 `gameBoardActionHandlers`의 BUILD/sync 레거시 제거와 `GameBoard.tsx` 시각 레이어 수렴이다.
-`roomId`, money unit, 현재 보드 view model은 갑자기 제거하지 않고 compatibility layer로 안전하게 이행한다.
+현재 단계의 핵심은 **코드 정리보다 계약 고정**이다.
+특히 `gameId` canonical, ActionType(건설), prompt/snapshot 스키마를 먼저 고정해야 실서버 연동에서 재작업을 줄일 수 있다.
+그 후 `GameBoard.tsx`의 로컬 엔진 성격 로직을 제거하고, 이벤트 연출 레이어로 수렴한다.

--- a/docs/game-event-spec-migration-plan.md
+++ b/docs/game-event-spec-migration-plan.md
@@ -70,37 +70,36 @@
 - transport 모델은 새 명세(`0..7`)를 목표로 설계
 - 현재 렌더/레거시 fallback은 compatibility mapping 유지
 
-## 2. 수정 대상과 방법 (2026-03-05 기준)
+## 2. 수정 대상과 방법 (2026-03-10 기준)
 
-아래 표에서 **상태** 열 기준: ✅ 완료 / ⚠️ 명세 불일치 수정 필요 / ❌ 미구현
+아래 표에서 **상태** 열 기준: ✅ 완료 / ⚠️ 런타임 정합성 조정 필요 / ❌ 미구현
 
-| 파일                                                | 현재 상태         | 남은 수정 방향                                                                                                         | 담당                       |
-| --------------------------------------------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------- | -------------------------- |
-| `src/types/domain.ts`                               | ✅ 완료           | —                                                                                                                      | FE-B                       |
-| `src/stores/game.store.ts`                          | ✅ 완료           | —                                                                                                                      | FE-B                       |
-| `src/services/socket/game.handler.ts`               | ✅ 완료           | —                                                                                                                      | FE-B                       |
-| `src/hooks/game/useGameState.ts`                    | ✅ 완료           | —                                                                                                                      | FE-B                       |
-| `src/services/game/game.api.ts`                     | ⚠️ 레거시 격리 중 | deprecated 표시 완료. `gameBoardActionHandlers.ts`의 BUY/SELL/END_TURN non-mock 전환 완료, BUILD/sync는 레거시 유지    | FE-B                       |
-| `src/hooks/game/useDiceRoll.ts`                     | ✅ 완료           | —                                                                                                                      | FE-B                       |
-| `src/pages/GamePage.tsx`                            | ✅ 3차 완료       | `prompt` 오버레이 응답 + `prompt.type` board-modal 분기 연결 완료. 미매핑 prompt는 오버레이 fallback 유지              | FE-B                       |
-| `src/components/board/GameBoard.tsx`                | ⚠️ 부분 정리      | non-mock에서 `store.prompt` 기반 Buy/Build/Toll/Timer 모달 연결 완료. `applyMoney`, `advanceTurn`, 파산 판정 제거 필요 | FE-C 주도 / FE-B 선행 필요 |
-| `src/components/game/modals/*`                      | ✅ 3차 완료       | `store.prompt.type` 기준 모달 열림 조건/응답 연결 완료. `DiceTimerModal` timeout 연동 완료                             | FE-B                       |
-| `src/mocks/handlers/game.handler.ts`                | ✅ 완료           | —                                                                                                                      | FE-B                       |
-| `src/components/board/gameBoardStoreBridge.ts`      | ❌ 버그           | `toStoreBuildingLevel` 상한 5→7                                                                                        | FE-C                       |
-| `src/components/board/gameBoardTransactionUtils.ts` | ❌ 버그           | `upgradeBoardTileOwner` 상한 5→7                                                                                       | FE-C                       |
-| `src/components/board/gameBoardActionUtils.ts`      | ❌ 버그           | `getBoardSellFallbackRefund` level 5, 6 케이스 추가                                                                    | FE-C                       |
-| `src/components/board/*` (렌더 레이어)              | ❌ 미구현         | `store.eventQueue` 소비 연출. `playerState` 시각화                                                                     | FE-C                       |
+| 파일                                                | 현재 상태         | 남은 수정 방향                                                                                            | 담당                  |
+| --------------------------------------------------- | ----------------- | --------------------------------------------------------------------------------------------------------- | --------------------- |
+| `src/types/domain.ts`                               | ✅ 완료           | —                                                                                                         | FE-B                  |
+| `src/stores/game.store.ts`                          | ✅ 완료           | —                                                                                                         | FE-B                  |
+| `src/services/socket/game.handler.ts`               | ✅ 완료           | —                                                                                                         | FE-B                  |
+| `src/hooks/game/useGameState.ts`                    | ✅ 완료           | —                                                                                                         | FE-B                  |
+| `src/services/game/game.api.ts`                     | ⚠️ 레거시 보관 중 | deprecated 표시는 완료됐고, 직접 호출 경로는 제거 상태. fallback 유틸로만 보관 중                         | FE-B                  |
+| `src/hooks/game/useDiceRoll.ts`                     | ✅ 완료           | —                                                                                                         | FE-B                  |
+| `src/pages/GamePage.tsx`                            | ✅ 3차 완료       | `prompt` 오버레이 응답 + `prompt.type` board-modal 분기 연결 완료. 미매핑 prompt는 오버레이 fallback 유지 | FE-B                  |
+| `src/components/board/GameBoard.tsx`                | ⚠️ 부분 정리      | `store.prompt` 기반 모달 연결은 완료. 로컬 엔진 성격(`applyMoney`, `advanceTurn`, 파산 판정) 제거 필요    | FE-C 주도 / FE-B 협업 |
+| `src/components/game/modals/*`                      | ✅ 3차 완료       | `store.prompt.type` 기준 모달 열림 조건/응답 연결 완료. `DiceTimerModal` timeout 연동 완료                | FE-B                  |
+| `src/mocks/handlers/game.handler.ts`                | ✅ 완료           | —                                                                                                         | FE-B                  |
+| `src/components/board/gameBoardStoreBridge.ts`      | ✅ 완료           | `toStoreBuildingLevel` 상한 7 반영 완료                                                                   | FE-C                  |
+| `src/components/board/gameBoardTransactionUtils.ts` | ✅ 완료           | `upgradeBoardTileOwner` 상한 7 반영 완료                                                                  | FE-C                  |
+| `src/components/board/gameBoardActionUtils.ts`      | ✅ 완료           | `getBoardSellFallbackRefund` level 5, 6 반영 완료                                                         | FE-C                  |
+| `src/components/board/*` (렌더 레이어)              | ❌ 미구현         | `store.eventQueue` 소비 연출. `playerState` 시각화                                                        | FE-C                  |
 
-### 2-1. `src/mocks/handlers/game.handler.ts` 명세 불일치 상세
+### 2-1. 백엔드와 최종 고정이 필요한 항목
 
-| 항목                        | 현재 코드                                                                                     | `gamesocket.md` 명세                                                                                                                                |
-| --------------------------- | --------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ActionType                  | `ROLL_DICE`, `BUY_PROPERTY`, `BUILD_PROPERTY`, `SELL_PROPERTY`, `REQUEST_BUY_PROPERTY_PROMPT` | `ROLL_DICE`, `BUY_PROPERTY`, `SELL_PROPERTY`, `END_TURN`                                                                                            |
-| ServerEvent type            | `ROLL_DICE`, `MOVE_PLAYER`, `BUY_PROPERTY`, `SELL_PROPERTY`, `BUILD_PROPERTY`                 | `DICE_ROLLED`, `PLAYER_MOVED`, `BOUGHT_PROPERTY`, `SOLD_PROPERTY`, `TURNED_ENDED`, `LANDED`, `PAID_TOLL`, `PLAYER_STATE_CHANGED`, `CHANCE_RESOLVED` |
-| `BUY_PROPERTY` payload      | `{ tile_index }` (snake_case)                                                                 | `{ tileId }` (camelCase)                                                                                                                            |
-| `SELL_PROPERTY` payload     | `{ tile_index, level }`                                                                       | `{ tileId, buildingLevel }`                                                                                                                         |
-| `BuildingLevel` 상한        | `>= 5` 에서 차단                                                                              | `>= 7` 에서 차단                                                                                                                                    |
-| `game:prompt_response` 처리 | `response.value` 참조                                                                         | `response.choice` 참조                                                                                                                              |
+| 항목             | 현재 코드                              | `gamesocket.md` 기준 / 협의 필요 내용                                                                         |
+| ---------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| 식별자 canonical | 일부 emit 경로에서 `roomId` 사용       | 게임 소켓 입력(`game:action`,`game:sync`,`game:prompt_response`)의 canonical을 `gameId`로 고정할지 확인       |
+| ActionType(건설) | `BUILD_PROPERTY`를 송신 중             | 문서 ActionType은 `ROLL_DICE`,`BUY_PROPERTY`,`SELL_PROPERTY`,`END_TURN`만 정의. 건설 처리 방식 최종 고정 필요 |
+| prompt 필드      | FE는 `prompt.id`, `timeoutSec` 중심    | 문서 예시는 `promptId`, `payload.timeoutMs`. 필드명/단위 통일 필요                                            |
+| snapshot 필드    | FE Snapshot 타입과 문서 예시 일부 차이 | 서버 snapshot 최종 스키마(player/tile field) 확정 필요                                                        |
+| money 단위       | FE는 원 정수 중심                      | 문서는 프로젝트 canonical unit 합의 요구. FE/BE 단일 단위 고정 필요                                           |
 
 ## 3. 파일별 상세 작업
 
@@ -260,50 +259,49 @@
 7. `src/components/board/GameBoard.tsx`
 8. `src/components/game/modals/*`
 
-## 5-1. 현재 상태 (2026-03-05 기준)
+## 5-1. 현재 상태 (2026-03-10 기준)
 
 ### 완료 항목
 
 - `src/types/domain.ts`: `BuildingLevel 0..7`, `GamePhase`, `PlayerStateType`, `GameSnapshot`, `GamePatchEnvelope`, `GamePatchOperation`, `GameAck`, `GameError`, `GamePrompt`, `GamePromptResponse`, `ServerEvent`, `PendingGameAction`, `GameConnectionMeta`, `GameState` 전부 도입
 - `src/stores/game.store.ts`: `replaceFromSnapshot`, `applyPatchEnvelope`(revision guard + set/inc/push/remove), `setPendingAction`, `resolveAck`, `setPrompt`, `clearPrompt`, `enqueueEvents`, `consumeNextEvent`, `setLastError`, `resetGame` 전부 구현
 - `src/services/socket/game.handler.ts`: `game:ack`, `game:patch`, `game:prompt`, `game:error` 구독. `emitGameAction`, `emitGameSync`, `emitPromptResponse` 구현
-- `src/hooks/game/useGameState.ts`: `game:sync` 우선, REST bootstrap fallback 병행
+- `src/hooks/game/useGameState.ts`: `game:sync` 기반 동기화 경로로 정리
 - `src/pages/GamePage.tsx`: store 단일 소스, `gameViewModel` mapper로 board 데이터 조립 + `prompt` 오버레이 응답, `pendingAction`/`lastAck`/`lastError` UI 연결
-- `src/components/board/gameBoardActionHandlers.ts`: mock 경로 BUY/BUILD 성공 시 턴이 다음 플레이어로 넘어가지 않던 문제 수정 (`advanceTurn` 보장)
+- `src/components/board/gameBoardActionHandlers.ts`: non-mock 경로에서 BUY/BUILD/SELL/END_TURN를 `emitGameAction`으로 송신
 
-### 명세 불일치 (수정 완료 — 2026-03-05)
+### 명세 불일치 (코드 측 반영 완료, 계약 고정 대기)
 
-- `src/types/domain.ts`: `GamePromptResponse.choice`, `GameAck.error: { code, message }`, `GamePatchEnvelope.gameId/turn` ✅
-- `src/services/socket/game.handler.ts`: `emitGameSync` knownRevision 추가, `emitPromptResponse` choice 전환 ✅
-- `src/mocks/handlers/game.handler.ts`: `END_TURN` 핸들러 추가, `BUILD_PROPERTY` 제거, ServerEventType 명세 정렬, payload camelCase, `BuildingLevel` 상한 7 ✅
+- `src/types/domain.ts`: `GamePromptResponse.choice`, `GameAck.error`, `GamePatchEnvelope.gameId/turn` 반영 완료
+- `src/services/socket/game.handler.ts`: `emitGameSync(knownRevision)`, `emitPromptResponse(choice)` 반영 완료
+- `src/mocks/handlers/game.handler.ts`: `END_TURN`, camelCase payload, `BuildingLevel 0..7`, `ServerEventType` 정렬 반영 완료
+- 남은 이슈는 BE와 최종 합의(`gameId` canonical, ActionType에서 건설 처리, prompt/snapshot 필드 고정)
 
-### 버그 (수정 미완료 — FE-C 담당)
+### FE-C 버그 (수정 완료)
 
-- `src/components/board/gameBoardStoreBridge.ts:6`: `toStoreBuildingLevel` 상한 5 (→ 7 필요)
-- `src/components/board/gameBoardTransactionUtils.ts`: `upgradeBoardTileOwner` 상한 5 (→ 7 필요)
-- `src/components/board/gameBoardActionUtils.ts`: `getBoardSellFallbackRefund` level 5, 6 누락
+- `src/components/board/gameBoardStoreBridge.ts`: `toStoreBuildingLevel` 상한 7 반영
+- `src/components/board/gameBoardTransactionUtils.ts`: `upgradeBoardTileOwner` 상한 7 반영
+- `src/components/board/gameBoardActionUtils.ts`: `getBoardSellFallbackRefund` level 5, 6 반영
 
-### 구조 미구현 (FE-B 2단계)
+### 구조 미구현 (현재 잔여)
 
 - `GamePage` + `GameBoard`: `prompt.type` → Buy/Build/Toll/Timer 모달 매핑, `emitPromptResponse` 응답 경로 연결 완료
 - `store.eventQueue` → 소비 컴포넌트 없음
-- `gameBoardActionHandlers.ts` → BUY/SELL/END_TURN non-mock 전환 완료, mock 턴 전환 회귀 수정 완료. BUILD/sync 레거시 호출 정리 필요
+- `GameBoard.tsx` → 로컬 게임 엔진 성격(`applyMoney`, `advanceTurn`, 파산/턴 전환) 제거 필요
 
 ## 5-2. 다음 우선순위
 
 **FE-B**
 
-1. ~~`src/types/domain.ts`, `src/services/socket/game.handler.ts`: 명세 불일치 수정~~ ✅ 완료
-2. ~~`src/mocks/handlers/game.handler.ts`: 명세 불일치 수정~~ ✅ 완료
-3. ~~`src/components/game/modals/*`, `src/components/board/GameBoard.tsx`: `store.prompt.type` → modal 연결, `DiceTimerModal` → `prompt.timeoutSec` 연결~~ ✅ 완료
-4. `src/components/board/gameBoardActionHandlers.ts`: BUILD/sync 레거시 호출 정리 및 prompt.type 기반 액션 확정
+1. 백엔드와 `gameId` canonical / ActionType(건설) / prompt 필드 / snapshot 스키마 최종 고정
+2. emit 호출부(`game:action`,`game:sync`,`game:prompt_response`)의 `gameId` 정렬
+3. 문서와 타입의 `TURN_ENDED`/prompt/snapshot 표기 통일 유지
 
 **FE-C**
 
-1. `gameBoardStoreBridge.ts`, `gameBoardTransactionUtils.ts`, `gameBoardActionUtils.ts`: BuildingLevel 버그 수정 (FE-B와 무관하게 선행 가능)
-2. `GameBoard.tsx`: `applyMoney`, `advanceTurn`, 통행료 계산, 파산 판정 제거 (FE-B 5-3 선행 필요)
-3. `store.eventQueue` 소비 훅/컴포넌트 구현 (FE-B 5-4 선행 필요)
-4. `playerState`(`island`, `locked`) 시각화
+1. `GameBoard.tsx`의 로컬 엔진 성격 로직 제거
+2. `store.eventQueue` 소비 훅/컴포넌트 구현
+3. `playerState`(`island`, `locked`) + `stateDuration` 시각화
 
 ## 6. 문서 사용법
 

--- a/docs/game-ownership-corrected-table.md
+++ b/docs/game-ownership-corrected-table.md
@@ -18,16 +18,16 @@
 
 ## 진행도 요약
 
-| 파트 | 진행도  | 상태                                                                                                                  |
-| ---- | ------- | --------------------------------------------------------------------------------------------------------------------- |
-| FE-B | 진행 중 | prompt modal 연결 완료 + `gameBoardActionHandlers` non-mock 전환 및 mock 턴 전환 버그 수정 완료, BUILD/sync 정리 단계 |
-| FE-C | 진행 중 | 보드를 표현/연출 중심 레이어로 더 줄여야 하는 단계                                                                    |
+| 파트 | 진행도  | 상태                                                                                                                      |
+| ---- | ------- | ------------------------------------------------------------------------------------------------------------------------- |
+| FE-B | 진행 중 | prompt/ack 연결 및 event-socket 계약 전환 완료. `gameId` canonical/ActionType(건설)/prompt-snapshot 스키마 최종 고정 단계 |
+| FE-C | 진행 중 | 보드를 표현/연출 중심 레이어로 더 줄이고 로컬 엔진 성격 로직을 제거해야 하는 단계                                         |
 
 ## FE-B 현재 최우선 작업
 
-- `src/components/board/gameBoardActionHandlers.ts`의 BUILD/sync 레거시 호출 정리
-- prompt.type별 choice 표준(BUY/SKIP, BUILD/SKIP, PAY_TOLL, END_TURN)을 문서/목업과 최종 고정
-- 미매핑 prompt의 fallback 표면(오버레이) 유지 범위 확정
+- `game:action`/`game:sync`/`game:prompt_response`의 `gameId` canonical 사용 범위 고정
+- ActionType에서 건설 처리 방식(`BUILD_PROPERTY` 유지 여부) 백엔드 최종 합의
+- prompt/snapshot 필드(`id/promptId`, `timeoutSec/timeoutMs`) 최종 계약 고정
 
 ## FE-C 현재 최우선 작업
 
@@ -38,12 +38,10 @@
 
 ## 현재 가장 큰 리스크
 
-- `GamePage` + `GameBoard`는 `prompt.type` 중심 소비 구조로 전환됐지만, mock 로컬 fallback과 실서버 경로가 이원화돼 있다.
-- `gameBoardActionHandlers`는 BUY/SELL/END_TURN만 non-mock 전환됐고 BUILD/sync는 레거시 경로가 남아 있다.
-- mock 경로 턴 전환 버그는 수정됐지만, BUILD/sync 레거시 경로가 남아 동작 축이 분리돼 있다.
-- `GameBoard.tsx`가 여전히 일부 게임 엔진 성격 로직을 들고 있다.
+- `GamePage` + `GameBoard`는 `prompt.type` 소비 구조로 전환됐지만 mock fallback과 실서버 경로가 일부 이원화돼 있다.
+- `GameBoard.tsx`가 여전히 `applyMoney`/`advanceTurn`/파산 판정 등 게임 엔진 성격 로직을 들고 있다.
 - 게임 REST fallback이 장기화되면 중앙 docs 기준과 실제 런타임이 다시 벌어질 수 있다.
-- `gameId`, money unit, tile/building enum 기준이 문서와 코드에서 완전히 수렴하지 않았다.
+- `gameId` canonical, money unit, prompt/snapshot 필드 기준이 문서와 코드에서 완전히 수렴하지 않았다.
 
 ## 작업 운영 규칙 (2026-03-05 추가)
 

--- a/docs/game-ownership.md
+++ b/docs/game-ownership.md
@@ -88,15 +88,15 @@
 
 - 새 이벤트 계약용 타입/store/socket/mock 골격 반영
 - `GamePage.tsx`의 store 단일 상태 렌더 구조 1차 정리
-- `GameBoard.tsx` 내부 액션/동기화/거래 로직 분리 착수
+- `GameBoard.tsx`의 `prompt.type` 기반 모달 소비 및 `emitPromptResponse` 연결
+- `gameBoardActionHandlers` non-mock 경로 BUY/BUILD/SELL/END_TURN `emitGameAction` 전환
 
 남은 것:
 
-- `prompt/ack/error/pendingAction`의 실제 UI 연결
-- `game:prompt_response` 기반 사용자 응답 흐름 정리
-- 남아 있는 게임 REST fallback 추가 축소
-- `gameId` 중심 식별자 정리
-- money unit, tile/building enum 기준 문서와 코드의 최종 정렬
+- `gameId` 중심 식별자 정리(`game:action`/`game:sync`/`game:prompt_response`)
+- ActionType에서 건설 처리(`BUILD_PROPERTY` 유지 여부) 백엔드 최종 합의
+- prompt/snapshot 필드(`id/promptId`, `timeoutSec/timeoutMs`) 계약 고정
+- money unit, tile/building enum 기준 문서-코드-백엔드 최종 정렬
 
 ### FE-C 현재 단계
 
@@ -109,16 +109,14 @@
 
 ## 7. 현재 다음 우선순위
 
-중앙 docs와 현재 코드 상태 기준으로, FE-B의 다음 작업은 `prompt/ack` UI 연결이다.
+중앙 docs와 현재 코드 상태 기준으로, FE-B의 다음 작업은 **백엔드 계약 최종 고정 + 식별자 canonical 정리**다.
 
-- `src/components/game/modals/*`
-  - `gameStore.prompt`를 실제 modal 열림 조건과 연결
-- `src/pages/GamePage.tsx`
-  - `pendingAction`, `lastAck`, `lastError`를 버튼/상태 문구/실패 메시지와 연결
-- `src/components/board/GameBoard.tsx`
-  - 기존 로컬 modal 분기를 `game:prompt` 소비 구조로 전환
-- `src/services/socket/game.handler.ts`
-  - `emitPromptResponse`가 실사용 UI 흐름에서 호출되도록 정리
+- `src/services/socket/game.handler.ts`, `src/hooks/game/useGameState.ts`
+  - emit payload의 `gameId` canonical 사용 범위 정렬
+- `src/components/board/gameBoardActionHandlers.ts`
+  - 건설 액션 타입(`BUILD_PROPERTY` vs `BUY_PROPERTY`) 확정 결과 반영
+- `src/types/domain.ts`, `src/pages/GamePage.tsx`
+  - prompt/snapshot 최종 필드명(`promptId`, `timeoutMs` 등) 고정값 반영
 
 ## 8. 작업 충돌 방지 규칙
 


### PR DESCRIPTION
## 관련 이슈
> closes #이슈번호

---

## 작업 내용
- 중앙 docs(`gamesocket.md`, `api.md`, `erd.md`)와 현재 코드 기준으로 게임 문서 정합성 재점검
- 오래된 진행도/불일치 항목 정리 및 현재 상태 기준으로 갱신
- FE-B/FE-C 우선순위를 실제 코드 상태에 맞춰 재정렬
- 문서 표기 통일(`TURN_ENDED`), BE 협의 필요 항목(`gameId` canonical, ActionType 건설, prompt/snapshot 필드, money unit) 명시

주요 반영:
- `docs/game-delivery-roadmap.md`
  - 진행도 섹션을 2026-03-10 기준으로 갱신
  - FE-B 잔여 과제를 “계약 고정/런타임 정합성” 중심으로 재정의
  - FE-C는 버그 수정 완료 상태를 반영하고 보드 엔진 제거/연출 분리 단계로 갱신
- `docs/game-event-spec-migration-plan.md`
  - 수정 대상 표의 상태를 현재 코드 기준으로 갱신
  - 기존 mock 불일치 표를 “백엔드 최종 고정 필요 항목”으로 교체
  - 다음 우선순위를 `gameId` canonical/ActionType/prompt-snapshot 스키마 확정 중심으로 갱신
- `docs/game-ownership-corrected-table.md`
  - FE-B/FE-C 진행 상태 및 리스크를 최신화
  - FE-B 최우선 작업을 BE 협의 항목 중심으로 정리
- `docs/game-ownership.md`
  - FE-B 완료/잔여 단계 최신화
  - 다음 우선순위를 prompt UI 연결 단계에서 계약 고정 단계로 재정의

---

## 체크리스트
- [x] 중앙 docs 기준으로 게임 문서 불일치 항목 정리
- [x] 진행도 + 다음 작업 반영
- [x] 용어/이벤트 표기 통일(`TURN_ENDED`)
- [x] 문서 변경만 커밋/푸시 (코드 변경 미포함)
