### PR TITLE
feat: Vercel 데모 배포용 mock 모드와 env 구조 정리

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,4 @@
+# 로컬 개발 서버는 mock API/socket을 기본 사용
+VITE_USE_SOCKET_MOCK=true
+VITE_ENABLE_DEMO_MOCK=false
+VITE_ALLOW_ALL_MOCK_TURNS=false

--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,12 @@
+# 실백엔드 연결 예시
 VITE_API_URL=http://localhost:3000/api
 VITE_SOCKET_URL=http://localhost:3000
+
+# 로컬 개발 mock 사용 여부(dev에서만 의미 있음)
+VITE_USE_SOCKET_MOCK=true
+
+# 배포 환경에서도 mock 데모를 강제로 켤지 여부
+VITE_ENABLE_DEMO_MOCK=false
+
+# mock 게임에서 턴 제한을 무시할지 여부
+VITE_ALLOW_ALL_MOCK_TURNS=false

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,3 @@
+# 현재 배포는 백엔드 없이 데모 mock 모드로 동작
+VITE_ENABLE_DEMO_MOCK=true
+VITE_ALLOW_ALL_MOCK_TURNS=false

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,3 +1,17 @@
-// DEV + 환경변수 조합으로 소켓 목 모드 활성 여부를 단일 규칙으로 계산
+// 문자열 env flag를 boolean 의미로 정규화
+function isEnabled(value: string | undefined) {
+  return value === 'true'
+}
+
+// 배포 환경에서도 데모 목 모드를 명시적으로 켤 수 있는 플래그
+export const IS_DEMO_MOCK_ENABLED = isEnabled(
+  import.meta.env.VITE_ENABLE_DEMO_MOCK
+)
+
+// MSW는 개발 서버 또는 배포 데모 모드에서만 활성화
+export const SHOULD_ENABLE_MSW = import.meta.env.DEV || IS_DEMO_MOCK_ENABLED
+
+// 소켓/REST 목 모드는 개발 기본값 또는 배포 데모 플래그로 활성화
 export const IS_SOCKET_MOCK_ENABLED =
-  import.meta.env.DEV && import.meta.env.VITE_USE_SOCKET_MOCK !== 'false'
+  (import.meta.env.DEV && import.meta.env.VITE_USE_SOCKET_MOCK !== 'false') ||
+  IS_DEMO_MOCK_ENABLED

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,11 +3,12 @@ import { createRoot } from 'react-dom/client'
 import { AppProviders } from './providers/AppProviders'
 import App from './App'
 import './index.css'
+import { SHOULD_ENABLE_MSW } from './config/env'
 
-// 개발 환경에서만 MSW를 활성화해 API 모킹 연결
+// 개발 서버 또는 배포 데모 모드에서만 MSW를 활성화해 API 모킹 연결
 async function enableMocking() {
-  // 배포 환경에서는 네트워크 요청을 그대로 사용
-  if (import.meta.env.DEV) {
+  // 일반 배포 환경에서는 네트워크 요청을 그대로 사용
+  if (SHOULD_ENABLE_MSW) {
     const { worker } = await import('./mocks/browser')
     return worker.start({
       onUnhandledRequest: 'bypass',

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -3,6 +3,9 @@
 interface ImportMetaEnv {
   readonly VITE_API_URL?: string
   readonly VITE_SOCKET_URL?: string
+  readonly VITE_USE_SOCKET_MOCK?: string
+  readonly VITE_ENABLE_DEMO_MOCK?: string
+  readonly VITE_ALLOW_ALL_MOCK_TURNS?: string
 }
 
 interface ImportMeta {

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,11 @@
+{
+  "routes": [
+    {
+      "handle": "filesystem"
+    },
+    {
+      "src": "/(.*)",
+      "dest": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
## 📌 관련 이슈

> closes #373 

---

## 📝 작업 내용

> 백엔드 없이도 Vercel에서 로비/대기방/게임 데모 흐름을 확인할 수 있도록 배포용 mock 모드와 env 구조를 정리했습니다.

- `VITE_ENABLE_DEMO_MOCK` 플래그를 추가해 production build에서도 demo mock 모드를 켤 수 있도록 구성
- MSW 초기화 조건을 개발 환경 전용에서 `개발 환경 또는 데모 배포 환경`으로 확장
- `vite-env.d.ts`에 배포/데모 env 타입 선언 추가
- `vercel.json`을 추가해 SPA 라우팅(`/lobby`, `/rooms/:roomId`, `/game/:gameId`) 새로고침 대응
- `.env.development`, `.env.production`, `.env.example`를 역할별로 분리해 로컬 mock / 배포 mock / 실백엔드 전환 구조 정리
- 중복되던 `.env` 의존을 제거하고 모드별 설정 기준을 명확히 정리

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

> Vercel 배포 후 홈 → 로비 → 대기방 데모 동작 화면 첨부
