### PR TITLE
 Test : game:action ~ prompt_response 한 턴 계약 시나리오 테스트 추가

### DIFF
--- a/docs/game-delivery-roadmap.md
+++ b/docs/game-delivery-roadmap.md
@@ -98,8 +98,8 @@
   새 명세 기준으로는 `game:ack`, `game:patch`, `game:prompt`, `game:error`만 처리하도록 바뀌어야 한다.
 
 - `src/services/game/game.api.ts`
-  현재는 `buy`, `build`, `sell`, `state` REST 액션이 중심이다.
-  중앙 docs `api.md` 기준으로 게임 로직은 `game:*` 소켓이 중심이므로, REST는 제거하거나 **이행 중 레거시 fallback으로 격리**해야 한다.
+  레거시 게임 REST 모듈은 삭제됐다.
+  중앙 docs `api.md` 기준으로 게임 로직은 `game:*` 소켓 경로를 단일 경로로 유지한다.
 
 - `src/hooks/game/useGameState.ts`
   현재는 진입 시 REST `getState`를 호출하고 기존 소켓 핸들러를 붙인다.
@@ -145,6 +145,8 @@
 - `src/mocks/handlers/game.handler.ts`: `game:ack` + `game:patch(snapshot)` 기반 mock 계약 정렬
 - `src/pages/GamePage.tsx`: prompt/ack/error/pendingAction UI 연결 완료
 - `src/components/board/gameBoardActionHandlers.ts`: non-mock 경로에서 BUY/BUILD/SELL/END_TURN를 `emitGameAction`으로 송신
+- `src/services/game/game.api.ts`: 레거시 게임 REST 모듈 삭제 완료
+- `src/mocks/handlers/game.handler.test.ts`: 한 턴 계약 시나리오(`action -> ack -> patch -> prompt_response`) 테스트 추가
 
 남은 핵심 축 — **중앙 docs 대비 런타임 정합성**:
 
@@ -184,7 +186,7 @@
 
 - `emitGameAction`/`emitGameSync`/`emitPromptResponse` 호출부를 `gameId` 기준으로 정리
 - `GameBoard` prompt 소비 경로의 로컬 fallback 분기 축소
-- `src/services/game/game.api.ts`는 레거시 fallback 유틸로만 격리 유지(직접 호출 금지)
+- 게임 런타임에서 REST 의존(`game.api`) 재도입 금지 유지
 
 ### 5-3. mock 검증 흐름 유지
 

--- a/docs/game-event-spec-migration-plan.md
+++ b/docs/game-event-spec-migration-plan.md
@@ -74,22 +74,22 @@
 
 아래 표에서 **상태** 열 기준: ✅ 완료 / ⚠️ 런타임 정합성 조정 필요 / ❌ 미구현
 
-| 파일                                                | 현재 상태         | 남은 수정 방향                                                                                            | 담당                  |
-| --------------------------------------------------- | ----------------- | --------------------------------------------------------------------------------------------------------- | --------------------- |
-| `src/types/domain.ts`                               | ✅ 완료           | —                                                                                                         | FE-B                  |
-| `src/stores/game.store.ts`                          | ✅ 완료           | —                                                                                                         | FE-B                  |
-| `src/services/socket/game.handler.ts`               | ✅ 완료           | —                                                                                                         | FE-B                  |
-| `src/hooks/game/useGameState.ts`                    | ✅ 완료           | —                                                                                                         | FE-B                  |
-| `src/services/game/game.api.ts`                     | ⚠️ 레거시 보관 중 | deprecated 표시는 완료됐고, 직접 호출 경로는 제거 상태. fallback 유틸로만 보관 중                         | FE-B                  |
-| `src/hooks/game/useDiceRoll.ts`                     | ✅ 완료           | —                                                                                                         | FE-B                  |
-| `src/pages/GamePage.tsx`                            | ✅ 3차 완료       | `prompt` 오버레이 응답 + `prompt.type` board-modal 분기 연결 완료. 미매핑 prompt는 오버레이 fallback 유지 | FE-B                  |
-| `src/components/board/GameBoard.tsx`                | ⚠️ 부분 정리      | `store.prompt` 기반 모달 연결은 완료. 로컬 엔진 성격(`applyMoney`, `advanceTurn`, 파산 판정) 제거 필요    | FE-C 주도 / FE-B 협업 |
-| `src/components/game/modals/*`                      | ✅ 3차 완료       | `store.prompt.type` 기준 모달 열림 조건/응답 연결 완료. `DiceTimerModal` timeout 연동 완료                | FE-B                  |
-| `src/mocks/handlers/game.handler.ts`                | ✅ 완료           | —                                                                                                         | FE-B                  |
-| `src/components/board/gameBoardStoreBridge.ts`      | ✅ 완료           | `toStoreBuildingLevel` 상한 7 반영 완료                                                                   | FE-C                  |
-| `src/components/board/gameBoardTransactionUtils.ts` | ✅ 완료           | `upgradeBoardTileOwner` 상한 7 반영 완료                                                                  | FE-C                  |
-| `src/components/board/gameBoardActionUtils.ts`      | ✅ 완료           | `getBoardSellFallbackRefund` level 5, 6 반영 완료                                                         | FE-C                  |
-| `src/components/board/*` (렌더 레이어)              | ❌ 미구현         | `store.eventQueue` 소비 연출. `playerState` 시각화                                                        | FE-C                  |
+| 파일                                                | 현재 상태    | 남은 수정 방향                                                                                            | 담당                  |
+| --------------------------------------------------- | ------------ | --------------------------------------------------------------------------------------------------------- | --------------------- |
+| `src/types/domain.ts`                               | ✅ 완료      | —                                                                                                         | FE-B                  |
+| `src/stores/game.store.ts`                          | ✅ 완료      | —                                                                                                         | FE-B                  |
+| `src/services/socket/game.handler.ts`               | ✅ 완료      | —                                                                                                         | FE-B                  |
+| `src/hooks/game/useGameState.ts`                    | ✅ 완료      | —                                                                                                         | FE-B                  |
+| `src/services/game/game.api.ts`                     | ✅ 완료      | 레거시 REST 모듈 삭제 완료(게임 런타임은 event-socket 단일 경로 유지)                                     | FE-B                  |
+| `src/hooks/game/useDiceRoll.ts`                     | ✅ 완료      | —                                                                                                         | FE-B                  |
+| `src/pages/GamePage.tsx`                            | ✅ 3차 완료  | `prompt` 오버레이 응답 + `prompt.type` board-modal 분기 연결 완료. 미매핑 prompt는 오버레이 fallback 유지 | FE-B                  |
+| `src/components/board/GameBoard.tsx`                | ⚠️ 부분 정리 | `store.prompt` 기반 모달 연결은 완료. 로컬 엔진 성격(`applyMoney`, `advanceTurn`, 파산 판정) 제거 필요    | FE-C 주도 / FE-B 협업 |
+| `src/components/game/modals/*`                      | ✅ 3차 완료  | `store.prompt.type` 기준 모달 열림 조건/응답 연결 완료. `DiceTimerModal` timeout 연동 완료                | FE-B                  |
+| `src/mocks/handlers/game.handler.ts`                | ✅ 완료      | —                                                                                                         | FE-B                  |
+| `src/components/board/gameBoardStoreBridge.ts`      | ✅ 완료      | `toStoreBuildingLevel` 상한 7 반영 완료                                                                   | FE-C                  |
+| `src/components/board/gameBoardTransactionUtils.ts` | ✅ 완료      | `upgradeBoardTileOwner` 상한 7 반영 완료                                                                  | FE-C                  |
+| `src/components/board/gameBoardActionUtils.ts`      | ✅ 완료      | `getBoardSellFallbackRefund` level 5, 6 반영 완료                                                         | FE-C                  |
+| `src/components/board/*` (렌더 레이어)              | ❌ 미구현    | `store.eventQueue` 소비 연출. `playerState` 시각화                                                        | FE-C                  |
 
 ### 2-1. 백엔드와 최종 고정이 필요한 항목
 
@@ -173,14 +173,11 @@
 
 ### 3-4. `src/services/game/game.api.ts`
 
-현재 `buy/build/sell/sync`는 새 명세 기준의 주 경로가 아니다.
+해당 모듈은 삭제 완료됐다.
 
-권장 처리:
-
-- `getState`, `buyTile`, `buildTile`, `sellTile`, `syncState`를 레거시로 표시
-- 새 소켓 경로 전환 후 사용처 제거
-- 당장 삭제가 부담되면 `deprecated` 성격의 얇은 래퍼로 격리
-- 단, backend rollout 전까지는 `roomId` 기준 fallback이므로 FE-B 소유 범위에 둔다
+- `src/services/game/game.api.ts` 삭제
+- 게임 액션 호출 경로는 `emitGameAction`/`emitPromptResponse` 기반 socket 경로로 단일화
+- 이후 게임 런타임에서 REST 재의존이 생기지 않도록 테스트/리뷰 단계에서 차단
 
 ### 3-5. `src/pages/GamePage.tsx`
 
@@ -269,6 +266,8 @@
 - `src/hooks/game/useGameState.ts`: `game:sync` 기반 동기화 경로로 정리
 - `src/pages/GamePage.tsx`: store 단일 소스, `gameViewModel` mapper로 board 데이터 조립 + `prompt` 오버레이 응답, `pendingAction`/`lastAck`/`lastError` UI 연결
 - `src/components/board/gameBoardActionHandlers.ts`: non-mock 경로에서 BUY/BUILD/SELL/END_TURN를 `emitGameAction`으로 송신
+- `src/services/game/game.api.ts`: 레거시 REST 모듈 삭제 완료
+- `src/mocks/handlers/game.handler.test.ts`: `game:action -> game:ack -> game:patch -> game:prompt_response` 한 턴 계약 시나리오 테스트 추가
 
 ### 명세 불일치 (코드 측 반영 완료, 계약 고정 대기)
 
@@ -294,7 +293,7 @@
 **FE-B**
 
 1. 백엔드와 `gameId` canonical / ActionType(건설) / prompt 필드 / snapshot 스키마 최종 고정
-2. emit 호출부(`game:action`,`game:sync`,`game:prompt_response`)의 `gameId` 정렬
+2. `#362` 범위로 MSW 소켓 계약 검증(식별자/choice/revision) 강화
 3. 문서와 타입의 `TURN_ENDED`/prompt/snapshot 표기 통일 유지
 
 **FE-C**

--- a/docs/game-ownership-corrected-table.md
+++ b/docs/game-ownership-corrected-table.md
@@ -18,16 +18,17 @@
 
 ## 진행도 요약
 
-| 파트 | 진행도  | 상태                                                                                                                      |
-| ---- | ------- | ------------------------------------------------------------------------------------------------------------------------- |
-| FE-B | 진행 중 | prompt/ack 연결 및 event-socket 계약 전환 완료. `gameId` canonical/ActionType(건설)/prompt-snapshot 스키마 최종 고정 단계 |
-| FE-C | 진행 중 | 보드를 표현/연출 중심 레이어로 더 줄이고 로컬 엔진 성격 로직을 제거해야 하는 단계                                         |
+| 파트 | 진행도  | 상태                                                                                                                   |
+| ---- | ------- | ---------------------------------------------------------------------------------------------------------------------- |
+| FE-B | 진행 중 | event-socket 계약 전환 + `game.api` 제거 + 한 턴 계약 시나리오 테스트(#298) 반영 완료. `#362`(MSW 계약 검증 강화) 단계 |
+| FE-C | 진행 중 | 보드를 표현/연출 중심 레이어로 더 줄이고 로컬 엔진 성격 로직을 제거해야 하는 단계                                      |
 
 ## FE-B 현재 최우선 작업
 
 - `game:action`/`game:sync`/`game:prompt_response`의 `gameId` canonical 사용 범위 고정
 - ActionType에서 건설 처리 방식(`BUILD_PROPERTY` 유지 여부) 백엔드 최종 합의
 - prompt/snapshot 필드(`id/promptId`, `timeoutSec/timeoutMs`) 최종 계약 고정
+- `#362` 범위로 MSW 소켓 계약 검증(식별자/choice/revision) 테스트 강화
 
 ## FE-C 현재 최우선 작업
 
@@ -40,7 +41,7 @@
 
 - `GamePage` + `GameBoard`는 `prompt.type` 소비 구조로 전환됐지만 mock fallback과 실서버 경로가 일부 이원화돼 있다.
 - `GameBoard.tsx`가 여전히 `applyMoney`/`advanceTurn`/파산 판정 등 게임 엔진 성격 로직을 들고 있다.
-- 게임 REST fallback이 장기화되면 중앙 docs 기준과 실제 런타임이 다시 벌어질 수 있다.
+- 레거시 REST(`game.api`)가 삭제된 이후, 소켓 계약 변경 시 회귀를 잡는 테스트 보강이 필요하다.
 - `gameId` canonical, money unit, prompt/snapshot 필드 기준이 문서와 코드에서 완전히 수렴하지 않았다.
 
 ## 작업 운영 규칙 (2026-03-05 추가)

--- a/src/mocks/handlers/game.handler.test.ts
+++ b/src/mocks/handlers/game.handler.test.ts
@@ -247,4 +247,85 @@ describe('mock game socket handlers contract', () => {
 
     teardown()
   })
+
+  it('runs one-turn contract flow from game:action to prompt_response', async () => {
+    const { acks, errors, patches, teardown } = captureGameSocketEvents()
+
+    const gameId = 'game-turn-flow'
+    mockEmitGameSync({
+      gameId,
+      knownRevision: 0,
+    })
+    await flushMockTimers()
+
+    expect(patches).toHaveLength(1)
+    const syncRevision = patches[0].revision
+    expect(patches[0].snapshot?.gameId).toBe(gameId)
+
+    const rollActionId = 'action-roll-flow'
+    mockEmitGameAction({
+      actionId: rollActionId,
+      type: 'ROLL_DICE',
+      gameId,
+    })
+    await flushMockTimers()
+
+    const rollAck = acks.find((ack) => ack.actionId === rollActionId)
+    expect(rollAck).toBeDefined()
+    expect(rollAck).toMatchObject({
+      actionId: rollActionId,
+      type: 'ROLL_DICE',
+      ok: true,
+      revision: syncRevision + 1,
+    })
+
+    const rollPatch = patches.find(
+      (patch) => patch.revision === rollAck?.revision
+    )
+    expect(rollPatch).toBeDefined()
+    expect(rollPatch?.events?.map((event) => event.type)).toEqual(
+      expect.arrayContaining(['DICE_ROLLED', 'PLAYER_MOVED'])
+    )
+
+    const prompt: GamePrompt = {
+      id: 'prompt-turn-flow',
+      type: 'BUY_OR_SKIP',
+      playerId: rollPatch?.snapshot?.currentTurn ?? null,
+      timeoutSec: 30,
+    }
+    mockDevSetPromptForTest(prompt)
+
+    mockEmitPromptResponse({
+      gameId,
+      promptId: prompt.id,
+      choice: 'buy',
+    })
+    await flushMockTimers()
+
+    const promptAck = acks.find(
+      (ack) => ack.type === 'PROMPT_RESPONSE' && ack.promptId === prompt.id
+    )
+    expect(promptAck).toBeDefined()
+    expect(promptAck).toMatchObject({
+      type: 'PROMPT_RESPONSE',
+      ok: true,
+      promptId: prompt.id,
+    })
+
+    const promptPatch = patches.find(
+      (patch) => patch.revision === promptAck?.revision
+    )
+    expect(promptPatch).toBeDefined()
+    expect(promptPatch?.events?.[0]).toMatchObject({
+      type: 'PROMPT_RESPONSE',
+      payload: {
+        promptId: prompt.id,
+        choice: 'BUY',
+      },
+    })
+    expect(promptPatch?.snapshot?.prompt).toBeNull()
+    expect(errors).toHaveLength(0)
+
+    teardown()
+  })
 })


### PR DESCRIPTION
## 📌 관련 이슈

> closes #298

---

## 📝 작업 내용

- mock game socket 계약 테스트에 한 턴 시나리오를 추가했습니다.
  - `game:sync`로 초기 스냅샷 동기화
  - `game:action(ROLL_DICE)` 송신 후 `game:ack`/`game:patch` 검증
  - prompt 상태에서 `game:prompt_response` 응답 후 `game:ack(promptId 포함)`/`game:patch` 검증
  - choice canonical(`buy` -> `BUY`) 반영 여부 검증
- 문서 3종에 진행도와 다음 작업을 업데이트했습니다.
  - `#354`(레거시 `game.api` 제거) 반영
  - `#298` 테스트 진행 반영
  - 다음 작업을 `#362`로 정렬

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

검증:
- `npm run lint`
- `npm run test`
- `npm run test:coverage`
- `npm run e2e:ci`
- `npm run build`

---

## 📸 스크린샷 (선택)

> UI 변경 없음
