### PR TITLE
 FEAT : gameStore.eventQueue 기반 보드 이벤트 애니메이션 세분화

### DIFF
--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -61,6 +61,10 @@ import {
   removeOwnedTilesByPlayerId,
 } from './gameBoardLocalEngine'
 import { useBoardEventQueue } from './useBoardEventQueue'
+import {
+  getBoardEventAnimationHoldMs,
+  type BoardEventAnimationKind,
+} from './gameBoardEventQueueUtils'
 import type {
   AIPenaltyModalState,
   BankruptModalState,
@@ -314,6 +318,8 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
     const [dice2, setDice2] = useState(1)
     const [rolling, setRolling] = useState(false)
     const [status, setStatus] = useState(GAME_START_STATUS)
+    const [eventFxKind, setEventFxKind] =
+      useState<BoardEventAnimationKind>('none')
     const lock = useRef(false)
     const boardPageRef = useRef<HTMLDivElement | null>(null)
     const boardStatusRef = useRef<HTMLDivElement | null>(null)
@@ -330,7 +336,28 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       setStatus,
       setDice1,
       setDice2,
+      onEventAnimation: setEventFxKind,
     })
+
+    useEffect(() => {
+      if (eventFxKind === 'none') {
+        return
+      }
+
+      const holdMs = getBoardEventAnimationHoldMs(eventFxKind)
+      if (holdMs <= 0) {
+        setEventFxKind('none')
+        return
+      }
+
+      const timer = window.setTimeout(() => {
+        setEventFxKind('none')
+      }, holdMs)
+
+      return () => {
+        window.clearTimeout(timer)
+      }
+    }, [eventFxKind])
 
     const bankruptSetRef = useRef<Set<number>>(new Set())
     const [optimisticTileOwners, setOptimisticTileOwners] = useState<Record<
@@ -1581,7 +1608,14 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
         ref={boardPageRef}
         style={{ width: '100%', height: '100%' }}
       >
-        <div className="board-status" ref={boardStatusRef}>
+        <div
+          className={
+            eventFxKind === 'none'
+              ? 'board-status'
+              : `board-status board-status--${eventFxKind}`
+          }
+          ref={boardStatusRef}
+        >
           {status}
         </div>
 
@@ -1747,7 +1781,11 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
             )}
 
             <div
-              className="board-center"
+              className={
+                eventFxKind === 'none'
+                  ? 'board-center'
+                  : `board-center board-center--${eventFxKind}`
+              }
               style={{
                 gridRow: '2 / 9',
                 gridColumn: '2 / 9',

--- a/src/components/board/gameBoardEventQueueUtils.test.ts
+++ b/src/components/board/gameBoardEventQueueUtils.test.ts
@@ -4,6 +4,9 @@ import type { PlayerState, TileData } from './board.constants'
 import {
   createBoardStatusFromEvent,
   extractEventDice,
+  getBoardEventAnimationHoldMs,
+  getBoardEventConsumeDelayMs,
+  resolveBoardEventAnimationKind,
 } from './gameBoardEventQueueUtils'
 
 const players: PlayerState[] = [
@@ -89,5 +92,47 @@ describe('gameBoardEventQueueUtils', () => {
     }
 
     expect(createBoardStatusFromEvent(event, players, tiles)).toBeNull()
+  })
+
+  it('maps server events to animation kinds', () => {
+    expect(
+      resolveBoardEventAnimationKind({ type: 'DICE_ROLLED' } as ServerEvent)
+    ).toBe('dice')
+    expect(
+      resolveBoardEventAnimationKind({ type: 'PLAYER_MOVED' } as ServerEvent)
+    ).toBe('move')
+    expect(
+      resolveBoardEventAnimationKind({ type: 'LANDED' } as ServerEvent)
+    ).toBe('land')
+    expect(
+      resolveBoardEventAnimationKind({ type: 'PAID_TOLL' } as ServerEvent)
+    ).toBe('toll')
+    expect(
+      resolveBoardEventAnimationKind({ type: 'TURN_ENDED' } as ServerEvent)
+    ).toBe('turn_end')
+    expect(
+      resolveBoardEventAnimationKind({ type: 'SYNCED' } as ServerEvent)
+    ).toBe('sync')
+    expect(
+      resolveBoardEventAnimationKind({ type: 'SOMETHING_ELSE' } as ServerEvent)
+    ).toBe('none')
+  })
+
+  it('returns event-specific consume delays', () => {
+    expect(
+      getBoardEventConsumeDelayMs({ type: 'PLAYER_MOVED' } as ServerEvent)
+    ).toBe(520)
+    expect(
+      getBoardEventConsumeDelayMs({ type: 'UNKNOWN_EVENT' } as ServerEvent)
+    ).toBe(160)
+  })
+
+  it('keeps animation hold shorter than consume delay', () => {
+    const event = { type: 'PAID_TOLL' } as ServerEvent
+    const kind = resolveBoardEventAnimationKind(event)
+
+    expect(getBoardEventAnimationHoldMs(kind)).toBeLessThan(
+      getBoardEventConsumeDelayMs(event)
+    )
   })
 })

--- a/src/components/board/gameBoardEventQueueUtils.ts
+++ b/src/components/board/gameBoardEventQueueUtils.ts
@@ -2,8 +2,55 @@ import type { PlayerState, TileData } from './board.constants'
 import type { ServerEvent } from '../../types/domain'
 import { formatWon } from '../../lib/utils'
 
+export type BoardEventAnimationKind =
+  | 'none'
+  | 'dice'
+  | 'move'
+  | 'land'
+  | 'toll'
+  | 'turn_end'
+  | 'sync'
+
 const normalizeEventType = (type: unknown) =>
   typeof type === 'string' ? type.trim().toUpperCase() : ''
+
+export const resolveBoardEventAnimationKind = (
+  event: ServerEvent
+): BoardEventAnimationKind => {
+  const normalizedType = normalizeEventType(event.type)
+
+  if (normalizedType === 'DICE_ROLLED') return 'dice'
+  if (normalizedType === 'PLAYER_MOVED') return 'move'
+  if (normalizedType === 'LANDED') return 'land'
+  if (normalizedType === 'PAID_TOLL') return 'toll'
+  if (normalizedType === 'TURN_ENDED') return 'turn_end'
+  if (normalizedType === 'SYNCED') return 'sync'
+
+  return 'none'
+}
+
+export const getBoardEventConsumeDelayMs = (event: ServerEvent): number => {
+  const kind = resolveBoardEventAnimationKind(event)
+  if (kind === 'dice') return 420
+  if (kind === 'move') return 520
+  if (kind === 'land') return 420
+  if (kind === 'toll') return 460
+  if (kind === 'turn_end') return 380
+  if (kind === 'sync') return 220
+  return 160
+}
+
+export const getBoardEventAnimationHoldMs = (
+  kind: BoardEventAnimationKind
+): number => {
+  if (kind === 'dice') return 300
+  if (kind === 'move') return 380
+  if (kind === 'land') return 300
+  if (kind === 'toll') return 340
+  if (kind === 'turn_end') return 280
+  if (kind === 'sync') return 160
+  return 0
+}
 
 const getPayloadNumber = (
   payload: Record<string, unknown> | undefined,

--- a/src/components/board/useBoardEventQueue.ts
+++ b/src/components/board/useBoardEventQueue.ts
@@ -6,9 +6,10 @@ import { TILES } from './board.constants'
 import {
   createBoardStatusFromEvent,
   extractEventDice,
+  getBoardEventConsumeDelayMs,
+  resolveBoardEventAnimationKind,
+  type BoardEventAnimationKind,
 } from './gameBoardEventQueueUtils'
-
-const EVENT_QUEUE_CONSUME_DELAY_MS = 120
 
 interface UseBoardEventQueueParams {
   enabled: boolean
@@ -16,6 +17,7 @@ interface UseBoardEventQueueParams {
   setStatus: Dispatch<SetStateAction<string>>
   setDice1: Dispatch<SetStateAction<number>>
   setDice2: Dispatch<SetStateAction<number>>
+  onEventAnimation?: (kind: BoardEventAnimationKind) => void
 }
 
 export function useBoardEventQueue({
@@ -24,51 +26,88 @@ export function useBoardEventQueue({
   setStatus,
   setDice1,
   setDice2,
+  onEventAnimation,
 }: UseBoardEventQueueParams) {
-  const eventQueueLength = useGameStore((state) => state.eventQueue.length)
-  const consumeNextEvent = useGameStore((state) => state.consumeNextEvent)
   const consumingRef = useRef(false)
+  const consumeTimerRef = useRef<number | null>(null)
 
   useEffect(() => {
-    if (!enabled || eventQueueLength <= 0 || consumingRef.current) {
+    if (!enabled) {
       return
     }
 
-    consumingRef.current = true
-
-    const timer = window.setTimeout(() => {
-      const nextEvent = consumeNextEvent()
-      if (nextEvent) {
-        const dice = extractEventDice(nextEvent)
-        if (dice) {
-          setDice1(dice[0])
-          setDice2(dice[1])
-        }
-
-        const statusText = createBoardStatusFromEvent(
-          nextEvent,
-          playersRef.current,
-          TILES
-        )
-        if (statusText) {
-          setStatus(statusText)
-        }
+    let disposed = false
+    const clearConsumeTimer = () => {
+      if (consumeTimerRef.current !== null) {
+        window.clearTimeout(consumeTimerRef.current)
+        consumeTimerRef.current = null
       }
-
-      consumingRef.current = false
-    }, EVENT_QUEUE_CONSUME_DELAY_MS)
-
-    return () => {
-      window.clearTimeout(timer)
+    }
+    const releaseLock = () => {
+      clearConsumeTimer()
       consumingRef.current = false
     }
-  }, [
-    enabled,
-    eventQueueLength,
-    consumeNextEvent,
-    playersRef,
-    setStatus,
-    setDice1,
-    setDice2,
-  ])
+
+    const consumeIfPossible = () => {
+      if (disposed || consumingRef.current) {
+        return
+      }
+
+      const storeState = useGameStore.getState()
+      if (storeState.eventQueue.length <= 0) {
+        return
+      }
+
+      consumingRef.current = true
+      const nextEvent = storeState.consumeNextEvent()
+
+      if (!nextEvent) {
+        releaseLock()
+        return
+      }
+
+      const dice = extractEventDice(nextEvent)
+      if (dice) {
+        setDice1(dice[0])
+        setDice2(dice[1])
+      }
+
+      const statusText = createBoardStatusFromEvent(
+        nextEvent,
+        playersRef.current,
+        TILES
+      )
+      if (statusText) {
+        setStatus(statusText)
+      }
+
+      onEventAnimation?.(resolveBoardEventAnimationKind(nextEvent))
+
+      const delayMs = getBoardEventConsumeDelayMs(nextEvent)
+      consumeTimerRef.current = window.setTimeout(() => {
+        consumeTimerRef.current = null
+        consumingRef.current = false
+        consumeIfPossible()
+      }, delayMs)
+    }
+
+    const unsubscribe = useGameStore.subscribe((state, prevState) => {
+      if (
+        state.eventQueue.length === prevState.eventQueue.length ||
+        state.eventQueue.length <= 0
+      ) {
+        return
+      }
+
+      consumeIfPossible()
+    })
+
+    consumeIfPossible()
+
+    return () => {
+      disposed = true
+      releaseLock()
+      unsubscribe()
+    }
+  }, [enabled, playersRef, setStatus, setDice1, setDice2, onEventAnimation])
 }

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -41,6 +41,34 @@
   padding: 5px 16px;
   border-radius: 20px;
   box-shadow: 0 2px 8px rgba(59, 130, 246, 0.15);
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease,
+    background-color 180ms ease;
+}
+
+.board-status--dice {
+  animation: board-status-dice 300ms ease;
+}
+
+.board-status--move {
+  animation: board-status-move 380ms ease;
+}
+
+.board-status--land {
+  animation: board-status-land 300ms ease;
+}
+
+.board-status--toll {
+  animation: board-status-toll 340ms ease;
+}
+
+.board-status--turn_end {
+  animation: board-status-turn-end 280ms ease;
+}
+
+.board-status--sync {
+  animation: board-status-sync 160ms ease;
 }
 
 /* ─── Board Outer Shell ─────────────────────────────────────── */
@@ -75,6 +103,196 @@
   align-items: center;
   justify-content: center;
   gap: 12px;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease,
+    filter 180ms ease;
+}
+
+.board-center--dice {
+  animation: board-center-dice 300ms ease;
+}
+
+.board-center--move {
+  animation: board-center-move 380ms ease;
+}
+
+.board-center--land {
+  animation: board-center-land 300ms ease;
+}
+
+.board-center--toll {
+  animation: board-center-toll 340ms ease;
+}
+
+.board-center--turn_end {
+  animation: board-center-turn-end 280ms ease;
+}
+
+.board-center--sync {
+  animation: board-center-sync 160ms ease;
+}
+
+@keyframes board-status-dice {
+  0% {
+    transform: translateY(0);
+  }
+  35% {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 14px rgba(59, 130, 246, 0.28);
+  }
+  100% {
+    transform: translateY(0);
+  }
+}
+
+@keyframes board-status-move {
+  0% {
+    transform: translateX(0);
+  }
+  30% {
+    transform: translateX(3px);
+  }
+  60% {
+    transform: translateX(-2px);
+  }
+  100% {
+    transform: translateX(0);
+  }
+}
+
+@keyframes board-status-land {
+  0% {
+    transform: scale(1);
+  }
+  45% {
+    transform: scale(1.03);
+    background: rgba(219, 234, 254, 0.94);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+@keyframes board-status-toll {
+  0% {
+    transform: scale(1);
+  }
+  40% {
+    transform: scale(1.02);
+    background: rgba(254, 226, 226, 0.95);
+    color: #b91c1c;
+    box-shadow: 0 8px 16px rgba(239, 68, 68, 0.22);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+@keyframes board-status-turn-end {
+  0% {
+    transform: translateY(0);
+    opacity: 1;
+  }
+  50% {
+    transform: translateY(-2px);
+    opacity: 0.88;
+  }
+  100% {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@keyframes board-status-sync {
+  0% {
+    filter: saturate(1);
+  }
+  50% {
+    filter: saturate(1.25);
+    box-shadow: 0 6px 14px rgba(14, 165, 233, 0.24);
+  }
+  100% {
+    filter: saturate(1);
+  }
+}
+
+@keyframes board-center-dice {
+  0% {
+    transform: translateY(0) scale(1);
+  }
+  40% {
+    transform: translateY(-2px) scale(1.01);
+    box-shadow: inset 0 0 0 1px rgba(147, 197, 253, 0.48);
+  }
+  100% {
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes board-center-move {
+  0% {
+    transform: translateX(0);
+  }
+  35% {
+    transform: translateX(3px);
+  }
+  70% {
+    transform: translateX(-2px);
+  }
+  100% {
+    transform: translateX(0);
+  }
+}
+
+@keyframes board-center-land {
+  0% {
+    transform: scale(1);
+  }
+  45% {
+    transform: scale(1.012);
+    filter: brightness(1.03);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+@keyframes board-center-toll {
+  0% {
+    filter: saturate(1);
+  }
+  45% {
+    filter: saturate(1.2);
+    box-shadow: inset 0 0 0 1px rgba(252, 165, 165, 0.42);
+  }
+  100% {
+    filter: saturate(1);
+  }
+}
+
+@keyframes board-center-turn-end {
+  0% {
+    opacity: 1;
+  }
+  45% {
+    opacity: 0.82;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+@keyframes board-center-sync {
+  0% {
+    filter: hue-rotate(0deg);
+  }
+  50% {
+    filter: hue-rotate(8deg) saturate(1.15);
+  }
+  100% {
+    filter: hue-rotate(0deg);
+  }
 }
 
 .board-center__title {


### PR DESCRIPTION
## 관련 이슈
> closes #410
> closes #415

---

## 작업 내용
- game 이벤트를 애니메이션 kind로 매핑하는 유틸을 추가했습니다. (`DICE_ROLLED`, `PLAYER_MOVED`, `LANDED`, `PAID_TOLL`, `TURN_ENDED`, `SYNCED`)
- 이벤트별 소비 지연 시간(`consume delay`)과 연출 유지 시간(`hold`)을 분리해 정의했습니다.
- `useBoardEventQueue`를 store 구독 기반 연속 소비 구조로 변경해, 큐가 중간에 멈추지 않고 순차 소비되도록 정리했습니다.
- `GameBoard`에 `eventFxKind` 상태를 연결해 `board-status`, `board-center`에 이벤트별 클래스가 반영되도록 했습니다.
- `board.css`에 이벤트별 키프레임 애니메이션을 추가해 상태바/센터 연출을 분리 적용했습니다.
- 유틸 테스트를 확장해 매핑/지연/hold 규칙을 검증했습니다.

---

## 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 간단 이슈 해결 완료
