### PR TITLE
feat: presence 실백엔드 계약 반영

### DIFF
--- a/docs/ai/tasks/backend-presence-contract-adoption/checklist.md
+++ b/docs/ai/tasks/backend-presence-contract-adoption/checklist.md
@@ -1,0 +1,23 @@
+# Checklist
+
+## Implementation
+
+- [x] 관련 manual과 기존 문서를 읽었다
+- [x] presence 범위와 room cleanup 범위를 분리해 정리했다
+- [x] `/users/online` 응답 shape를 실제 계약 기준으로 확인했다
+- [x] `online_users` socket payload와 enum을 실백엔드 기준으로 맞췄다
+- [x] mock/real 경로가 같은 `OnlineUserPayload` 의미를 유지하도록 정리했다
+- [x] 필요 시 lobby/waiting-room presence 소비 코드를 함께 맞췄다
+
+## Testing
+
+- [x] `src/features/presence/useOnlineUsersSocket.test.tsx`를 실행했다
+- [ ] 필요 시 `npm run ai:check:lobby`를 실행했다
+- [x] 필요 시 `npm run lint`를 실행했다
+- [x] 필요 시 `npm run build`를 실행했다
+
+## Review
+
+- [x] 접속자 상태 literal과 mock/real 경계가 어긋나지 않는지 확인했다
+- [x] room cleanup 서버 이슈를 프론트에서 잘못 덮고 있지 않은지 확인했다
+- [ ] 변경 파일 / 실행한 검증 / 남은 리스크를 정리했다

--- a/docs/ai/tasks/backend-presence-contract-adoption/context.md
+++ b/docs/ai/tasks/backend-presence-contract-adoption/context.md
@@ -1,0 +1,37 @@
+# Context
+
+## Current Behavior
+
+- 실백엔드 검증 중 auth와 room/waiting-room 기본 계약은 정리됐지만, 접속자 목록은 `/users/online` REST snapshot과 `online_users` socket 이벤트를 함께 써서 동기화한다.
+- 프론트 `OnlineUserStatus`는 `lobby | in_room | playing`을 기대한다.
+- mock 모드에서는 `mockData`와 mock socket broadcast를 사용하고, real 모드에서는 초기 REST snapshot 뒤 socket 이벤트를 구독한다.
+- room cleanup 이슈가 있어 서버에서 stale room/player 정리가 완전히 맞지 않을 수 있으므로, presence 계약과 room membership 문제를 분리해서 봐야 한다.
+
+## Related Files
+
+- `src/features/presence/api.ts`
+- `src/features/presence/types.ts`
+- `src/features/presence/useOnlineUsersSocket.ts`
+- `src/features/presence/onlineUsersSocket.ts`
+- `src/features/presence/useOnlineUsersSocket.test.tsx`
+- `src/pages/lobby/LobbyPage.tsx`
+- `src/pages/waiting-room/WaitingRoomPage.tsx`
+- `docs/ai/manuals/lobby.md`
+
+## Constraints
+
+- mock 모드와 real 모드를 동시에 유지해야 한다.
+- `OnlineUserStatus` literal은 backend 계약과 동일해야 한다.
+- presence 갱신 때문에 DM 정책이나 unread 로직을 바꾸지 않는다.
+- room cleanup 서버 이슈는 presence 계약 수정으로 우회하지 않는다.
+
+## Decision Notes
+
+- 이번 작업은 room cleanup을 프론트에서 덮는 게 아니라, 접속자 목록 데이터 출처와 상태값 해석을 명확히 맞추는 데 집중한다.
+- 초기 REST snapshot과 이후 socket 이벤트가 같은 payload shape를 유지해야 테스트와 실환경이 덜 흔들린다.
+- 필요하면 lobby/waiting-room에서 presence 소비 경계를 살짝 보정하되, source of truth는 `useOnlineUsersSocket`에 유지한다.
+
+## Open Risks
+
+- 서버가 stale room/player를 정리하지 못하는 경우, presence만 맞아도 room card와 waiting-room player card는 여전히 어긋날 수 있다.
+- `/users/online` 응답 shape가 문서와 다르면 타입만 맞춰도 UI는 깨질 수 있어 실제 응답 예시 확인이 필요하다.

--- a/docs/ai/tasks/backend-presence-contract-adoption/plan.md
+++ b/docs/ai/tasks/backend-presence-contract-adoption/plan.md
@@ -1,0 +1,55 @@
+# Plan
+
+## Task
+
+- 작업 이름: presence 실백엔드 계약 반영
+- 요청 날짜: 2026-03-16
+- 담당 범위: lobby presence, online users snapshot/socket 정렬
+
+## Goal
+
+- 실백엔드 기준으로 `/users/online` REST 스냅샷과 `online_users` 소켓 이벤트 계약을 프론트와 일치시킨다.
+- `lobby | in_room | playing` 상태값과 접속자 목록 갱신 흐름이 mock/real 모두에서 같은 의미로 동작하도록 정리한다.
+- 로비와 대기방에서 접속자 목록이 실데이터와 어긋나지 않도록 초기화/구독 경계를 안정화한다.
+
+## In Scope
+
+- `/api/users/online` 응답 shape와 프론트 `OnlineUserPayload` 매핑 재확인
+- `online_users` 이벤트 수신 시 상태 업데이트 규칙 점검
+- real 모드 초기 REST snapshot + socket 후속 동기화 흐름 정렬
+- `OnlineUserStatus` enum과 backend 계약 literal 재확인
+- presence 관련 mock/real 분기와 테스트 기대값 정리
+- 필요 시 lobby/waiting-room에서 presence 데이터 소비 방식 보정
+
+## Out Of Scope
+
+- DM 정책 변경
+- room cleanup/disconnect 서버 처리 변경
+- waiting-room ready/start/leave 플로우 재수정
+- game runtime 관련 상태 복구
+
+## Target Files
+
+- `src/features/presence/api.ts`
+- `src/features/presence/types.ts`
+- `src/features/presence/useOnlineUsersSocket.ts`
+- `src/features/presence/onlineUsersSocket.ts`
+- `src/features/presence/useOnlineUsersSocket.test.tsx`
+- 필요 시 `src/pages/lobby/LobbyPage.tsx`
+- 필요 시 `src/pages/waiting-room/WaitingRoomPage.tsx`
+
+## Completion Criteria
+
+- real 모드에서 `/users/online` 초기 snapshot이 실백엔드 응답 기준으로 정상 반영된다.
+- `online_users` 소켓 이벤트가 `lobby | in_room | playing` 상태값을 프론트 enum과 일치하게 갱신한다.
+- mock 모드와 real 모드가 같은 `OnlineUserPayload` 의미를 유지한다.
+- 접속자 목록 관련 Vitest와 필요한 lobby 검증이 통과한다.
+
+## Test Plan
+
+- 최소 실행 테스트
+  - `npx vitest run src/features/presence/useOnlineUsersSocket.test.tsx`
+- 추가 검증
+  - `npm run ai:check:lobby`
+  - 필요 시 `npm run lint`
+  - 필요 시 `npm run build`

--- a/src/features/presence/api.test.ts
+++ b/src/features/presence/api.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeOnlineUsersPayload } from './api'
+
+describe('normalizeOnlineUsersPayload', () => {
+  it('숫자 id를 문자열로 정규화하고 nickname 공백을 제거한다', () => {
+    expect(
+      normalizeOnlineUsersPayload([
+        {
+          id: 7,
+          nickname: '  실유저 ',
+          status: 'lobby',
+        },
+      ])
+    ).toEqual([
+      {
+        id: '7',
+        nickname: '실유저',
+        status: 'lobby',
+      },
+    ])
+  })
+
+  it('지원하지 않는 status나 잘못된 레코드는 제외한다', () => {
+    expect(
+      normalizeOnlineUsersPayload([
+        {
+          id: 1,
+          nickname: '유효유저',
+          status: 'playing',
+        },
+        {
+          id: 2,
+          nickname: '   ',
+          status: 'lobby',
+        },
+        {
+          id: 3,
+          nickname: '레거시상태',
+          status: 'online',
+        },
+        null,
+      ])
+    ).toEqual([
+      {
+        id: '1',
+        nickname: '유효유저',
+        status: 'playing',
+      },
+    ])
+  })
+})

--- a/src/features/presence/api.ts
+++ b/src/features/presence/api.ts
@@ -1,9 +1,72 @@
 import { apiClient } from '../../lib/axios'
-import type { OnlineUserPayload } from './types'
+import type { OnlineUserPayload, OnlineUserStatus } from './types'
 
 // 접속자 목록 초기 스냅샷 응답 타입
 interface OnlineUsersResponsePayload {
-  users: OnlineUserPayload[]
+  users: unknown
+}
+
+type UnknownRecord = Record<string, unknown>
+const ONLINE_USER_STATUS_VALUES: OnlineUserStatus[] = [
+  'lobby',
+  'in_room',
+  'playing',
+]
+
+function toRecord(value: unknown): UnknownRecord | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null
+  }
+
+  return value as UnknownRecord
+}
+
+function normalizeOnlineUserStatus(value: unknown): OnlineUserStatus | null {
+  if (
+    typeof value !== 'string' ||
+    !ONLINE_USER_STATUS_VALUES.includes(value as OnlineUserStatus)
+  ) {
+    return null
+  }
+
+  return value as OnlineUserStatus
+}
+
+function normalizeOnlineUserPayload(value: unknown): OnlineUserPayload | null {
+  const record = toRecord(value)
+  if (!record) {
+    return null
+  }
+
+  const id = record.id
+  const nickname = record.nickname
+  const status = normalizeOnlineUserStatus(record.status)
+
+  if (
+    (typeof id !== 'string' && typeof id !== 'number') ||
+    typeof nickname !== 'string' ||
+    nickname.trim().length === 0 ||
+    !status
+  ) {
+    return null
+  }
+
+  return {
+    id: String(id),
+    nickname: nickname.trim(),
+    status,
+  }
+}
+
+export function normalizeOnlineUsersPayload(payloadUsers: unknown) {
+  if (!Array.isArray(payloadUsers)) {
+    return []
+  }
+
+  return payloadUsers.flatMap((user) => {
+    const normalizedUser = normalizeOnlineUserPayload(user)
+    return normalizedUser ? [normalizedUser] : []
+  })
 }
 
 // 전체 온라인 유저 목록 초기 스냅샷 조회
@@ -11,5 +74,5 @@ export async function getOnlineUsersSnapshot() {
   const { data } =
     await apiClient.get<OnlineUsersResponsePayload>('/users/online')
 
-  return data.users
+  return normalizeOnlineUsersPayload(data.users)
 }

--- a/src/features/presence/useOnlineUsersSocket.test.tsx
+++ b/src/features/presence/useOnlineUsersSocket.test.tsx
@@ -12,6 +12,7 @@ const {
   socketOnMock,
   socketOffMock,
   getOnlineUsersSnapshotMock,
+  normalizeOnlineUsersPayloadMock,
   isOnlineUsersSocketMockModeMock,
   startOnlineUsersMockBroadcastMock,
   stopMockBroadcastMock,
@@ -20,6 +21,7 @@ const {
   socketOnMock: vi.fn(),
   socketOffMock: vi.fn(),
   getOnlineUsersSnapshotMock: vi.fn(),
+  normalizeOnlineUsersPayloadMock: vi.fn((users) => users),
   isOnlineUsersSocketMockModeMock: vi.fn(),
   startOnlineUsersMockBroadcastMock: vi.fn(),
   stopMockBroadcastMock: vi.fn(),
@@ -35,6 +37,7 @@ vi.mock('../../lib/socket', () => ({
 
 vi.mock('./api', () => ({
   getOnlineUsersSnapshot: getOnlineUsersSnapshotMock,
+  normalizeOnlineUsersPayload: normalizeOnlineUsersPayloadMock,
 }))
 
 vi.mock('./onlineUsersSocket', () => ({
@@ -50,6 +53,15 @@ describe('useOnlineUsersSocket', () => {
 
     isOnlineUsersSocketMockModeMock.mockReturnValue(false)
     getOnlineUsersSnapshotMock.mockResolvedValue([])
+    normalizeOnlineUsersPayloadMock.mockImplementation((users) =>
+      Array.isArray(users)
+        ? users.map((user) => ({
+            ...user,
+            id: String(user.id),
+            nickname: user.nickname.trim(),
+          }))
+        : []
+    )
     startOnlineUsersMockBroadcastMock.mockReturnValue(stopMockBroadcastMock)
   })
 
@@ -95,18 +107,19 @@ describe('useOnlineUsersSocket', () => {
     act(() => {
       emitSocketEvent(socketOnMock, 'online_users', {
         users: [
-          createOnlineUserPayloadFixture({
-            id: 'user-2',
+          {
+            id: 2,
             nickname: '  alpha ',
             status: 'in_room',
-          }),
+          },
         ],
       })
     })
 
     expect(result.current.data).toHaveLength(1)
     expect(result.current.data[0]).toMatchObject({
-      id: 'user-2',
+      id: '2',
+      nickname: 'alpha',
       status: 'in_room',
       avatarText: 'A',
     })

--- a/src/features/presence/useOnlineUsersSocket.ts
+++ b/src/features/presence/useOnlineUsersSocket.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { socket } from '../../lib/socket'
-import { getOnlineUsersSnapshot } from './api'
+import { getOnlineUsersSnapshot, normalizeOnlineUsersPayload } from './api'
 import { mapOnlineUsersToViewModel } from './onlineUsersModel'
 import {
   ensureOnlineUsersSocketConnection,
@@ -9,6 +9,14 @@ import {
   startOnlineUsersMockBroadcast,
 } from './onlineUsersSocket'
 import type { OnlineUser, OnlineUsersEventPayload } from './types'
+
+function readOnlineUsersEventPayloadUsers(payload: unknown) {
+  if (!payload || typeof payload !== 'object' || !('users' in payload)) {
+    return []
+  }
+
+  return (payload as { users: unknown }).users
+}
 
 // 접속자 목록 소켓 구독과 로딩/에러 상태를 관리
 export function useOnlineUsersSocket() {
@@ -20,14 +28,16 @@ export function useOnlineUsersSocket() {
     let isActive = true
 
     // 접속자 이벤트 수신 시 목록과 상태를 갱신
-    const handleOnlineUsers = ({
-      users: payloadUsers,
-    }: OnlineUsersEventPayload) => {
+    const handleOnlineUsers = (payload: OnlineUsersEventPayload | unknown) => {
       if (!isActive) {
         return
       }
 
-      setUsers(mapOnlineUsersToViewModel(payloadUsers))
+      setUsers(
+        mapOnlineUsersToViewModel(
+          normalizeOnlineUsersPayload(readOnlineUsersEventPayloadUsers(payload))
+        )
+      )
       setIsLoading(false)
       setIsError(false)
     }


### PR DESCRIPTION
## 📌 관련 이슈

> closes #421 

---

## 📝 작업 내용

> `/users/online` REST snapshot과 `online_users` socket payload를 실백엔드 계약에 맞게 정리했습니다.

- 접속자 목록 초기 snapshot 응답을 프론트 경계에서 정규화하도록 변경했습니다.
- `/users/online`와 `online_users` 이벤트 모두에서 `id`를 문자열로 정규화하고, nickname 공백을 정리하도록 맞췄습니다.
- `lobby | in_room | playing` 외의 status 값이나 비정상 레코드는 접속자 목록에서 제외하도록 정리했습니다.
- socket 이벤트 수신도 REST snapshot과 동일한 정규화 함수를 사용하도록 맞췄습니다.
- 관련 Vitest를 추가/갱신해 숫자 id와 잘못된 payload 케이스를 검증했습니다.
- task 문서(`plan/context/checklist`)를 추가해 이번 계약 정렬 범위와 리스크를 기록했습니다.

### 검증

- `npx vitest run src/features/presence/api.test.ts src/features/presence/useOnlineUsersSocket.test.tsx`
- `npm run lint -- src/features/presence/api.ts src/features/presence/api.test.ts src/features/presence/useOnlineUsersSocket.ts src/features/presence/useOnlineUsersSocket.test.tsx`
- `npm run build`

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

> UI 개편보다 presence 계약 정렬이 중심이라 스크린샷은 생략했습니다.

## 📌 추가 메모

- room cleanup(브라우저 종료 후 stale room/player) 문제는 별도 백엔드 이슈로 추적 중입니다.
- 이번 변경은 room state를 덮지 않고, 접속자 목록 payload와 상태값 해석만 실백엔드 기준으로 맞추는 데 집중했습니다.
