### PR TITLE
fix: 로그아웃 시 mock 접속자 목록에서 현재 사용자 제거

### DIFF
--- a/src/features/presence/mockData.test.ts
+++ b/src/features/presence/mockData.test.ts
@@ -53,4 +53,22 @@ describe('presence mockData SSOT', () => {
       }
     })
   })
+
+  it('로그아웃한 목 접속자는 저장소에서 즉시 제거된다', async () => {
+    const { presence } = await loadMockModules()
+    const userId = 'logout-user'
+
+    presence.setMockOnlineUserStatus(userId, 'lobby', '로그아웃테스터')
+
+    expect(
+      presence.getMockOnlineUsersSnapshot().some((user) => user.id === userId)
+    ).toBe(true)
+
+    const updatedSnapshot = presence.removeMockOnlineUser(userId)
+
+    expect(updatedSnapshot.some((user) => user.id === userId)).toBe(false)
+    expect(
+      presence.getMockOnlineUsersSnapshot().some((user) => user.id === userId)
+    ).toBe(false)
+  })
 })

--- a/src/features/presence/mockData.ts
+++ b/src/features/presence/mockData.ts
@@ -67,6 +67,16 @@ export function setMockOnlineUserStatus(
   return getMockOnlineUsersSnapshot()
 }
 
+// 특정 접속자를 저장소에서 제거하고 최신 스냅샷을 반환
+export function removeMockOnlineUser(userId: string) {
+  mockOnlineUsersStore = mockOnlineUsersStore.filter(
+    (user) => user.id !== userId
+  )
+  notifyMockOnlineUsersChanged()
+
+  return getMockOnlineUsersSnapshot()
+}
+
 // 접속자 저장소 변경을 구독하고 해제 함수를 반환
 export function subscribeMockOnlineUsersChange(
   listener: (users: OnlineUserPayload[]) => void

--- a/src/pages/lobby/LobbyPage.tsx
+++ b/src/pages/lobby/LobbyPage.tsx
@@ -15,7 +15,10 @@ import { DirectMessagePanel } from '../../features/presence/components/DirectMes
 import { DevPresenceControlPanel } from '../../features/presence/components/DevPresenceControlPanel'
 import { useOnlineUsersSocket } from '../../features/presence/useOnlineUsersSocket'
 import { useDirectMessageController } from '../../features/presence/useDirectMessageController'
-import { setMockOnlineUserStatus } from '../../features/presence/mockData'
+import {
+  removeMockOnlineUser,
+  setMockOnlineUserStatus,
+} from '../../features/presence/mockData'
 import type { LobbyRoomFilter } from './api'
 import { useLobbyRoomsQuery } from './hooks'
 import { LobbyControls } from './LobbyControls'
@@ -93,6 +96,10 @@ function LobbyPage() {
   }, [session])
 
   function handleLogout() {
+    if (IS_SOCKET_MOCK_ENABLED && session) {
+      removeMockOnlineUser(session.userId)
+    }
+
     clearSession()
     navigate('/', { replace: true })
   }

--- a/src/pages/waiting-room/WaitingRoomPage.tsx
+++ b/src/pages/waiting-room/WaitingRoomPage.tsx
@@ -13,7 +13,9 @@ import { DirectMessagePanel } from '../../features/presence/components/DirectMes
 import { UserListPanel } from '../../features/presence/components/UserListPanel'
 import { useOnlineUsersSocket } from '../../features/presence/useOnlineUsersSocket'
 import { useDirectMessageController } from '../../features/presence/useDirectMessageController'
+import { removeMockOnlineUser } from '../../features/presence/mockData'
 import { cn } from '../../lib/utils'
+import { IS_SOCKET_MOCK_ENABLED } from '../../config/env'
 import { WaitingRoomHeader } from './components/WaitingRoomHeader'
 import { WaitingSeatCard } from './components/WaitingSeatCard'
 import { WaitingRoomSidePanel } from './components/WaitingRoomSidePanel'
@@ -155,9 +157,13 @@ function WaitingRoomPage() {
       toast.error(result.message)
     }
 
+    if (IS_SOCKET_MOCK_ENABLED && session) {
+      removeMockOnlineUser(session.userId)
+    }
+
     clearSession()
     navigate('/', { replace: true })
-  }, [clearSession, leaveRoom, navigate])
+  }, [clearSession, leaveRoom, navigate, session])
 
   // 마이페이지 이동 전 대기방 퇴장 처리
   const handleGoMyPage = useCallback(async () => {


### PR DESCRIPTION
## 📌 관련 이슈

> closes #395

---

## 📝 작업 내용

> mock 환경에서 게스트 로그아웃 후 접속자 목록에 이전 세션 사용자가 남아 있던 문제를 수정했습니다.

- mock 접속자 저장소에 현재 사용자를 제거하는 `removeMockOnlineUser` 함수 추가
- 로비 로그아웃 시 현재 세션 사용자를 접속자 목록에서 즉시 제거하도록 수정
- 대기방 로그아웃 시에도 현재 세션 사용자를 즉시 제거하도록 수정
- mock 저장소 단위 회귀 테스트 추가

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

