### PR TITLE
fix: 실시간 상태 동기화와 DM unread UX 안정화

### DIFF
--- a/docs/ai/tasks/backend-presence-contract-adoption/checklist.md
+++ b/docs/ai/tasks/backend-presence-contract-adoption/checklist.md
@@ -7,6 +7,7 @@
 - [x] `/users/online` 응답 shape를 실제 계약 기준으로 확인했다
 - [x] `online_users` socket payload와 enum을 실백엔드 기준으로 맞췄다
 - [x] mock/real 경로가 같은 `OnlineUserPayload` 의미를 유지하도록 정리했다
+- [x] room enter/room update 직후 접속자 snapshot을 수동 재동기화할 수 있도록 정리했다
 - [x] 필요 시 lobby/waiting-room presence 소비 코드를 함께 맞췄다
 
 ## Testing

--- a/docs/ai/tasks/backend-room-waiting-contract-adoption/checklist.md
+++ b/docs/ai/tasks/backend-room-waiting-contract-adoption/checklist.md
@@ -7,7 +7,9 @@
 - [x] 로비 방 생성 후 `create -> join -> enter_room` 흐름을 구현했다
 - [x] waiting-room 초기 상태를 join 응답 snapshot 기준으로 정리했다
 - [x] `lobby_updated` 타입을 `removed` / full payload로 분리했다
+- [x] waiting-room이 `room_updated` 이벤트로 최신 플레이어 snapshot을 직접 반영한다
 - [x] waiting-room에서 방 삭제 이벤트를 구독하고 로비 복귀 흐름을 구현했다
+- [x] viewport guard가 waiting-room을 unmount시키지 않도록 overlay 방식으로 유지했다
 - [x] mock/real 경로를 함께 확인했다
 - [x] 관련 테스트 기대값을 계약 기준으로 갱신했다
 

--- a/src/components/DesktopViewportGuard.test.tsx
+++ b/src/components/DesktopViewportGuard.test.tsx
@@ -1,0 +1,51 @@
+import { useEffect } from 'react'
+import { act, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { DesktopViewportGuard } from './DesktopViewportGuard'
+
+function setViewportWidth(width: number) {
+  Object.defineProperty(window, 'innerWidth', {
+    configurable: true,
+    writable: true,
+    value: width,
+  })
+}
+
+describe('DesktopViewportGuard', () => {
+  const originalInnerWidth = window.innerWidth
+
+  beforeEach(() => {
+    setViewportWidth(1440)
+  })
+
+  afterEach(() => {
+    setViewportWidth(originalInnerWidth)
+  })
+
+  it('작은 화면 안내가 떠도 children을 언마운트하지 않는다', () => {
+    const unmountSpy = vi.fn()
+
+    function TrackedChild() {
+      useEffect(() => unmountSpy, [])
+      return <div>앱 본문</div>
+    }
+
+    render(
+      <DesktopViewportGuard>
+        <TrackedChild />
+      </DesktopViewportGuard>
+    )
+
+    expect(screen.getByText('앱 본문')).toBeInTheDocument()
+    expect(screen.queryByText('넓은 화면이 필요합니다')).not.toBeInTheDocument()
+
+    act(() => {
+      setViewportWidth(1024)
+      window.dispatchEvent(new Event('resize'))
+    })
+
+    expect(screen.getByText('앱 본문')).toBeInTheDocument()
+    expect(screen.getByText('넓은 화면이 필요합니다')).toBeInTheDocument()
+    expect(unmountSpy).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/DesktopViewportGuard.tsx
+++ b/src/components/DesktopViewportGuard.tsx
@@ -19,6 +19,7 @@ export function DesktopViewportGuard({
   children: React.ReactNode
 }) {
   const [viewportWidth, setViewportWidth] = useState(readViewportWidth)
+  const isDesktopViewport = viewportWidth >= MIN_DESKTOP_VIEWPORT_WIDTH
 
   useEffect(() => {
     // 브라우저 크기 변경 시 즉시 다시 계산해 차단/해제를 동기화
@@ -33,42 +34,55 @@ export function DesktopViewportGuard({
     }
   }, [])
 
-  if (viewportWidth >= MIN_DESKTOP_VIEWPORT_WIDTH) {
-    return <>{children}</>
-  }
-
   return (
-    <div className="flex min-h-screen items-center justify-center bg-ui-app-bg px-5 py-8">
-      <div className="w-full max-w-md rounded-[32px] border border-ui-border bg-ui-surface px-7 py-8 text-center shadow-[0_16px_40px_rgba(15,23,42,0.08)]">
-        <div className="mx-auto flex size-18 items-center justify-center rounded-3xl bg-ui-brand-soft text-ui-brand">
-          <MonitorCog className="size-9" strokeWidth={2.1} />
-        </div>
-
-        <h1 className="mt-5 select-none text-[1.55rem] font-extrabold text-ui-text-strong">
-          넓은 화면이 필요합니다
-        </h1>
-
-        <p className="mt-3 select-none text-sm font-medium leading-6 text-ui-text-muted">
-          이 웹사이트는 로비, 대기방, 게임 보드가 넓은 가로 화면을 전제로
-          설계되어 있습니다.
-        </p>
-
-        <div className="mt-6 rounded-2xl border border-ui-border bg-ui-surface-muted px-4 py-4">
-          <div className="flex items-center justify-center gap-2 text-ui-text-primary">
-            <TabletSmartphone className="size-4 shrink-0" strokeWidth={2} />
-            <span className="select-none text-sm font-semibold">
-              현재 브라우저 폭 {viewportWidth}px
-            </span>
-          </div>
-          <p className="mt-2 select-none text-sm font-medium text-ui-text-subtle">
-            최소 권장 폭은 {MIN_DESKTOP_VIEWPORT_WIDTH}px 입니다.
-          </p>
-        </div>
-
-        <p className="mt-5 select-none text-xs font-medium leading-5 text-ui-text-subtle">
-          브라우저 창을 넓히거나 데스크톱/노트북 환경에서 다시 접속해 주세요.
-        </p>
+    <div className="relative min-h-screen">
+      <div
+        aria-hidden={!isDesktopViewport}
+        className={
+          isDesktopViewport
+            ? 'min-h-screen'
+            : 'min-h-screen pointer-events-none'
+        }
+        data-testid="desktop-viewport-guard-content"
+      >
+        {children}
       </div>
+
+      {!isDesktopViewport ? (
+        <div className="fixed inset-0 z-[999] flex min-h-screen items-center justify-center bg-ui-app-bg px-5 py-8">
+          <div className="w-full max-w-md rounded-[32px] border border-ui-border bg-ui-surface px-7 py-8 text-center shadow-[0_16px_40px_rgba(15,23,42,0.08)]">
+            <div className="mx-auto flex size-18 items-center justify-center rounded-3xl bg-ui-brand-soft text-ui-brand">
+              <MonitorCog className="size-9" strokeWidth={2.1} />
+            </div>
+
+            <h1 className="mt-5 select-none text-[1.55rem] font-extrabold text-ui-text-strong">
+              넓은 화면이 필요합니다
+            </h1>
+
+            <p className="mt-3 select-none text-sm font-medium leading-6 text-ui-text-muted">
+              이 웹사이트는 로비, 대기방, 게임 보드가 넓은 가로 화면을 전제로
+              설계되어 있습니다.
+            </p>
+
+            <div className="mt-6 rounded-2xl border border-ui-border bg-ui-surface-muted px-4 py-4">
+              <div className="flex items-center justify-center gap-2 text-ui-text-primary">
+                <TabletSmartphone className="size-4 shrink-0" strokeWidth={2} />
+                <span className="select-none text-sm font-semibold">
+                  현재 브라우저 폭 {viewportWidth}px
+                </span>
+              </div>
+              <p className="mt-2 select-none text-sm font-medium text-ui-text-subtle">
+                최소 권장 폭은 {MIN_DESKTOP_VIEWPORT_WIDTH}px 입니다.
+              </p>
+            </div>
+
+            <p className="mt-5 select-none text-xs font-medium leading-5 text-ui-text-subtle">
+              브라우저 창을 넓히거나 데스크톱/노트북 환경에서 다시 접속해
+              주세요.
+            </p>
+          </div>
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/src/features/presence/components/UserListPanel.test.tsx
+++ b/src/features/presence/components/UserListPanel.test.tsx
@@ -62,4 +62,51 @@ describe('UserListPanel', () => {
       '마블러 채팅',
     ])
   })
+
+  it('같은 사용자의 unread 개수는 badge 숫자로 표시된다', () => {
+    render(
+      <UserListPanel
+        users={[
+          createOnlineUserFixture({
+            id: 'u-1',
+            nickname: '상대유저',
+            status: 'lobby',
+          }),
+        ]}
+        isLoading={false}
+        isError={false}
+        isOpen
+        currentUserId="u-me"
+        unreadDirectMessageCountByUserId={{ 'u-1': 3 }}
+        onToggle={vi.fn()}
+        onOpenDirectMessage={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('3')).toBeInTheDocument()
+  })
+
+  it('현재 열려 있는 DM 대상에게는 unread badge를 숨긴다', () => {
+    render(
+      <UserListPanel
+        users={[
+          createOnlineUserFixture({
+            id: 'u-1',
+            nickname: '상대유저',
+            status: 'lobby',
+          }),
+        ]}
+        isLoading={false}
+        isError={false}
+        isOpen
+        currentUserId="u-me"
+        activeDirectMessageUserId="u-1"
+        unreadDirectMessageCountByUserId={{ 'u-1': 3 }}
+        onToggle={vi.fn()}
+        onOpenDirectMessage={vi.fn()}
+      />
+    )
+
+    expect(screen.queryByText('3')).not.toBeInTheDocument()
+  })
 })

--- a/src/features/presence/components/UserListPanel.tsx
+++ b/src/features/presence/components/UserListPanel.tsx
@@ -15,6 +15,7 @@ interface UserListPanelProps {
   isOpen: boolean
   onToggle: () => void
   currentUserId?: string
+  activeDirectMessageUserId?: string
   unreadDirectMessageCountByUserId?: Record<string, number>
   onOpenDirectMessage?: (user: OnlineUser) => void
   heightMode?: 'screen' | 'full'
@@ -36,6 +37,7 @@ export function UserListPanel({
   isOpen,
   onToggle,
   currentUserId,
+  activeDirectMessageUserId,
   unreadDirectMessageCountByUserId = {},
   onOpenDirectMessage,
   heightMode = 'screen',
@@ -144,7 +146,9 @@ export function UserListPanel({
                   user={user}
                   isCurrentUser={currentUserId === user.id}
                   unreadDirectMessageCount={
-                    unreadDirectMessageCountByUserId[user.id] ?? 0
+                    user.id === activeDirectMessageUserId
+                      ? 0
+                      : (unreadDirectMessageCountByUserId[user.id] ?? 0)
                   }
                   onOpenDirectMessage={onOpenDirectMessage}
                 />
@@ -187,7 +191,8 @@ export function UserListPanel({
                       ONLINE_USER_STATUS_DOT_CLASS_MAP[user.status]
                     )}
                   />
-                  {(unreadDirectMessageCountByUserId[user.id] ?? 0) > 0 ? (
+                  {user.id !== activeDirectMessageUserId &&
+                  (unreadDirectMessageCountByUserId[user.id] ?? 0) > 0 ? (
                     <span className="absolute -left-1 -top-1 inline-flex h-4 min-w-4 select-none items-center justify-center rounded-full border border-white bg-ui-danger px-1 text-[9px] font-semibold leading-none tracking-tight text-white">
                       {formatUnreadBadgeCount(
                         unreadDirectMessageCountByUserId[user.id] ?? 0

--- a/src/features/presence/onlineUsersSocket.ts
+++ b/src/features/presence/onlineUsersSocket.ts
@@ -8,6 +8,8 @@ import type { OnlineUserPayload, OnlineUsersEventPayload } from './types'
 
 // 접속자 목록 소켓 이벤트 이름
 export const ONLINE_USERS_EVENT_NAME = 'online_users'
+export const ONLINE_USERS_REFRESH_REQUEST_EVENT_NAME =
+  'online-users-refresh-request'
 const SOCKET_MOCK_INTERVAL_MS = 5_000
 const USE_SOCKET_MOCK = IS_SOCKET_MOCK_ENABLED
 
@@ -59,4 +61,13 @@ export function startOnlineUsersMockBroadcast() {
 // 실제 소켓 모드에서 연결이 없으면 명시적으로 연결
 export function ensureOnlineUsersSocketConnection() {
   connectSocketWithAuthIfNeeded()
+}
+
+// 로컬 사용자 상태 변화 직후 접속자 스냅샷 재동기화를 요청
+export function requestOnlineUsersSnapshotSync() {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  window.dispatchEvent(new Event(ONLINE_USERS_REFRESH_REQUEST_EVENT_NAME))
 }

--- a/src/features/presence/useDirectMessageController.test.tsx
+++ b/src/features/presence/useDirectMessageController.test.tsx
@@ -231,6 +231,77 @@ describe('useDirectMessageController', () => {
     ).toBeUndefined()
   })
 
+  it('현재 열어본 DM 대상은 창을 닫아도 이전 unread badge가 다시 보이지 않는다', () => {
+    const user = createOnlineUserFixture({
+      id: 'user-2',
+      nickname: '상대',
+      status: 'lobby',
+    })
+
+    const { result } = renderDirectMessageControllerHook({
+      users: [user],
+    })
+
+    act(() => {
+      directMessageReceiveHandlerRef.current?.({
+        message_id: 'dm-1',
+        sender_id: 'user-2',
+        sender_nickname: '상대',
+        message: '첫 메시지',
+        sent_at: '2026-03-03T10:00:00.000Z',
+      })
+    })
+
+    expect(result.current.unreadDirectMessageCountByUserId['user-2']).toBe(1)
+
+    act(() => {
+      result.current.openDirectMessage(user)
+    })
+
+    act(() => {
+      result.current.sendDirectMessage('응답 메시지')
+      result.current.closeDirectMessage()
+    })
+
+    expect(result.current.dmTargetUser).toBeNull()
+    expect(
+      result.current.unreadDirectMessageCountByUserId['user-2']
+    ).toBeUndefined()
+  })
+
+  it('DM 창을 열고 닫아도 수신 구독은 유지되고 닫은 직후 메시지는 unread로 반영된다', () => {
+    const user = createOnlineUserFixture({
+      id: 'user-2',
+      nickname: '상대',
+      status: 'lobby',
+    })
+
+    const { result } = renderDirectMessageControllerHook({
+      users: [user],
+    })
+
+    expect(subscribeDirectMessageSocketEventsMock).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      result.current.openDirectMessage(user)
+      result.current.closeDirectMessage()
+    })
+
+    expect(subscribeDirectMessageSocketEventsMock).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      directMessageReceiveHandlerRef.current?.({
+        message_id: 'dm-after-close',
+        sender_id: 'user-2',
+        sender_nickname: '상대',
+        message: '닫은 직후 메시지',
+        sent_at: '2026-03-03T10:05:00.000Z',
+      })
+    })
+
+    expect(result.current.unreadDirectMessageCountByUserId['user-2']).toBe(1)
+  })
+
   it('현재 열려 있는 대상의 수신 메시지는 unread가 증가하지 않는다', () => {
     const user = createOnlineUserFixture({
       id: 'user-2',
@@ -261,7 +332,7 @@ describe('useDirectMessageController', () => {
     ).toBeUndefined()
   })
 
-  it('다른 사용자의 수신 메시지는 unread가 독립적으로 누적된다', () => {
+  it('다른 사용자의 수신 메시지는 unread가 사용자별로 독립 누적된다', () => {
     const user2 = createOnlineUserFixture({
       id: 'user-2',
       nickname: '상대A',
@@ -295,6 +366,45 @@ describe('useDirectMessageController', () => {
       result.current.unreadDirectMessageCountByUserId['user-2']
     ).toBeUndefined()
     expect(result.current.unreadDirectMessageCountByUserId['user-3']).toBe(1)
+  })
+
+  it('같은 사용자의 수신 메시지가 여러 개 오면 unread가 메시지 수만큼 증가한다', () => {
+    const user = createOnlineUserFixture({
+      id: 'user-2',
+      nickname: '상대',
+      status: 'lobby',
+    })
+
+    const { result } = renderDirectMessageControllerHook({
+      users: [user],
+    })
+
+    act(() => {
+      directMessageReceiveHandlerRef.current?.({
+        message_id: 'dm-1',
+        sender_id: 'user-2',
+        sender_nickname: '상대',
+        message: '첫 메시지',
+        sent_at: '2026-03-03T10:00:00.000Z',
+      })
+      directMessageReceiveHandlerRef.current?.({
+        message_id: 'dm-2',
+        sender_id: 'user-2',
+        sender_nickname: '상대',
+        message: '두 번째 메시지',
+        sent_at: '2026-03-03T10:01:00.000Z',
+      })
+      directMessageReceiveHandlerRef.current?.({
+        message_id: 'dm-3',
+        sender_id: 'user-2',
+        sender_nickname: '상대',
+        message: '세 번째 메시지',
+        sent_at: '2026-03-03T10:02:00.000Z',
+      })
+    })
+
+    expect(result.current.directMessagesByUserId['user-2']).toHaveLength(3)
+    expect(result.current.unreadDirectMessageCountByUserId['user-2']).toBe(3)
   })
 
   it('동일 message_id 수신은 중복 삽입하지 않는다', () => {

--- a/src/features/presence/useDirectMessageController.ts
+++ b/src/features/presence/useDirectMessageController.ts
@@ -47,6 +47,11 @@ export function useDirectMessageController({
 
   const openedDirectMessageUserId = dmTargetUser?.id
   const directMessagesByUserIdRef = useRef<Record<string, DirectMessage[]>>({})
+  const openedDirectMessageUserIdRef = useRef<string | undefined>(
+    openedDirectMessageUserId
+  )
+
+  openedDirectMessageUserIdRef.current = openedDirectMessageUserId
 
   // 최신 DM 목록 상태를 ref에 동기화해 수신 이벤트 중복 판정에 사용
   useEffect(() => {
@@ -68,7 +73,6 @@ export function useDirectMessageController({
           content: payload.message,
           sentAt: payload.sent_at,
         }
-
         const previousMessages =
           directMessagesByUserIdRef.current[payload.sender_id] ?? []
         const hasSameMessage = previousMessages.some(
@@ -88,7 +92,7 @@ export function useDirectMessageController({
         setDirectMessagesByUserId(nextMessagesByUserId)
 
         // 현재 열려 있는 사용자 메시지는 unread 카운트에서 제외
-        if (payload.sender_id === openedDirectMessageUserId) {
+        if (payload.sender_id === openedDirectMessageUserIdRef.current) {
           return
         }
 
@@ -106,7 +110,7 @@ export function useDirectMessageController({
     return () => {
       unsubscribe()
     }
-  }, [openedDirectMessageUserId, session])
+  }, [session])
 
   // 접속자 목록 갱신 시 DM 대상 사용자 참조를 최신 객체로 동기화
   useEffect(() => {
@@ -155,8 +159,22 @@ export function useDirectMessageController({
 
   // DM 창 닫기
   const closeDirectMessage = useCallback(() => {
+    const targetUserId = dmTargetUser?.id
+
+    if (targetUserId) {
+      setUnreadDirectMessageCountByUserId((previousCountByUserId) => {
+        if (!previousCountByUserId[targetUserId]) {
+          return previousCountByUserId
+        }
+
+        const nextCountByUserId = { ...previousCountByUserId }
+        delete nextCountByUserId[targetUserId]
+        return nextCountByUserId
+      })
+    }
+
     setDmTargetUser(null)
-  }, [])
+  }, [dmTargetUser?.id])
 
   // 로컬 DM 목록에 메시지를 추가하고 소켓 전송 실행
   const sendDirectMessage = useCallback(

--- a/src/features/presence/useOnlineUsersSocket.test.tsx
+++ b/src/features/presence/useOnlineUsersSocket.test.tsx
@@ -17,6 +17,7 @@ const {
   startOnlineUsersMockBroadcastMock,
   stopMockBroadcastMock,
   ensureOnlineUsersSocketConnectionMock,
+  onlineUsersRefreshRequestEventName,
 } = vi.hoisted(() => ({
   socketOnMock: vi.fn(),
   socketOffMock: vi.fn(),
@@ -26,6 +27,7 @@ const {
   startOnlineUsersMockBroadcastMock: vi.fn(),
   stopMockBroadcastMock: vi.fn(),
   ensureOnlineUsersSocketConnectionMock: vi.fn(),
+  onlineUsersRefreshRequestEventName: 'online-users-refresh-request',
 }))
 
 vi.mock('../../lib/socket', () => ({
@@ -42,6 +44,7 @@ vi.mock('./api', () => ({
 
 vi.mock('./onlineUsersSocket', () => ({
   ONLINE_USERS_EVENT_NAME: 'online_users',
+  ONLINE_USERS_REFRESH_REQUEST_EVENT_NAME: onlineUsersRefreshRequestEventName,
   isOnlineUsersSocketMockMode: isOnlineUsersSocketMockModeMock,
   startOnlineUsersMockBroadcast: startOnlineUsersMockBroadcastMock,
   ensureOnlineUsersSocketConnection: ensureOnlineUsersSocketConnectionMock,
@@ -154,6 +157,36 @@ describe('useOnlineUsersSocket', () => {
       id: 'user-2',
       nickname: 'Relogin',
       status: 'lobby',
+    })
+  })
+
+  it('refresh request 이벤트 수신 시 최신 REST snapshot으로 다시 동기화한다', async () => {
+    getOnlineUsersSnapshotMock.mockResolvedValueOnce([]).mockResolvedValueOnce([
+      createOnlineUserPayloadFixture({
+        id: 'user-3',
+        nickname: 'Waiting',
+        status: 'in_room',
+      }),
+    ])
+
+    const { result } = renderHook(() => useOnlineUsersSocket())
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    act(() => {
+      window.dispatchEvent(new Event(onlineUsersRefreshRequestEventName))
+    })
+
+    await waitFor(() => {
+      expect(result.current.data).toHaveLength(1)
+    })
+
+    expect(result.current.data[0]).toMatchObject({
+      id: 'user-3',
+      nickname: 'Waiting',
+      status: 'in_room',
     })
   })
 

--- a/src/features/presence/useOnlineUsersSocket.ts
+++ b/src/features/presence/useOnlineUsersSocket.ts
@@ -6,6 +6,7 @@ import {
   ensureOnlineUsersSocketConnection,
   isOnlineUsersSocketMockMode,
   ONLINE_USERS_EVENT_NAME,
+  ONLINE_USERS_REFRESH_REQUEST_EVENT_NAME,
   startOnlineUsersMockBroadcast,
 } from './onlineUsersSocket'
 import type { OnlineUser, OnlineUsersEventPayload } from './types'
@@ -85,6 +86,15 @@ export function useOnlineUsersSocket() {
       void syncOnlineUsersSnapshot()
     }
 
+    // room enter/refresh 같은 로컬 상태 변화 직후 snapshot 재동기화를 허용
+    const handleRefreshRequest = () => {
+      if (!isActive || isOnlineUsersSocketMockMode()) {
+        return
+      }
+
+      void syncOnlineUsersSnapshot()
+    }
+
     // 연결 종료 상태를 에러로 표시
     const handleDisconnect = () => {
       if (!isActive) {
@@ -113,12 +123,25 @@ export function useOnlineUsersSocket() {
       void syncOnlineUsersSnapshot()
     }
 
+    if (typeof window !== 'undefined') {
+      window.addEventListener(
+        ONLINE_USERS_REFRESH_REQUEST_EVENT_NAME,
+        handleRefreshRequest
+      )
+    }
+
     return () => {
       isActive = false
       socket.off(ONLINE_USERS_EVENT_NAME, handleOnlineUsers)
       socket.off('connect', handleConnect)
       socket.off('connect_error', handleConnectError)
       socket.off('disconnect', handleDisconnect)
+      if (typeof window !== 'undefined') {
+        window.removeEventListener(
+          ONLINE_USERS_REFRESH_REQUEST_EVENT_NAME,
+          handleRefreshRequest
+        )
+      }
       stopMockBroadcast()
     }
   }, [])

--- a/src/pages/lobby/LobbyPage.tsx
+++ b/src/pages/lobby/LobbyPage.tsx
@@ -169,6 +169,7 @@ function LobbyPage() {
             isError={isUsersError}
             isOpen={isUserListOpen}
             currentUserId={session.userId}
+            activeDirectMessageUserId={dmTargetUser?.id}
             unreadDirectMessageCountByUserId={unreadDirectMessageCountByUserId}
             onOpenDirectMessage={openDirectMessage}
             onToggle={() => setIsUserListOpen((prev) => !prev)}

--- a/src/pages/waiting-room/WaitingRoomPage.test.tsx
+++ b/src/pages/waiting-room/WaitingRoomPage.test.tsx
@@ -1,5 +1,6 @@
 import { act, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import type { MemoryRouterProps } from 'react-router-dom'
 import { Route, Routes } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useAuthStore } from '../../features/auth/store'
@@ -150,7 +151,7 @@ function renderWaitingRoomPage({
   initialEntries = ['/rooms/room-5'],
 }: {
   routePath?: string
-  initialEntries?: string[]
+  initialEntries?: MemoryRouterProps['initialEntries']
 } = {}) {
   return renderWithProviders(
     <Routes>

--- a/src/pages/waiting-room/WaitingRoomPage.test.tsx
+++ b/src/pages/waiting-room/WaitingRoomPage.test.tsx
@@ -38,6 +38,7 @@ const {
   useOnlineUsersSocketMock,
   useDirectMessageControllerMock,
   navigateMock,
+  navigationTypeMock,
   toastErrorMock,
   waitingRoomControllerStateRef,
   gameStartHandlerRef,
@@ -46,6 +47,7 @@ const {
   useOnlineUsersSocketMock: vi.fn(),
   useDirectMessageControllerMock: vi.fn(),
   navigateMock: vi.fn(),
+  navigationTypeMock: vi.fn(),
   toastErrorMock: vi.fn(),
   waitingRoomControllerStateRef: {
     current: null as WaitingRoomControllerResult | null,
@@ -173,6 +175,7 @@ describe('WaitingRoomPage interaction', () => {
 
     waitingRoomControllerStateRef.current = createWaitingRoomControllerState()
     gameStartHandlerRef.current = null
+    navigationTypeMock.mockReturnValue('POP')
 
     useWaitingRoomControllerMock.mockImplementation((params) => {
       gameStartHandlerRef.current = params.onGameStart
@@ -378,5 +381,110 @@ describe('WaitingRoomPage interaction', () => {
       expect(handleStartGameMock).toHaveBeenCalledTimes(1)
       expect(toastErrorMock).toHaveBeenCalledWith('시작 실패')
     })
+  })
+
+  it('대기방 접속자 목록은 room.players 기준으로 현재 방 참가자를 in_room 상태로 보정한다', async () => {
+    useOnlineUsersSocketMock.mockReturnValue({
+      data: [
+        {
+          id: 'user-1',
+          nickname: '테스터',
+          status: 'lobby',
+          avatarText: '테',
+          avatarBackground: '#ef4444',
+        },
+        {
+          id: 'user-2',
+          nickname: '상대방',
+          status: 'lobby',
+          avatarText: '상',
+          avatarBackground: '#3b82f6',
+        },
+      ],
+      isLoading: false,
+      isError: false,
+    })
+
+    renderWaitingRoomPage()
+
+    await waitFor(() => {
+      expect(screen.getAllByText('대기방')).toHaveLength(2)
+    })
+  })
+
+  it('초기 진입(POP)에서는 location.state의 preJoinedSnapshot을 재사용하지 않는다', () => {
+    renderWaitingRoomPage({
+      initialEntries: [
+        {
+          pathname: '/rooms/room-5',
+          state: {
+            roomId: 'room-5',
+            roomTitle: '테스트 방',
+            preJoinedSnapshot: {
+              roomId: 'room-5',
+              title: '테스트 방',
+              status: 'waiting',
+              maxPlayers: 4,
+              isPrivate: false,
+              players: [
+                {
+                  id: 'user-1',
+                  nickname: '테스터',
+                  isReady: false,
+                  isHost: true,
+                },
+              ],
+              chatMessages: [],
+            },
+          },
+        },
+      ],
+    })
+
+    expect(useWaitingRoomControllerMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        preJoinedSnapshot: null,
+      })
+    )
+  })
+
+  it('로비에서 PUSH로 진입하면 location.state의 preJoinedSnapshot을 사용한다', () => {
+    navigationTypeMock.mockReturnValue('PUSH')
+
+    const preJoinedSnapshot: WaitingRoomSnapshot = {
+      roomId: 'room-5',
+      title: '테스트 방',
+      status: 'waiting',
+      maxPlayers: 4,
+      isPrivate: false,
+      players: [
+        {
+          id: 'user-1',
+          nickname: '테스터',
+          isReady: false,
+          isHost: true,
+        },
+      ],
+      chatMessages: [],
+    }
+
+    renderWaitingRoomPage({
+      initialEntries: [
+        {
+          pathname: '/rooms/room-5',
+          state: {
+            roomId: 'room-5',
+            roomTitle: '테스트 방',
+            preJoinedSnapshot,
+          },
+        },
+      ],
+    })
+
+    expect(useWaitingRoomControllerMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        preJoinedSnapshot,
+      })
+    )
   })
 })

--- a/src/pages/waiting-room/WaitingRoomPage.test.tsx
+++ b/src/pages/waiting-room/WaitingRoomPage.test.tsx
@@ -68,6 +68,7 @@ vi.mock('react-router-dom', async () => {
   return {
     ...actual,
     useNavigate: () => navigateMock,
+    useNavigationType: () => navigationTypeMock(),
   }
 })
 

--- a/src/pages/waiting-room/WaitingRoomPage.tsx
+++ b/src/pages/waiting-room/WaitingRoomPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { AnimatePresence } from 'framer-motion'
 import toast from 'react-hot-toast'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
@@ -11,6 +11,11 @@ import {
 } from '../../components/header/profileMenu'
 import { DirectMessagePanel } from '../../features/presence/components/DirectMessagePanel'
 import { UserListPanel } from '../../features/presence/components/UserListPanel'
+import {
+  getOnlineUserAvatarBackground,
+  getOnlineUserAvatarText,
+} from '../../features/presence/onlineUsersModel'
+import type { OnlineUser } from '../../features/presence/types'
 import { useOnlineUsersSocket } from '../../features/presence/useOnlineUsersSocket'
 import { useDirectMessageController } from '../../features/presence/useDirectMessageController'
 import { removeMockOnlineUser } from '../../features/presence/mockData'
@@ -109,6 +114,40 @@ function WaitingRoomPage() {
     isError: isUsersError,
   } = useOnlineUsersSocket()
 
+  const waitingRoomUsers = useMemo(() => {
+    if (!room) {
+      return users
+    }
+
+    const currentRoomStatus = room.status === 'playing' ? 'playing' : 'in_room'
+    const mergedUsersById = new Map<string, OnlineUser>(
+      users.map((user) => [user.id, user])
+    )
+
+    room.players.forEach((player) => {
+      const existingUser = mergedUsersById.get(player.id)
+
+      if (existingUser) {
+        mergedUsersById.set(player.id, {
+          ...existingUser,
+          nickname: player.nickname,
+          status: currentRoomStatus,
+        })
+        return
+      }
+
+      mergedUsersById.set(player.id, {
+        id: player.id,
+        nickname: player.nickname,
+        status: currentRoomStatus,
+        avatarText: getOnlineUserAvatarText(player.nickname),
+        avatarBackground: getOnlineUserAvatarBackground(player.id),
+      })
+    })
+
+    return Array.from(mergedUsersById.values())
+  }, [room, users])
+
   const {
     dmTargetUser,
     directMessagesByUserId,
@@ -118,7 +157,7 @@ function WaitingRoomPage() {
     sendDirectMessage,
   } = useDirectMessageController({
     session,
-    users,
+    users: waitingRoomUsers,
     onBlockedByPlaying: () => {
       toast.error('게임중인 유저에게는 DM을 보낼 수 없습니다.')
     },
@@ -310,7 +349,7 @@ function WaitingRoomPage() {
 
           <div className="min-h-0 xl:h-full xl:shrink-0">
             <UserListPanel
-              users={users}
+              users={waitingRoomUsers}
               isLoading={isUsersLoading}
               isError={isUsersError}
               isOpen={isUserListOpen}

--- a/src/pages/waiting-room/WaitingRoomPage.tsx
+++ b/src/pages/waiting-room/WaitingRoomPage.tsx
@@ -354,6 +354,7 @@ function WaitingRoomPage() {
               isError={isUsersError}
               isOpen={isUserListOpen}
               currentUserId={session.userId}
+              activeDirectMessageUserId={dmTargetUser?.id}
               unreadDirectMessageCountByUserId={
                 unreadDirectMessageCountByUserId
               }

--- a/src/pages/waiting-room/WaitingRoomPage.tsx
+++ b/src/pages/waiting-room/WaitingRoomPage.tsx
@@ -1,7 +1,12 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { AnimatePresence } from 'framer-motion'
 import toast from 'react-hot-toast'
-import { useLocation, useNavigate, useParams } from 'react-router-dom'
+import {
+  useLocation,
+  useNavigate,
+  useNavigationType,
+  useParams,
+} from 'react-router-dom'
 import { useRequireActiveSession } from '../../features/auth/hooks/useRequireActiveSession'
 import { useAuthStore } from '../../features/auth/store'
 import {
@@ -53,6 +58,7 @@ function WaitingRoomPage() {
   const currentRoomId = roomId ?? ''
   const location = useLocation()
   const navigate = useNavigate()
+  const navigationType = useNavigationType()
   const session = useAuthStore((state) => state.session)
   const clearSession = useAuthStore((state) => state.clearSession)
   const [isUserListOpen, setIsUserListOpen] = useState(true)
@@ -60,10 +66,12 @@ function WaitingRoomPage() {
 
   const locationState = location.state as WaitingRoomLocationState | null
   const isSameRoomState = locationState?.roomId === currentRoomId
+  const shouldUsePreJoinedSnapshot = navigationType !== 'POP'
   const selectedRoomTitle = isSameRoomState ? locationState?.roomTitle : null
-  const preJoinedSnapshot = isSameRoomState
-    ? (locationState?.preJoinedSnapshot ?? null)
-    : null
+  const preJoinedSnapshot =
+    isSameRoomState && shouldUsePreJoinedSnapshot
+      ? (locationState?.preJoinedSnapshot ?? null)
+      : null
 
   const handleGameStart = useCallback(
     (payload: GameStartEventPayload) => {

--- a/src/pages/waiting-room/api.ts
+++ b/src/pages/waiting-room/api.ts
@@ -234,7 +234,7 @@ function mapChatMessage(payload: WaitingRoomChatPayload) {
 }
 
 // 계약 검증된 입장 응답 payload를 대기방 스냅샷으로 변환
-function mapJoinResponse(
+export function mapWaitingRoomSnapshotPayload(
   payload: JoinWaitingRoomResponsePayload
 ): WaitingRoomSnapshot {
   return {
@@ -307,7 +307,7 @@ export async function joinWaitingRoom(params: JoinWaitingRoomParams) {
   )
 
   const joinPayload = parseJoinWaitingRoomPayload(data)
-  return mapJoinResponse(joinPayload)
+  return mapWaitingRoomSnapshotPayload(joinPayload)
 }
 
 // 대기방 퇴장 API 호출 또는 목 게이트웨이 호출

--- a/src/pages/waiting-room/controller/actions.test.ts
+++ b/src/pages/waiting-room/controller/actions.test.ts
@@ -174,6 +174,41 @@ describe('useWaitingRoomActions', () => {
     expect(params.shouldSkipNextCleanupLeaveRef.current).toBe(false)
   })
 
+  it('browser unload 이후 cleanup에서는 퇴장 시퀀스를 실행하지 않는다', () => {
+    const params = createActionsHookParams()
+
+    const { unmount } = renderHook(() => useWaitingRoomActions(params))
+
+    act(() => {
+      window.dispatchEvent(new Event('beforeunload'))
+    })
+
+    unmount()
+
+    expect(leaveWaitingRoomMock).not.toHaveBeenCalled()
+    expect(params.shouldSkipNextCleanupLeaveRef.current).toBe(false)
+  })
+
+  it('문서 visibility가 hidden이면 cleanup leave를 실행하지 않는다', () => {
+    const params = createActionsHookParams()
+    const originalVisibilityState = document.visibilityState
+
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      value: 'hidden',
+    })
+
+    const { unmount } = renderHook(() => useWaitingRoomActions(params))
+    unmount()
+
+    expect(leaveWaitingRoomMock).not.toHaveBeenCalled()
+
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      value: originalVisibilityState,
+    })
+  })
+
   it('handleToggleReady 성공 시 setRoom updater로 내 준비 상태를 갱신한다', async () => {
     toggleWaitingReadyMock.mockResolvedValue({ isReady: true })
     const params = createActionsHookParams({

--- a/src/pages/waiting-room/controller/actions.ts
+++ b/src/pages/waiting-room/controller/actions.ts
@@ -54,6 +54,20 @@ export function useWaitingRoomActions({
   setIsStartPending,
   setIsLeavePending,
 }: UseWaitingRoomActionsParams) {
+  useEffect(() => {
+    const markBrowserUnload = () => {
+      shouldSkipNextCleanupLeaveRef.current = true
+    }
+
+    window.addEventListener('beforeunload', markBrowserUnload)
+    window.addEventListener('pagehide', markBrowserUnload)
+
+    return () => {
+      window.removeEventListener('beforeunload', markBrowserUnload)
+      window.removeEventListener('pagehide', markBrowserUnload)
+    }
+  }, [shouldSkipNextCleanupLeaveRef])
+
   // 수동 퇴장과 언마운트 cleanup에서 재사용하는 공통 퇴장 시퀀스
   const runLeaveRoomSequence = useCallback(
     async ({
@@ -147,6 +161,11 @@ export function useWaitingRoomActions({
       // StrictMode 첫 cleanup은 테스트성 호출이므로 1회 스킵
       if (shouldSkipNextCleanupLeaveRef.current) {
         shouldSkipNextCleanupLeaveRef.current = false
+        return
+      }
+
+      // 브라우저 새로고침/탭 종료처럼 문서가 hidden 상태면 cleanup leave를 보내지 않는다.
+      if (document.visibilityState === 'hidden') {
         return
       }
 

--- a/src/pages/waiting-room/controller/lifecycle.test.ts
+++ b/src/pages/waiting-room/controller/lifecycle.test.ts
@@ -8,10 +8,12 @@ const {
   joinWaitingRoomMock,
   getWaitingRoomErrorMessageMock,
   enterWaitingRoomSocketMock,
+  requestOnlineUsersSnapshotSyncMock,
 } = vi.hoisted(() => ({
   joinWaitingRoomMock: vi.fn(),
   getWaitingRoomErrorMessageMock: vi.fn(),
   enterWaitingRoomSocketMock: vi.fn(),
+  requestOnlineUsersSnapshotSyncMock: vi.fn(),
 }))
 
 vi.mock('../api', () => ({
@@ -21,6 +23,10 @@ vi.mock('../api', () => ({
 
 vi.mock('../socket', () => ({
   enterWaitingRoomSocket: enterWaitingRoomSocketMock,
+}))
+
+vi.mock('../../../features/presence/onlineUsersSocket', () => ({
+  requestOnlineUsersSnapshotSync: requestOnlineUsersSnapshotSyncMock,
 }))
 
 function createPreJoinedSnapshot(): WaitingRoomSnapshot {
@@ -48,6 +54,7 @@ function createLifecycleParams(overrides: Record<string, unknown> = {}) {
     session,
     fallbackRoomTitle: 'fallback',
     preJoinedSnapshot: null,
+    hasReceivedRoomUpdatedRef: { current: false },
     hasEnteredRoomRef: { current: false },
     hasLeftRoomRef: { current: false },
     hasInitializedPreJoinRef: { current: false },
@@ -102,6 +109,7 @@ describe('useWaitingRoomLifecycle', () => {
     expect(enterWaitingRoomSocketMock).toHaveBeenCalledWith({
       roomId: 'room-5',
     })
+    expect(requestOnlineUsersSnapshotSyncMock).toHaveBeenCalledTimes(1)
     expect(params.hasEnteredRoomRef.current).toBe(true)
     expect(params.hasInitializedPreJoinRef.current).toBe(true)
   })
@@ -129,8 +137,31 @@ describe('useWaitingRoomLifecycle', () => {
     expect(enterWaitingRoomSocketMock).toHaveBeenCalledWith({
       roomId: 'room-5',
     })
+    expect(requestOnlineUsersSnapshotSyncMock).toHaveBeenCalledTimes(1)
     expect(params.setIsRoomLoading).toHaveBeenCalledWith(true)
     expect(params.setIsRoomLoading).toHaveBeenLastCalledWith(false)
+  })
+
+  it('room_updated를 이미 받은 경우에는 뒤늦은 join 응답이 room 상태를 다시 덮지 않는다', async () => {
+    const joinedSnapshot = createPreJoinedSnapshot()
+    joinWaitingRoomMock.mockResolvedValue(joinedSnapshot)
+    const params = createLifecycleParams({
+      hasReceivedRoomUpdatedRef: { current: true },
+    })
+
+    renderHook(() => useWaitingRoomLifecycle(params))
+
+    await waitFor(() => {
+      expect(joinWaitingRoomMock).toHaveBeenCalled()
+    })
+
+    expect(params.setRoom).not.toHaveBeenCalledWith(joinedSnapshot)
+    expect(params.setChatMessages).not.toHaveBeenCalledWith(
+      joinedSnapshot.chatMessages
+    )
+    expect(enterWaitingRoomSocketMock).toHaveBeenCalledWith({
+      roomId: 'room-5',
+    })
   })
 
   it('join 실패 시 파싱된 오류 메시지를 roomError로 설정한다', async () => {

--- a/src/pages/waiting-room/controller/lifecycle.ts
+++ b/src/pages/waiting-room/controller/lifecycle.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react'
 import type { Dispatch, MutableRefObject, SetStateAction } from 'react'
 import type { AuthSession } from '../../../features/auth/types'
+import { requestOnlineUsersSnapshotSync } from '../../../features/presence/onlineUsersSocket'
 import { getWaitingRoomErrorMessage, joinWaitingRoom } from '../api'
 import { enterWaitingRoomSocket } from '../socket'
 import type { WaitingRoomChatMessage, WaitingRoomSnapshot } from '../types'
@@ -11,6 +12,7 @@ interface UseWaitingRoomLifecycleParams {
   session: AuthSession | null
   fallbackRoomTitle?: string
   preJoinedSnapshot?: WaitingRoomSnapshot | null
+  hasReceivedRoomUpdatedRef: MutableRefObject<boolean>
   hasEnteredRoomRef: MutableRefObject<boolean>
   hasLeftRoomRef: MutableRefObject<boolean>
   hasInitializedPreJoinRef: MutableRefObject<boolean>
@@ -26,6 +28,7 @@ export function useWaitingRoomLifecycle({
   session,
   fallbackRoomTitle,
   preJoinedSnapshot,
+  hasReceivedRoomUpdatedRef,
   hasEnteredRoomRef,
   hasLeftRoomRef,
   hasInitializedPreJoinRef,
@@ -43,6 +46,7 @@ export function useWaitingRoomLifecycle({
       setChatMessages([])
       setIsRoomLoading(false)
       setRoomErrorMessage(null)
+      hasReceivedRoomUpdatedRef.current = false
       hasEnteredRoomRef.current = false
       hasLeftRoomRef.current = false
       hasInitializedPreJoinRef.current = false
@@ -55,6 +59,7 @@ export function useWaitingRoomLifecycle({
       setChatMessages([])
       setIsRoomLoading(false)
       setRoomErrorMessage(null)
+      hasReceivedRoomUpdatedRef.current = false
       hasEnteredRoomRef.current = false
       hasLeftRoomRef.current = false
       hasInitializedPreJoinRef.current = false
@@ -82,6 +87,7 @@ export function useWaitingRoomLifecycle({
       setRoomErrorMessage(null)
       setIsRoomLoading(false)
       enterWaitingRoomSocket({ roomId })
+      requestOnlineUsersSnapshotSync()
       hasEnteredRoomRef.current = true
       hasLeftRoomRef.current = false
       hasInitializedPreJoinRef.current = true
@@ -108,9 +114,12 @@ export function useWaitingRoomLifecycle({
           return
         }
 
-        setRoom(joinedRoom)
-        setChatMessages(joinedRoom.chatMessages)
+        if (!hasReceivedRoomUpdatedRef.current) {
+          setRoom(joinedRoom)
+          setChatMessages(joinedRoom.chatMessages)
+        }
         enterWaitingRoomSocket({ roomId })
+        requestOnlineUsersSnapshotSync()
         hasEnteredRoomRef.current = true
         hasLeftRoomRef.current = false
       } catch (error) {
@@ -137,6 +146,7 @@ export function useWaitingRoomLifecycle({
     }
   }, [
     fallbackRoomTitle,
+    hasReceivedRoomUpdatedRef,
     hasEnteredRoomRef,
     hasInitializedPreJoinRef,
     hasLeftRoomRef,

--- a/src/pages/waiting-room/controller/socketSync.test.ts
+++ b/src/pages/waiting-room/controller/socketSync.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react'
+import { act, renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Dispatch, SetStateAction } from 'react'
 import { createAuthSessionFixture } from '../../../test/fixtures'
@@ -9,18 +9,32 @@ import type {
   HostChangedEventPayload,
   LobbyUpdatedEventPayload,
   PlayerReadyEventPayload,
+  RoomUpdatedEventPayload,
   WaitingRoomSnapshot,
 } from '../types'
 
-const { subscribeWaitingRoomSocketEventsMock, unsubscribeMock } = vi.hoisted(
-  () => ({
-    subscribeWaitingRoomSocketEventsMock: vi.fn(),
-    unsubscribeMock: vi.fn(),
-  })
-)
+const {
+  subscribeWaitingRoomSocketEventsMock,
+  unsubscribeMock,
+  mapWaitingRoomSnapshotPayloadMock,
+  requestOnlineUsersSnapshotSyncMock,
+} = vi.hoisted(() => ({
+  subscribeWaitingRoomSocketEventsMock: vi.fn(),
+  unsubscribeMock: vi.fn(),
+  mapWaitingRoomSnapshotPayloadMock: vi.fn(),
+  requestOnlineUsersSnapshotSyncMock: vi.fn(),
+}))
 
 vi.mock('../socket', () => ({
   subscribeWaitingRoomSocketEvents: subscribeWaitingRoomSocketEventsMock,
+}))
+
+vi.mock('../api', () => ({
+  mapWaitingRoomSnapshotPayload: mapWaitingRoomSnapshotPayloadMock,
+}))
+
+vi.mock('../../../features/presence/onlineUsersSocket', () => ({
+  requestOnlineUsersSnapshotSync: requestOnlineUsersSnapshotSyncMock,
 }))
 
 function createRoomSnapshot(): WaitingRoomSnapshot {
@@ -38,10 +52,43 @@ function createRoomSnapshot(): WaitingRoomSnapshot {
   }
 }
 
+function createJoinedRoomSnapshotPayload(): WaitingRoomSnapshot {
+  return {
+    roomId: 'room-5',
+    title: '즐거운 게임 한판!',
+    status: 'waiting',
+    maxPlayers: 4,
+    isPrivate: false,
+    players: [
+      { id: 'user-1', nickname: '테스터', isReady: false, isHost: true },
+      { id: 'user-2', nickname: '상대', isReady: false, isHost: false },
+      { id: 'user-3', nickname: '새 참가자', isReady: false, isHost: false },
+    ],
+    chatMessages: [],
+  }
+}
+
+function createRoomUpdatedPayload(): RoomUpdatedEventPayload {
+  return {
+    room_id: 'room-5',
+    title: '즐거운 게임 한판!',
+    status: 'waiting',
+    max_players: 4,
+    is_private: false,
+    players: [
+      { id: 'user-1', nickname: '테스터', is_ready: false, is_host: true },
+      { id: 'user-2', nickname: '상대', is_ready: false, is_host: false },
+      { id: 'user-3', nickname: '새 참가자', is_ready: false, is_host: false },
+    ],
+    chat_messages: [],
+  }
+}
+
 interface SocketSyncHookParams {
   roomId: string
   session: ReturnType<typeof createAuthSessionFixture> | null
   activeRoomId?: string
+  hasReceivedRoomUpdatedRef: { current: boolean }
   onGameStart: (payload: GameStartEventPayload) => void
   onRoomRemoved: () => void
   setRoom: Dispatch<SetStateAction<WaitingRoomSnapshot | null>>
@@ -61,6 +108,7 @@ function createBaseParams(): SocketSyncHookParams {
       nickname: '테스터',
     }),
     activeRoomId: 'room-5',
+    hasReceivedRoomUpdatedRef: { current: false },
     onGameStart: vi.fn(),
     onRoomRemoved: vi.fn(),
     setRoom: setRoomMock as unknown as Dispatch<
@@ -78,11 +126,14 @@ describe('useWaitingRoomSocketSync', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     subscribeWaitingRoomSocketEventsMock.mockReturnValue(unsubscribeMock)
+    mapWaitingRoomSnapshotPayloadMock.mockReturnValue(
+      createJoinedRoomSnapshotPayload()
+    )
   })
 
-  it('핵심 입력값(roomId/session/activeRoomId)이 없으면 구독을 생략한다', () => {
+  it('핵심 입력값(roomId/session)이 없으면 구독을 생략한다', () => {
     const params = createBaseParams()
-    params.activeRoomId = undefined
+    params.session = null
 
     renderHook(() => useWaitingRoomSocketSync(params))
 
@@ -252,5 +303,55 @@ describe('useWaitingRoomSocketSync', () => {
     expect(params.setRoomMock).toHaveBeenCalledWith(null)
     expect(params.setChatMessagesMock).toHaveBeenCalledWith([])
     expect(params.onRoomRemoved).toHaveBeenCalledTimes(1)
+  })
+
+  it('room_updated는 현재 방 snapshot을 반영해 플레이어 목록을 갱신한다', async () => {
+    const params = createBaseParams()
+    renderHook(() => useWaitingRoomSocketSync(params))
+
+    const handlers = subscribeWaitingRoomSocketEventsMock.mock
+      .calls[0]?.[0] as {
+      onRoomUpdated: (payload: RoomUpdatedEventPayload) => void
+    }
+
+    act(() => {
+      handlers.onRoomUpdated(createRoomUpdatedPayload())
+    })
+
+    await waitFor(() => {
+      expect(mapWaitingRoomSnapshotPayloadMock).toHaveBeenCalledWith(
+        createRoomUpdatedPayload()
+      )
+    })
+
+    expect(params.setRoomMock).toHaveBeenCalledWith(
+      createJoinedRoomSnapshotPayload()
+    )
+    expect(params.setChatMessagesMock).toHaveBeenCalledWith([])
+    expect(requestOnlineUsersSnapshotSyncMock).toHaveBeenCalledTimes(1)
+    expect(params.hasReceivedRoomUpdatedRef.current).toBe(true)
+  })
+
+  it('activeRoomId가 없어도 route roomId 기준으로 room_updated를 반영한다', async () => {
+    const params = createBaseParams()
+    params.activeRoomId = undefined
+    renderHook(() => useWaitingRoomSocketSync(params))
+
+    expect(subscribeWaitingRoomSocketEventsMock).toHaveBeenCalledTimes(1)
+
+    const handlers = subscribeWaitingRoomSocketEventsMock.mock
+      .calls[0]?.[0] as {
+      onRoomUpdated: (payload: RoomUpdatedEventPayload) => void
+    }
+
+    act(() => {
+      handlers.onRoomUpdated(createRoomUpdatedPayload())
+    })
+
+    await waitFor(() => {
+      expect(mapWaitingRoomSnapshotPayloadMock).toHaveBeenCalledWith(
+        createRoomUpdatedPayload()
+      )
+    })
   })
 })

--- a/src/pages/waiting-room/controller/socketSync.ts
+++ b/src/pages/waiting-room/controller/socketSync.ts
@@ -1,10 +1,13 @@
 import { useEffect } from 'react'
-import type { Dispatch, SetStateAction } from 'react'
+import type { Dispatch, MutableRefObject, SetStateAction } from 'react'
 import type { AuthSession } from '../../../features/auth/types'
+import { requestOnlineUsersSnapshotSync } from '../../../features/presence/onlineUsersSocket'
+import { mapWaitingRoomSnapshotPayload } from '../api'
 import { subscribeWaitingRoomSocketEvents } from '../socket'
 import type {
   GameStartEventPayload,
   LobbyUpdatedEventPayload,
+  RoomUpdatedEventPayload,
   WaitingRoomChatMessage,
   WaitingRoomSnapshot,
 } from '../types'
@@ -15,6 +18,7 @@ interface UseWaitingRoomSocketSyncParams {
   roomId: string
   session: AuthSession | null
   activeRoomId?: string
+  hasReceivedRoomUpdatedRef: MutableRefObject<boolean>
   onGameStart: (payload: GameStartEventPayload) => void
   onRoomRemoved: () => void
   setRoom: Dispatch<SetStateAction<WaitingRoomSnapshot | null>>
@@ -26,15 +30,18 @@ export function useWaitingRoomSocketSync({
   roomId,
   session,
   activeRoomId,
+  hasReceivedRoomUpdatedRef,
   onGameStart,
   onRoomRemoved,
   setRoom,
   setChatMessages,
 }: UseWaitingRoomSocketSyncParams) {
   useEffect(() => {
-    if (!roomId || !session || !activeRoomId) {
+    if (!roomId || !session) {
       return
     }
+
+    const targetRoomId = activeRoomId ?? roomId
 
     const unsubscribe = subscribeWaitingRoomSocketEvents({
       onPlayerReady: (payload) => {
@@ -77,7 +84,7 @@ export function useWaitingRoomSocketSync({
       },
       onChat: (payload) => {
         // 다른 방 채팅 이벤트는 무시
-        if (payload.room_id !== activeRoomId) {
+        if (payload.room_id !== targetRoomId) {
           return
         }
 
@@ -98,20 +105,34 @@ export function useWaitingRoomSocketSync({
       },
       onGameStart: (payload) => {
         // 다른 방 시작 이벤트는 무시
-        if (payload.room_id !== activeRoomId) {
+        if (payload.room_id !== targetRoomId) {
           return
         }
 
         onGameStart(payload)
       },
-      onLobbyUpdated: (payload: LobbyUpdatedEventPayload) => {
-        if (payload.action !== 'removed' || payload.room.id !== activeRoomId) {
+      onRoomUpdated: (payload: RoomUpdatedEventPayload) => {
+        if (payload.room_id !== targetRoomId) {
           return
         }
 
-        setRoom(null)
-        setChatMessages([])
-        onRoomRemoved()
+        hasReceivedRoomUpdatedRef.current = true
+        const latestRoomSnapshot = mapWaitingRoomSnapshotPayload(payload)
+        setRoom(latestRoomSnapshot)
+        setChatMessages(latestRoomSnapshot.chatMessages)
+        requestOnlineUsersSnapshotSync()
+      },
+      onLobbyUpdated: (payload: LobbyUpdatedEventPayload) => {
+        if (payload.room.id !== targetRoomId) {
+          return
+        }
+
+        if (payload.action === 'removed') {
+          setRoom(null)
+          setChatMessages([])
+          onRoomRemoved()
+          return
+        }
       },
     })
 
@@ -120,6 +141,7 @@ export function useWaitingRoomSocketSync({
     }
   }, [
     activeRoomId,
+    hasReceivedRoomUpdatedRef,
     onGameStart,
     onRoomRemoved,
     roomId,

--- a/src/pages/waiting-room/hooks.ts
+++ b/src/pages/waiting-room/hooks.ts
@@ -44,6 +44,7 @@ export function useWaitingRoomController({
   const hasEnteredRoomRef = useRef(false)
   const hasLeftRoomRef = useRef(false)
   const hasInitializedPreJoinRef = useRef(false)
+  const hasReceivedRoomUpdatedRef = useRef(false)
   const shouldSkipNextCleanupLeaveRef = useRef(import.meta.env.DEV)
   const leaveInFlightRef = useRef<Promise<WaitingRoomActionResult> | null>(null)
   const sessionRef = useRef<AuthSession | null>(session)
@@ -65,6 +66,7 @@ export function useWaitingRoomController({
 
   const handleRoomRemoved = useCallback(() => {
     roomRef.current = null
+    hasReceivedRoomUpdatedRef.current = false
     hasEnteredRoomRef.current = false
     hasLeftRoomRef.current = true
     hasInitializedPreJoinRef.current = false
@@ -78,6 +80,7 @@ export function useWaitingRoomController({
     session,
     fallbackRoomTitle,
     preJoinedSnapshot,
+    hasReceivedRoomUpdatedRef,
     hasEnteredRoomRef,
     hasLeftRoomRef,
     hasInitializedPreJoinRef,
@@ -93,6 +96,7 @@ export function useWaitingRoomController({
     roomId,
     session,
     activeRoomId,
+    hasReceivedRoomUpdatedRef,
     onGameStart,
     onRoomRemoved: handleRoomRemoved,
     setRoom,

--- a/src/pages/waiting-room/mockGateway.ts
+++ b/src/pages/waiting-room/mockGateway.ts
@@ -10,6 +10,7 @@ import type {
   HostChangedEventPayload,
   LobbyUpdatedEventPayload,
   PlayerReadyEventPayload,
+  RoomUpdatedEventPayload,
   WaitingRoomChatMessage,
   WaitingRoomChatPayload,
   WaitingRoomSnapshot,
@@ -225,6 +226,26 @@ function getLobbyUpdatedPayload(
   }
 }
 
+// room_updated 브로드캐스트에 맞는 대기방 snapshot payload 생성
+function getRoomUpdatedPayload(room: MockRoom): RoomUpdatedEventPayload {
+  return {
+    room_id: room.id,
+    title: room.title,
+    status: room.status,
+    max_players: room.max_players,
+    is_private: room.is_private,
+    players: room.players.map((player) => ({
+      id: player.id,
+      nickname: player.nickname,
+      is_ready: player.is_ready,
+      is_host: player.is_host,
+    })),
+    chat_messages: room.chat_messages.map((chatMessage) => ({
+      ...chatMessage,
+    })),
+  }
+}
+
 // 소켓 이벤트를 직접 리스너에 전달하는 목 emit 유틸
 function emitSocketEvent<TPayload>(eventName: string, payload: TPayload) {
   const socketWithListeners = socket as unknown as SocketWithListeners
@@ -242,6 +263,12 @@ function emitLobbyUpdated(
 ) {
   const payload = getLobbyUpdatedPayload(room, action)
   emitSocketEvent<LobbyUpdatedEventPayload>('lobby_updated', payload)
+}
+
+// 대기방 내부 인원/상태 변경을 snapshot 이벤트로 반영
+function emitRoomUpdated(room: MockRoom) {
+  const payload = getRoomUpdatedPayload(room)
+  emitSocketEvent<RoomUpdatedEventPayload>('room_updated', payload)
 }
 
 // 시작 가능 조건(2명 이상 + 방장 제외 전원 ready) 판별
@@ -389,6 +416,7 @@ export async function mockJoinWaitingRoom({
   // 이미 입장한 사용자는 현재 스냅샷 그대로 반환
   if (existingPlayer) {
     emitLobbyUpdated(room, 'updated')
+    emitRoomUpdated(room)
     setMockOnlineUserStatus(existingPlayer.id, 'in_room')
     return toWaitingRoomSnapshot(room)
   }
@@ -410,6 +438,7 @@ export async function mockJoinWaitingRoom({
   setMockOnlineUserStatus(userId, 'in_room', nickname)
 
   emitLobbyUpdated(room, 'status_changed')
+  emitRoomUpdated(room)
   return toWaitingRoomSnapshot(room)
 }
 
@@ -526,6 +555,7 @@ export async function mockLeaveWaitingRoom({
   }
 
   emitLobbyUpdated(room, 'status_changed')
+  emitRoomUpdated(room)
 
   return {
     success: true,
@@ -726,6 +756,7 @@ export function mockDevAddWaitingRoomParticipant(roomId: string) {
   room.players.push(createdBot)
   setMockOnlineUserStatus(createdBot.id, 'in_room', createdBot.nickname)
   emitLobbyUpdated(room, 'status_changed')
+  emitRoomUpdated(room)
 
   return toWaitingRoomSnapshot(room)
 }
@@ -780,6 +811,7 @@ export function mockDevRemoveWaitingRoomParticipant(
     setMockOnlineUserStatus(removedPlayer.id, 'lobby')
   }
   emitLobbyUpdated(room, 'status_changed')
+  emitRoomUpdated(room)
 
   return toWaitingRoomSnapshot(room)
 }
@@ -818,6 +850,7 @@ export function mockDevSeedStartCondition(roomId: string) {
 
   const snapshot = mockDevSetAllNonHostReady(roomId, true)
   emitLobbyUpdated(room, 'status_changed')
+  emitRoomUpdated(room)
   return snapshot
 }
 
@@ -859,6 +892,7 @@ export function mockDevTransferWaitingRoomHost(roomId: string) {
 
   applyHostTransfer(room, nextHost.id)
   emitLobbyUpdated(room, 'status_changed')
+  emitRoomUpdated(room)
 
   return toWaitingRoomSnapshot(room)
 }
@@ -899,6 +933,7 @@ export function mockDevResetWaitingRoom(
   // 멀티 클라이언트에서도 방장 표시가 즉시 맞도록 host_changed를 함께 발행
   applyHostTransfer(room, currentUserId)
   emitLobbyUpdated(room, 'status_changed')
+  emitRoomUpdated(room)
 
   return toWaitingRoomSnapshot(room)
 }

--- a/src/pages/waiting-room/socket.ts
+++ b/src/pages/waiting-room/socket.ts
@@ -13,6 +13,7 @@ import type {
   LobbyUpdatedEventPayload,
   LeaveRoomSocketPayload,
   PlayerReadyEventPayload,
+  RoomUpdatedEventPayload,
   SendChatSocketPayload,
 } from './types'
 
@@ -26,6 +27,7 @@ const WAITING_ROOM_EVENT_NAMES = {
   chat: 'chat',
   gameStart: 'game_start',
   lobbyUpdated: 'lobby_updated',
+  roomUpdated: 'room_updated',
 } as const
 
 const USE_WAITING_ROOM_SOCKET_MOCK = IS_SOCKET_MOCK_ENABLED
@@ -53,6 +55,7 @@ interface WaitingRoomSocketHandlers {
   onChat: (payload: ChatEventPayload) => void
   onGameStart: (payload: GameStartEventPayload) => void
   onLobbyUpdated: (payload: LobbyUpdatedEventPayload) => void
+  onRoomUpdated: (payload: RoomUpdatedEventPayload) => void
 }
 
 // 실소켓 모드에서만 연결 상태를 확인해 connect 실행
@@ -73,6 +76,7 @@ export function subscribeWaitingRoomSocketEvents(
   socket.on(WAITING_ROOM_EVENT_NAMES.chat, handlers.onChat)
   socket.on(WAITING_ROOM_EVENT_NAMES.gameStart, handlers.onGameStart)
   socket.on(WAITING_ROOM_EVENT_NAMES.lobbyUpdated, handlers.onLobbyUpdated)
+  socket.on(WAITING_ROOM_EVENT_NAMES.roomUpdated, handlers.onRoomUpdated)
 
   connectSocketIfNeeded()
 
@@ -82,6 +86,7 @@ export function subscribeWaitingRoomSocketEvents(
     socket.off(WAITING_ROOM_EVENT_NAMES.chat, handlers.onChat)
     socket.off(WAITING_ROOM_EVENT_NAMES.gameStart, handlers.onGameStart)
     socket.off(WAITING_ROOM_EVENT_NAMES.lobbyUpdated, handlers.onLobbyUpdated)
+    socket.off(WAITING_ROOM_EVENT_NAMES.roomUpdated, handlers.onRoomUpdated)
   }
 }
 

--- a/src/pages/waiting-room/types.ts
+++ b/src/pages/waiting-room/types.ts
@@ -68,6 +68,9 @@ export interface JoinWaitingRoomResponsePayload {
   chat_messages: WaitingRoomChatPayload[]
 }
 
+// room_updated는 대기방 snapshot과 동일한 payload 계약을 사용
+export type RoomUpdatedEventPayload = JoinWaitingRoomResponsePayload
+
 // 방 생성 API 응답 타입
 export interface CreateRoomResponsePayload {
   id: string


### PR DESCRIPTION
## 📌 관련 이슈

> closes #427

---

## 📝 작업 내용

> waiting-room refresh/입장 상태 동기화 문제와 DM unread badge UX를 함께 정리했습니다.

### 1. waiting-room 상태 동기화 안정화

- `room_updated` 이벤트를 직접 반영하도록 정리해 방장/참가자 플레이어 카드가 최신 snapshot으로 갱신되게 했습니다.
- waiting-room 진입 및 room update 직후 `/users/online` snapshot을 다시 읽어 접속자 목록 상태가 늦게 반영되던 문제를 보정했습니다.
- waiting-room에서는 `room.players`를 기준으로 현재 방 참가자를 `대기방` 상태로 보정해 플레이어 카드와 접속자 목록 상태가 어긋나지 않게 맞췄습니다.
- refresh 시 `location.state.preJoinedSnapshot`을 재사용하지 않도록 바꿔, 새로고침 후 stale snapshot 때문에 `/join`이 생략되던 문제를 수정했습니다.
- `DesktopViewportGuard`를 overlay 방식으로 변경해 작은 화면 보호 화면이 떠도 waiting-room이 unmount되지 않게 했습니다.
- `beforeunload/pagehide/hidden` 경계에서 cleanup `leave`가 잘못 나가지 않도록 보강했습니다.

### 2. DM unread badge UX 정리

- 현재 열려 있는 DM 대상에게는 unread badge가 보이지 않도록 정리했습니다.
- DM 창을 닫을 때 현재 대상 unread가 남아 다시 보이던 경계를 정리했습니다.
- unread badge는 읽지 않은 상대 메시지 수를 기준으로 유지되도록 정리했습니다.
- 로비/대기방 user list에서 같은 규칙으로 동작하도록 맞췄습니다.

### 3. 테스트/계약 보강

- waiting-room socket/mock/test 계약을 `room_updated` 기준으로 맞췄습니다.
- build에서 드러난 `WaitingRoomPage.test.tsx`의 router entry 타입 오류를 같이 보정했습니다.

---

## ✅ 검증

- `npm run ai:check:lobby`
- `npm run ai:check:waiting-room`
- `npm run ai:check:build`
- `npm run ai:check:waiting-room-e2e`
- `npm run ai:check:chat-e2e`
- `npm run ai:self-review -- --files src/components/DesktopViewportGuard.tsx src/components/DesktopViewportGuard.test.tsx src/pages/waiting-room/WaitingRoomPage.tsx src/pages/waiting-room/WaitingRoomPage.test.tsx src/pages/waiting-room/controller/actions.ts src/pages/waiting-room/controller/actions.test.ts src/pages/waiting-room/controller/socketSync.ts src/pages/waiting-room/controller/lifecycle.ts src/features/presence/useOnlineUsersSocket.ts src/features/presence/onlineUsersSocket.ts src/features/presence/useDirectMessageController.ts src/features/presence/components/UserListPanel.tsx`

---

## 📌 추가 메모

- 브라우저 강제 종료 후 stale room/player가 남는 `room cleanup / stale membership` 문제는 백엔드 이슈로 별도 추적 중입니다.
- 빠른 연속 DM 누락은 프론트가 아니라 백엔드 `DM_RATE_LIMITED` 정책 문제로 확인됐습니다.
- 로컬 `.env` 변경과 임시 task 문서는 PR 범위에서 제외했습니다.
