### PR TITLE
refactor: 헤더와 접속자 목록 인터랙션 범위 정리

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -1,4 +1,3 @@
-import { Dice5 } from 'lucide-react'
 import { ProfileDropdown } from './ProfileDropdown'
 import type { ProfileMenuItem } from './profileMenu'
 
@@ -21,11 +20,13 @@ function Header({
 }: HeaderProps) {
   return (
     <header className="sticky top-0 z-40 flex h-14 items-center justify-between border-b border-ui-border bg-ui-surface/95 px-4 backdrop-blur sm:px-6">
-      <div className="flex select-none items-center gap-2.5">
-        <div className="flex size-9 items-center justify-center rounded-lg bg-ui-brand text-white">
-          <Dice5 className="size-5" strokeWidth={2} />
-        </div>
-        <h1 className="text-lg font-bold text-ui-text-strong">MARBLE POP</h1>
+      <div className="flex select-none items-center">
+        <h1 className="text-[1.45rem] font-extrabold leading-none tracking-tight text-ui-text-strong">
+          <span className="text-ui-text-strong">MARBLE</span>
+          <span className="ml-1 bg-linear-to-r from-ui-brand-strong via-ui-brand to-[#0ea5e9] bg-clip-text text-transparent">
+            POP
+          </span>
+        </h1>
       </div>
 
       <ProfileDropdown

--- a/src/components/header/ProfileDropdown.tsx
+++ b/src/components/header/ProfileDropdown.tsx
@@ -68,16 +68,18 @@ export function ProfileDropdown({
 
   return (
     <div className="flex items-center gap-2 text-sm font-medium text-ui-text-muted">
-      <span className="max-w-[140px] truncate select-none">{playerLabel}</span>
       {hasMenuItems ? (
         <div ref={menuContainerRef} className="relative group/menu">
           <button
             type="button"
-            className="rounded-full outline-none select-none"
+            className="flex items-center gap-2 rounded-full outline-none select-none"
             aria-label="프로필 메뉴 열기"
             aria-expanded={isMenuOpen}
             onClick={() => setIsMenuOpen((previous) => !previous)}
           >
+            <span className="max-w-[140px] truncate select-none">
+              {playerLabel}
+            </span>
             {avatar}
           </button>
 
@@ -112,7 +114,12 @@ export function ProfileDropdown({
           </div>
         </div>
       ) : (
-        avatar
+        <>
+          <span className="max-w-[140px] truncate select-none">
+            {playerLabel}
+          </span>
+          {avatar}
+        </>
       )}
     </div>
   )

--- a/src/features/presence/components/UserRow.tsx
+++ b/src/features/presence/components/UserRow.tsx
@@ -29,9 +29,44 @@ export function UserRow({
     isCurrentUser ||
     !onOpenDirectMessage ||
     !isDirectMessageAllowed(user.status)
+  const interactiveRowClass = isDmDisabled
+    ? 'cursor-not-allowed'
+    : 'cursor-pointer'
+
+  function handleOpenDirectMessage() {
+    // 비활성 상태에서는 DM 열기 동작을 차단
+    if (isDmDisabled) {
+      return
+    }
+    onOpenDirectMessage?.(user)
+  }
 
   return (
-    <div className="group flex select-none items-center gap-3 px-4 py-2.5 hover:bg-ui-surface-muted">
+    <div
+      role={isDmDisabled ? undefined : 'button'}
+      tabIndex={isDmDisabled ? undefined : 0}
+      aria-disabled={isDmDisabled || undefined}
+      onClick={handleOpenDirectMessage}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault()
+          handleOpenDirectMessage()
+        }
+      }}
+      title={
+        isCurrentUser
+          ? '본인에게는 DM을 보낼 수 없습니다.'
+          : !isDirectMessageAllowed(user.status)
+            ? '게임중인 유저에게는 DM을 보낼 수 없습니다.'
+            : isDmDisabled
+              ? 'DM 기능을 사용할 수 없습니다.'
+              : 'DM 열기'
+      }
+      className={cn(
+        'group flex select-none items-center gap-3 px-4 py-2.5 hover:bg-ui-surface-muted',
+        interactiveRowClass
+      )}
+    >
       <div className="relative shrink-0">
         <Avatar
           size="md"
@@ -61,12 +96,9 @@ export function UserRow({
       <button
         type="button"
         disabled={isDmDisabled}
-        onClick={() => {
-          // 비활성 상태에서는 DM 열기 동작을 차단
-          if (isDmDisabled) {
-            return
-          }
-          onOpenDirectMessage?.(user)
+        onClick={(event) => {
+          event.stopPropagation()
+          handleOpenDirectMessage()
         }}
         className={cn(
           'rounded-lg p-2 text-ui-text-subtle transition select-none',


### PR DESCRIPTION
## 📌 관련 이슈

> closes #393

---

## 📝 작업 내용

> 헤더 프로필 드롭다운과 접속자 목록 DM 트리거 범위를 정리해 인터랙션 일관성을 맞췄습니다.

- 헤더 좌측 로고를 아이콘 없이 텍스트 워드마크 중심으로 정리
- 닉네임과 프로필 이미지를 하나의 드롭다운 트리거 버튼으로 통합
- 닉네임 hover/click 시에도 프로필 드롭다운이 열리도록 수정
- 접속자 목록 열린 상태에서 행 전체 클릭으로 DM 패널이 열리도록 확장
- DM 불가 대상은 행 전체에 `cursor-not-allowed`, 안내 `title`, `aria-disabled`를 적용
- 메시지 아이콘 버튼은 유지하되 행 클릭과 중복 실행되지 않도록 정리

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

