### PR TITLE
Refactor : 보드 eventQueue 소비 훅 연결 및 로컬 엔진 분리 2차 정리

### DIFF
--- a/docs/game-delivery-roadmap.md
+++ b/docs/game-delivery-roadmap.md
@@ -165,11 +165,12 @@
 
 - `gameBoardStoreBridge.ts`, `gameBoardTransactionUtils.ts`, `gameBoardActionUtils.ts`의 `BuildingLevel 0..7` 관련 버그 수정 반영
 - `gameBoardLocalEngine.ts` 분리로 `GameBoard.tsx`의 로컬 엔진(`applyMoney`, `advanceTurn`, 파산 자산 집계) 1차 모듈화 완료
+- `useBoardEventQueue.ts` 추가로 `store.eventQueue` 소비, 상태 메시지/주사위 반영 1차 연결 완료
 
 남은 핵심 축:
 
 - `GameBoard.tsx` 내부 `applyMoney`/`advanceTurn`/파산 판정/로컬 턴 전환 등 로컬 엔진 성격 로직 제거
-- `store.eventQueue` 소비 레이어 구현(이동/연출 분리)
+- `store.eventQueue` 이벤트별 이동/효과 애니메이션 세분화
 - `playerState`(`island`, `locked`)와 `stateDuration` 시각화 보강
 
 ## 5. FE-B 우선 작업
@@ -206,7 +207,7 @@
 
 ### 6-2. 이벤트 기반 연출
 
-- `store.eventQueue`를 소비하는 훅/컴포넌트 구현
+- `useBoardEventQueue` 기반 이벤트 소비는 연결 완료
 - `DICE_ROLLED`/`PLAYER_MOVED`/`LANDED`/`PAID_TOLL`/`CHANCE_RESOLVED`/`TURN_ENDED` 연출 분기 정리
 
 ### 6-3. 시각 규격 보강
@@ -219,7 +220,7 @@
 1. **FE-B + BE**: `gameId`/ActionType/prompt/snapshot/money 계약 고정
 2. **FE-B**: 호출부 canonical(`gameId`) 정리 + 문서/타입 동기화
 3. **FE-C**: `GameBoard.tsx` 로컬 엔진 제거 및 presentational 수렴
-4. **FE-C**: `eventQueue` 기반 이동/연출 구현
+4. **FE-C**: `eventQueue` 기반 이동/연출 고도화
 5. **FE-B + FE-C**: prompt 흐름 + 타이머 + 턴 종료(`TURN_ENDED`) 통합 검증
 
 ## 8. 완료 조건

--- a/docs/game-event-spec-migration-plan.md
+++ b/docs/game-event-spec-migration-plan.md
@@ -74,22 +74,22 @@
 
 아래 표에서 **상태** 열 기준: ✅ 완료 / ⚠️ 런타임 정합성 조정 필요 / ❌ 미구현
 
-| 파일                                                | 현재 상태   | 남은 수정 방향                                                                                            | 담당                  |
-| --------------------------------------------------- | ----------- | --------------------------------------------------------------------------------------------------------- | --------------------- |
-| `src/types/domain.ts`                               | ✅ 완료     | —                                                                                                         | FE-B                  |
-| `src/stores/game.store.ts`                          | ✅ 완료     | —                                                                                                         | FE-B                  |
-| `src/services/socket/game.handler.ts`               | ✅ 완료     | —                                                                                                         | FE-B                  |
-| `src/hooks/game/useGameState.ts`                    | ✅ 완료     | —                                                                                                         | FE-B                  |
-| `src/services/game/game.api.ts`                     | ✅ 완료     | 레거시 REST 모듈 삭제 완료(게임 런타임은 event-socket 단일 경로 유지)                                     | FE-B                  |
-| `src/hooks/game/useDiceRoll.ts`                     | ✅ 완료     | —                                                                                                         | FE-B                  |
-| `src/pages/GamePage.tsx`                            | ✅ 3차 완료 | `prompt` 오버레이 응답 + `prompt.type` board-modal 분기 연결 완료. 미매핑 prompt는 오버레이 fallback 유지 | FE-B                  |
-| `src/components/board/GameBoard.tsx`                | ⚠️ 1차 정리 | `store.prompt` 기반 모달 연결 + 로컬 엔진 유틸 분리(`gameBoardLocalEngine`) 완료. 엔진 제거는 후속 필요   | FE-C 주도 / FE-B 협업 |
-| `src/components/game/modals/*`                      | ✅ 3차 완료 | `store.prompt.type` 기준 모달 열림 조건/응답 연결 완료. `DiceTimerModal` timeout 연동 완료                | FE-B                  |
-| `src/mocks/handlers/game.handler.ts`                | ✅ 완료     | —                                                                                                         | FE-B                  |
-| `src/components/board/gameBoardStoreBridge.ts`      | ✅ 완료     | `toStoreBuildingLevel` 상한 7 반영 완료                                                                   | FE-C                  |
-| `src/components/board/gameBoardTransactionUtils.ts` | ✅ 완료     | `upgradeBoardTileOwner` 상한 7 반영 완료                                                                  | FE-C                  |
-| `src/components/board/gameBoardActionUtils.ts`      | ✅ 완료     | `getBoardSellFallbackRefund` level 5, 6 반영 완료                                                         | FE-C                  |
-| `src/components/board/*` (렌더 레이어)              | ❌ 미구현   | `store.eventQueue` 소비 연출. `playerState` 시각화                                                        | FE-C                  |
+| 파일                                                | 현재 상태   | 남은 수정 방향                                                                                                  | 담당                  |
+| --------------------------------------------------- | ----------- | --------------------------------------------------------------------------------------------------------------- | --------------------- |
+| `src/types/domain.ts`                               | ✅ 완료     | —                                                                                                               | FE-B                  |
+| `src/stores/game.store.ts`                          | ✅ 완료     | —                                                                                                               | FE-B                  |
+| `src/services/socket/game.handler.ts`               | ✅ 완료     | —                                                                                                               | FE-B                  |
+| `src/hooks/game/useGameState.ts`                    | ✅ 완료     | —                                                                                                               | FE-B                  |
+| `src/services/game/game.api.ts`                     | ✅ 완료     | 레거시 REST 모듈 삭제 완료(게임 런타임은 event-socket 단일 경로 유지)                                           | FE-B                  |
+| `src/hooks/game/useDiceRoll.ts`                     | ✅ 완료     | —                                                                                                               | FE-B                  |
+| `src/pages/GamePage.tsx`                            | ✅ 3차 완료 | `prompt` 오버레이 응답 + `prompt.type` board-modal 분기 연결 완료. 미매핑 prompt는 오버레이 fallback 유지       | FE-B                  |
+| `src/components/board/GameBoard.tsx`                | ⚠️ 1차 정리 | `store.prompt` 기반 모달 연결 + 로컬 엔진 유틸 분리(`gameBoardLocalEngine`) 완료. 엔진 제거는 후속 필요         | FE-C 주도 / FE-B 협업 |
+| `src/components/game/modals/*`                      | ✅ 3차 완료 | `store.prompt.type` 기준 모달 열림 조건/응답 연결 완료. `DiceTimerModal` timeout 연동 완료                      | FE-B                  |
+| `src/mocks/handlers/game.handler.ts`                | ✅ 완료     | —                                                                                                               | FE-B                  |
+| `src/components/board/gameBoardStoreBridge.ts`      | ✅ 완료     | `toStoreBuildingLevel` 상한 7 반영 완료                                                                         | FE-C                  |
+| `src/components/board/gameBoardTransactionUtils.ts` | ✅ 완료     | `upgradeBoardTileOwner` 상한 7 반영 완료                                                                        | FE-C                  |
+| `src/components/board/gameBoardActionUtils.ts`      | ✅ 완료     | `getBoardSellFallbackRefund` level 5, 6 반영 완료                                                               | FE-C                  |
+| `src/components/board/*` (렌더 레이어)              | ⚠️ 1차 완료 | `useBoardEventQueue`로 `eventQueue` 소비/상태연출 연결 완료. 이동 애니메이션 고도화와 `playerState` 시각화 필요 | FE-C                  |
 
 ### 2-1. 백엔드와 최종 고정이 필요한 항목
 
@@ -284,11 +284,12 @@
 - `src/components/board/gameBoardTransactionUtils.ts`: `upgradeBoardTileOwner` 상한 7 반영
 - `src/components/board/gameBoardActionUtils.ts`: `getBoardSellFallbackRefund` level 5, 6 반영
 - `src/components/board/gameBoardLocalEngine.ts`: `applyMoney`/`advanceTurn`/결과 집계를 분리해 `GameBoard.tsx` 책임 1차 축소
+- `src/components/board/useBoardEventQueue.ts`: `eventQueue` 소비 훅 추가, 상태 메시지/주사위 연출 연결
 
 ### 구조 미구현 (현재 잔여)
 
 - `GamePage` + `GameBoard`: `prompt.type` → Buy/Build/Toll/Timer 모달 매핑, `emitPromptResponse` 응답 경로 연결 완료
-- `store.eventQueue` → 소비 컴포넌트 없음
+- `store.eventQueue` → `useBoardEventQueue` 소비 훅 연결 완료(상태 메시지/주사위 반영). 이벤트별 애니메이션 세분화는 후속
 - `GameBoard.tsx` → 로컬 게임 엔진 성격(`applyMoney`, `advanceTurn`, 파산/턴 전환) 제거 필요
 
 ## 5-2. 다음 우선순위
@@ -302,7 +303,7 @@
 **FE-C**
 
 1. `GameBoard.tsx`의 로컬 엔진 성격 로직 제거
-2. `store.eventQueue` 소비 훅/컴포넌트 구현
+2. `store.eventQueue` 이벤트별 애니메이션(이동/칸 효과/턴 종료) 세분화
 3. `playerState`(`island`, `locked`) + `stateDuration` 시각화
 
 ## 6. 문서 사용법

--- a/docs/game-ownership-corrected-table.md
+++ b/docs/game-ownership-corrected-table.md
@@ -21,7 +21,7 @@
 | 파트 | 진행도  | 상태                                                                                                             |
 | ---- | ------- | ---------------------------------------------------------------------------------------------------------------- |
 | FE-B | 진행 중 | event-socket 계약 전환 + `game.api` 제거 + 한 턴 계약 시나리오 테스트(#298) + MSW 계약 검증 강화(#362) 반영 완료 |
-| FE-C | 진행 중 | 보드 로컬 엔진 유틸 분리(`gameBoardLocalEngine`) 1차 완료. 표현/연출 중심 구조로 최종 수렴이 남은 단계           |
+| FE-C | 진행 중 | 보드 로컬 엔진 유틸 분리 + `useBoardEventQueue` 연결(상태 메시지/주사위 반영) 1차 완료. 연출 고도화 단계         |
 
 ## FE-B 현재 최우선 작업
 
@@ -34,7 +34,7 @@
 ## FE-C 현재 최우선 작업
 
 - `GameBoard.tsx`에서 남아 있는 로컬 게임 로직 제거 (`gameBoardLocalEngine` 의존 축소/해소)
-- `eventQueue` 기반 이동/효과 애니메이션 계층 추가
+- `eventQueue` 기반 이동/효과 애니메이션 분기 고도화
 - store selector 기반 보드 렌더 구조 추가 정리
 - 새 `buildingLevel`, `tileType`, `playerState` 표시 반영
 
@@ -43,6 +43,7 @@
 - `GamePage` + `GameBoard`는 `prompt.type` 소비 구조로 전환됐지만 mock fallback과 실서버 경로가 일부 이원화돼 있다.
 - `GameBoard.tsx`가 여전히 `applyMoney`/`advanceTurn`/파산 판정 등 게임 엔진 성격 로직을 들고 있다.
 - 레거시 REST(`game.api`)가 삭제된 이후, 소켓 계약 변경 시 회귀를 잡는 테스트 보강이 필요하다.
+- `eventQueue` 소비는 연결됐지만 이벤트별 시각 연출 완성도가 아직 균일하지 않다.
 - `gameId` canonical, money unit, prompt/snapshot 필드 기준이 문서와 코드에서 완전히 수렴하지 않았다.
 
 ## 작업 운영 규칙 (2026-03-05 추가)

--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -60,6 +60,7 @@ import {
   buildPlayerResults,
   removeOwnedTilesByPlayerId,
 } from './gameBoardLocalEngine'
+import { useBoardEventQueue } from './useBoardEventQueue'
 import type {
   AIPenaltyModalState,
   BankruptModalState,
@@ -322,6 +323,14 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
     const playersRef = useRef<PlayerState[]>(players)
     curPlayerRef.current = curPlayer
     playersRef.current = players
+
+    useBoardEventQueue({
+      enabled: !USE_GAME_SOCKET_MOCK,
+      playersRef,
+      setStatus,
+      setDice1,
+      setDice2,
+    })
 
     const bankruptSetRef = useRef<Set<number>>(new Set())
     const [optimisticTileOwners, setOptimisticTileOwners] = useState<Record<

--- a/src/components/board/gameBoardEventQueueUtils.test.ts
+++ b/src/components/board/gameBoardEventQueueUtils.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+import type { ServerEvent } from '../../types/domain'
+import type { PlayerState, TileData } from './board.constants'
+import {
+  createBoardStatusFromEvent,
+  extractEventDice,
+} from './gameBoardEventQueueUtils'
+
+const players: PlayerState[] = [
+  {
+    id: 1,
+    name: '플레이어1',
+    color: '#f00',
+    pos: 0,
+    money: 1000,
+    skipTurns: 0,
+  },
+  {
+    id: 2,
+    name: '플레이어2',
+    color: '#0f0',
+    pos: 0,
+    money: 1000,
+    skipTurns: 0,
+  },
+]
+
+const tiles: TileData[] = [
+  { id: 0, name: 'START', type: 'START' },
+  { id: 1, name: '서울', type: 'PROPERTY', price: 1000, color: '#f00' },
+  { id: 2, name: '부산', type: 'PROPERTY', price: 1000, color: '#0f0' },
+]
+
+describe('gameBoardEventQueueUtils', () => {
+  it('extracts dice values from DICE_ROLLED payload', () => {
+    const event: ServerEvent = {
+      type: 'DICE_ROLLED',
+      playerId: 1,
+      payload: {
+        dice: [3, 4],
+        total: 7,
+      },
+    }
+
+    expect(extractEventDice(event)).toEqual([3, 4])
+  })
+
+  it('returns move status message with player and tile name', () => {
+    const event: ServerEvent = {
+      type: 'PLAYER_MOVED',
+      playerId: 1,
+      tileIndex: 2,
+    }
+
+    expect(createBoardStatusFromEvent(event, players, tiles)).toBe(
+      '플레이어1님이 부산 칸으로 이동했습니다.'
+    )
+  })
+
+  it('returns toll status with formatted amount', () => {
+    const event: ServerEvent = {
+      type: 'PAID_TOLL',
+      playerId: 2,
+      amount: 250000000,
+    }
+
+    expect(createBoardStatusFromEvent(event, players, tiles)).toBe(
+      '플레이어2님이 통행료 2.5억을 지불했습니다.'
+    )
+  })
+
+  it('returns synced status for sync event', () => {
+    const event: ServerEvent = {
+      type: 'SYNCED',
+      payload: {
+        serverRevision: 10,
+      },
+    }
+
+    expect(createBoardStatusFromEvent(event, players, tiles)).toBe(
+      '게임 상태를 동기화했습니다.'
+    )
+  })
+
+  it('returns null for unsupported event types', () => {
+    const event: ServerEvent = {
+      type: 'UNKNOWN_EVENT',
+      playerId: 1,
+    }
+
+    expect(createBoardStatusFromEvent(event, players, tiles)).toBeNull()
+  })
+})

--- a/src/components/board/gameBoardEventQueueUtils.ts
+++ b/src/components/board/gameBoardEventQueueUtils.ts
@@ -1,0 +1,139 @@
+import type { PlayerState, TileData } from './board.constants'
+import type { ServerEvent } from '../../types/domain'
+import { formatWon } from '../../lib/utils'
+
+const normalizeEventType = (type: unknown) =>
+  typeof type === 'string' ? type.trim().toUpperCase() : ''
+
+const getPayloadNumber = (
+  payload: Record<string, unknown> | undefined,
+  keys: string[]
+) => {
+  if (!payload) {
+    return null
+  }
+
+  for (const key of keys) {
+    const raw = payload[key]
+    if (typeof raw === 'number' && Number.isFinite(raw)) {
+      return raw
+    }
+    if (typeof raw === 'string' && raw.trim() !== '') {
+      const parsed = Number.parseFloat(raw)
+      if (Number.isFinite(parsed)) {
+        return parsed
+      }
+    }
+  }
+
+  return null
+}
+
+const resolvePlayerName = (
+  players: PlayerState[],
+  playerId: ServerEvent['playerId']
+) => {
+  if (playerId == null) {
+    return '플레이어'
+  }
+
+  return (
+    players.find((player) => String(player.id) === String(playerId))?.name ??
+    `플레이어 ${String(playerId)}`
+  )
+}
+
+const resolveTileName = (tiles: TileData[], tileIndex: number | null) => {
+  if (tileIndex == null) {
+    return '알 수 없는 칸'
+  }
+
+  return tiles[tileIndex]?.name?.replace('\n', ' ') ?? `칸 ${tileIndex}`
+}
+
+const resolveTileIndex = (event: ServerEvent) => {
+  if (typeof event.tileIndex === 'number' && Number.isFinite(event.tileIndex)) {
+    return event.tileIndex
+  }
+
+  const payload = event.payload
+  if (!payload) {
+    return null
+  }
+
+  return getPayloadNumber(payload, ['toIndex', 'tileIndex', 'toTileId'])
+}
+
+export const extractEventDice = (
+  event: ServerEvent
+): [number, number] | null => {
+  const normalizedType = normalizeEventType(event.type)
+  if (normalizedType !== 'DICE_ROLLED') {
+    return null
+  }
+
+  const payload = event.payload
+  if (!payload || !Array.isArray(payload.dice) || payload.dice.length < 2) {
+    return null
+  }
+
+  const first = Number(payload.dice[0])
+  const second = Number(payload.dice[1])
+
+  if (!Number.isFinite(first) || !Number.isFinite(second)) {
+    return null
+  }
+
+  return [first, second]
+}
+
+export const createBoardStatusFromEvent = (
+  event: ServerEvent,
+  players: PlayerState[],
+  tiles: TileData[]
+) => {
+  const normalizedType = normalizeEventType(event.type)
+  const playerName = resolvePlayerName(players, event.playerId)
+
+  if (normalizedType === 'DICE_ROLLED') {
+    const dice = extractEventDice(event)
+    const total =
+      getPayloadNumber(event.payload, ['total']) ??
+      (dice ? dice[0] + dice[1] : null)
+
+    if (total != null) {
+      return `${playerName}님이 주사위를 굴렸습니다 (${total})`
+    }
+
+    return `${playerName}님이 주사위를 굴렸습니다.`
+  }
+
+  if (normalizedType === 'PLAYER_MOVED') {
+    const tileName = resolveTileName(tiles, resolveTileIndex(event))
+    return `${playerName}님이 ${tileName} 칸으로 이동했습니다.`
+  }
+
+  if (normalizedType === 'LANDED') {
+    const tileName = resolveTileName(tiles, resolveTileIndex(event))
+    return `${playerName}님이 ${tileName} 칸에 도착했습니다.`
+  }
+
+  if (normalizedType === 'PAID_TOLL') {
+    const amount =
+      typeof event.amount === 'number'
+        ? event.amount
+        : (getPayloadNumber(event.payload, ['amount', 'toll', 'tollAmount']) ??
+          0)
+    return `${playerName}님이 통행료 ${formatWon(amount)}을 지불했습니다.`
+  }
+
+  if (normalizedType === 'TURN_ENDED') {
+    return `${playerName}님 턴이 종료되었습니다.`
+  }
+
+  if (normalizedType === 'SYNCED') {
+    return '게임 상태를 동기화했습니다.'
+  }
+
+  return null
+}

--- a/src/components/board/useBoardEventQueue.ts
+++ b/src/components/board/useBoardEventQueue.ts
@@ -1,0 +1,74 @@
+import { useEffect, useRef } from 'react'
+import type { Dispatch, MutableRefObject, SetStateAction } from 'react'
+import { useGameStore } from '../../stores/game.store'
+import type { PlayerState } from './board.constants'
+import { TILES } from './board.constants'
+import {
+  createBoardStatusFromEvent,
+  extractEventDice,
+} from './gameBoardEventQueueUtils'
+
+const EVENT_QUEUE_CONSUME_DELAY_MS = 120
+
+interface UseBoardEventQueueParams {
+  enabled: boolean
+  playersRef: MutableRefObject<PlayerState[]>
+  setStatus: Dispatch<SetStateAction<string>>
+  setDice1: Dispatch<SetStateAction<number>>
+  setDice2: Dispatch<SetStateAction<number>>
+}
+
+export function useBoardEventQueue({
+  enabled,
+  playersRef,
+  setStatus,
+  setDice1,
+  setDice2,
+}: UseBoardEventQueueParams) {
+  const eventQueueLength = useGameStore((state) => state.eventQueue.length)
+  const consumeNextEvent = useGameStore((state) => state.consumeNextEvent)
+  const consumingRef = useRef(false)
+
+  useEffect(() => {
+    if (!enabled || eventQueueLength <= 0 || consumingRef.current) {
+      return
+    }
+
+    consumingRef.current = true
+
+    const timer = window.setTimeout(() => {
+      const nextEvent = consumeNextEvent()
+      if (nextEvent) {
+        const dice = extractEventDice(nextEvent)
+        if (dice) {
+          setDice1(dice[0])
+          setDice2(dice[1])
+        }
+
+        const statusText = createBoardStatusFromEvent(
+          nextEvent,
+          playersRef.current,
+          TILES
+        )
+        if (statusText) {
+          setStatus(statusText)
+        }
+      }
+
+      consumingRef.current = false
+    }, EVENT_QUEUE_CONSUME_DELAY_MS)
+
+    return () => {
+      window.clearTimeout(timer)
+      consumingRef.current = false
+    }
+  }, [
+    enabled,
+    eventQueueLength,
+    consumeNextEvent,
+    playersRef,
+    setStatus,
+    setDice1,
+    setDice2,
+  ])
+}


### PR DESCRIPTION
## 📌 관련 이슈

> closes #410 

---

## 📝 작업 내용

- `store.eventQueue`를 보드에서 직접 소비하는 `useBoardEventQueue` 훅을 추가했습니다.
- 이벤트 소비 시 보드 상태 메시지/주사위 표시를 연결해 런타임 반응 경로를 단일화했습니다.
- `gameBoardEventQueueUtils` 유틸을 분리해 이벤트→UI 상태 변환 로직을 테스트 가능한 구조로 정리했습니다.
- `gameBoardEventQueueUtils.test.ts`를 추가해 이벤트 메시지/주사위 추출 규칙을 검증했습니다.
- 문서 3종(`game-event-spec-migration-plan`, `game-delivery-roadmap`, `game-ownership-corrected-table`)에
  진행도/잔여 작업을 최신 기준으로 반영했습니다.
  - `eventQueue 소비 훅 구현 완료`
  - 남은 작업을 `이벤트별 애니메이션 세분화 + playerState/stateDuration 시각화`로 갱신

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [ ] 관련 이슈 연결 완료 (이슈 번호 입력 후 체크)

---

## 📸 스크린샷 (선택)

> UI 변경이 주목적이 아니라 스크린샷은 생략합니다.
