### PR TITLE
refactor: 클릭형 UI 선택 방지와 홈 화면 높이 보정

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -21,7 +21,7 @@ function Header({
 }: HeaderProps) {
   return (
     <header className="sticky top-0 z-40 flex h-14 items-center justify-between border-b border-ui-border bg-ui-surface/95 px-4 backdrop-blur sm:px-6">
-      <div className="flex items-center gap-2.5">
+      <div className="flex select-none items-center gap-2.5">
         <div className="flex size-9 items-center justify-center rounded-lg bg-ui-brand text-white">
           <Dice5 className="size-5" strokeWidth={2} />
         </div>

--- a/src/components/header/ProfileDropdown.tsx
+++ b/src/components/header/ProfileDropdown.tsx
@@ -68,12 +68,12 @@ export function ProfileDropdown({
 
   return (
     <div className="flex items-center gap-2 text-sm font-medium text-ui-text-muted">
-      <span className="max-w-[140px] truncate">{playerLabel}</span>
+      <span className="max-w-[140px] truncate select-none">{playerLabel}</span>
       {hasMenuItems ? (
         <div ref={menuContainerRef} className="relative group/menu">
           <button
             type="button"
-            className="rounded-full outline-none"
+            className="rounded-full outline-none select-none"
             aria-label="프로필 메뉴 열기"
             aria-expanded={isMenuOpen}
             onClick={() => setIsMenuOpen((previous) => !previous)}
@@ -98,7 +98,7 @@ export function ProfileDropdown({
                       item.onSelect()
                       setIsMenuOpen(false)
                     }}
-                    className={`flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm font-medium transition hover:bg-ui-surface-muted ${
+                    className={`flex w-full select-none items-center gap-2 rounded-lg px-3 py-2 text-left text-sm font-medium transition hover:bg-ui-surface-muted ${
                       item.tone === 'danger'
                         ? 'text-ui-danger'
                         : 'text-ui-text-primary'

--- a/src/features/presence/components/UserListPanel.tsx
+++ b/src/features/presence/components/UserListPanel.tsx
@@ -96,7 +96,7 @@ export function UserListPanel({
         <div
           className={cn('flex h-full min-h-[280px] flex-col', panelHeightClass)}
         >
-          <div className="flex items-center justify-between border-b border-ui-border px-4 py-3">
+          <div className="flex items-center justify-between border-b border-ui-border px-4 py-3 select-none">
             <div className="flex items-center gap-2">
               <h2 className="text-base font-semibold text-ui-text-strong">
                 접속자 목록
@@ -108,7 +108,7 @@ export function UserListPanel({
             <button
               type="button"
               onClick={onToggle}
-              className="rounded-lg p-1.5 text-ui-text-subtle transition-colors hover:bg-ui-surface-soft hover:text-ui-text-muted"
+              className="rounded-lg p-1.5 text-ui-text-subtle transition-colors hover:bg-ui-surface-soft hover:text-ui-text-muted select-none"
               aria-label="접속자 목록 닫기"
             >
               <ChevronRight className="size-4" />
@@ -161,13 +161,13 @@ export function UserListPanel({
           <button
             type="button"
             onClick={onToggle}
-            className="rounded-lg p-2 text-ui-text-subtle transition-colors hover:bg-ui-surface-soft hover:text-ui-text-muted"
+            className="rounded-lg p-2 text-ui-text-subtle transition-colors hover:bg-ui-surface-soft hover:text-ui-text-muted select-none"
             aria-label="접속자 목록 열기"
           >
             <ChevronLeft className="size-4" />
           </button>
 
-          <span className="rounded-full bg-ui-brand-soft px-2 py-0.5 text-xs font-semibold text-ui-brand">
+          <span className="rounded-full bg-ui-brand-soft px-2 py-0.5 text-xs font-semibold text-ui-brand select-none">
             {sortedUsers.length}
           </span>
 

--- a/src/features/presence/components/UserRow.tsx
+++ b/src/features/presence/components/UserRow.tsx
@@ -31,7 +31,7 @@ export function UserRow({
     !isDirectMessageAllowed(user.status)
 
   return (
-    <div className="group flex items-center gap-3 px-4 py-2.5 hover:bg-ui-surface-muted">
+    <div className="group flex select-none items-center gap-3 px-4 py-2.5 hover:bg-ui-surface-muted">
       <div className="relative shrink-0">
         <Avatar
           size="md"
@@ -69,7 +69,7 @@ export function UserRow({
           onOpenDirectMessage?.(user)
         }}
         className={cn(
-          'rounded-lg p-2 text-ui-text-subtle transition',
+          'rounded-lg p-2 text-ui-text-subtle transition select-none',
           isDmDisabled
             ? 'cursor-not-allowed opacity-45'
             : 'hover:bg-ui-surface-soft hover:text-ui-text-muted'

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -74,7 +74,7 @@ function HomePage() {
   }
 
   return (
-    <div className="relative min-h-screen overflow-hidden bg-ui-app-bg px-4 py-8 sm:px-8 sm:py-10">
+    <div className="relative min-h-screen overflow-hidden bg-ui-app-bg px-4 py-5 sm:px-8 sm:py-6 lg:py-8">
       {/* 브랜드 중심을 받쳐주는 배경 레이어 */}
       <div className="pointer-events-none absolute inset-0">
         <picture>
@@ -89,32 +89,32 @@ function HomePage() {
         <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_28%,rgba(255,255,255,0.24),transparent_28%),linear-gradient(180deg,rgba(250,248,240,0.1),rgba(250,248,240,0.08))]" />
       </div>
 
-      <main className="relative mx-auto flex min-h-[calc(100vh-4rem)] w-full max-w-6xl flex-col items-center justify-center gap-12">
+      <main className="relative mx-auto flex min-h-[calc(100dvh-2.5rem)] w-full max-w-6xl flex-col items-center justify-center gap-8 sm:min-h-[calc(100dvh-3rem)] lg:min-h-[calc(100dvh-4rem)] lg:gap-10">
         <motion.section
           initial={{ opacity: 0, y: 28 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.72, ease: [0.18, 0.9, 0.28, 1] }}
           className="w-full max-w-4xl text-center"
         >
-          <h1 className="text-[clamp(3.2rem,8vw,5.8rem)] font-extrabold leading-[0.92] tracking-tight text-ui-text-strong">
+          <h1 className="select-none text-[clamp(3.2rem,8vw,5.8rem)] font-extrabold leading-[0.92] tracking-tight text-ui-text-strong">
             <span className="text-ui-text-strong">MARBLE</span>
             <span className="ml-1.5 bg-linear-to-r from-ui-brand-strong via-ui-brand to-[#0ea5e9] bg-clip-text text-transparent sm:ml-2">
               POP
             </span>
           </h1>
 
-          <p className="mx-auto mt-6 max-w-116 whitespace-pre-line text-[clamp(1rem,1.8vw,1.22rem)] font-bold leading-relaxed text-ui-text-primary">
+          <p className="mx-auto mt-5 max-w-112 select-none whitespace-pre-line text-[clamp(1rem,1.8vw,1.22rem)] font-bold leading-relaxed text-ui-text-primary">
             {
               '주사위를 굴려 나만의 도시를 건설하세요!\n귀엽고 신나는 실시간 보드게임'
             }
           </p>
 
-          <div className="mx-auto mt-9 flex w-full max-w-[430px] flex-col gap-3">
+          <div className="mx-auto mt-7 flex w-full max-w-[430px] flex-col gap-3">
             <button
               type="button"
               onClick={handleKakaoLogin}
               disabled={isAnyLoading}
-              className="flex h-14 items-center justify-center gap-2.5 rounded-2xl bg-[#ffe812] py-3 text-[1.125rem] font-bold text-[#191919] shadow-[0_6px_14px_rgba(15,23,42,0.08)] transition-all hover:bg-[#f5dc00] hover:shadow-[0_8px_18px_rgba(15,23,42,0.1)] active:scale-[0.98] disabled:opacity-70"
+              className="flex h-14 select-none items-center justify-center gap-2.5 rounded-2xl bg-[#ffe812] py-3 text-[1.125rem] font-bold text-[#191919] shadow-[0_6px_14px_rgba(15,23,42,0.08)] transition-all hover:bg-[#f5dc00] hover:shadow-[0_8px_18px_rgba(15,23,42,0.1)] active:scale-[0.98] disabled:opacity-70"
             >
               <MessageCircle className="size-6 shrink-0 fill-[#191919]" />
               {isKakaoLoading ? '로그인 중...' : '카카오 로그인으로 시작'}
@@ -123,18 +123,18 @@ function HomePage() {
               type="button"
               onClick={handleGuestLogin}
               disabled={isAnyLoading}
-              className="flex h-14 items-center justify-center gap-2.5 rounded-2xl border-2 border-ui-border bg-ui-surface/92 py-3 text-[1.125rem] font-bold text-ui-text-primary shadow-[0_4px_10px_rgba(15,23,42,0.03)] transition-colors hover:border-ui-text-subtle hover:bg-ui-surface-muted active:scale-[0.98] disabled:opacity-70"
+              className="flex h-14 select-none items-center justify-center gap-2.5 rounded-2xl border-2 border-ui-border bg-ui-surface/92 py-3 text-[1.125rem] font-bold text-ui-text-primary shadow-[0_4px_10px_rgba(15,23,42,0.03)] transition-colors hover:border-ui-text-subtle hover:bg-ui-surface-muted active:scale-[0.98] disabled:opacity-70"
             >
               <UserRound className="size-6 shrink-0 text-ui-text-muted" />
               {isGuestLoading ? '입장 중...' : '게스트로 시작'}
             </button>
-            <p className="pt-0.5 text-[0.75rem] font-medium text-ui-text-subtle">
+            <p className="select-none pt-0.5 text-[0.75rem] font-medium text-ui-text-subtle">
               * 게스트는 전적이 저장되지 않으며 일부 기능이 제한됩니다.
             </p>
           </div>
         </motion.section>
 
-        <section className="grid w-full max-w-[980px] grid-cols-1 gap-4 md:grid-cols-3">
+        <section className="grid w-full max-w-[980px] grid-cols-1 gap-3.5 md:grid-cols-3">
           {featureCards.map((card, index) => {
             const Icon = card.icon
 
@@ -148,17 +148,17 @@ function HomePage() {
                   delay: 0.15 + index * 0.12,
                   ease: [0.18, 0.9, 0.28, 1],
                 }}
-                className="group relative overflow-hidden rounded-[28px] border border-ui-border/80 bg-ui-surface/88 px-6 py-5 text-center shadow-[0_3px_10px_rgba(15,23,42,0.03)]"
+                className="group relative overflow-hidden rounded-[28px] border border-ui-border/80 bg-ui-surface/88 px-5 py-4 text-center shadow-[0_3px_10px_rgba(15,23,42,0.03)] select-none"
               >
                 <div
-                  className={`relative mx-auto mb-3 flex size-11 items-center justify-center rounded-xl ${card.iconBackground}`}
+                  className={`relative mx-auto mb-2.5 flex size-10 items-center justify-center rounded-xl ${card.iconBackground}`}
                 >
-                  <Icon className="size-5 text-white" strokeWidth={2} />
+                  <Icon className="size-[1.15rem] text-white" strokeWidth={2} />
                 </div>
-                <h2 className="text-[1rem] font-bold text-ui-text-primary">
+                <h2 className="text-[0.95rem] font-bold text-ui-text-primary">
                   {card.title}
                 </h2>
-                <p className="mt-1.5 text-[0.875rem] font-medium text-ui-text-muted">
+                <p className="mt-1 text-[0.84rem] font-medium text-ui-text-muted">
                   {card.description}
                 </p>
               </motion.article>

--- a/src/pages/lobby/LobbyControls.tsx
+++ b/src/pages/lobby/LobbyControls.tsx
@@ -47,7 +47,7 @@ export function LobbyControls({
           <button
             type="button"
             onClick={onCreateRoom}
-            className="inline-flex h-10 shrink-0 items-center justify-center gap-2 rounded-xl bg-ui-brand px-4 text-sm font-semibold text-white transition-colors hover:bg-ui-brand-strong active:scale-[0.98]"
+            className="inline-flex h-10 shrink-0 select-none items-center justify-center gap-2 rounded-xl bg-ui-brand px-4 text-sm font-semibold text-white transition-colors hover:bg-ui-brand-strong active:scale-[0.98]"
           >
             <Plus className="size-4" />방 만들기
           </button>
@@ -59,7 +59,7 @@ export function LobbyControls({
               aria-checked={excludePrivateRoom}
               onClick={() => onExcludePrivateRoomChange(!excludePrivateRoom)}
               className={cn(
-                'relative inline-flex h-6 w-11 shrink-0 rounded-full transition-colors',
+                'relative inline-flex h-6 w-11 shrink-0 select-none rounded-full transition-colors',
                 excludePrivateRoom ? 'bg-ui-brand' : 'bg-ui-text-subtle/40'
               )}
             >
@@ -70,7 +70,7 @@ export function LobbyControls({
                 )}
               />
             </button>
-            <span className="text-sm font-medium text-ui-text-muted">
+            <span className="select-none text-sm font-medium text-ui-text-muted">
               비밀방 제외
             </span>
           </div>
@@ -84,7 +84,7 @@ export function LobbyControls({
             type="button"
             onClick={() => onRoomFilterChange(filter.value)}
             className={cn(
-              'flex-1 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
+              'flex-1 select-none rounded-lg px-3 py-2 text-sm font-medium transition-colors',
               roomFilter === filter.value
                 ? 'bg-ui-surface text-ui-brand shadow-sm'
                 : 'text-ui-text-muted hover:text-ui-text-primary'

--- a/src/pages/lobby/RoomCard.tsx
+++ b/src/pages/lobby/RoomCard.tsx
@@ -43,7 +43,7 @@ export function RoomCard({ room, onJoinRoom }: RoomCardProps) {
   const joinButtonLabel = getJoinButtonLabel(room)
 
   return (
-    <article className="flex min-h-[160px] flex-col rounded-2xl border border-ui-border bg-ui-surface px-5 py-4 shadow-[0_2px_8px_rgba(0,0,0,0.04)] transition-shadow hover:shadow-[0_4px_12px_rgba(0,0,0,0.06)]">
+    <article className="flex min-h-[160px] select-none flex-col rounded-2xl border border-ui-border bg-ui-surface px-5 py-4 shadow-[0_2px_8px_rgba(0,0,0,0.04)] transition-shadow hover:shadow-[0_4px_12px_rgba(0,0,0,0.06)]">
       <div className="flex flex-wrap items-center gap-1.5">
         <span
           className={cn(
@@ -80,7 +80,7 @@ export function RoomCard({ room, onJoinRoom }: RoomCardProps) {
           disabled={isJoinDisabled}
           onClick={() => onJoinRoom?.(room)}
           className={cn(
-            'shrink-0 rounded-xl px-4 py-2 text-sm font-semibold transition-colors',
+            'shrink-0 select-none rounded-xl px-4 py-2 text-sm font-semibold transition-colors',
             isJoinDisabled
               ? 'cursor-not-allowed bg-ui-disabled-bg text-ui-disabled-text'
               : 'bg-ui-brand text-white hover:bg-ui-brand-strong active:scale-[0.98]'

--- a/src/pages/waiting-room/components/WaitingRoomActionPanel.tsx
+++ b/src/pages/waiting-room/components/WaitingRoomActionPanel.tsx
@@ -35,7 +35,7 @@ export function WaitingRoomActionPanel({
           disabled={isStartButtonDisabled}
           onClick={onStartGame}
           className={cn(
-            'h-16 w-full rounded-2xl text-[2.1rem] font-bold transition-colors',
+            'h-16 w-full select-none rounded-2xl text-[2.1rem] font-bold transition-colors',
             !isStartButtonDisabled
               ? 'bg-ui-brand text-white hover:bg-ui-brand-strong'
               : 'cursor-not-allowed bg-ui-disabled-bg text-ui-disabled-text'
@@ -49,7 +49,7 @@ export function WaitingRoomActionPanel({
           disabled={isReadyButtonDisabled}
           onClick={onToggleReady}
           className={cn(
-            'h-16 w-full rounded-2xl text-[2.1rem] font-bold transition-colors',
+            'h-16 w-full select-none rounded-2xl text-[2.1rem] font-bold transition-colors',
             isReadyButtonDisabled
               ? 'cursor-not-allowed border border-ui-border bg-ui-surface-soft text-ui-text-subtle'
               : isReady

--- a/src/pages/waiting-room/components/WaitingRoomHeader.tsx
+++ b/src/pages/waiting-room/components/WaitingRoomHeader.tsx
@@ -27,12 +27,12 @@ export function WaitingRoomHeader({
 }: WaitingRoomHeaderProps) {
   return (
     <header className="flex h-14 items-center justify-between border-b border-ui-border bg-ui-surface px-4 sm:px-6">
-      <div className="flex min-w-0 items-center gap-2.5">
+      <div className="flex min-w-0 items-center gap-2.5 select-none">
         <button
           type="button"
           onClick={onBackToLobby}
           aria-label="로비로 이동"
-          className="inline-flex size-8 items-center justify-center rounded-lg text-ui-text-primary transition-colors hover:bg-ui-surface-muted"
+          className="inline-flex size-8 select-none items-center justify-center rounded-lg text-ui-text-primary transition-colors hover:bg-ui-surface-muted"
         >
           <ArrowLeft className="size-4" />
         </button>

--- a/src/pages/waiting-room/components/WaitingSeatCard.tsx
+++ b/src/pages/waiting-room/components/WaitingSeatCard.tsx
@@ -13,7 +13,7 @@ export function WaitingSeatCard({ seat }: WaitingSeatCardProps) {
   // 좌석 데이터가 없으면 빈 자리 플레이스홀더를 렌더링
   if (!seat) {
     return (
-      <article className="flex h-full min-h-[260px] flex-col items-center justify-center rounded-[34px] border-[3px] border-dashed border-ui-border/80 bg-ui-app-bg text-ui-text-subtle">
+      <article className="flex h-full min-h-[260px] select-none flex-col items-center justify-center rounded-[34px] border-[3px] border-dashed border-ui-border/80 bg-ui-app-bg text-ui-text-subtle">
         <div className="mb-4 flex size-20 items-center justify-center rounded-full border-4 border-ui-border bg-ui-surface-soft">
           <UserRound className="size-9" />
         </div>
@@ -25,7 +25,7 @@ export function WaitingSeatCard({ seat }: WaitingSeatCardProps) {
   }
 
   return (
-    <article className="relative flex h-full min-h-[260px] flex-col rounded-[34px] border border-ui-border bg-ui-surface px-7 py-7 shadow-[0_2px_10px_rgba(15,23,42,0.06)]">
+    <article className="relative flex h-full min-h-[260px] select-none flex-col rounded-[34px] border border-ui-border bg-ui-surface px-7 py-7 shadow-[0_2px_10px_rgba(15,23,42,0.06)]">
       <div className="flex flex-1 flex-col items-center justify-center">
         <div className="relative mb-5">
           <Avatar


### PR DESCRIPTION
## 📌 관련 이슈

> closes #385 

---

## 📝 작업 내용

> 클릭 중심 UI에서 불필요한 텍스트 선택을 막고, 홈 화면이 일부 데스크톱 환경에서 뷰포트를 살짝 넘기던 문제를 함께 정리했습니다.

- 헤더, 로비, 접속자 목록, 대기방의 클릭형 UI에 `select-none` 적용
- 입력창/채팅 본문처럼 복사나 입력이 필요한 영역은 제외
- 홈 화면의 상하 패딩 조정
- 홈 메인 컨테이너 높이를 `100dvh` 기준으로 보정
- 히어로와 하단 소개 카드 사이 간격 축소
- 하단 소개 카드 패딩, 아이콘, 텍스트 크기를 줄여 한 화면 내 밀도 정리

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)
