### PR TITLE
refactor: 로비 헤더와 접속자 목록 sticky 정렬 개선

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -20,7 +20,7 @@ function Header({
   menuItems = [],
 }: HeaderProps) {
   return (
-    <header className="flex h-14 items-center justify-between border-b border-ui-border bg-ui-surface px-4 sm:px-6">
+    <header className="sticky top-0 z-40 flex h-14 items-center justify-between border-b border-ui-border bg-ui-surface/95 px-4 backdrop-blur sm:px-6">
       <div className="flex items-center gap-2.5">
         <div className="flex size-9 items-center justify-center rounded-lg bg-ui-brand text-white">
           <Dice5 className="size-5" strokeWidth={2} />

--- a/src/pages/lobby/LobbyPage.tsx
+++ b/src/pages/lobby/LobbyPage.tsx
@@ -123,7 +123,7 @@ function LobbyPage() {
         menuItems={headerMenuItems}
       />
 
-      <main className="flex flex-col gap-4 p-4 sm:p-6 xl:flex-row">
+      <main className="flex flex-col gap-4 p-4 sm:p-6 xl:flex-row xl:items-start">
         <section className="min-w-0 flex-1">
           <LobbyControls
             searchKeyword={searchRoom}
@@ -144,16 +144,18 @@ function LobbyPage() {
           />
         </section>
 
-        <UserListPanel
-          users={users}
-          isLoading={isUsersLoading}
-          isError={isUsersError}
-          isOpen={isUserListOpen}
-          currentUserId={session.userId}
-          unreadDirectMessageCountByUserId={unreadDirectMessageCountByUserId}
-          onOpenDirectMessage={openDirectMessage}
-          onToggle={() => setIsUserListOpen((prev) => !prev)}
-        />
+        <div className="xl:sticky xl:top-20 xl:self-start">
+          <UserListPanel
+            users={users}
+            isLoading={isUsersLoading}
+            isError={isUsersError}
+            isOpen={isUserListOpen}
+            currentUserId={session.userId}
+            unreadDirectMessageCountByUserId={unreadDirectMessageCountByUserId}
+            onOpenDirectMessage={openDirectMessage}
+            onToggle={() => setIsUserListOpen((prev) => !prev)}
+          />
+        </div>
       </main>
 
       {selectedPrivateRoom ? (


### PR DESCRIPTION
## 📌 관련 이슈

> closes #356 

---

## 📝 작업 내용

> 로비에서 방 목록이 길어질 때도 헤더와 접속자 목록이 안정적인 기준선에서 보이도록 sticky 정렬을 정리했습니다.

- 공통 헤더를 로비에서 `sticky top-0` 기준으로 고정
- 헤더에 배경 투명도와 blur를 적용해 스크롤 상황에서도 자연스럽게 보이도록 정리
- 접속자 목록 패널을 데스크톱 기준 sticky 유지
- 접속자 목록의 `top` 값을 헤더 높이에 맞게 보정해 겹침 없이 정렬되도록 수정

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

![무제](https://github.com/user-attachments/assets/1eb5a8cc-0e8f-4b2a-9945-80599080b7dd)

