### PR TITLE
fix: 닉네임 중복 확인 상태 고착과 helper 메시지 분기 수정

### DIFF
--- a/src/features/auth/hooks/useNicknameAvailability.test.tsx
+++ b/src/features/auth/hooks/useNicknameAvailability.test.tsx
@@ -1,0 +1,38 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { useNicknameAvailability } from './useNicknameAvailability'
+
+vi.mock('../mockApi', () => ({
+  validateNickname: vi.fn((nickname: string) => {
+    const normalizedNickname = nickname.trim()
+
+    if (normalizedNickname.length < 2) {
+      return {
+        ok: false,
+        normalizedNickname,
+        message: '닉네임은 2~10자여야 합니다.',
+      }
+    }
+
+    return {
+      ok: true,
+      normalizedNickname,
+    }
+  }),
+  mockCheckNicknameAvailability: vi.fn(async (nickname: string) => ({
+    ok: true,
+    normalizedNickname: nickname,
+    isAvailable: true,
+  })),
+}))
+
+describe('useNicknameAvailability', () => {
+  it('형식 검증을 통과하면 중복 확인이 완료된 뒤 사용 가능 상태로 수렴한다', async () => {
+    const { result } = renderHook(() => useNicknameAvailability('마블왕자'))
+
+    await waitFor(() => {
+      expect(result.current.isCheckingNickname).toBe(false)
+      expect(result.current.isNicknameAvailable).toBe(true)
+    })
+  })
+})

--- a/src/features/auth/hooks/useNicknameAvailability.ts
+++ b/src/features/auth/hooks/useNicknameAvailability.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { mockCheckNicknameAvailability, validateNickname } from '../mockApi'
 import { NICKNAME_CHECK_DEBOUNCE_MS } from '../nicknameSetupRules'
 import type { NicknameValidationResult } from '../types'
@@ -18,7 +18,10 @@ export function useNicknameAvailability(
     boolean | null
   >(null)
 
-  const nicknameValidation = validateNickname(nickname)
+  const nicknameValidation = useMemo(
+    () => validateNickname(nickname),
+    [nickname]
+  )
 
   useEffect(() => {
     setIsCheckingNickname(false)
@@ -50,7 +53,7 @@ export function useNicknameAvailability(
       isDisposed = true
       window.clearTimeout(debounceTimer)
     }
-  }, [nicknameValidation])
+  }, [nicknameValidation.ok, nicknameValidation.normalizedNickname])
 
   return {
     nicknameValidation,

--- a/src/features/auth/nicknameSetupRules.test.ts
+++ b/src/features/auth/nicknameSetupRules.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { createNicknameHelperFeedback } from './nicknameSetupRules'
+
+describe('createNicknameHelperFeedback', () => {
+  it('형식 검증을 통과하면 디바운스 구간에도 즉시 중복 확인 상태를 보여준다', () => {
+    const helperFeedback = createNicknameHelperFeedback({
+      submitMessage: null,
+      isNicknameFocused: true,
+      nickname: '마블왕자',
+      nicknameValidation: {
+        ok: true,
+        normalizedNickname: '마블왕자',
+      },
+      isCheckingNickname: false,
+      isNicknameAvailable: null,
+      showValidationMessage: false,
+    })
+
+    expect(helperFeedback).toEqual({
+      message: '• 닉네임 중복 확인 중...',
+      tone: 'default',
+    })
+  })
+
+  it('형식 오류 상태에서는 디바운스 동안 기본 길이 안내를 유지한다', () => {
+    const helperFeedback = createNicknameHelperFeedback({
+      submitMessage: null,
+      isNicknameFocused: true,
+      nickname: 'a',
+      nicknameValidation: {
+        ok: false,
+        normalizedNickname: 'a',
+        message: '닉네임은 2~10자여야 합니다.',
+      },
+      isCheckingNickname: false,
+      isNicknameAvailable: null,
+      showValidationMessage: false,
+    })
+
+    expect(helperFeedback).toEqual({
+      message: '• 닉네임은 2~10자여야 합니다.',
+      tone: 'default',
+    })
+  })
+})

--- a/src/features/auth/nicknameSetupRules.ts
+++ b/src/features/auth/nicknameSetupRules.ts
@@ -90,11 +90,6 @@ export function createNicknameHelperFeedback({
     }
   }
 
-  // 디바운스 구간에는 기본 안내 메시지만 유지
-  if (!showValidationMessage) {
-    return createLengthFeedback()
-  }
-
   // 형식 검증 통과 후에는 중복 검사 상태/결과를 노출
   if (nicknameValidation.ok) {
     // 중복 확인 중이면 로딩 메시지 표시
@@ -118,6 +113,11 @@ export function createNicknameHelperFeedback({
       message: '• 사용 가능한 닉네임입니다.',
       tone: 'success',
     }
+  }
+
+  // 형식 오류 안내만 디바운스로 지연해 깜빡임을 줄임
+  if (!showValidationMessage) {
+    return createLengthFeedback()
   }
 
   // 입력 중에는 현재 검증 오류를 즉시 노출


### PR DESCRIPTION
## 📌 관련 이슈

> closes #389 

---

## 📝 작업 내용

> 닉네임 중복 확인이 정상 결과로 수렴하지 않고 `중복 확인 중...` 상태에 머무르던 문제와 helper 메시지 분기를 함께 수정했습니다.

- `useNicknameAvailability`에서 닉네임 validation 결과를 `useMemo`로 고정
- effect dependency를 validation 객체 전체가 아니라 실제 판별 값(`ok`, `normalizedNickname`) 기준으로 정리
- 형식 오류 helper 메시지 디바운스는 유지하면서, 중복 확인 상태/결과는 즉시 반영되도록 우선순위 조정
- 닉네임 availability 상태가 정상적으로 `사용 가능`/`이미 사용 중`으로 수렴하는 테스트 추가
- helper 메시지 분기 회귀 테스트 추가

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

