### PR TITLE
refactor: 온보딩과 모달 DM 패널 UI 폴리시 정리

### DIFF
--- a/src/features/presence/components/DirectMessagePanel.tsx
+++ b/src/features/presence/components/DirectMessagePanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { SendHorizontal, X } from 'lucide-react'
+import { motion } from 'framer-motion'
 import { Avatar } from '../../../components/avatar/Avatar'
 import { cn } from '../../../lib/utils'
 import type { DirectMessage, OnlineUser } from '../types'
@@ -53,7 +54,13 @@ export function DirectMessagePanel({
   const canSend = inputMessage.trim().length > 0
 
   return (
-    <section className="fixed bottom-6 right-4 z-40 w-[340px] max-w-[calc(100vw-1rem)] overflow-hidden rounded-2xl border border-ui-border bg-ui-surface shadow-[0_18px_40px_rgba(15,23,42,0.2)] sm:right-6">
+    <motion.section
+      className="fixed bottom-6 right-4 z-40 w-[340px] max-w-[calc(100vw-1rem)] overflow-hidden rounded-2xl border border-ui-border bg-ui-surface shadow-[0_18px_40px_rgba(15,23,42,0.2)] sm:right-6"
+      initial={{ opacity: 0, y: 20, scale: 0.98 }}
+      animate={{ opacity: 1, y: 0, scale: 1 }}
+      exit={{ opacity: 0, y: 14, scale: 0.98 }}
+      transition={{ duration: 0.24, ease: [0.18, 0.9, 0.28, 1] }}
+    >
       <header className="flex h-14 items-center justify-between border-b border-ui-border px-4">
         <div className="flex min-w-0 items-center gap-3">
           <Avatar
@@ -155,6 +162,6 @@ export function DirectMessagePanel({
           <SendHorizontal className="size-4" />
         </button>
       </form>
-    </section>
+    </motion.section>
   )
 }

--- a/src/pages/NicknameSetupPage.tsx
+++ b/src/pages/NicknameSetupPage.tsx
@@ -1,4 +1,5 @@
 import { ArrowLeft, UserRound } from 'lucide-react'
+import { motion } from 'framer-motion'
 import { useNicknameSetupForm } from '../features/auth/hooks/useNicknameSetupForm'
 
 // 최초 닉네임 설정 폼 화면 렌더링
@@ -22,32 +23,51 @@ function NicknameSetupPage() {
   }
 
   return (
-    <div className="relative min-h-screen bg-ui-app-bg">
+    <div className="relative min-h-screen overflow-hidden bg-ui-app-bg">
+      <div className="pointer-events-none absolute inset-0">
+        <picture>
+          <source srcSet="/HomePage_background.webp" type="image/webp" />
+          <img
+            src="/HomePage_background.jpg"
+            alt=""
+            aria-hidden="true"
+            className="absolute inset-0 h-full w-full object-cover object-center opacity-45"
+          />
+        </picture>
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_28%,rgba(255,255,255,0.52),transparent_32%),linear-gradient(180deg,rgba(250,248,240,0.76),rgba(250,248,240,0.88))]" />
+      </div>
+
       <button
         type="button"
         onClick={handleBackToHome}
         aria-label="홈으로 이동"
-        className="absolute left-4 top-4 flex size-10 items-center justify-center rounded-full border border-ui-border bg-ui-surface text-ui-text-primary transition-colors hover:bg-ui-surface-muted sm:left-6 sm:top-6"
+        className="absolute left-4 top-4 z-10 inline-flex select-none items-center gap-2 rounded-full border border-ui-border bg-ui-surface/92 px-4 py-2 text-sm font-semibold text-ui-text-primary shadow-[0_6px_18px_rgba(15,23,42,0.06)] transition-colors hover:bg-ui-surface-muted sm:left-6 sm:top-6"
       >
         <ArrowLeft className="size-5" />
+        홈으로
       </button>
 
-      <main className="mx-auto flex min-h-screen max-w-6xl items-center justify-center px-4 py-10 sm:px-6">
-        <section className="-mt-24 w-full max-w-[560px] rounded-3xl border border-ui-border bg-ui-surface px-8 py-10 shadow-[0_12px_32px_rgba(15,23,42,0.08)]">
-          <div className="mb-6 flex justify-center">
-            <div className="flex size-[72px] items-center justify-center rounded-full bg-ui-brand-soft">
+      <main className="relative z-10 mx-auto flex min-h-screen max-w-6xl items-center justify-center px-4 py-10 sm:px-6">
+        <motion.section
+          className="w-full max-w-[520px] rounded-[32px] border border-ui-border bg-ui-surface/94 px-8 py-9 shadow-[0_18px_42px_rgba(15,23,42,0.08)] backdrop-blur-sm"
+          initial={{ opacity: 0, y: 22, scale: 0.98 }}
+          animate={{ opacity: 1, y: 0, scale: 1 }}
+          transition={{ duration: 0.34, ease: [0.18, 0.9, 0.28, 1] }}
+        >
+          <div className="mb-5 flex justify-center">
+            <div className="flex size-[68px] items-center justify-center rounded-full bg-ui-brand-soft">
               <UserRound className="size-8 text-ui-brand" />
             </div>
           </div>
 
-          <h1 className="text-center text-4xl font-extrabold tracking-tight text-ui-text-strong">
+          <h1 className="select-none text-center text-4xl font-extrabold tracking-tight text-ui-text-strong">
             닉네임 설정
           </h1>
-          <p className="mt-2 text-center text-base font-medium text-ui-text-muted">
+          <p className="mt-2 select-none text-center text-[0.97rem] font-medium leading-7 text-ui-text-muted">
             친구들이 당신을 알아볼 수 있도록 닉네임을 정해 주세요.
           </p>
 
-          <form className="mt-9" onSubmit={handleSubmit}>
+          <form className="mt-8" onSubmit={handleSubmit}>
             <label
               htmlFor="nickname"
               className="mb-2 block text-base font-semibold text-ui-text-primary"
@@ -86,12 +106,12 @@ function NicknameSetupPage() {
             <button
               type="submit"
               disabled={isSubmitDisabled}
-              className="mt-6 flex h-12 w-full items-center justify-center rounded-2xl bg-ui-brand text-lg font-bold text-white transition-colors hover:bg-ui-brand-strong disabled:cursor-not-allowed disabled:bg-ui-disabled-bg disabled:text-ui-disabled-text"
+              className="mt-6 flex h-12 w-full select-none items-center justify-center rounded-2xl bg-ui-brand text-lg font-bold text-white shadow-[0_8px_20px_rgba(59,130,246,0.16)] transition-colors hover:bg-ui-brand-strong disabled:cursor-not-allowed disabled:bg-ui-disabled-bg disabled:text-ui-disabled-text disabled:shadow-none"
             >
               {isSubmitting ? '처리 중...' : '시작하기'}
             </button>
           </form>
-        </section>
+        </motion.section>
       </main>
     </div>
   )

--- a/src/pages/lobby/CreateRoomModal.tsx
+++ b/src/pages/lobby/CreateRoomModal.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { Plus, Lock, X } from 'lucide-react'
+import { Lock, X } from 'lucide-react'
+import { motion } from 'framer-motion'
 import {
   ROOM_PASSWORD_LENGTH,
   ROOM_PASSWORD_PATTERN,
@@ -78,13 +79,23 @@ export function CreateRoomModal({
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-[rgba(15,23,42,0.35)] p-4 backdrop-blur-[2px]">
-      <div className="absolute inset-0" onClick={handleClose} aria-hidden />
+      <motion.div
+        className="absolute inset-0"
+        onClick={handleClose}
+        aria-hidden
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.2, ease: 'easeOut' }}
+      />
 
-      <section
+      <motion.section
         role="dialog"
         aria-modal="true"
         aria-label="방 만들기"
         className="relative z-10 w-full max-w-[430px] rounded-[32px] border border-ui-border bg-ui-surface px-7 pb-7 pt-8 shadow-[0_24px_60px_rgba(15,23,42,0.2)]"
+        initial={{ opacity: 0, y: 22, scale: 0.96 }}
+        animate={{ opacity: 1, y: 0, scale: 1 }}
+        transition={{ duration: 0.28, ease: [0.18, 0.9, 0.28, 1] }}
       >
         <button
           type="button"
@@ -101,14 +112,10 @@ export function CreateRoomModal({
           <X className="size-5" />
         </button>
 
-        <div className="mx-auto mb-4 flex size-[62px] items-center justify-center rounded-full bg-ui-surface-soft text-ui-text-subtle">
-          <Plus className="size-8" />
-        </div>
-
-        <h2 className="text-center text-[2.1rem] font-extrabold tracking-tight text-ui-text-strong">
+        <h2 className="text-center text-[1.85rem] font-extrabold tracking-tight text-ui-text-strong">
           방 만들기
         </h2>
-        <p className="mt-1 text-center text-lg font-semibold text-ui-text-muted">
+        <p className="mt-1 text-center text-base font-semibold text-ui-text-muted">
           친구들을 초대하고 게임을 즐기세요!
         </p>
 
@@ -131,7 +138,7 @@ export function CreateRoomModal({
         >
           <label
             htmlFor="create-room-title"
-            className="text-[1.05rem] font-semibold text-ui-text-primary"
+            className="text-base font-semibold text-ui-text-primary"
           >
             방 제목
           </label>
@@ -145,12 +152,12 @@ export function CreateRoomModal({
               setRoomTitle(event.target.value)
             }}
             placeholder={defaultRoomTitle}
-            className="mt-2 h-12 w-full rounded-2xl border border-ui-border bg-white px-4 text-[1.2rem] font-semibold text-ui-text-primary outline-none placeholder:text-ui-text-subtle focus:border-ui-brand focus:ring-2 focus:ring-ui-brand/20"
+            className="mt-2 h-12 w-full rounded-2xl border border-ui-border bg-white px-4 text-[1.05rem] font-semibold text-ui-text-primary outline-none placeholder:text-ui-text-subtle focus:border-ui-brand focus:ring-2 focus:ring-ui-brand/20"
             autoComplete="off"
           />
 
-          <div className="mt-8 flex items-center justify-between">
-            <div className="inline-flex items-center gap-2 text-[1.05rem] font-semibold text-ui-text-primary">
+          <div className="mt-7 flex items-center justify-between">
+            <div className="inline-flex items-center gap-2 text-base font-semibold text-ui-text-primary">
               <Lock className="size-4 text-ui-text-subtle" />
               비밀방 설정
             </div>
@@ -199,7 +206,7 @@ export function CreateRoomModal({
                 setRoomPassword(nextValue)
               }}
               placeholder="비밀번호 (4자리)"
-              className="mt-4 h-12 w-full rounded-2xl border border-ui-border bg-white px-4 text-[1.2rem] font-semibold text-ui-text-primary outline-none placeholder:text-ui-text-subtle focus:border-ui-brand focus:ring-2 focus:ring-ui-brand/20"
+              className="mt-4 h-12 w-full rounded-2xl border border-ui-border bg-white px-4 text-[1.05rem] font-semibold text-ui-text-primary outline-none placeholder:text-ui-text-subtle focus:border-ui-brand focus:ring-2 focus:ring-ui-brand/20"
             />
           ) : null}
 
@@ -207,7 +214,7 @@ export function CreateRoomModal({
             type="submit"
             disabled={isSubmitDisabled}
             className={cn(
-              'mt-6 h-12 w-full rounded-2xl text-lg font-bold transition-colors',
+              'mt-5 h-12 w-full rounded-2xl text-base font-bold transition-colors',
               isSubmitDisabled
                 ? 'cursor-not-allowed bg-ui-disabled-bg text-ui-disabled-text'
                 : 'bg-ui-brand text-white hover:bg-ui-brand-strong'
@@ -216,7 +223,7 @@ export function CreateRoomModal({
             {isSubmitting ? '생성 중...' : '방 만들기 완료'}
           </button>
         </form>
-      </section>
+      </motion.section>
     </div>
   )
 }

--- a/src/pages/lobby/LobbyPage.test.tsx
+++ b/src/pages/lobby/LobbyPage.test.tsx
@@ -322,7 +322,7 @@ describe('LobbyPage filter and toggle regression', () => {
       screen.queryByText('비밀번호가 올바르지 않습니다.')
     ).not.toBeInTheDocument()
     expect(
-      screen.getByText('비밀번호 4자리를 입력해주세요')
+      screen.getByText(/비밀번호 4자리를 입력해주세요/)
     ).toBeInTheDocument()
   })
 

--- a/src/pages/lobby/LobbyPage.tsx
+++ b/src/pages/lobby/LobbyPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { AnimatePresence } from 'framer-motion'
 import toast from 'react-hot-toast'
 import { useNavigate } from 'react-router-dom'
 import Header from '../../components/header/Header'
@@ -183,15 +184,17 @@ function LobbyPage() {
         />
       ) : null}
 
-      {dmTargetUser ? (
-        <DirectMessagePanel
-          user={dmTargetUser}
-          currentUserId={session.userId}
-          messages={directMessagesByUserId[dmTargetUser.id] ?? []}
-          onClose={closeDirectMessage}
-          onSendMessage={sendDirectMessage}
-        />
-      ) : null}
+      <AnimatePresence>
+        {dmTargetUser ? (
+          <DirectMessagePanel
+            user={dmTargetUser}
+            currentUserId={session.userId}
+            messages={directMessagesByUserId[dmTargetUser.id] ?? []}
+            onClose={closeDirectMessage}
+            onSendMessage={sendDirectMessage}
+          />
+        ) : null}
+      </AnimatePresence>
 
       <DevPresenceControlPanel users={users} currentUserId={session.userId} />
     </div>

--- a/src/pages/lobby/PrivateRoomJoinModal.tsx
+++ b/src/pages/lobby/PrivateRoomJoinModal.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect } from 'react'
 import { Lock, X } from 'lucide-react'
+import { motion } from 'framer-motion'
 import {
   ROOM_PASSWORD_LENGTH,
   ROOM_PASSWORD_PATTERN,
@@ -27,12 +28,10 @@ export function PrivateRoomJoinModal({
   onClose,
   onSubmit,
 }: PrivateRoomJoinModalProps) {
-  const [isPasswordInputFocused, setIsPasswordInputFocused] = useState(false)
   const isJoinDisabled = !ROOM_PASSWORD_PATTERN.test(password) || isSubmitting
-  const shouldShowHelperMessage = isPasswordInputFocused || isPasswordInvalid
   const helperMessage = isPasswordInvalid
     ? '비밀번호가 올바르지 않습니다.'
-    : '비밀번호 4자리를 입력해주세요'
+    : '• 비밀번호 4자리를 입력해주세요'
   const canClose = !isSubmitting
 
   // 제출 중이 아닐 때만 모달 닫기를 허용
@@ -60,13 +59,23 @@ export function PrivateRoomJoinModal({
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-[rgba(15,23,42,0.35)] p-4 backdrop-blur-[2px]">
-      <div className="absolute inset-0" onClick={handleClose} aria-hidden />
+      <motion.div
+        className="absolute inset-0"
+        onClick={handleClose}
+        aria-hidden
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.2, ease: 'easeOut' }}
+      />
 
-      <section
+      <motion.section
         role="dialog"
         aria-modal="true"
         aria-label="비밀방 입장"
-        className="relative z-1 w-full max-w-[430px] rounded-[32px] border border-ui-border bg-ui-surface px-7 pb-7 pt-8 shadow-[0_24px_60px_rgba(15,23,42,0.2)]"
+        className="relative z-10 w-full max-w-[430px] rounded-[32px] border border-ui-border bg-ui-surface px-7 pb-7 pt-8 shadow-[0_24px_60px_rgba(15,23,42,0.2)]"
+        initial={{ opacity: 0, y: 22, scale: 0.96 }}
+        animate={{ opacity: 1, y: 0, scale: 1 }}
+        transition={{ duration: 0.28, ease: [0.18, 0.9, 0.28, 1] }}
       >
         <button
           type="button"
@@ -83,15 +92,15 @@ export function PrivateRoomJoinModal({
           <X className="size-5" />
         </button>
 
-        <div className="mx-auto mb-4 flex size-[62px] items-center justify-center rounded-full bg-ui-surface-soft text-ui-text-subtle">
+        <div className="mx-auto mb-4 flex size-[58px] items-center justify-center rounded-full bg-ui-surface-soft text-ui-text-subtle">
           <Lock className="size-8" />
         </div>
 
-        <h2 className="text-center text-[2.1rem] font-extrabold tracking-tight text-ui-text-strong">
+        <h2 className="text-center text-[1.85rem] font-extrabold tracking-tight text-ui-text-strong">
           비밀방 입장
         </h2>
 
-        <p className="mt-1 text-center text-lg font-semibold text-ui-text-muted">
+        <p className="mt-1 text-center text-base font-semibold text-ui-text-muted">
           {roomTitle}
         </p>
 
@@ -112,7 +121,6 @@ export function PrivateRoomJoinModal({
             pattern="[0-9]*"
             maxLength={ROOM_PASSWORD_LENGTH}
             value={password}
-            onFocus={() => setIsPasswordInputFocused(true)}
             onChange={(event) => {
               const nextValue = event.target.value
                 .replace(/\D/g, '')
@@ -121,30 +129,28 @@ export function PrivateRoomJoinModal({
             }}
             placeholder="비밀번호 입력"
             className={cn(
-              'h-12 w-full rounded-2xl border bg-white px-4 text-[1.2rem] font-semibold text-ui-text-strong placeholder:text-ui-text-subtle focus:outline-none focus:ring-0 transition-colors',
+              'h-12 w-full rounded-2xl border bg-white px-4 text-[1.05rem] font-semibold text-ui-text-strong placeholder:text-ui-text-subtle focus:outline-none focus:ring-0 transition-colors',
               isPasswordInvalid
                 ? 'border-2 border-ui-danger bg-ui-danger-bg/30 focus:border-ui-danger'
                 : 'border-ui-border focus:border-ui-border'
             )}
           />
 
-          {shouldShowHelperMessage ? (
-            <p
-              className={cn(
-                'mt-2 text-sm font-semibold',
-                isPasswordInvalid ? 'text-ui-danger' : 'text-ui-text-muted'
-              )}
-            >
-              {helperMessage}
-            </p>
-          ) : null}
+          <p
+            className={cn(
+              'mt-2 min-h-5 text-sm font-semibold',
+              isPasswordInvalid ? 'text-ui-danger' : 'text-ui-text-muted'
+            )}
+          >
+            {helperMessage}
+          </p>
 
           <div className="mt-5 grid grid-cols-2 gap-3">
             <button
               type="button"
               onClick={handleClose}
               disabled={isSubmitting}
-              className="h-12 rounded-2xl bg-ui-disabled-bg text-lg font-bold text-ui-text-muted transition-colors hover:bg-ui-surface-soft"
+              className="h-12 rounded-2xl bg-ui-disabled-bg text-base font-bold text-ui-text-muted transition-colors hover:bg-ui-surface-soft"
             >
               취소
             </button>
@@ -152,7 +158,7 @@ export function PrivateRoomJoinModal({
               type="submit"
               disabled={isJoinDisabled}
               className={cn(
-                'h-12 rounded-2xl text-lg font-bold transition-colors',
+                'h-12 rounded-2xl text-base font-bold transition-colors',
                 isJoinDisabled
                   ? 'cursor-not-allowed bg-ui-disabled-bg text-ui-disabled-text'
                   : 'bg-ui-brand text-white hover:bg-ui-brand-strong'
@@ -162,7 +168,7 @@ export function PrivateRoomJoinModal({
             </button>
           </div>
         </form>
-      </section>
+      </motion.section>
     </div>
   )
 }

--- a/src/pages/waiting-room/WaitingRoomPage.tsx
+++ b/src/pages/waiting-room/WaitingRoomPage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
+import { AnimatePresence } from 'framer-motion'
 import toast from 'react-hot-toast'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
 import { useRequireActiveSession } from '../../features/auth/hooks/useRequireActiveSession'
@@ -324,15 +325,17 @@ function WaitingRoomPage() {
         }}
       />
 
-      {dmTargetUser ? (
-        <DirectMessagePanel
-          user={dmTargetUser}
-          currentUserId={session.userId}
-          messages={directMessagesByUserId[dmTargetUser.id] ?? []}
-          onClose={closeDirectMessage}
-          onSendMessage={sendDirectMessage}
-        />
-      ) : null}
+      <AnimatePresence>
+        {dmTargetUser ? (
+          <DirectMessagePanel
+            user={dmTargetUser}
+            currentUserId={session.userId}
+            messages={directMessagesByUserId[dmTargetUser.id] ?? []}
+            onClose={closeDirectMessage}
+            onSendMessage={sendDirectMessage}
+          />
+        ) : null}
+      </AnimatePresence>
     </div>
   )
 }


### PR DESCRIPTION
## 📌 관련 이슈

> closes #390 

---

## 📝 작업 내용

> 닉네임 설정 페이지, 로비 모달, DM 패널의 시각 밀도와 진입/종료 애니메이션을 정리해 제품 톤을 더 일관되게 맞췄습니다.

- 닉네임 설정 페이지에 홈과 연결되는 배경 에셋을 약하게 재사용
- 닉네임 설정 카드 폭과 내부 간격을 조정하고 진입 애니메이션 추가
- `첫 로그인 설정` 배지 제거 및 상단 `홈으로` 버튼 정리
- 방 만들기 모달과 비밀방 입장 모달의 타이포/간격 밀도 조정
- 방 만들기 모달 상단 `+` 아이콘 제거
- 비밀방 입장 helper text를 기본 안내(`• 비밀번호 4자리를 입력해주세요`)와 에러 상태(`비밀번호가 올바르지 않습니다.`)로 명확히 분리
- DM 패널에 진입/종료 애니메이션 추가
- `LobbyPage`, `WaitingRoomPage`에 `AnimatePresence`를 적용해 DM 패널 닫힘 애니메이션이 자연스럽게 동작하도록 정리
- helper 문구 변경에 맞춰 로비 회귀 테스트 matcher 수정

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)
