### PR TITLE
feat: 데스크톱 전용 뷰포트 가드 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,18 +5,21 @@ import LobbyPage from './pages/lobby/LobbyPage'
 import NicknameSetupPage from './pages/NicknameSetupPage'
 import MyPage from './pages/MyPage'
 import WaitingRoomPage from './pages/waiting-room/WaitingRoomPage'
+import { DesktopViewportGuard } from './components/DesktopViewportGuard'
 
 // 앱 전체 페이지 라우팅 테이블 정의
 function App() {
   return (
-    <Routes>
-      <Route path="/" element={<HomePage />} />
-      <Route path="/nickname-setup" element={<NicknameSetupPage />} />
-      <Route path="/my-page" element={<MyPage />} />
-      <Route path="/game/:gameId" element={<GamePage />} />
-      <Route path="/lobby" element={<LobbyPage />} />
-      <Route path="/rooms/:roomId" element={<WaitingRoomPage />} />
-    </Routes>
+    <DesktopViewportGuard>
+      <Routes>
+        <Route path="/" element={<HomePage />} />
+        <Route path="/nickname-setup" element={<NicknameSetupPage />} />
+        <Route path="/my-page" element={<MyPage />} />
+        <Route path="/game/:gameId" element={<GamePage />} />
+        <Route path="/lobby" element={<LobbyPage />} />
+        <Route path="/rooms/:roomId" element={<WaitingRoomPage />} />
+      </Routes>
+    </DesktopViewportGuard>
   )
 }
 

--- a/src/components/DesktopViewportGuard.tsx
+++ b/src/components/DesktopViewportGuard.tsx
@@ -1,0 +1,74 @@
+import { MonitorCog, TabletSmartphone } from 'lucide-react'
+import { useEffect, useState } from 'react'
+
+const MIN_DESKTOP_VIEWPORT_WIDTH = 1280
+
+// 현재 브라우저 폭을 읽어 데스크톱 지원 여부를 판단
+function readViewportWidth() {
+  if (typeof window === 'undefined') {
+    return MIN_DESKTOP_VIEWPORT_WIDTH
+  }
+
+  return window.innerWidth
+}
+
+// 최소 지원 폭 미만에서는 앱 대신 데스크톱 전용 안내 화면을 렌더링
+export function DesktopViewportGuard({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const [viewportWidth, setViewportWidth] = useState(readViewportWidth)
+
+  useEffect(() => {
+    // 브라우저 크기 변경 시 즉시 다시 계산해 차단/해제를 동기화
+    function handleResize() {
+      setViewportWidth(readViewportWidth())
+    }
+
+    window.addEventListener('resize', handleResize)
+
+    return () => {
+      window.removeEventListener('resize', handleResize)
+    }
+  }, [])
+
+  if (viewportWidth >= MIN_DESKTOP_VIEWPORT_WIDTH) {
+    return <>{children}</>
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-ui-app-bg px-5 py-8">
+      <div className="w-full max-w-md rounded-[32px] border border-ui-border bg-ui-surface px-7 py-8 text-center shadow-[0_16px_40px_rgba(15,23,42,0.08)]">
+        <div className="mx-auto flex size-18 items-center justify-center rounded-3xl bg-ui-brand-soft text-ui-brand">
+          <MonitorCog className="size-9" strokeWidth={2.1} />
+        </div>
+
+        <h1 className="mt-5 select-none text-[1.55rem] font-extrabold text-ui-text-strong">
+          넓은 화면이 필요합니다
+        </h1>
+
+        <p className="mt-3 select-none text-sm font-medium leading-6 text-ui-text-muted">
+          이 웹사이트는 로비, 대기방, 게임 보드가 넓은 가로 화면을 전제로
+          설계되어 있습니다.
+        </p>
+
+        <div className="mt-6 rounded-2xl border border-ui-border bg-ui-surface-muted px-4 py-4">
+          <div className="flex items-center justify-center gap-2 text-ui-text-primary">
+            <TabletSmartphone className="size-4 shrink-0" strokeWidth={2} />
+            <span className="select-none text-sm font-semibold">
+              현재 브라우저 폭 {viewportWidth}px
+            </span>
+          </div>
+          <p className="mt-2 select-none text-sm font-medium text-ui-text-subtle">
+            최소 권장 폭은 {MIN_DESKTOP_VIEWPORT_WIDTH}px 입니다.
+          </p>
+        </div>
+
+        <p className="mt-5 select-none text-xs font-medium leading-5 text-ui-text-subtle">
+          브라우저 창을 넓히거나 데스크톱/노트북 환경에서 다시 접속해 주세요.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -103,7 +103,7 @@ function HomePage() {
             </span>
           </h1>
 
-          <p className="mx-auto mt-5 max-w-112 select-none whitespace-pre-line text-[clamp(1rem,1.8vw,1.22rem)] font-bold leading-relaxed text-ui-text-primary">
+          <p className="mx-auto mt-5 max-w-md select-none whitespace-pre-line text-[clamp(1rem,1.8vw,1.22rem)] font-bold leading-relaxed text-ui-text-primary">
             {
               '주사위를 굴려 나만의 도시를 건설하세요!\n귀엽고 신나는 실시간 보드게임'
             }


### PR DESCRIPTION
## 📌 관련 이슈

> closes #387 

---

## 📝 작업 내용

> 최소 지원 폭 미만의 브라우저에서는 앱 대신 안내 화면을 보여주는 데스크톱 전용 뷰포트 가드를 추가했습니다.

- `DesktopViewportGuard` 컴포넌트 신규 추가
- 브라우저 현재 폭이 `1280px` 미만이면 안내 화면 렌더
- 브라우저 리사이즈 시 뷰포트 폭을 다시 계산해 차단/해제를 즉시 동기화
- 현재 폭과 최소 권장 폭을 안내 화면에 함께 표시
- 앱 루트에 공통 적용해 홈/로비/대기방/게임/마이페이지/닉네임 설정 화면이 동일 기준을 따르도록 구성

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

![무제](https://github.com/user-attachments/assets/11f9886f-af60-45d4-aadf-a5070fcd09d9)

