### PR TITLE
Feat : gameId canonical 정렬 및 게임 prompt/action 계약 고정

### DIFF
--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -106,7 +106,7 @@ const AI_PENALTY_RESULTS = [
 
 const DEFAULT_OPPONENT_NAME = '상대방'
 const GAME_START_STATUS = '게임 시작!'
-const ROOM_ID_REQUIRED_MESSAGE = '게임 방 식별자를 찾을 수 없습니다.'
+const GAME_ID_REQUIRED_MESSAGE = '게임 식별자를 찾을 수 없습니다.'
 const BOARD_GRID_BASE_SIZE = CORNER_SIZE * 2 + STRAIGHT_SIZE * 7 + GRID_GAP * 8
 const BOARD_INNER_PADDING = 10 * 2
 const BOARD_INNER_BORDER = 4 * 2
@@ -220,7 +220,7 @@ export interface BoardGameHandle {
 }
 
 interface GameBoardProps {
-  roomId?: string | null
+  gameId?: string | null
   players: PlayerState[]
   curPlayer: number
   suppressDiceTimerModal?: boolean
@@ -288,7 +288,7 @@ function buildTileOwnersFromProps(
 const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
   (
     {
-      roomId = null,
+      gameId = null,
       players,
       curPlayer,
       suppressDiceTimerModal = false,
@@ -761,9 +761,9 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       handleBuildCancel,
       handleTollConfirm,
     } = createGameBoardActionHandlers({
-      roomId,
+      gameId,
       useGameSocketMock: USE_GAME_SOCKET_MOCK,
-      roomIdRequiredMessage: ROOM_ID_REQUIRED_MESSAGE,
+      gameIdRequiredMessage: GAME_ID_REQUIRED_MESSAGE,
       setStatus,
       setBuyModal,
       setBuildModal,

--- a/src/components/board/gameBoardActionHandlers.test.ts
+++ b/src/components/board/gameBoardActionHandlers.test.ts
@@ -1,34 +1,28 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { createGameBoardActionHandlers } from './gameBoardActionHandlers'
 import { emitGameAction } from '../../services/socket/game.handler'
+import { createGameBoardActionHandlers } from './gameBoardActionHandlers'
 import type { BuildModalState } from './gameBoard.types'
 
 vi.mock('../../services/socket/game.handler', () => ({
   emitGameAction: vi.fn(),
 }))
 
-vi.mock('../../services/game/game.api', () => ({
-  gameApi: {
-    sellTile: vi.fn(),
-  },
-}))
-
 type SetState<T> = (value: T | ((prev: T) => T)) => void
 
 const createDefaultHandlers = (overrides?: {
-  roomId?: string | null
+  gameId?: string | null
   setStatus?: SetState<string>
   setBuildModal?: SetState<BuildModalState>
 }) => {
   const setStatus = overrides?.setStatus ?? vi.fn()
   const setBuildModal = overrides?.setBuildModal ?? vi.fn()
-  const roomId: string | null =
-    overrides?.roomId === undefined ? 'room-1' : overrides.roomId
+  const gameId: string | null =
+    overrides?.gameId === undefined ? 'game-1' : overrides.gameId
 
   return createGameBoardActionHandlers({
-    roomId,
+    gameId,
     useGameSocketMock: false,
-    roomIdRequiredMessage: 'room id is required',
+    gameIdRequiredMessage: 'game id is required',
     setStatus: setStatus as never,
     setBuyModal: vi.fn() as never,
     setBuildModal: setBuildModal as never,
@@ -53,7 +47,7 @@ describe('createGameBoardActionHandlers - non mock build action', () => {
     vi.clearAllMocks()
   })
 
-  it('BUILD_PROPERTY 액션을 전송하고 모달을 닫는다', async () => {
+  it('sends BUY_PROPERTY action and closes modal', async () => {
     const setBuildModal = vi.fn<SetState<BuildModalState>>()
     const onDoneCallback = vi.fn()
     const handlers = createDefaultHandlers({ setBuildModal })
@@ -65,20 +59,20 @@ describe('createGameBoardActionHandlers - non mock build action', () => {
     })
 
     expect(emitGameAction).toHaveBeenCalledWith({
-      type: 'BUILD_PROPERTY',
-      roomId: 'room-1',
+      type: 'BUY_PROPERTY',
+      gameId: 'game-1',
       payload: { tileId: 7 },
     })
     expect(setBuildModal).toHaveBeenCalledWith({ open: false, tileId: null })
     expect(onDoneCallback).toHaveBeenCalledTimes(1)
   })
 
-  it('roomId가 없으면 상태만 갱신하고 종료한다', async () => {
+  it('does not emit when gameId is missing', async () => {
     const setStatus = vi.fn<SetState<string>>()
     const setBuildModal = vi.fn<SetState<BuildModalState>>()
     const onDoneCallback = vi.fn()
     const handlers = createDefaultHandlers({
-      roomId: null,
+      gameId: null,
       setStatus,
       setBuildModal,
     })
@@ -90,12 +84,12 @@ describe('createGameBoardActionHandlers - non mock build action', () => {
     })
 
     expect(emitGameAction).not.toHaveBeenCalled()
-    expect(setStatus).toHaveBeenCalledWith('room id is required')
+    expect(setStatus).toHaveBeenCalledWith('game id is required')
     expect(setBuildModal).not.toHaveBeenCalled()
     expect(onDoneCallback).not.toHaveBeenCalled()
   })
 
-  it('tileId가 없으면 아무 동작도 하지 않는다', async () => {
+  it('does nothing when tileId is missing', async () => {
     const setStatus = vi.fn<SetState<string>>()
     const setBuildModal = vi.fn<SetState<BuildModalState>>()
     const handlers = createDefaultHandlers({ setStatus, setBuildModal })

--- a/src/components/board/gameBoardActionHandlers.ts
+++ b/src/components/board/gameBoardActionHandlers.ts
@@ -28,9 +28,9 @@ interface TollResolvedPayload {
 }
 
 interface CreateGameBoardActionHandlersParams {
-  roomId: string | null
+  gameId: string | null
   useGameSocketMock: boolean
-  roomIdRequiredMessage: string
+  gameIdRequiredMessage: string
   setStatus: Dispatch<SetStateAction<string>>
   setBuyModal: Dispatch<SetStateAction<BuyModalState>>
   setBuildModal: Dispatch<SetStateAction<BuildModalState>>
@@ -58,9 +58,9 @@ export function createGameBoardActionHandlers(
   params: CreateGameBoardActionHandlersParams
 ) {
   const {
-    roomId,
+    gameId,
     useGameSocketMock,
-    roomIdRequiredMessage,
+    gameIdRequiredMessage,
     setStatus,
     setBuyModal,
     setBuildModal,
@@ -84,14 +84,14 @@ export function createGameBoardActionHandlers(
     type: string,
     payload?: Record<string, unknown>
   ): boolean {
-    if (!roomId) {
-      setStatus(roomIdRequiredMessage)
+    if (!gameId) {
+      setStatus(gameIdRequiredMessage)
       return false
     }
 
     emitGameAction({
       type,
-      roomId,
+      gameId,
       payload,
     })
     return true
@@ -211,7 +211,7 @@ export function createGameBoardActionHandlers(
     if (tileId === null) return
 
     if (!useGameSocketMock) {
-      const emitted = emitSocketAction('BUILD_PROPERTY', {
+      const emitted = emitSocketAction('BUY_PROPERTY', {
         tileId,
       })
       if (!emitted) {

--- a/src/hooks/game/useDiceRoll.ts
+++ b/src/hooks/game/useDiceRoll.ts
@@ -11,16 +11,16 @@ export const useDiceRoll = (boardRef: RefObject<BoardGameHandle | null>) => {
   const currentTurn = useGameStore((state) => state.currentTurn)
 
   return useCallback(
-    (roomId: string | null) => {
-      if (!roomId) {
+    (gameId: string | null) => {
+      if (!gameId) {
         return
       }
 
       // Prefer server-authoritative roll via socket.
-      if (!USE_GAME_SOCKET_MOCK && socket.connected && currentTurn) {
+      if (!USE_GAME_SOCKET_MOCK && socket.connected && currentTurn !== null) {
         emitGameAction({
           type: 'ROLL_DICE',
-          roomId,
+          gameId,
         })
         return
       }

--- a/src/hooks/game/useGameState.ts
+++ b/src/hooks/game/useGameState.ts
@@ -9,15 +9,15 @@ import { useGameStore } from '../../stores/game.store'
 
 const USE_GAME_SOCKET_MOCK = IS_SOCKET_MOCK_ENABLED
 
-export const useGameState = (roomId: string | null) => {
-  const syncedRoomIdRef = useRef<string | null>(null)
+export const useGameState = (gameId: string | null) => {
+  const syncedGameIdRef = useRef<string | null>(null)
 
   useEffect(() => {
-    if (!roomId) {
+    if (!gameId) {
       return
     }
 
-    const teardownHandlers = setupGameHandlers({ roomId })
+    const teardownHandlers = setupGameHandlers({ gameId })
 
     // mock 환경에서는 공유 소켓이 불필요하게 재연결되지 않도록 차단한다.
     if (USE_GAME_SOCKET_MOCK) {
@@ -27,17 +27,17 @@ export const useGameState = (roomId: string | null) => {
     }
 
     const syncGameState = () => {
-      const roomChanged = syncedRoomIdRef.current !== roomId
+      const gameChanged = syncedGameIdRef.current !== gameId
       const { players, revision } = useGameStore.getState()
 
-      // 같은 방에서 이미 상태를 들고 있으면 초기 동기화를 반복하지 않는다.
-      if (!roomChanged && players.length > 0) return
+      // 같은 게임에서 이미 상태를 들고 있으면 초기 동기화를 반복하지 않는다.
+      if (!gameChanged && players.length > 0) return
 
       emitGameSync({
-        roomId,
-        knownRevision: roomChanged ? 0 : revision,
+        gameId,
+        knownRevision: gameChanged ? 0 : revision,
       })
-      syncedRoomIdRef.current = roomId
+      syncedGameIdRef.current = gameId
     }
 
     syncGameState()
@@ -45,7 +45,7 @@ export const useGameState = (roomId: string | null) => {
     return () => {
       teardownHandlers()
     }
-  }, [roomId])
+  }, [gameId])
 
   return {}
 }

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -61,11 +61,10 @@ interface GamePageLocationState {
 }
 
 const GamePage: React.FC = () => {
-  const { gameId } = useParams<{ gameId: string }>()
+  const { gameId: routeGameId } = useParams<{ gameId: string }>()
   const location = useLocation()
   const locationState = location.state as GamePageLocationState | null
-  const activeRoomId = locationState?.roomId ?? gameId ?? null
-  const session = useAuthStore((state) => state.session)
+  const authSession = useAuthStore((state) => state.session)
   const {
     currentTurn,
     messages,
@@ -77,10 +76,18 @@ const GamePage: React.FC = () => {
     pendingAction,
     lastAck,
     lastError,
+    session: gameSession,
     gameId: storeGameId,
     clearPrompt,
     setLastError,
   } = useGameStore()
+  const activeGameId =
+    locationState?.gameId ??
+    routeGameId ??
+    storeGameId ??
+    gameSession.gameId ??
+    null
+  const activeRoomId = locationState?.roomId ?? gameSession.roomId ?? null
   const [promptSubmittingChoice, setPromptSubmittingChoice] = useState<
     string | null
   >(null)
@@ -91,12 +98,13 @@ const GamePage: React.FC = () => {
   })
   const boardRef = useRef<BoardGameHandle>(null)
 
-  useGameState(activeRoomId)
+  useGameState(activeGameId)
 
   const currentUserId =
-    session?.userId ?? (USE_GAME_SOCKET_MOCK ? DEFAULT_MOCK_PLAYER_ID : null)
+    authSession?.userId ??
+    (USE_GAME_SOCKET_MOCK ? DEFAULT_MOCK_PLAYER_ID : null)
   const currentNickname =
-    session?.nickname ??
+    authSession?.nickname ??
     (USE_GAME_SOCKET_MOCK ? DEFAULT_MOCK_NICKNAME : 'Guest')
   const normalizedCurrentTurn =
     USE_GAME_SOCKET_MOCK &&
@@ -229,7 +237,7 @@ const GamePage: React.FC = () => {
 
     setPromptSubmittingChoice(choice)
     emitPromptResponse({
-      gameId: storeGameId ?? gameId ?? null,
+      gameId: activeGameId,
       promptId: prompt.id,
       choice,
     })
@@ -304,7 +312,7 @@ const GamePage: React.FC = () => {
           >
             <BoardGame
               ref={boardRef}
-              roomId={activeRoomId ?? ''}
+              gameId={activeGameId}
               players={boardPlayers}
               curPlayer={boardCurPlayer}
               suppressDiceTimerModal={isExitModalOpen}
@@ -356,7 +364,7 @@ const GamePage: React.FC = () => {
           <RollButton
             timeLeft={timeLeft}
             isMyTurn={isMyTurn && !isActionPending && !isPromptVisible}
-            onRoll={() => diceRoll(activeRoomId)}
+            onRoll={() => diceRoll(activeGameId)}
           />
         )}
       </div>

--- a/src/services/socket/game.handler.ts
+++ b/src/services/socket/game.handler.ts
@@ -14,14 +14,13 @@ import type {
   GamePromptResponse,
   GameSnapshot,
   PendingGameAction,
-  RoomId,
   GameId,
+  GamePromptChoice,
 } from '../../types/domain'
 
 type Teardown = () => void
 
 type SetupGameHandlersOptions = {
-  roomId?: RoomId | null
   gameId?: GameId | null
 }
 
@@ -32,26 +31,187 @@ type GamePatchPayload = GamePatchEnvelope & {
 type GameActionPayload = {
   actionId?: string
   type: string
-  roomId?: RoomId | null
   gameId?: GameId | null
   payload?: Record<string, unknown>
 }
 
 type GameSyncPayload = {
-  roomId?: RoomId | null
   gameId?: GameId | null
   knownRevision?: number
 }
 
 type PromptResponsePayload = GamePromptResponse & {
-  roomId?: RoomId | null
   gameId?: GameId | null
+}
+
+type PromptCompatPayload = Partial<GamePrompt> & {
+  promptId?: string | null
+  timeoutMs?: number | null
+  payload?: Record<string, unknown>
 }
 
 let teardownGameHandlersRef: Teardown | null = null
 const USE_GAME_SOCKET_MOCK = IS_SOCKET_MOCK_ENABLED
 
 const createActionId = () => `game-action-${Date.now()}`
+
+const PROMPT_ID_REQUIRED_ERROR: GameError = {
+  code: 'INVALID_PROMPT',
+  message: '유효한 promptId를 포함한 game:prompt payload가 필요합니다.',
+}
+
+const GAME_ID_REQUIRED_ERROR: GameError = {
+  code: 'INVALID_GAME_ID',
+  message: '게임 이벤트는 gameId를 필수로 전송해야 합니다.',
+}
+
+const PHASE_TO_INTERNAL_MAP: Record<string, GameSnapshot['phase']> = {
+  WAIT_ROLL: 'rolling',
+  MOVING: 'moving',
+  RESOLVING: 'resolving',
+  WAIT_PROMPT: 'prompt',
+  TURN_END: 'resolving',
+  GAME_OVER: 'finished',
+}
+
+const normalizePhase = (phase: unknown): GameSnapshot['phase'] => {
+  if (typeof phase !== 'string') {
+    return 'waiting'
+  }
+
+  const normalizedPhase = phase.trim().toUpperCase()
+  return PHASE_TO_INTERNAL_MAP[normalizedPhase] ?? 'waiting'
+}
+
+const normalizePromptChoiceValue = (choice: unknown): string =>
+  typeof choice === 'string' ? choice.trim().toUpperCase() : ''
+
+const normalizePromptChoice = (
+  choice: unknown,
+  fallbackIndex: number
+): GamePromptChoice | null => {
+  if (!choice || typeof choice !== 'object') {
+    return null
+  }
+
+  const candidate = choice as Partial<GamePromptChoice>
+  const value = normalizePromptChoiceValue(candidate.value)
+  if (!value) {
+    return null
+  }
+
+  return {
+    id:
+      typeof candidate.id === 'string' && candidate.id.trim().length > 0
+        ? candidate.id
+        : `${value.toLowerCase()}-${fallbackIndex}`,
+    label:
+      typeof candidate.label === 'string' && candidate.label.trim().length > 0
+        ? candidate.label
+        : value,
+    value,
+    description:
+      typeof candidate.description === 'string' &&
+      candidate.description.trim().length > 0
+        ? candidate.description
+        : undefined,
+  }
+}
+
+const toFiniteNumber = (value: unknown): number | null => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value
+  }
+
+  if (typeof value === 'string' && value.trim().length > 0) {
+    const parsed = Number.parseFloat(value)
+    if (Number.isFinite(parsed)) {
+      return parsed
+    }
+  }
+
+  return null
+}
+
+const normalizePromptPayload = (
+  promptPayload: PromptCompatPayload
+): GamePrompt | null => {
+  const promptIdCandidate =
+    (typeof promptPayload.promptId === 'string' && promptPayload.promptId) ||
+    (typeof promptPayload.id === 'string' && promptPayload.id) ||
+    null
+  const promptId = promptIdCandidate?.trim()
+
+  if (!promptId) {
+    return null
+  }
+
+  const payloadRecord =
+    promptPayload.payload && typeof promptPayload.payload === 'object'
+      ? promptPayload.payload
+      : undefined
+  const timeoutSecFromPayload = toFiniteNumber(
+    payloadRecord ? payloadRecord.timeoutSec : undefined
+  )
+  const timeoutMsFromPayload = toFiniteNumber(
+    payloadRecord ? payloadRecord.timeoutMs : undefined
+  )
+  const timeoutSecDirect = toFiniteNumber(promptPayload.timeoutSec)
+  const timeoutMsDirect = toFiniteNumber(promptPayload.timeoutMs)
+
+  const timeoutSecRaw =
+    timeoutSecDirect ??
+    timeoutSecFromPayload ??
+    (timeoutMsDirect != null
+      ? Math.ceil(timeoutMsDirect / 1000)
+      : timeoutMsFromPayload != null
+        ? Math.ceil(timeoutMsFromPayload / 1000)
+        : null)
+  const timeoutSec =
+    timeoutSecRaw != null && timeoutSecRaw > 0 ? timeoutSecRaw : undefined
+
+  const normalizedChoices = Array.isArray(promptPayload.choices)
+    ? promptPayload.choices
+        .map((choice, index) => normalizePromptChoice(choice, index))
+        .filter((choice): choice is GamePromptChoice => choice !== null)
+    : undefined
+
+  return {
+    id: promptId,
+    type:
+      typeof promptPayload.type === 'string' && promptPayload.type.trim().length
+        ? promptPayload.type
+        : 'UNKNOWN_PROMPT',
+    playerId:
+      promptPayload.playerId === undefined
+        ? null
+        : (promptPayload.playerId ?? null),
+    title:
+      typeof promptPayload.title === 'string' &&
+      promptPayload.title.trim().length > 0
+        ? promptPayload.title
+        : undefined,
+    message:
+      typeof promptPayload.message === 'string' &&
+      promptPayload.message.trim().length > 0
+        ? promptPayload.message
+        : undefined,
+    timeoutSec,
+    choices: normalizedChoices,
+    payload: payloadRecord,
+  }
+}
+
+const normalizeSnapshotPayload = (snapshot: GameSnapshot): GameSnapshot => ({
+  ...snapshot,
+  phase: normalizePhase(snapshot.phase),
+  prompt: snapshot.prompt ? normalizePromptPayload(snapshot.prompt) : null,
+})
+
+const getResolvedGameId = (gameId?: GameId | null): GameId | null => {
+  const gameStore = useGameStore.getState()
+  return gameId ?? gameStore.gameId ?? gameStore.session.gameId ?? null
+}
 
 const createPendingAction = (
   action: Required<Pick<GameActionPayload, 'actionId' | 'type'>> &
@@ -81,7 +241,7 @@ export const setupGameHandlers = (
     const gameStore = useGameStore.getState()
 
     if (payload.snapshot) {
-      gameStore.replaceFromSnapshot(payload.snapshot)
+      gameStore.replaceFromSnapshot(normalizeSnapshotPayload(payload.snapshot))
       return
     }
 
@@ -92,8 +252,14 @@ export const setupGameHandlers = (
     })
   }
 
-  const handleGamePrompt = (prompt: GamePrompt) => {
-    useGameStore.getState().setPrompt(prompt)
+  const handleGamePrompt = (promptPayload: PromptCompatPayload) => {
+    const normalizedPrompt = normalizePromptPayload(promptPayload)
+    if (!normalizedPrompt) {
+      useGameStore.getState().setLastError(PROMPT_ID_REQUIRED_ERROR)
+      return
+    }
+
+    useGameStore.getState().setPrompt(normalizedPrompt)
   }
 
   const handleGameError = (error: GameError) => {
@@ -114,14 +280,12 @@ export const setupGameHandlers = (
 
   teardownGameHandlersRef = teardown
 
-  if (options.roomId || options.gameId) {
+  if (options.gameId) {
     const gameStore = useGameStore.getState()
     gameStore.setGameState({
-      roomId: options.roomId ?? gameStore.roomId,
       gameId: options.gameId ?? gameStore.gameId,
       session: {
         ...gameStore.session,
-        roomId: options.roomId ?? gameStore.session.roomId,
         gameId: options.gameId ?? gameStore.session.gameId,
         transport: 'event-socket',
       },
@@ -134,11 +298,16 @@ export const setupGameHandlers = (
 export const emitGameAction = ({
   actionId = createActionId(),
   type,
-  roomId,
   gameId,
   payload,
 }: GameActionPayload) => {
   const gameStore = useGameStore.getState()
+  const resolvedGameId = getResolvedGameId(gameId)
+
+  if (!resolvedGameId) {
+    gameStore.setLastError(GAME_ID_REQUIRED_ERROR)
+    return null
+  }
 
   gameStore.setPendingAction(
     createPendingAction({
@@ -152,8 +321,7 @@ export const emitGameAction = ({
     mockEmitGameAction({
       actionId,
       type,
-      roomId,
-      gameId,
+      gameId: resolvedGameId,
       payload,
     })
     return actionId
@@ -162,8 +330,7 @@ export const emitGameAction = ({
   socket.emit('game:action', {
     actionId,
     type,
-    roomId,
-    gameId,
+    gameId: resolvedGameId,
     payload,
   })
 
@@ -171,21 +338,25 @@ export const emitGameAction = ({
 }
 
 export const emitGameSync = ({
-  roomId,
   gameId,
   knownRevision,
 }: GameSyncPayload) => {
+  const resolvedGameId = getResolvedGameId(gameId)
+  if (!resolvedGameId) {
+    useGameStore.getState().setLastError(GAME_ID_REQUIRED_ERROR)
+    return
+  }
+
   if (USE_GAME_SOCKET_MOCK) {
     mockEmitGameSync({
-      roomId,
-      gameId,
+      gameId: resolvedGameId,
       knownRevision,
     })
     return
   }
 
   socket.emit('game:sync', {
-    gameId,
+    gameId: resolvedGameId,
     knownRevision,
   })
 }
@@ -195,25 +366,37 @@ export const emitPromptResponse = ({
   choice,
   gameId,
 }: PromptResponsePayload) => {
+  const resolvedGameId = getResolvedGameId(gameId)
+  if (!resolvedGameId) {
+    useGameStore.getState().setLastError(GAME_ID_REQUIRED_ERROR)
+    return
+  }
+
+  const normalizedChoice = normalizePromptChoiceValue(choice)
+  if (!promptId || !normalizedChoice) {
+    useGameStore.getState().setLastError(PROMPT_ID_REQUIRED_ERROR)
+    return
+  }
+
   if (USE_GAME_SOCKET_MOCK) {
     mockEmitPromptResponse({
       promptId,
-      choice,
+      choice: normalizedChoice,
     })
     return
   }
 
   socket.emit('game:prompt_response', {
-    gameId,
+    gameId: resolvedGameId,
     promptId,
-    choice,
+    choice: normalizedChoice,
   })
 }
 
 // Deprecated compatibility wrapper until all callers move to emitGameAction.
-export const emitRollDice = (payload: { room_id: string }) => {
+export const emitRollDice = (payload: { room_id: string; game_id?: string }) => {
   emitGameAction({
     type: 'ROLL_DICE',
-    roomId: payload.room_id,
+    gameId: payload.game_id ?? payload.room_id,
   })
 }


### PR DESCRIPTION
## 관련 이슈

> closes #360 

---

## 작업 내용

> 게임 소켓 계약을 최신 합의안 기준으로 고정했습니다.
> 
> - `game:action`, `game:sync`, `game:prompt_response` 송신 식별자를 `gameId` 기준으로 통일
> - `emitGameAction`/`emitGameSync`/`emitPromptResponse`의 `gameId` 필수 흐름 정리
> - `game:prompt` 수신 시 `promptId(id alias 포함)`, `timeoutSec(timeoutMs alias 포함)` 정규화 처리 반영
> - prompt choice 값 전송/처리를 canonical(대문자) 기준으로 정리
> - `useGameState`, `useDiceRoll`, `GamePage`, `GameBoard` 연결부를 `gameId` 중심으로 전환
> - 보드 빌드 액션 송신을 `BUILD_PROPERTY`에서 `BUY_PROPERTY` 재사용 규약으로 정렬
> - 관련 단위 테스트(`gameBoardActionHandlers.test.ts`) 기대값을 새 계약에 맞게 갱신
> 
> 추가로 pre-push 검증(lint/test/coverage/e2e:ci/build)까지 모두 통과했습니다.

---

## 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 해결 완료

---

## 스크린샷 (선택)

> UI 변경 없음
