### PR TITLE
feat: 방 생성 및 대기방 계약 반영

### DIFF
--- a/docs/ai/tasks/backend-room-waiting-contract-adoption/checklist.md
+++ b/docs/ai/tasks/backend-room-waiting-contract-adoption/checklist.md
@@ -1,0 +1,28 @@
+# Checklist
+
+## Implementation
+
+- [x] 관련 manual과 기존 문서를 읽었다
+- [x] 영향 범위를 정리했다
+- [x] 로비 방 생성 후 `create -> join -> enter_room` 흐름을 구현했다
+- [x] waiting-room 초기 상태를 join 응답 snapshot 기준으로 정리했다
+- [x] `lobby_updated` 타입을 `removed` / full payload로 분리했다
+- [x] waiting-room에서 방 삭제 이벤트를 구독하고 로비 복귀 흐름을 구현했다
+- [x] mock/real 경로를 함께 확인했다
+- [x] 관련 테스트 기대값을 계약 기준으로 갱신했다
+
+## Testing
+
+- [x] `src/pages/waiting-room/controller/lifecycle.test.ts`를 실행했다
+- [x] `src/pages/waiting-room/controller/socketSync.test.ts`를 실행했다
+- [x] `src/pages/lobby/LobbyPage.test.tsx`를 실행했다
+- [x] `npm run ai:check:waiting-room`를 실행했다
+- [x] 필요 시 `npm run ai:check:lobby`를 실행했다
+- [x] `npm run e2e -- e2e/waiting-room-start-flow.spec.ts`를 포함한 waiting-room Playwright를 실행했다
+- [x] `npm run e2e -- e2e/chat-flow-waiting-room.spec.ts`를 실행했다
+
+## Review
+
+- [x] `docs/rules.md` 기준으로 셀프 리뷰했다
+- [x] cleanup, 중복 join, 방 삭제 이벤트 경계를 확인했다
+- [ ] 변경 파일 / 실행한 검증 / 남은 리스크를 정리했다

--- a/docs/ai/tasks/backend-room-waiting-contract-adoption/context.md
+++ b/docs/ai/tasks/backend-room-waiting-contract-adoption/context.md
@@ -1,0 +1,48 @@
+# Context
+
+## Current Behavior
+
+- 로비에서 방 생성 후 `preJoinedSnapshot`을 직접 만들어 waiting-room으로 넘긴다.
+- waiting-room lifecycle은 `preJoinedSnapshot`이 있으면 join API 없이 즉시 상태를 반영한다.
+- 백엔드는 방 생성 직후 host가 이미 입장 상태이지만, 초기 snapshot 확보를 위해 `POST /rooms/{room_id}/join` 재호출을 권장하고 있다.
+- waiting-room은 `player_ready`, `host_changed`, `chat`, `game_start`만 구독하며, 방 삭제 신호인 `lobby_updated(action: "removed")`는 아직 듣지 않는다.
+- `LobbyUpdatedEventPayload`는 full room payload를 전제로 작성되어 있어 `removed`의 `{ room: { id } }` 최소 payload를 안전하게 표현하지 못한다.
+
+## Related Files
+
+- `src/pages/lobby/useLobbyRoomActions.ts`
+- `src/pages/lobby/LobbyPage.tsx`
+- `src/pages/lobby/LobbyPage.test.tsx`
+- `src/pages/waiting-room/api.ts`
+- `src/pages/waiting-room/types.ts`
+- `src/pages/waiting-room/WaitingRoomPage.tsx`
+- `src/pages/waiting-room/hooks.ts`
+- `src/pages/waiting-room/controller/lifecycle.ts`
+- `src/pages/waiting-room/controller/socketSync.ts`
+- `src/pages/waiting-room/controller/lifecycle.test.ts`
+- `src/pages/waiting-room/controller/socketSync.test.ts`
+- `src/pages/waiting-room/WaitingRoomFlow.test.tsx`
+
+## Constraints
+
+- 수동 퇴장과 cleanup 퇴장 시퀀스 재사용 규칙을 깨면 안 된다.
+- `leaveWaitingRoom` 성공 전에 `leave_room` 소켓 이벤트를 먼저 보내면 안 된다.
+- host의 join 재호출은 안전하지만, UI에서 중복 입장처럼 보이면 안 된다.
+- `lobby_updated`는
+  - `created / updated / status_changed`: full room card + `host_id`
+  - `removed`: `{ room: { id } }`
+    로 분기된다.
+- waiting-room 수정 시 lobby/presence 경계도 함께 봐야 하지만 DM 정책 자체는 바꾸지 않는다.
+
+## Decision Notes
+
+- fake `preJoinedSnapshot`은 빠른 UX를 위한 임시 가정이었고, 실제 서버 snapshot과 drift 위험이 있으므로 join 응답을 진실 소스로 맞춘다.
+- waiting-room 삭제 감지는 전용 room 삭제 이벤트가 없으므로 `lobby_updated(action: "removed")`를 직접 구독하는 방식으로 간다.
+- `LobbyUpdatedEventPayload`는 discriminated union으로 나눠 removed 최소 payload를 타입 안정적으로 처리한다.
+- create 이후 즉시 navigate하더라도 waiting-room이 join 응답을 기준으로 렌더링을 잡게 하면 host 재진입/초기 스냅샷 불일치 위험을 줄일 수 있다.
+
+## Open Risks
+
+- create -> join -> enter_room 순서가 바뀌면서 기존 `WaitingRoomFlow` 테스트가 snapshot 기대를 다시 맞춰야 할 수 있다.
+- waiting-room에서 lobby 이벤트를 추가 구독하면 cleanup 타이밍과 언마운트 시 중복 처리 위험이 생길 수 있다.
+- mockGateway와 실제 socket 경로가 같은 삭제 계약을 따르도록 같이 맞추지 않으면 local E2E만 통과하고 real path가 어긋날 수 있다.

--- a/docs/ai/tasks/backend-room-waiting-contract-adoption/plan.md
+++ b/docs/ai/tasks/backend-room-waiting-contract-adoption/plan.md
@@ -1,0 +1,66 @@
+# Plan
+
+## Task
+
+- 작업 이름: 방 생성 및 대기방 계약 반영
+- 요청 날짜: 2026-03-16
+- 담당 범위: lobby, waiting-room, presence 연결 계약 정렬
+
+## Goal
+
+- 백엔드 최종 계약에 맞춰 방 생성 이후 진입 흐름을 `create -> join -> enter_room` 순서로 정렬한다.
+- waiting-room이 `lobby_updated(action: "removed")`를 감지해 방 삭제 시 안전하게 로비로 복귀하도록 만든다.
+- `lobby_updated` payload를 `removed` 최소 payload / 그 외 full room card로 타입 분리해 socket 계약을 안정화한다.
+
+## In Scope
+
+- `POST /rooms` 이후 fake `preJoinedSnapshot` 가정을 줄이고 `POST /rooms/{room_id}/join` 기반 초기 snapshot 사용
+- waiting-room 초기화에서 `preJoinedSnapshot` 우선 처리 규칙 재검토
+- `enter_room` 소켓 송신 시점 정렬
+- `lobby_updated` 타입을 discriminated union으로 분리
+- waiting-room에서 `lobby_updated(action: "removed")` 구독 추가
+- 방 삭제 시 stale room state 정리 및 로비 복귀
+- 필요 시 로비 방 생성/입장 테스트 기대값 갱신
+
+## Out Of Scope
+
+- auth 세션/카카오 로그인 흐름 수정
+- game runtime 전면 수정
+- DM/접속자 목록 정책 변경
+- `/users/online` 계약 반영
+
+## Target Files
+
+- `src/pages/lobby/useLobbyRoomActions.ts`
+- `src/pages/lobby/LobbyPage.tsx`
+- `src/pages/lobby/LobbyPage.test.tsx`
+- `src/pages/waiting-room/api.ts`
+- `src/pages/waiting-room/types.ts`
+- `src/pages/waiting-room/WaitingRoomPage.tsx`
+- `src/pages/waiting-room/hooks.ts`
+- `src/pages/waiting-room/controller/lifecycle.ts`
+- `src/pages/waiting-room/controller/socketSync.ts`
+- `src/pages/waiting-room/controller/lifecycle.test.ts`
+- `src/pages/waiting-room/controller/socketSync.test.ts`
+- `src/pages/waiting-room/WaitingRoomFlow.test.tsx`
+- 필요 시 `src/pages/waiting-room/mockGateway.ts`
+
+## Completion Criteria
+
+- 방 생성 후 waiting-room 진입은 `POST /rooms -> POST /rooms/{room_id}/join -> enter_room` 순서로 맞춘다.
+- waiting-room은 join 응답 snapshot을 기준으로 초기 상태를 구성한다.
+- `lobby_updated`는 `removed`와 full payload action을 구분한 타입으로 정리된다.
+- waiting-room에서 현재 room이 `removed`되면 중복 퇴장 없이 로비로 복귀한다.
+- 관련 lobby/waiting-room Vitest와 시작/채팅 E2E가 통과한다.
+
+## Test Plan
+
+- 최소 실행 테스트
+  - `npx vitest run src/pages/waiting-room/controller/lifecycle.test.ts`
+  - `npx vitest run src/pages/waiting-room/controller/socketSync.test.ts`
+  - `npx vitest run src/pages/lobby/LobbyPage.test.tsx`
+- 추가 검증
+  - `npm run ai:check:waiting-room`
+  - `npm run ai:check:lobby`
+  - `npm run ai:check:waiting-room-e2e`
+  - 필요 시 `npm run ai:check:chat-e2e`

--- a/src/pages/lobby/LobbyPage.test.tsx
+++ b/src/pages/lobby/LobbyPage.test.tsx
@@ -175,17 +175,31 @@ describe('LobbyPage filter and toggle regression', () => {
     })
     getWaitingRoomErrorMessageMock.mockReturnValue('에러')
     isJoinPasswordMismatchErrorMock.mockReturnValue(false)
-    joinWaitingRoomMock.mockResolvedValue({
-      roomId: 'room-2',
-      title: '초보 비밀 방',
-      status: 'waiting',
-      maxPlayers: 4,
-      isPrivate: true,
-      players: [
-        { id: 'user-1', nickname: '테스터', isReady: false, isHost: false },
-      ],
-      chatMessages: [],
-    } satisfies WaitingRoomSnapshot)
+    joinWaitingRoomMock.mockImplementation(
+      async ({
+        roomId,
+        fallbackTitle,
+      }: {
+        roomId: string
+        fallbackTitle?: string
+      }) =>
+        ({
+          roomId,
+          title: fallbackTitle ?? '대기방',
+          status: 'waiting',
+          maxPlayers: 4,
+          isPrivate: roomId === 'room-2',
+          players: [
+            {
+              id: 'user-1',
+              nickname: '테스터',
+              isReady: false,
+              isHost: roomId === 'room-10',
+            },
+          ],
+          chatMessages: [],
+        }) satisfies WaitingRoomSnapshot
+    )
   })
 
   it('검색/탭/비밀방 토글 조합에 따라 조회 파라미터와 카드 목록이 함께 바뀐다', async () => {
@@ -283,6 +297,77 @@ describe('LobbyPage filter and toggle regression', () => {
         roomId: 'room-2',
         roomTitle: '초보 비밀 방',
         preJoinedSnapshot: expect.any(Object),
+      },
+    })
+  })
+
+  it('일반방 입장하기 클릭 시 join 응답 snapshot을 확보한 뒤 대기방으로 이동한다', async () => {
+    const user = userEvent.setup()
+    renderLobbyPage()
+
+    const publicRoomCard = screen
+      .getByText('초보 환영 방')
+      .closest('article') as HTMLElement
+
+    await user.click(
+      within(publicRoomCard).getByRole('button', { name: '입장하기' })
+    )
+
+    await waitFor(() => {
+      expect(joinWaitingRoomMock).toHaveBeenCalledWith({
+        roomId: 'room-1',
+        userId: 'user-1',
+        nickname: '테스터',
+        fallbackTitle: '초보 환영 방',
+        password: undefined,
+      })
+    })
+
+    expect(navigateMock).toHaveBeenCalledWith('/rooms/room-1', {
+      state: {
+        roomId: 'room-1',
+        roomTitle: '초보 환영 방',
+        preJoinedSnapshot: expect.objectContaining({
+          roomId: 'room-1',
+        }),
+      },
+    })
+  })
+
+  it('방 생성 후 join snapshot을 다시 받아 waiting-room으로 이동한다', async () => {
+    const user = userEvent.setup()
+    renderLobbyPage()
+
+    await user.click(screen.getByRole('button', { name: '방 만들기' }))
+    await user.click(screen.getByRole('button', { name: '방 만들기 완료' }))
+
+    await waitFor(() => {
+      expect(createWaitingRoomMock).toHaveBeenCalledWith({
+        title: '테스터님의 방',
+        isPrivate: false,
+        password: undefined,
+        hostUserId: 'user-1',
+        hostNickname: '테스터',
+      })
+    })
+
+    await waitFor(() => {
+      expect(joinWaitingRoomMock).toHaveBeenCalledWith({
+        roomId: 'room-10',
+        userId: 'user-1',
+        nickname: '테스터',
+        fallbackTitle: '테스트 방',
+        password: undefined,
+      })
+    })
+
+    expect(navigateMock).toHaveBeenCalledWith('/rooms/room-10', {
+      state: {
+        roomId: 'room-10',
+        roomTitle: '테스트 방',
+        preJoinedSnapshot: expect.objectContaining({
+          roomId: 'room-10',
+        }),
       },
     })
   })

--- a/src/pages/lobby/useLobbyRoomActions.ts
+++ b/src/pages/lobby/useLobbyRoomActions.ts
@@ -31,17 +31,45 @@ export function useLobbyRoomActions({ session }: UseLobbyRoomActionsParams) {
     useState(false)
 
   // 대기방 페이지로 이동하면서 roomId/title/snapshot을 전달
-  function enterWaitingRoom(
-    room: LobbyRoom,
+  function enterWaitingRoom(params: {
+    roomId: string
+    roomTitle: string
     preJoinedSnapshot?: WaitingRoomSnapshot
-  ) {
-    navigate(`/rooms/${room.id}`, {
+  }) {
+    navigate(`/rooms/${params.roomId}`, {
       state: {
-        roomId: room.id,
-        roomTitle: room.title,
-        preJoinedSnapshot,
+        roomId: params.roomId,
+        roomTitle: params.roomTitle,
+        preJoinedSnapshot: params.preJoinedSnapshot,
       },
     })
+  }
+
+  // waiting-room 진입 전 join 응답 snapshot을 확보해 초기 렌더 기준을 맞춘다.
+  async function joinRoomAndEnter(params: {
+    roomId: string
+    roomTitle: string
+    password?: string
+  }) {
+    if (!session) {
+      return null
+    }
+
+    const joinedRoomSnapshot = await joinWaitingRoom({
+      roomId: params.roomId,
+      userId: session.userId,
+      nickname: session.nickname,
+      fallbackTitle: params.roomTitle,
+      password: params.password,
+    })
+
+    enterWaitingRoom({
+      roomId: params.roomId,
+      roomTitle: params.roomTitle,
+      preJoinedSnapshot: joinedRoomSnapshot,
+    })
+
+    return joinedRoomSnapshot
   }
 
   // 방 생성 모달 열기
@@ -59,7 +87,7 @@ export function useLobbyRoomActions({ session }: UseLobbyRoomActionsParams) {
   }
 
   // 비밀방은 비밀번호 모달을 열고, 일반방은 바로 입장 처리
-  function joinRoom(room: LobbyRoom) {
+  async function joinRoom(room: LobbyRoom) {
     if (room.isPrivate) {
       setSelectedPrivateRoom(room)
       setPrivateRoomPassword('')
@@ -67,7 +95,14 @@ export function useLobbyRoomActions({ session }: UseLobbyRoomActionsParams) {
       return
     }
 
-    enterWaitingRoom(room)
+    try {
+      await joinRoomAndEnter({
+        roomId: room.id,
+        roomTitle: room.title,
+      })
+    } catch (error) {
+      toast.error(getWaitingRoomErrorMessage(error, '방 입장에 실패했습니다.'))
+    }
   }
 
   // 비밀방 모달 상태 초기화 후 닫기
@@ -105,13 +140,22 @@ export function useLobbyRoomActions({ session }: UseLobbyRoomActionsParams) {
       })
 
       setIsCreateRoomModalOpen(false)
-      navigate(`/rooms/${createdRoom.roomId}`, {
-        state: {
+
+      try {
+        await joinRoomAndEnter({
           roomId: createdRoom.roomId,
           roomTitle: createdRoom.roomTitle,
-          preJoinedSnapshot: createdRoom.preJoinedSnapshot,
-        },
-      })
+        })
+      } catch (error) {
+        // 생성은 이미 완료됐으므로 fallback 진입으로 한 번 더 snapshot 복구를 시도한다.
+        toast.error(
+          getWaitingRoomErrorMessage(error, '방 입장에 실패했습니다.')
+        )
+        enterWaitingRoom({
+          roomId: createdRoom.roomId,
+          roomTitle: createdRoom.roomTitle,
+        })
+      }
     } catch (error) {
       toast.error(getWaitingRoomErrorMessage(error, '방 생성에 실패했습니다.'))
     } finally {
@@ -128,15 +172,12 @@ export function useLobbyRoomActions({ session }: UseLobbyRoomActionsParams) {
     setIsPrivateRoomJoinPending(true)
 
     try {
-      const joinedRoomSnapshot = await joinWaitingRoom({
+      await joinRoomAndEnter({
         roomId: selectedPrivateRoom.id,
-        userId: session.userId,
-        nickname: session.nickname,
-        fallbackTitle: selectedPrivateRoom.title,
+        roomTitle: selectedPrivateRoom.title,
         password: privateRoomPassword,
       })
 
-      enterWaitingRoom(selectedPrivateRoom, joinedRoomSnapshot)
       closePrivateRoomModal()
     } catch (error) {
       // 비밀번호 불일치 에러는 인풋 에러 상태를 별도 표시

--- a/src/pages/waiting-room/WaitingRoomPage.tsx
+++ b/src/pages/waiting-room/WaitingRoomPage.tsx
@@ -72,6 +72,10 @@ function WaitingRoomPage() {
     [navigate]
   )
 
+  const handleRoomRemoved = useCallback(() => {
+    navigate('/lobby', { replace: true })
+  }, [navigate])
+
   const {
     room,
     seats,
@@ -96,6 +100,7 @@ function WaitingRoomPage() {
     fallbackRoomTitle: selectedRoomTitle ?? undefined,
     preJoinedSnapshot,
     onGameStart: handleGameStart,
+    onRoomRemoved: handleRoomRemoved,
   })
 
   const {

--- a/src/pages/waiting-room/api.ts
+++ b/src/pages/waiting-room/api.ts
@@ -22,7 +22,6 @@ import type {
 
 // 대기방 기본 제목/정원과 모드 전환 플래그
 const DEFAULT_WAITING_ROOM_TITLE = '즐거운 게임 한판!'
-const DEFAULT_WAITING_ROOM_MAX_PLAYERS = 4
 const USE_WAITING_ROOM_MOCK = IS_SOCKET_MOCK_ENABLED
 const WAITING_ROOM_STATUS_VALUES = new Set(['waiting', 'playing'])
 // 비밀번호 불일치로 간주할 서버 에러 코드 집합
@@ -54,7 +53,6 @@ interface CreateWaitingRoomParams {
 export interface CreateWaitingRoomResult {
   roomId: string
   roomTitle: string
-  preJoinedSnapshot?: WaitingRoomSnapshot
 }
 
 // 퇴장/준비/시작 요청 파라미터 타입
@@ -253,29 +251,11 @@ function mapJoinResponse(
 
 // 방 생성 응답 payload를 생성 결과 모델로 변환
 function mapCreateRoomResponse(
-  payload: CreateRoomResponsePayload,
-  hostUserId: string,
-  hostNickname: string
+  payload: CreateRoomResponsePayload
 ): CreateWaitingRoomResult {
   return {
     roomId: payload.id,
-    roomTitle: payload.title,
-    preJoinedSnapshot: {
-      roomId: payload.id,
-      title: payload.title || DEFAULT_WAITING_ROOM_TITLE,
-      status: payload.status ?? 'waiting',
-      maxPlayers: payload.max_players ?? DEFAULT_WAITING_ROOM_MAX_PLAYERS,
-      isPrivate: payload.is_private ?? false,
-      players: [
-        {
-          id: hostUserId,
-          nickname: hostNickname,
-          isReady: false,
-          isHost: true,
-        },
-      ],
-      chatMessages: [],
-    },
+    roomTitle: payload.title || DEFAULT_WAITING_ROOM_TITLE,
   }
 }
 
@@ -305,7 +285,7 @@ export async function createWaitingRoom({
   })
 
   // 실서버 응답을 화면 모델로 정규화
-  return mapCreateRoomResponse(data, hostUserId, hostNickname)
+  return mapCreateRoomResponse(data)
 }
 
 // 대기방 입장 API 호출 또는 목 게이트웨이 호출

--- a/src/pages/waiting-room/controller/socketSync.test.ts
+++ b/src/pages/waiting-room/controller/socketSync.test.ts
@@ -7,6 +7,7 @@ import type {
   ChatEventPayload,
   GameStartEventPayload,
   HostChangedEventPayload,
+  LobbyUpdatedEventPayload,
   PlayerReadyEventPayload,
   WaitingRoomSnapshot,
 } from '../types'
@@ -42,6 +43,7 @@ interface SocketSyncHookParams {
   session: ReturnType<typeof createAuthSessionFixture> | null
   activeRoomId?: string
   onGameStart: (payload: GameStartEventPayload) => void
+  onRoomRemoved: () => void
   setRoom: Dispatch<SetStateAction<WaitingRoomSnapshot | null>>
   setChatMessages: Dispatch<SetStateAction<WaitingRoomSnapshot['chatMessages']>>
   setRoomMock: ReturnType<typeof vi.fn>
@@ -60,6 +62,7 @@ function createBaseParams(): SocketSyncHookParams {
     }),
     activeRoomId: 'room-5',
     onGameStart: vi.fn(),
+    onRoomRemoved: vi.fn(),
     setRoom: setRoomMock as unknown as Dispatch<
       SetStateAction<WaitingRoomSnapshot | null>
     >,
@@ -213,5 +216,41 @@ describe('useWaitingRoomSocketSync', () => {
 
     unmount()
     expect(unsubscribeMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('lobby_updated removed는 현재 방 삭제일 때만 상태를 비우고 콜백을 호출한다', () => {
+    const params = createBaseParams()
+    renderHook(() => useWaitingRoomSocketSync(params))
+
+    const handlers = subscribeWaitingRoomSocketEventsMock.mock
+      .calls[0]?.[0] as {
+      onLobbyUpdated: (payload: LobbyUpdatedEventPayload) => void
+    }
+
+    act(() => {
+      handlers.onLobbyUpdated({
+        action: 'removed',
+        room: {
+          id: 'room-other',
+        },
+      })
+    })
+
+    expect(params.setRoomMock).not.toHaveBeenCalledWith(null)
+    expect(params.setChatMessagesMock).not.toHaveBeenCalledWith([])
+    expect(params.onRoomRemoved).not.toHaveBeenCalled()
+
+    act(() => {
+      handlers.onLobbyUpdated({
+        action: 'removed',
+        room: {
+          id: 'room-5',
+        },
+      })
+    })
+
+    expect(params.setRoomMock).toHaveBeenCalledWith(null)
+    expect(params.setChatMessagesMock).toHaveBeenCalledWith([])
+    expect(params.onRoomRemoved).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/pages/waiting-room/controller/socketSync.ts
+++ b/src/pages/waiting-room/controller/socketSync.ts
@@ -4,6 +4,7 @@ import type { AuthSession } from '../../../features/auth/types'
 import { subscribeWaitingRoomSocketEvents } from '../socket'
 import type {
   GameStartEventPayload,
+  LobbyUpdatedEventPayload,
   WaitingRoomChatMessage,
   WaitingRoomSnapshot,
 } from '../types'
@@ -15,6 +16,7 @@ interface UseWaitingRoomSocketSyncParams {
   session: AuthSession | null
   activeRoomId?: string
   onGameStart: (payload: GameStartEventPayload) => void
+  onRoomRemoved: () => void
   setRoom: Dispatch<SetStateAction<WaitingRoomSnapshot | null>>
   setChatMessages: Dispatch<SetStateAction<WaitingRoomChatMessage[]>>
 }
@@ -25,6 +27,7 @@ export function useWaitingRoomSocketSync({
   session,
   activeRoomId,
   onGameStart,
+  onRoomRemoved,
   setRoom,
   setChatMessages,
 }: UseWaitingRoomSocketSyncParams) {
@@ -101,10 +104,27 @@ export function useWaitingRoomSocketSync({
 
         onGameStart(payload)
       },
+      onLobbyUpdated: (payload: LobbyUpdatedEventPayload) => {
+        if (payload.action !== 'removed' || payload.room.id !== activeRoomId) {
+          return
+        }
+
+        setRoom(null)
+        setChatMessages([])
+        onRoomRemoved()
+      },
     })
 
     return () => {
       unsubscribe()
     }
-  }, [activeRoomId, onGameStart, roomId, session, setChatMessages, setRoom])
+  }, [
+    activeRoomId,
+    onGameStart,
+    onRoomRemoved,
+    roomId,
+    session,
+    setChatMessages,
+    setRoom,
+  ])
 }

--- a/src/pages/waiting-room/hooks.ts
+++ b/src/pages/waiting-room/hooks.ts
@@ -21,6 +21,7 @@ interface UseWaitingRoomControllerParams {
   fallbackRoomTitle?: string
   preJoinedSnapshot?: WaitingRoomSnapshot | null
   onGameStart: (payload: GameStartEventPayload) => void
+  onRoomRemoved: () => void
 }
 
 // 대기방 상태 동기화/소켓 구독/액션 핸들러를 통합한 컨트롤러 훅
@@ -30,6 +31,7 @@ export function useWaitingRoomController({
   fallbackRoomTitle,
   preJoinedSnapshot,
   onGameStart,
+  onRoomRemoved,
 }: UseWaitingRoomControllerParams) {
   const [room, setRoom] = useState<WaitingRoomSnapshot | null>(null)
   const [chatMessages, setChatMessages] = useState<WaitingRoomChatMessage[]>([])
@@ -61,6 +63,16 @@ export function useWaitingRoomController({
     roomRef.current = room
   }, [room])
 
+  const handleRoomRemoved = useCallback(() => {
+    roomRef.current = null
+    hasEnteredRoomRef.current = false
+    hasLeftRoomRef.current = true
+    hasInitializedPreJoinRef.current = false
+    setRoomErrorMessage(null)
+    setIsRoomLoading(false)
+    onRoomRemoved()
+  }, [onRoomRemoved])
+
   useWaitingRoomLifecycle({
     roomId,
     session,
@@ -82,6 +94,7 @@ export function useWaitingRoomController({
     session,
     activeRoomId,
     onGameStart,
+    onRoomRemoved: handleRoomRemoved,
     setRoom,
     setChatMessages,
   })

--- a/src/pages/waiting-room/mockGateway.ts
+++ b/src/pages/waiting-room/mockGateway.ts
@@ -195,11 +195,23 @@ function toWaitingRoomSnapshot(room: MockRoom): WaitingRoomSnapshot {
 }
 
 // 로비 갱신 브로드캐스트에 맞는 payload로 변환
-function getLobbyUpdatedPayload(room: MockRoom): LobbyUpdatedEventPayload {
+function getLobbyUpdatedPayload(
+  room: MockRoom,
+  action: LobbyUpdatedEventPayload['action']
+): LobbyUpdatedEventPayload {
+  if (action === 'removed') {
+    return {
+      action,
+      room: {
+        id: room.id,
+      },
+    }
+  }
+
   const hostPlayer = room.players.find((player) => player.is_host)
 
   return {
-    action: 'status_changed',
+    action,
     room: {
       id: room.id,
       title: room.title,
@@ -207,6 +219,7 @@ function getLobbyUpdatedPayload(room: MockRoom): LobbyUpdatedEventPayload {
       is_private: room.is_private,
       current_players: room.players.length,
       max_players: room.max_players,
+      host_id: hostPlayer?.id ?? '',
       host_nickname: hostPlayer?.nickname ?? '',
     },
   }
@@ -227,11 +240,8 @@ function emitLobbyUpdated(
   room: MockRoom,
   action: LobbyUpdatedEventPayload['action']
 ) {
-  const payload = getLobbyUpdatedPayload(room)
-  emitSocketEvent<LobbyUpdatedEventPayload>('lobby_updated', {
-    ...payload,
-    action,
-  })
+  const payload = getLobbyUpdatedPayload(room, action)
+  emitSocketEvent<LobbyUpdatedEventPayload>('lobby_updated', payload)
 }
 
 // 시작 가능 조건(2명 이상 + 방장 제외 전원 ready) 판별
@@ -345,7 +355,6 @@ interface MockCreateRoomParams {
 export interface MockCreateRoomResult {
   roomId: string
   roomTitle: string
-  preJoinedSnapshot: WaitingRoomSnapshot
 }
 
 // 대기방 입장 목 API 처리
@@ -379,6 +388,7 @@ export async function mockJoinWaitingRoom({
 
   // 이미 입장한 사용자는 현재 스냅샷 그대로 반환
   if (existingPlayer) {
+    emitLobbyUpdated(room, 'updated')
     setMockOnlineUserStatus(existingPlayer.id, 'in_room')
     return toWaitingRoomSnapshot(room)
   }
@@ -468,7 +478,6 @@ export async function mockCreateWaitingRoom({
   return {
     roomId: createdRoom.id,
     roomTitle: createdRoom.title,
-    preJoinedSnapshot: toWaitingRoomSnapshot(createdRoom),
   }
 }
 

--- a/src/pages/waiting-room/socket.ts
+++ b/src/pages/waiting-room/socket.ts
@@ -10,6 +10,7 @@ import type {
   EnterRoomSocketPayload,
   GameStartEventPayload,
   HostChangedEventPayload,
+  LobbyUpdatedEventPayload,
   LeaveRoomSocketPayload,
   PlayerReadyEventPayload,
   SendChatSocketPayload,
@@ -24,6 +25,7 @@ const WAITING_ROOM_EVENT_NAMES = {
   hostChanged: 'host_changed',
   chat: 'chat',
   gameStart: 'game_start',
+  lobbyUpdated: 'lobby_updated',
 } as const
 
 const USE_WAITING_ROOM_SOCKET_MOCK = IS_SOCKET_MOCK_ENABLED
@@ -50,6 +52,7 @@ interface WaitingRoomSocketHandlers {
   onHostChanged: (payload: HostChangedEventPayload) => void
   onChat: (payload: ChatEventPayload) => void
   onGameStart: (payload: GameStartEventPayload) => void
+  onLobbyUpdated: (payload: LobbyUpdatedEventPayload) => void
 }
 
 // 실소켓 모드에서만 연결 상태를 확인해 connect 실행
@@ -72,6 +75,7 @@ export function subscribeWaitingRoomSocketEvents(
   socket.on(WAITING_ROOM_EVENT_NAMES.hostChanged, handlers.onHostChanged)
   socket.on(WAITING_ROOM_EVENT_NAMES.chat, handlers.onChat)
   socket.on(WAITING_ROOM_EVENT_NAMES.gameStart, handlers.onGameStart)
+  socket.on(WAITING_ROOM_EVENT_NAMES.lobbyUpdated, handlers.onLobbyUpdated)
 
   connectSocketIfNeeded()
 
@@ -80,6 +84,7 @@ export function subscribeWaitingRoomSocketEvents(
     socket.off(WAITING_ROOM_EVENT_NAMES.hostChanged, handlers.onHostChanged)
     socket.off(WAITING_ROOM_EVENT_NAMES.chat, handlers.onChat)
     socket.off(WAITING_ROOM_EVENT_NAMES.gameStart, handlers.onGameStart)
+    socket.off(WAITING_ROOM_EVENT_NAMES.lobbyUpdated, handlers.onLobbyUpdated)
   }
 }
 

--- a/src/pages/waiting-room/types.ts
+++ b/src/pages/waiting-room/types.ts
@@ -133,22 +133,39 @@ export interface ChatEventPayload {
   sent_at: string
 }
 
-// 로비 갱신 이벤트의 방 정보 payload 타입
-export interface LobbyUpdatedRoomPayload {
+// created/updated/status_changed 시 내려오는 full room card payload 타입
+export interface LobbyUpdatedFullRoomPayload {
   id: string
   title: string
   status: LobbyRoomStatus
   is_private: boolean
   current_players: number
   max_players: number
+  host_id: string
   host_nickname: string
 }
 
-// 로비 갱신 이벤트 payload 타입
-export interface LobbyUpdatedEventPayload {
-  action: 'created' | 'removed' | 'status_changed' | 'updated'
-  room: LobbyUpdatedRoomPayload
+// removed 시에는 room id만 내려오는 최소 payload 타입
+export interface LobbyUpdatedRemovedRoomPayload {
+  id: string
 }
+
+// room card 전체 정보가 포함된 로비 갱신 이벤트 타입
+export interface LobbyUpdatedFullEventPayload {
+  action: 'created' | 'status_changed' | 'updated'
+  room: LobbyUpdatedFullRoomPayload
+}
+
+// 방 삭제 시 최소 payload만 전달되는 이벤트 타입
+export interface LobbyUpdatedRemovedEventPayload {
+  action: 'removed'
+  room: LobbyUpdatedRemovedRoomPayload
+}
+
+// 로비 갱신 이벤트 payload 타입
+export type LobbyUpdatedEventPayload =
+  | LobbyUpdatedFullEventPayload
+  | LobbyUpdatedRemovedEventPayload
 
 // 게임 시작 이벤트 payload 타입
 export interface GameStartEventPayload {


### PR DESCRIPTION
## 📌 관련 이슈

> closes #417

---

## 📝 작업 내용

> 백엔드 최종 계약에 맞춰 로비의 방 생성/입장 흐름과 waiting-room 삭제 cleanup 흐름을 정리했습니다.

- 로비에서 방 생성 후 waiting-room으로 진입하는 흐름을 `POST /rooms -> POST /rooms/{room_id}/join -> enter_room` 기준으로 맞췄습니다.
- 기존 fake `preJoinedSnapshot`에 의존하던 흐름을 줄이고, `joinWaitingRoom()` 응답 snapshot을 waiting-room 초기 상태 기준으로 사용하도록 변경했습니다.
- `lobby_updated` payload를 `removed` 최소 payload와 그 외 full room payload로 구분할 수 있도록 타입을 정리했습니다.
- waiting-room에서도 `lobby_updated(action: "removed")`를 구독해 현재 방이 삭제되면 상태를 정리하고 로비로 복귀하도록 추가했습니다.
- mock gateway도 같은 계약을 따르도록 맞춰 `removed`는 `{ room: { id } }`, 그 외는 full room card + `host_id`를 emit하도록 수정했습니다.
- 로비/대기방 테스트를 실제 계약 흐름 기준으로 갱신했습니다.

### 참고한 백엔드 계약

- host는 `POST /rooms/{room_id}/join` 재호출이 안전하며 `200 + RoomSnapshotResponse`를 반환
- 마지막 유저 퇴장 시 전용 room 삭제 이벤트는 없고 `lobby_updated(action: "removed")`만 전체 broadcast
- `created / updated / status_changed`는 full room card, `removed`는 `{ room: { id } }`

### 검증

- `npx vitest run src/pages/lobby/LobbyPage.test.tsx src/pages/waiting-room/controller/socketSync.test.ts src/pages/waiting-room/controller/lifecycle.test.ts src/pages/waiting-room/WaitingRoomFlow.test.tsx src/pages/waiting-room/api.test.ts`
- `tsc --noEmit`
- `npm run lint`
- `npm run build`
- `npm run ai:check:lobby`
- `npm run ai:check:waiting-room`
- `npm run ai:self-review -- --files src/pages/lobby/useLobbyRoomActions.ts src/pages/lobby/LobbyPage.test.tsx src/pages/waiting-room/WaitingRoomPage.tsx src/pages/waiting-room/api.ts src/pages/waiting-room/controller/socketSync.ts src/pages/waiting-room/controller/socketSync.test.ts src/pages/waiting-room/hooks.ts src/pages/waiting-room/mockGateway.ts src/pages/waiting-room/socket.ts src/pages/waiting-room/types.ts`
- `npm run e2e -- e2e/chat-flow-waiting-room.spec.ts e2e/waiting-room-start-flow.spec.ts`

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

> UI 개편보다 로비 진입/대기방 cleanup 계약 정리가 중심이라 스크린샷은 생략했습니다.
