### PR TITLE
fix: 실백엔드 검증 중 발견된 auth/session 및 로컬 UX 안정화

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,116 @@
+import type { ReactNode } from 'react'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import App from './App'
+import { createAuthSessionFixture } from './test/fixtures'
+
+const { useAuthBootstrapMock, useAuthStoreMock } = vi.hoisted(() => ({
+  useAuthBootstrapMock: vi.fn(),
+  useAuthStoreMock: vi.fn(),
+}))
+
+vi.mock('./components/DesktopViewportGuard', () => ({
+  DesktopViewportGuard: ({ children }: { children: ReactNode }) => (
+    <>{children}</>
+  ),
+}))
+
+vi.mock('./features/auth/hooks/useAuthBootstrap', () => ({
+  useAuthBootstrap: useAuthBootstrapMock,
+}))
+
+vi.mock('./features/auth/store', () => ({
+  useAuthStore: useAuthStoreMock,
+}))
+
+vi.mock('./pages/HomePage', () => ({
+  default: () => <div>홈 페이지</div>,
+}))
+
+vi.mock('./pages/GamePage', () => ({
+  default: () => <div>게임 페이지</div>,
+}))
+
+vi.mock('./pages/lobby/LobbyPage', () => ({
+  default: () => <div>로비 페이지</div>,
+}))
+
+vi.mock('./pages/KakaoLoginCallbackPage', () => ({
+  default: () => <div>카카오 콜백 페이지</div>,
+}))
+
+vi.mock('./pages/NicknameSetupPage', () => ({
+  default: () => <div>닉네임 설정 페이지</div>,
+}))
+
+vi.mock('./pages/MyPage', () => ({
+  default: () => <div>마이페이지</div>,
+}))
+
+vi.mock('./pages/waiting-room/WaitingRoomPage', () => ({
+  default: () => <div>대기방 페이지</div>,
+}))
+
+function renderApp(initialEntry: string) {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <App />
+    </MemoryRouter>
+  )
+}
+
+describe('App auth bootstrap gating', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useAuthStoreMock.mockImplementation((selector) =>
+      selector({
+        session: null,
+      })
+    )
+  })
+
+  it('홈 경로에서는 bootstrap 중이어도 홈 화면을 그대로 렌더링한다', () => {
+    useAuthBootstrapMock.mockReturnValue(true)
+
+    renderApp('/')
+
+    expect(screen.getByText('홈 페이지')).toBeInTheDocument()
+    expect(
+      screen.queryByText('세션 정보를 확인하고 있습니다.')
+    ).not.toBeInTheDocument()
+  })
+
+  it('보호 경로에서는 bootstrap 중일 때 세션 확인 화면을 보여준다', () => {
+    useAuthBootstrapMock.mockReturnValue(true)
+
+    renderApp('/lobby')
+
+    expect(
+      screen.getByText('세션 정보를 확인하고 있습니다.')
+    ).toBeInTheDocument()
+    expect(screen.queryByText('로비 페이지')).not.toBeInTheDocument()
+  })
+
+  it('persisted session이 있으면 보호 경로에서도 bootstrap을 백그라운드로 진행한다', () => {
+    useAuthBootstrapMock.mockReturnValue(true)
+    useAuthStoreMock.mockImplementation((selector) =>
+      selector({
+        session: createAuthSessionFixture({
+          accessToken: 'guest-token',
+          userId: 'guest-user',
+          nickname: '게스트',
+          isGuest: true,
+          provider: 'guest',
+        }),
+      })
+    )
+
+    renderApp('/lobby')
+
+    expect(
+      screen.queryByText('세션 정보를 확인하고 있습니다.')
+    ).not.toBeInTheDocument()
+    expect(screen.getByText('로비 페이지')).toBeInTheDocument()
+  })
+})

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,18 +9,27 @@ import WaitingRoomPage from './pages/waiting-room/WaitingRoomPage'
 import { DesktopViewportGuard } from './components/DesktopViewportGuard'
 import { KAKAO_LOGIN_CALLBACK_PATH } from './features/auth/api'
 import { useAuthBootstrap } from './features/auth/hooks/useAuthBootstrap'
+import { useAuthStore } from './features/auth/store'
 
 // 앱 전체 페이지 라우팅 테이블 정의
 function App() {
   const location = useLocation()
+  const session = useAuthStore((state) => state.session)
+  const isHomeRoute = location.pathname === '/'
   const isKakaoCallbackRoute = location.pathname === KAKAO_LOGIN_CALLBACK_PATH
+  const hasPersistedSession = Boolean(session)
   const isAuthBootstrapping = useAuthBootstrap({
     skip: isKakaoCallbackRoute,
   })
+  const shouldShowBootstrapScreen =
+    isAuthBootstrapping &&
+    !hasPersistedSession &&
+    !isHomeRoute &&
+    !isKakaoCallbackRoute
 
   return (
     <DesktopViewportGuard>
-      {isAuthBootstrapping ? (
+      {shouldShowBootstrapScreen ? (
         <div className="flex min-h-screen items-center justify-center bg-ui-app-bg px-4">
           <p className="text-sm font-medium text-ui-text-muted">
             세션 정보를 확인하고 있습니다.
@@ -28,7 +37,10 @@ function App() {
         </div>
       ) : (
         <Routes>
-          <Route path="/" element={<HomePage />} />
+          <Route
+            path="/"
+            element={<HomePage isAuthBootstrapping={isAuthBootstrapping} />}
+          />
           <Route
             path={KAKAO_LOGIN_CALLBACK_PATH}
             element={<KakaoLoginCallbackPage />}

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -8,10 +8,10 @@ export const IS_DEMO_MOCK_ENABLED = isEnabled(
   import.meta.env.VITE_ENABLE_DEMO_MOCK
 )
 
-// MSW는 개발 서버 또는 배포 데모 모드에서만 활성화
-export const SHOULD_ENABLE_MSW = import.meta.env.DEV || IS_DEMO_MOCK_ENABLED
-
 // 소켓/REST 목 모드는 개발 기본값 또는 배포 데모 플래그로 활성화
 export const IS_SOCKET_MOCK_ENABLED =
   (import.meta.env.DEV && import.meta.env.VITE_USE_SOCKET_MOCK !== 'false') ||
   IS_DEMO_MOCK_ENABLED
+
+// MSW는 실제로 목 데이터를 사용할 때만 활성화
+export const SHOULD_ENABLE_MSW = IS_SOCKET_MOCK_ENABLED

--- a/src/features/auth/api.test.ts
+++ b/src/features/auth/api.test.ts
@@ -10,6 +10,7 @@ import {
   mapMyPageProfile,
   restoreAuthSession,
   setNickname,
+  shouldUseFallbackSessionForRestore,
   shouldClearAuthSession,
   startKakaoLogin,
 } from './api'
@@ -171,6 +172,22 @@ describe('auth api integration helpers', () => {
     })
     expect(restored.provider).toBe('kakao')
     expect(restored.needsNicknameSetup).toBe(true)
+  })
+
+  it('mock 모드에서는 persisted fallback session을 그대로 복구에 사용한다', () => {
+    expect(
+      shouldUseFallbackSessionForRestore({
+        fallbackSession: baseSession,
+        isAuthMockEnabled: true,
+      })
+    ).toBe(true)
+
+    expect(
+      shouldUseFallbackSessionForRestore({
+        fallbackSession: baseSession,
+        isAuthMockEnabled: false,
+      })
+    ).toBe(false)
   })
 
   it('completeKakaoLogin은 신규 사용자를 닉네임 설정 필요 상태로 저장한다', async () => {

--- a/src/features/auth/api.ts
+++ b/src/features/auth/api.ts
@@ -69,6 +69,11 @@ interface CompleteKakaoLoginParams {
   isNewUser: boolean
 }
 
+interface ShouldUseFallbackSessionForRestoreParams {
+  fallbackSession?: AuthSession | null
+  isAuthMockEnabled?: boolean
+}
+
 function normalizeId(id: number | string) {
   return String(id)
 }
@@ -135,10 +140,24 @@ async function getAuthSessionWithToken(accessToken: string) {
   return data
 }
 
+export function shouldUseFallbackSessionForRestore({
+  fallbackSession,
+  isAuthMockEnabled = IS_AUTH_MOCK_ENABLED,
+}: ShouldUseFallbackSessionForRestoreParams) {
+  return isAuthMockEnabled && Boolean(fallbackSession)
+}
+
 export async function restoreAuthSession({
   accessToken,
   fallbackSession,
 }: RestoreAuthSessionParams) {
+  if (
+    fallbackSession &&
+    shouldUseFallbackSessionForRestore({ fallbackSession })
+  ) {
+    return fallbackSession
+  }
+
   const user = await getAuthSessionWithToken(accessToken)
 
   return buildAuthSession({

--- a/src/features/auth/hooks/useAuthBootstrap.test.tsx
+++ b/src/features/auth/hooks/useAuthBootstrap.test.tsx
@@ -1,0 +1,101 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createAuthSessionFixture } from '../../../test/fixtures'
+import { useAuthStore } from '../store'
+import { useAuthBootstrap } from './useAuthBootstrap'
+
+const { restoreAuthSessionMock, shouldClearAuthSessionMock } = vi.hoisted(
+  () => ({
+    restoreAuthSessionMock: vi.fn(),
+    shouldClearAuthSessionMock: vi.fn(),
+  })
+)
+
+vi.mock('../api', () => ({
+  restoreAuthSession: restoreAuthSessionMock,
+  shouldClearAuthSession: shouldClearAuthSessionMock,
+}))
+
+function createDeferredPromise<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve
+    reject = nextReject
+  })
+
+  return { promise, resolve, reject }
+}
+
+describe('useAuthBootstrap', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.removeItem('marble-pop-auth-session')
+    useAuthStore.setState({ session: null })
+    shouldClearAuthSessionMock.mockReturnValue(true)
+  })
+
+  it('세션이 없으면 bootstrap을 바로 종료한다', async () => {
+    const { result } = renderHook(() => useAuthBootstrap())
+
+    await waitFor(() => {
+      expect(result.current).toBe(false)
+    })
+
+    expect(restoreAuthSessionMock).not.toHaveBeenCalled()
+  })
+
+  it('복구 중 새 세션이 들어오면 이전 복구 결과를 무시하고 bootstrap을 종료한다', async () => {
+    const deferredRestore =
+      createDeferredPromise<ReturnType<typeof createAuthSessionFixture>>()
+
+    restoreAuthSessionMock.mockReturnValue(deferredRestore.promise)
+
+    useAuthStore.setState({
+      session: createAuthSessionFixture({
+        accessToken: 'stale-token',
+        userId: 'stale-user',
+        nickname: '예전세션',
+      }),
+    })
+
+    const { result } = renderHook(() => useAuthBootstrap())
+
+    expect(result.current).toBe(true)
+
+    act(() => {
+      useAuthStore.getState().setSession(
+        createAuthSessionFixture({
+          accessToken: 'guest-token',
+          userId: 'guest-user',
+          nickname: '게스트',
+          isGuest: true,
+          provider: 'guest',
+        })
+      )
+    })
+
+    await waitFor(() => {
+      expect(result.current).toBe(false)
+    })
+
+    await act(async () => {
+      deferredRestore.resolve(
+        createAuthSessionFixture({
+          accessToken: 'restored-token',
+          userId: 'restored-user',
+          nickname: '복구세션',
+        })
+      )
+      await deferredRestore.promise
+    })
+
+    expect(useAuthStore.getState().session).toMatchObject({
+      accessToken: 'guest-token',
+      userId: 'guest-user',
+      nickname: '게스트',
+      isGuest: true,
+    })
+  })
+})

--- a/src/features/auth/hooks/useAuthBootstrap.ts
+++ b/src/features/auth/hooks/useAuthBootstrap.ts
@@ -16,10 +16,30 @@ export function useAuthBootstrap({
 
   const [isBootstrapping, setIsBootstrapping] = useState(!skip)
   const hasBootstrappedRef = useRef(false)
+  const activeAccessTokenRef = useRef(session?.accessToken.trim() ?? '')
+  const bootstrapAccessTokenRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    const currentAccessToken = session?.accessToken.trim() ?? ''
+    activeAccessTokenRef.current = currentAccessToken
+
+    if (!isBootstrapping) {
+      return
+    }
+
+    const bootstrapAccessToken = bootstrapAccessTokenRef.current
+    if (!bootstrapAccessToken || bootstrapAccessToken === currentAccessToken) {
+      return
+    }
+
+    bootstrapAccessTokenRef.current = null
+    setIsBootstrapping(false)
+  }, [isBootstrapping, session])
 
   useEffect(() => {
     if (skip) {
       hasBootstrappedRef.current = true
+      bootstrapAccessTokenRef.current = null
       setIsBootstrapping(false)
       return
     }
@@ -32,11 +52,13 @@ export function useAuthBootstrap({
 
     const accessToken = session?.accessToken.trim()
     if (!accessToken) {
+      bootstrapAccessTokenRef.current = null
       setIsBootstrapping(false)
       return
     }
 
     let isDisposed = false
+    bootstrapAccessTokenRef.current = accessToken
     setIsBootstrapping(true)
 
     restoreAuthSession({
@@ -44,14 +66,14 @@ export function useAuthBootstrap({
       fallbackSession: session,
     })
       .then((restoredSession) => {
-        if (isDisposed) {
+        if (isDisposed || activeAccessTokenRef.current !== accessToken) {
           return
         }
 
         setSession(restoredSession)
       })
       .catch((error) => {
-        if (isDisposed) {
+        if (isDisposed || activeAccessTokenRef.current !== accessToken) {
           return
         }
 
@@ -60,10 +82,11 @@ export function useAuthBootstrap({
         }
       })
       .finally(() => {
-        if (isDisposed) {
+        if (isDisposed || activeAccessTokenRef.current !== accessToken) {
           return
         }
 
+        bootstrapAccessTokenRef.current = null
         setIsBootstrapping(false)
       })
 

--- a/src/features/auth/hooks/useRedirectAuthenticatedToLobby.test.tsx
+++ b/src/features/auth/hooks/useRedirectAuthenticatedToLobby.test.tsx
@@ -1,0 +1,46 @@
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createAuthSessionFixture } from '../../../test/fixtures'
+import { useRedirectAuthenticatedToLobby } from './useRedirectAuthenticatedToLobby'
+
+const { navigateMock } = vi.hoisted(() => ({
+  navigateMock: vi.fn(),
+}))
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => navigateMock,
+}))
+
+describe('useRedirectAuthenticatedToLobby', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('bootstrap 중에는 세션이 있어도 로비 리다이렉트를 생략한다', () => {
+    const session = createAuthSessionFixture({
+      userId: 'user-1',
+      nickname: '테스터',
+      needsNicknameSetup: false,
+    })
+
+    renderHook(() =>
+      useRedirectAuthenticatedToLobby(session, {
+        skip: true,
+      })
+    )
+
+    expect(navigateMock).not.toHaveBeenCalled()
+  })
+
+  it('bootstrap이 끝난 뒤에는 활성 세션을 로비로 리다이렉트한다', () => {
+    const session = createAuthSessionFixture({
+      userId: 'user-1',
+      nickname: '테스터',
+      needsNicknameSetup: false,
+    })
+
+    renderHook(() => useRedirectAuthenticatedToLobby(session))
+
+    expect(navigateMock).toHaveBeenCalledWith('/lobby', { replace: true })
+  })
+})

--- a/src/features/auth/hooks/useRedirectAuthenticatedToLobby.ts
+++ b/src/features/auth/hooks/useRedirectAuthenticatedToLobby.ts
@@ -2,15 +2,26 @@ import { useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import type { AuthSession } from '../types'
 
+interface UseRedirectAuthenticatedToLobbyParams {
+  skip?: boolean
+}
+
 // 홈 화면에서 로그인 완료 사용자(닉네임 설정 완료)를 로비로 리다이렉트
-export function useRedirectAuthenticatedToLobby(session: AuthSession | null) {
+export function useRedirectAuthenticatedToLobby(
+  session: AuthSession | null,
+  { skip = false }: UseRedirectAuthenticatedToLobbyParams = {}
+) {
   const navigate = useNavigate()
 
   useEffect(() => {
+    if (skip) {
+      return
+    }
+
     if (!session || session.needsNicknameSetup) {
       return
     }
 
     navigate('/lobby', { replace: true })
-  }, [navigate, session])
+  }, [navigate, session, skip])
 }

--- a/src/features/auth/mock/session.ts
+++ b/src/features/auth/mock/session.ts
@@ -1,4 +1,6 @@
 import type { AuthSession } from '../types'
+import { resetMockOnlineUsers } from '../../presence/mockData'
+import { resetMockWaitingRooms } from '../../../pages/waiting-room/mockGateway'
 import { MOCK_AUTH_DELAY_MS } from './constants'
 import { createMockUuid, delay } from './helpers'
 import {
@@ -13,10 +15,17 @@ function createGuestNickname() {
   return `Guest_${uuid.slice(0, 4)}`
 }
 
+// 새 mock 세션을 시작할 때 이전 guest가 남긴 방/접속자 흔적을 초기화한다.
+function resetMockRealtimeState() {
+  resetMockWaitingRooms()
+  resetMockOnlineUsers()
+}
+
 // 카카오 mock 사용자 상태를 기준으로 세션 발급
 export async function mockKakaoLogin() {
   await delay(MOCK_AUTH_DELAY_MS)
   ensureTakenNicknamesSeeded()
+  resetMockRealtimeState()
 
   const kakaoUser = getOrCreateMockKakaoUser()
   const existingNickname =
@@ -44,6 +53,7 @@ export async function mockKakaoLogin() {
 export async function mockGuestLogin() {
   await delay(MOCK_AUTH_DELAY_MS)
   ensureTakenNicknamesSeeded()
+  resetMockRealtimeState()
 
   const userId = createMockUuid()
   const nickname = createGuestNickname()

--- a/src/features/auth/nicknameSetupRules.test.ts
+++ b/src/features/auth/nicknameSetupRules.test.ts
@@ -82,8 +82,8 @@ describe('createNicknameHelperFeedback', () => {
     })
 
     expect(helperFeedback).toEqual({
-      message: '• 형식이 올바른 닉네임입니다. 중복 여부는 제출 시 확인됩니다.',
-      tone: 'default',
+      message: '• 사용 가능한 닉네임입니다.',
+      tone: 'success',
     })
   })
 

--- a/src/features/auth/nicknameSetupRules.ts
+++ b/src/features/auth/nicknameSetupRules.ts
@@ -96,9 +96,8 @@ export function createNicknameHelperFeedback({
   if (nicknameValidation.ok) {
     if (!isAvailabilityCheckSupported) {
       return {
-        message:
-          '• 형식이 올바른 닉네임입니다. 중복 여부는 제출 시 확인됩니다.',
-        tone: 'default',
+        message: '• 사용 가능한 닉네임입니다.',
+        tone: 'success',
       }
     }
 

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -40,7 +40,11 @@ const featureCards = [
 ]
 
 // 로그인 진입 홈 화면 렌더링과 인증 흐름 제어
-function HomePage() {
+interface HomePageProps {
+  isAuthBootstrapping?: boolean
+}
+
+function HomePage({ isAuthBootstrapping = false }: HomePageProps) {
   const navigate = useNavigate()
   const session = useAuthStore((state) => state.session)
   const setSession = useAuthStore((state) => state.setSession)
@@ -48,7 +52,9 @@ function HomePage() {
   const [isKakaoLoading, setIsKakaoLoading] = useState(false)
   const [isGuestLoading, setIsGuestLoading] = useState(false)
 
-  useRedirectAuthenticatedToLobby(session)
+  useRedirectAuthenticatedToLobby(session, {
+    skip: isAuthBootstrapping,
+  })
 
   const isAnyLoading = isKakaoLoading || isGuestLoading
 

--- a/src/pages/lobby/CreateRoomModal.test.tsx
+++ b/src/pages/lobby/CreateRoomModal.test.tsx
@@ -67,6 +67,7 @@ describe('CreateRoomModal', () => {
     const passwordInput = screen.getByPlaceholderText(
       '비밀번호 (4자리)'
     ) as HTMLInputElement
+    expect(passwordInput).toHaveAttribute('autocomplete', 'new-password')
 
     await user.type(passwordInput, '12')
     expect(

--- a/src/pages/lobby/CreateRoomModal.tsx
+++ b/src/pages/lobby/CreateRoomModal.tsx
@@ -121,6 +121,9 @@ export function CreateRoomModal({
 
         <form
           className="mt-6"
+          autoComplete="off"
+          data-1p-ignore="true"
+          data-lpignore="true"
           onSubmit={(event) => {
             event.preventDefault()
 
@@ -145,6 +148,7 @@ export function CreateRoomModal({
 
           <input
             id="create-room-title"
+            name="room-title"
             type="text"
             value={roomTitle}
             maxLength={ROOM_TITLE_MAX_LENGTH}
@@ -194,10 +198,14 @@ export function CreateRoomModal({
 
           {isPrivateRoomEnabled ? (
             <input
+              name="room-access-code"
               type="password"
               inputMode="numeric"
               pattern="[0-9]*"
               maxLength={ROOM_PASSWORD_LENGTH}
+              autoComplete="new-password"
+              data-1p-ignore="true"
+              data-lpignore="true"
               value={roomPassword}
               onChange={(event) => {
                 const nextValue = event.target.value

--- a/src/pages/lobby/LobbyPage.test.tsx
+++ b/src/pages/lobby/LobbyPage.test.tsx
@@ -388,6 +388,10 @@ describe('LobbyPage filter and toggle regression', () => {
     )
 
     await user.type(screen.getByPlaceholderText('비밀번호 입력'), '1234')
+    expect(screen.getByPlaceholderText('비밀번호 입력')).toHaveAttribute(
+      'autocomplete',
+      'new-password'
+    )
     await user.click(screen.getByRole('button', { name: '입장' }))
 
     expect(

--- a/src/pages/lobby/PrivateRoomJoinModal.tsx
+++ b/src/pages/lobby/PrivateRoomJoinModal.tsx
@@ -106,6 +106,9 @@ export function PrivateRoomJoinModal({
 
         <form
           className="mt-6"
+          autoComplete="off"
+          data-1p-ignore="true"
+          data-lpignore="true"
           onSubmit={(event) => {
             event.preventDefault()
             // 비밀번호 형식이 맞지 않으면 입장 요청 차단
@@ -116,10 +119,14 @@ export function PrivateRoomJoinModal({
           }}
         >
           <input
+            name="private-room-access-code"
             type="password"
             inputMode="numeric"
             pattern="[0-9]*"
             maxLength={ROOM_PASSWORD_LENGTH}
+            autoComplete="new-password"
+            data-1p-ignore="true"
+            data-lpignore="true"
             value={password}
             onChange={(event) => {
               const nextValue = event.target.value

--- a/src/pages/waiting-room/mockGateway.test.ts
+++ b/src/pages/waiting-room/mockGateway.test.ts
@@ -223,4 +223,29 @@ describe('mockGateway waiting-room action sequence', () => {
     expect(leftUser).toBeTruthy()
     expect(leftUser?.status).toBe('lobby')
   })
+
+  it('resetMockWaitingRooms는 생성된 임시 방을 제거하고 초기 시드 상태로 되돌린다', async () => {
+    const gateway = await loadMockGateway()
+
+    await gateway.mockCreateWaitingRoom({
+      title: '임시 테스트 방',
+      isPrivate: false,
+      hostUserId: 'guest-user',
+      hostNickname: '게스트',
+    })
+
+    expect(
+      gateway
+        .getMockLobbyRooms()
+        .some((room) => room.title === '임시 테스트 방')
+    ).toBe(true)
+
+    gateway.resetMockWaitingRooms()
+
+    expect(
+      gateway
+        .getMockLobbyRooms()
+        .some((room) => room.title === '임시 테스트 방')
+    ).toBe(false)
+  })
 })

--- a/src/pages/waiting-room/mockGateway.ts
+++ b/src/pages/waiting-room/mockGateway.ts
@@ -160,7 +160,7 @@ function createInitialRooms(): Map<string, MockRoom> {
   return new Map(seededRooms.map((room) => [room.id, room]))
 }
 
-const roomsStore = createInitialRooms()
+let roomsStore = createInitialRooms()
 
 // 채팅 payload를 대기방 채팅 메시지 모델로 변환
 function mapChatPayloadToMessage(
@@ -684,6 +684,12 @@ export function getMockLobbyRooms(): LobbyRoom[] {
       maxPlayers: room.max_players,
       isPrivate: room.is_private,
     }))
+}
+
+// mock 로그인/시나리오 재시작 시 방 저장소를 초기 시드로 되돌린다.
+export function resetMockWaitingRooms() {
+  roomsStore = createInitialRooms()
+  devBotSequence = 1
 }
 
 // DEV 목 제어: 방 현재 스냅샷을 그대로 반환


### PR DESCRIPTION
## 📌 관련 이슈

> closes #419 

---

## 📝 작업 내용

> 실백엔드 연동 검증 과정에서 확인된 auth/session 경계 문제와 로컬 검증 UX를 함께 정리했습니다.

- real 모드에서도 개발 서버라는 이유로 MSW가 켜져 `/api/rooms`, `/api/users/online` mock 응답이 섞이던 문제를 수정했습니다.
- 게스트 세션이 persisted 된 상태에서 새로고침하면 `세션 정보를 확인하고 있습니다.` 화면이 과도하게 유지되던 흐름을 완화했습니다.
- auth bootstrap 중 새 세션 진입과 fallback session 복구 경계를 정리해, mock/demo와 실환경 모두에서 세션 복구 흐름이 덜 흔들리도록 보정했습니다.
- 홈/로비 진입 시 자동 리다이렉트와 bootstrap 로딩 화면의 우선순위를 조정했습니다.
- mock guest/kakao 로그인 시작 시 waiting-room / online user mock 상태를 초기화해 이전 로컬 세션 흔적이 남지 않도록 했습니다.
- 닉네임 성공 안내 문구를 `사용 가능한 닉네임입니다.`로 정리하고, 성공 상태를 초록색 톤으로 맞췄습니다.
- 방 생성/비밀방 입장 모달의 비밀번호 입력에 autofill 방지 힌트를 넣어 Chrome이 계정 비밀번호 필드로 오인하는 경고를 완화했습니다.

### 검증

- `npx vitest run src/App.test.tsx src/features/auth/hooks/useAuthBootstrap.test.tsx`
- `npx vitest run src/features/auth/api.test.ts src/features/auth/hooks/useAuthBootstrap.test.tsx`
- `npx vitest run src/features/auth/nicknameSetupRules.test.ts`
- `npx vitest run src/pages/lobby/CreateRoomModal.test.tsx src/pages/lobby/LobbyPage.test.tsx`
- `npx vitest run src/pages/waiting-room/mockGateway.test.ts src/features/presence/mockData.test.ts src/features/auth/hooks/useAuthBootstrap.test.tsx`
- `npm run lint -- src/config/env.ts src/main.tsx src/features/auth/hooks/useAuthBootstrap.test.tsx`
- `npm run lint -- src/App.tsx src/App.test.tsx src/features/auth/hooks/useAuthBootstrap.ts`
- `npm run lint -- src/features/auth/api.ts src/features/auth/api.test.ts`
- `npm run lint -- src/features/auth/nicknameSetupRules.ts src/features/auth/nicknameSetupRules.test.ts src/pages/NicknameSetupPage.tsx`
- `npm run lint -- src/pages/lobby/CreateRoomModal.tsx src/pages/lobby/PrivateRoomJoinModal.tsx src/pages/lobby/CreateRoomModal.test.tsx src/pages/lobby/LobbyPage.test.tsx`
- `npm run build`

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

> UI 개편보다 실백엔드 검증 안정화와 입력 UX 정리가 중심이라 스크린샷은 생략했습니다.

## 📌 추가 메모

- room cleanup(브라우저 종료 후 stale room/player 상태) 문제는 백엔드 이슈로 별도 확인 요청했습니다.
- 카카오 로그인은 여전히 Kakao Developers redirect URI / 백엔드 CORS / OAuth env 설정이 모두 맞아야 실환경에서 정상 동작합니다.
