### PR TITLE
Feat : game:patch/game:prompt canonical 어댑터 적용 및 소켓 핸들러 정리

### DIFF
--- a/src/services/socket/game.handler.ts
+++ b/src/services/socket/game.handler.ts
@@ -10,13 +10,16 @@ import type {
   GameAck,
   GameError,
   GamePatchEnvelope,
-  GamePrompt,
   GamePromptResponse,
-  GameSnapshot,
   PendingGameAction,
   GameId,
-  GamePromptChoice,
 } from '../../types/domain'
+import {
+  normalizePatchEnvelopePayload,
+  normalizePromptChoiceValue,
+  normalizePromptPayload,
+  normalizeSnapshotPayload,
+} from './gameContractAdapters'
 
 type Teardown = () => void
 
@@ -24,8 +27,13 @@ type SetupGameHandlersOptions = {
   gameId?: GameId | null
 }
 
-type GamePatchPayload = GamePatchEnvelope & {
-  snapshot?: GameSnapshot
+type GamePatchPayload = {
+  gameId?: GameId | null
+  revision?: number
+  turn?: number
+  patch?: GamePatchEnvelope['patch']
+  events?: GamePatchEnvelope['events']
+  snapshot?: unknown
 }
 
 type GameActionPayload = {
@@ -44,12 +52,6 @@ type PromptResponsePayload = GamePromptResponse & {
   gameId?: GameId | null
 }
 
-type PromptCompatPayload = Partial<GamePrompt> & {
-  promptId?: string | null
-  timeoutMs?: number | null
-  payload?: Record<string, unknown>
-}
-
 let teardownGameHandlersRef: Teardown | null = null
 const USE_GAME_SOCKET_MOCK = IS_SOCKET_MOCK_ENABLED
 
@@ -57,156 +59,13 @@ const createActionId = () => `game-action-${Date.now()}`
 
 const PROMPT_ID_REQUIRED_ERROR: GameError = {
   code: 'INVALID_PROMPT',
-  message: '유효한 promptId를 포함한 game:prompt payload가 필요합니다.',
+  message: 'game:prompt payload must include promptId.',
 }
 
 const GAME_ID_REQUIRED_ERROR: GameError = {
   code: 'INVALID_GAME_ID',
-  message: '게임 이벤트는 gameId를 필수로 전송해야 합니다.',
+  message: 'Game events must include a valid gameId.',
 }
-
-const PHASE_TO_INTERNAL_MAP: Record<string, GameSnapshot['phase']> = {
-  WAIT_ROLL: 'rolling',
-  MOVING: 'moving',
-  RESOLVING: 'resolving',
-  WAIT_PROMPT: 'prompt',
-  TURN_END: 'resolving',
-  GAME_OVER: 'finished',
-}
-
-const normalizePhase = (phase: unknown): GameSnapshot['phase'] => {
-  if (typeof phase !== 'string') {
-    return 'waiting'
-  }
-
-  const normalizedPhase = phase.trim().toUpperCase()
-  return PHASE_TO_INTERNAL_MAP[normalizedPhase] ?? 'waiting'
-}
-
-const normalizePromptChoiceValue = (choice: unknown): string =>
-  typeof choice === 'string' ? choice.trim().toUpperCase() : ''
-
-const normalizePromptChoice = (
-  choice: unknown,
-  fallbackIndex: number
-): GamePromptChoice | null => {
-  if (!choice || typeof choice !== 'object') {
-    return null
-  }
-
-  const candidate = choice as Partial<GamePromptChoice>
-  const value = normalizePromptChoiceValue(candidate.value)
-  if (!value) {
-    return null
-  }
-
-  return {
-    id:
-      typeof candidate.id === 'string' && candidate.id.trim().length > 0
-        ? candidate.id
-        : `${value.toLowerCase()}-${fallbackIndex}`,
-    label:
-      typeof candidate.label === 'string' && candidate.label.trim().length > 0
-        ? candidate.label
-        : value,
-    value,
-    description:
-      typeof candidate.description === 'string' &&
-      candidate.description.trim().length > 0
-        ? candidate.description
-        : undefined,
-  }
-}
-
-const toFiniteNumber = (value: unknown): number | null => {
-  if (typeof value === 'number' && Number.isFinite(value)) {
-    return value
-  }
-
-  if (typeof value === 'string' && value.trim().length > 0) {
-    const parsed = Number.parseFloat(value)
-    if (Number.isFinite(parsed)) {
-      return parsed
-    }
-  }
-
-  return null
-}
-
-const normalizePromptPayload = (
-  promptPayload: PromptCompatPayload
-): GamePrompt | null => {
-  const promptIdCandidate =
-    (typeof promptPayload.promptId === 'string' && promptPayload.promptId) ||
-    (typeof promptPayload.id === 'string' && promptPayload.id) ||
-    null
-  const promptId = promptIdCandidate?.trim()
-
-  if (!promptId) {
-    return null
-  }
-
-  const payloadRecord =
-    promptPayload.payload && typeof promptPayload.payload === 'object'
-      ? promptPayload.payload
-      : undefined
-  const timeoutSecFromPayload = toFiniteNumber(
-    payloadRecord ? payloadRecord.timeoutSec : undefined
-  )
-  const timeoutMsFromPayload = toFiniteNumber(
-    payloadRecord ? payloadRecord.timeoutMs : undefined
-  )
-  const timeoutSecDirect = toFiniteNumber(promptPayload.timeoutSec)
-  const timeoutMsDirect = toFiniteNumber(promptPayload.timeoutMs)
-
-  const timeoutSecRaw =
-    timeoutSecDirect ??
-    timeoutSecFromPayload ??
-    (timeoutMsDirect != null
-      ? Math.ceil(timeoutMsDirect / 1000)
-      : timeoutMsFromPayload != null
-        ? Math.ceil(timeoutMsFromPayload / 1000)
-        : null)
-  const timeoutSec =
-    timeoutSecRaw != null && timeoutSecRaw > 0 ? timeoutSecRaw : undefined
-
-  const normalizedChoices = Array.isArray(promptPayload.choices)
-    ? promptPayload.choices
-        .map((choice, index) => normalizePromptChoice(choice, index))
-        .filter((choice): choice is GamePromptChoice => choice !== null)
-    : undefined
-
-  return {
-    id: promptId,
-    type:
-      typeof promptPayload.type === 'string' && promptPayload.type.trim().length
-        ? promptPayload.type
-        : 'UNKNOWN_PROMPT',
-    playerId:
-      promptPayload.playerId === undefined
-        ? null
-        : (promptPayload.playerId ?? null),
-    title:
-      typeof promptPayload.title === 'string' &&
-      promptPayload.title.trim().length > 0
-        ? promptPayload.title
-        : undefined,
-    message:
-      typeof promptPayload.message === 'string' &&
-      promptPayload.message.trim().length > 0
-        ? promptPayload.message
-        : undefined,
-    timeoutSec,
-    choices: normalizedChoices,
-    payload: payloadRecord,
-  }
-}
-
-const normalizeSnapshotPayload = (snapshot: GameSnapshot): GameSnapshot => ({
-  ...snapshot,
-  phase: normalizePhase(snapshot.phase),
-  prompt: snapshot.prompt ? normalizePromptPayload(snapshot.prompt) : null,
-})
 
 const getResolvedGameId = (gameId?: GameId | null): GameId | null => {
   const gameStore = useGameStore.getState()
@@ -241,18 +100,44 @@ export const setupGameHandlers = (
     const gameStore = useGameStore.getState()
 
     if (payload.snapshot) {
-      gameStore.replaceFromSnapshot(normalizeSnapshotPayload(payload.snapshot))
+      const normalizedSnapshot = normalizeSnapshotPayload(payload.snapshot, {
+        envelopeRevision:
+          typeof payload.revision === 'number' &&
+          Number.isFinite(payload.revision)
+            ? payload.revision
+            : 0,
+        envelopeGameId:
+          typeof payload.gameId === 'string' ? payload.gameId : undefined,
+      })
+
+      if (!normalizedSnapshot) {
+        gameStore.setLastError({
+          code: 'INVALID_SNAPSHOT',
+          message: 'Received game:patch snapshot payload is invalid.',
+        })
+        return
+      }
+
+      gameStore.replaceFromSnapshot(normalizedSnapshot)
       return
     }
 
-    gameStore.applyPatchEnvelope({
-      revision: payload.revision,
-      patch: payload.patch,
-      events: payload.events,
-    })
+    gameStore.applyPatchEnvelope(
+      normalizePatchEnvelopePayload({
+        gameId: typeof payload.gameId === 'string' ? payload.gameId : undefined,
+        revision:
+          typeof payload.revision === 'number' &&
+          Number.isFinite(payload.revision)
+            ? payload.revision
+            : 0,
+        turn: typeof payload.turn === 'number' ? payload.turn : undefined,
+        patch: Array.isArray(payload.patch) ? payload.patch : [],
+        events: Array.isArray(payload.events) ? payload.events : [],
+      })
+    )
   }
 
-  const handleGamePrompt = (promptPayload: PromptCompatPayload) => {
+  const handleGamePrompt = (promptPayload: unknown) => {
     const normalizedPrompt = normalizePromptPayload(promptPayload)
     if (!normalizedPrompt) {
       useGameStore.getState().setLastError(PROMPT_ID_REQUIRED_ERROR)

--- a/src/services/socket/gameContractAdapters.test.ts
+++ b/src/services/socket/gameContractAdapters.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from 'vitest'
+import {
+  normalizePatchEnvelopePayload,
+  normalizePromptPayload,
+  normalizeSnapshotPayload,
+} from './gameContractAdapters'
+
+describe('gameContractAdapters', () => {
+  it('normalizes prompt payload with canonical and legacy fields', () => {
+    const normalized = normalizePromptPayload({
+      id: 'legacy-prompt-id',
+      type: 'BUY_OR_SKIP',
+      timeoutMs: 4500,
+      choices: [
+        { value: 'buy' },
+        { id: 'skip-option', label: 'Skip', value: 'skip' },
+      ],
+      payload: { reason: 'test' },
+    })
+
+    expect(normalized).toMatchObject({
+      id: 'legacy-prompt-id',
+      type: 'BUY_OR_SKIP',
+      timeoutSec: 5,
+      payload: { reason: 'test' },
+    })
+    expect(normalized?.choices).toEqual([
+      {
+        id: 'buy-0',
+        label: 'BUY',
+        value: 'BUY',
+        description: undefined,
+      },
+      {
+        id: 'skip-option',
+        label: 'Skip',
+        value: 'SKIP',
+        description: undefined,
+      },
+    ])
+  })
+
+  it('normalizes canonical snapshot payload to internal snapshot shape', () => {
+    const normalized = normalizeSnapshotPayload(
+      {
+        gameId: 'game-1',
+        revision: 12,
+        phase: 'WAIT_PROMPT',
+        turn: 4,
+        currentPlayerId: 'player-2',
+        turnTimeoutSec: 20,
+        players: [
+          {
+            id: 'player-1',
+            nickname: 'alpha',
+            currentTileId: 7,
+            balance: 300,
+            ownedTiles: [2, 4],
+            playerState: 'LOCKED',
+            stateDuration: 2,
+            color: '#000000',
+          },
+        ],
+        tiles: [
+          {
+            index: 2,
+            name: 'Seoul',
+            ownerId: 'player-1',
+            buildingLevel: 3,
+            tileType: 'PROPERTY',
+            price: 50,
+          },
+        ],
+        prompt: {
+          promptId: 'prompt-1',
+          type: 'CONFIRM_ONLY',
+          timeoutSec: 10,
+          choices: [{ value: 'confirm' }],
+        },
+      },
+      {
+        envelopeRevision: 99,
+      }
+    )
+
+    expect(normalized).not.toBeNull()
+    expect(normalized).toMatchObject({
+      gameId: 'game-1',
+      revision: 12,
+      phase: 'prompt',
+      currentPlayerId: 'player-2',
+      currentTurn: 'player-2',
+      round: 4,
+      turnTimeoutSec: 20,
+    })
+    expect(normalized?.players[0]).toMatchObject({
+      id: 'player-1',
+      position: 7,
+      owned_tiles: [2, 4],
+      state: 'locked',
+      is_in_jail: true,
+      jail_turn_count: 2,
+    })
+    expect(normalized?.tiles[0]).toMatchObject({
+      index: 2,
+      ownerId: 'player-1',
+      owner_id: 'player-1',
+      building: 3,
+      type: 'property',
+      transportType: 'PROPERTY',
+    })
+    expect(normalized?.prompt).toMatchObject({
+      id: 'prompt-1',
+      timeoutSec: 10,
+      choices: [{ value: 'CONFIRM' }],
+    })
+  })
+
+  it('normalizes patch envelope paths and canonical values', () => {
+    const normalized = normalizePatchEnvelopePayload({
+      gameId: 'game-1',
+      revision: 33,
+      patch: [
+        {
+          op: 'set',
+          path: 'phase',
+          value: 'WAIT_ROLL',
+        },
+        {
+          op: 'set',
+          path: ['players', 0, 'playerState'],
+          value: 'BANKRUPT',
+        },
+        {
+          op: 'set',
+          path: 'players.0.ownedTiles',
+          value: [1, { tileId: 2 }],
+        },
+        {
+          op: 'set',
+          path: 'players.0.currentTileId',
+          value: 9,
+        },
+        {
+          op: 'set',
+          path: 'tiles.1.buildingLevel',
+          value: 99,
+        },
+        {
+          op: 'set',
+          path: 'tiles.1.tileType',
+          value: 'MOVE_TO_ISLAND',
+        },
+      ],
+      events: [],
+    })
+
+    expect(normalized.patch).toEqual([
+      {
+        op: 'set',
+        path: 'phase',
+        value: 'rolling',
+      },
+      {
+        op: 'set',
+        path: ['players', 0, 'state'],
+        value: 'bankrupt',
+      },
+      {
+        op: 'set',
+        path: 'players.0.owned_tiles',
+        value: [1, 2],
+      },
+      {
+        op: 'set',
+        path: 'players.0.position',
+        value: 9,
+      },
+      {
+        op: 'set',
+        path: 'tiles.1.building',
+        value: 7,
+      },
+      {
+        op: 'set',
+        path: 'tiles.1.type',
+        value: 'go_to_island',
+      },
+    ])
+  })
+})

--- a/src/services/socket/gameContractAdapters.ts
+++ b/src/services/socket/gameContractAdapters.ts
@@ -1,0 +1,502 @@
+import type {
+  GamePatchEnvelope,
+  GamePatchOperation,
+  GamePrompt,
+  GamePromptChoice,
+  GameSnapshot,
+  Player,
+  PlayerId,
+  Tile,
+} from '../../types/domain'
+
+type PromptCompatPayload = Partial<GamePrompt> & {
+  promptId?: string | null
+  timeoutMs?: number | null
+  payload?: Record<string, unknown>
+}
+
+type SnapshotNormalizeOptions = {
+  envelopeRevision: number
+  envelopeGameId?: string | null
+}
+
+const DEFAULT_TURN_TIMEOUT_SEC = 30
+const DEFAULT_PLAYER_COLOR = '#94A3B8'
+
+const PHASE_TO_INTERNAL_MAP: Record<string, GameSnapshot['phase']> = {
+  WAIT_ROLL: 'rolling',
+  MOVING: 'moving',
+  RESOLVING: 'resolving',
+  WAIT_PROMPT: 'prompt',
+  TURN_END: 'resolving',
+  GAME_OVER: 'finished',
+}
+
+const TILE_TYPE_TO_INTERNAL_MAP: Record<string, Tile['type']> = {
+  START: 'start',
+  PROPERTY: 'property',
+  EVENT: 'event',
+  CHANCE: 'chance',
+  MOVE_TO_ISLAND: 'go_to_island',
+  ISLAND: 'island',
+}
+
+const PLAYER_STATE_TO_INTERNAL_MAP: Record<string, Player['state']> = {
+  NORMAL: 'normal',
+  LOCKED: 'locked',
+  BANKRUPT: 'bankrupt',
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null
+
+const toFiniteNumber = (value: unknown): number | null => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value
+  }
+
+  if (typeof value === 'string' && value.trim().length > 0) {
+    const parsed = Number.parseFloat(value)
+    if (Number.isFinite(parsed)) {
+      return parsed
+    }
+  }
+
+  return null
+}
+
+const toFiniteInt = (value: unknown, fallback = 0) => {
+  const numericValue = toFiniteNumber(value)
+  if (numericValue == null) {
+    return fallback
+  }
+
+  return Math.trunc(numericValue)
+}
+
+const toStringOrNull = (value: unknown): string | null =>
+  typeof value === 'string' && value.trim().length > 0 ? value : null
+
+const toPlayerIdOrNull = (value: unknown): PlayerId | null => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.trunc(value)
+  }
+
+  if (typeof value === 'string' && value.trim().length > 0) {
+    return value
+  }
+
+  return null
+}
+
+const toPlayerId = (value: unknown, fallback: PlayerId): PlayerId =>
+  toPlayerIdOrNull(value) ?? fallback
+
+const normalizeTileType = (value: unknown): Tile['type'] => {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    return 'event'
+  }
+
+  const normalized = value.trim().toUpperCase()
+  if (normalized in TILE_TYPE_TO_INTERNAL_MAP) {
+    return TILE_TYPE_TO_INTERNAL_MAP[normalized]
+  }
+
+  const lowered = normalized.toLowerCase()
+  return lowered as Tile['type']
+}
+
+const normalizeTransportTileType = (value: unknown): Tile['transportType'] => {
+  if (typeof value !== 'string') {
+    return undefined
+  }
+
+  const normalized = value.trim().toUpperCase()
+  if (normalized in TILE_TYPE_TO_INTERNAL_MAP) {
+    return normalized as Tile['transportType']
+  }
+
+  return undefined
+}
+
+export const normalizePlayerState = (value: unknown): Player['state'] => {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    return undefined
+  }
+
+  const normalized = value.trim().toUpperCase()
+  if (normalized in PLAYER_STATE_TO_INTERNAL_MAP) {
+    return PLAYER_STATE_TO_INTERNAL_MAP[normalized]
+  }
+
+  return normalized.toLowerCase() as Player['state']
+}
+
+export const normalizePhase = (phase: unknown): GameSnapshot['phase'] => {
+  if (typeof phase !== 'string') {
+    return 'waiting'
+  }
+
+  const normalizedPhase = phase.trim().toUpperCase()
+  return PHASE_TO_INTERNAL_MAP[normalizedPhase] ?? 'waiting'
+}
+
+export const normalizePromptChoiceValue = (choice: unknown): string =>
+  typeof choice === 'string' ? choice.trim().toUpperCase() : ''
+
+const normalizePromptChoice = (
+  choice: unknown,
+  fallbackIndex: number
+): GamePromptChoice | null => {
+  if (!isRecord(choice)) {
+    return null
+  }
+
+  const value = normalizePromptChoiceValue(
+    choice.value ?? choice.id ?? choice.label
+  )
+  if (!value) {
+    return null
+  }
+
+  const explicitId = toStringOrNull(choice.id)
+  const explicitLabel = toStringOrNull(choice.label)
+  const explicitDescription = toStringOrNull(choice.description)
+
+  return {
+    id: explicitId ?? `${value.toLowerCase()}-${fallbackIndex}`,
+    label: explicitLabel ?? value,
+    value,
+    description: explicitDescription ?? undefined,
+  }
+}
+
+export const normalizePromptPayload = (
+  promptPayload: unknown
+): GamePrompt | null => {
+  if (!isRecord(promptPayload)) {
+    return null
+  }
+
+  const promptCompatPayload = promptPayload as PromptCompatPayload
+  const promptIdCandidate =
+    (typeof promptCompatPayload.promptId === 'string' &&
+      promptCompatPayload.promptId) ||
+    (typeof promptCompatPayload.id === 'string' && promptCompatPayload.id) ||
+    null
+  const promptId = promptIdCandidate?.trim()
+
+  if (!promptId) {
+    return null
+  }
+
+  const payloadRecord =
+    promptCompatPayload.payload && isRecord(promptCompatPayload.payload)
+      ? promptCompatPayload.payload
+      : undefined
+
+  const timeoutSecFromPayload = toFiniteNumber(
+    payloadRecord ? payloadRecord.timeoutSec : undefined
+  )
+  const timeoutMsFromPayload = toFiniteNumber(
+    payloadRecord ? payloadRecord.timeoutMs : undefined
+  )
+  const timeoutSecDirect = toFiniteNumber(promptCompatPayload.timeoutSec)
+  const timeoutMsDirect = toFiniteNumber(promptCompatPayload.timeoutMs)
+
+  const timeoutSecRaw =
+    timeoutSecDirect ??
+    timeoutSecFromPayload ??
+    (timeoutMsDirect != null
+      ? Math.ceil(timeoutMsDirect / 1000)
+      : timeoutMsFromPayload != null
+        ? Math.ceil(timeoutMsFromPayload / 1000)
+        : null)
+  const timeoutSec =
+    timeoutSecRaw != null && timeoutSecRaw > 0 ? timeoutSecRaw : undefined
+
+  const normalizedChoices = Array.isArray(promptCompatPayload.choices)
+    ? promptCompatPayload.choices
+        .map((choice, index) => normalizePromptChoice(choice, index))
+        .filter((choice): choice is GamePromptChoice => choice !== null)
+    : undefined
+
+  return {
+    id: promptId,
+    type:
+      typeof promptCompatPayload.type === 'string' &&
+      promptCompatPayload.type.trim().length > 0
+        ? promptCompatPayload.type
+        : 'UNKNOWN_PROMPT',
+    playerId:
+      promptCompatPayload.playerId === undefined
+        ? null
+        : (promptCompatPayload.playerId ?? null),
+    title:
+      typeof promptCompatPayload.title === 'string' &&
+      promptCompatPayload.title.trim().length > 0
+        ? promptCompatPayload.title
+        : undefined,
+    message:
+      typeof promptCompatPayload.message === 'string' &&
+      promptCompatPayload.message.trim().length > 0
+        ? promptCompatPayload.message
+        : undefined,
+    timeoutSec,
+    choices: normalizedChoices,
+    payload: payloadRecord,
+  }
+}
+
+const normalizeOwnedTileIds = (value: unknown): number[] => {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value
+    .map((item) => {
+      if (typeof item === 'number') {
+        return Math.trunc(item)
+      }
+
+      if (isRecord(item)) {
+        return toFiniteInt(item.tileId, Number.NaN)
+      }
+
+      return Number.NaN
+    })
+    .filter((tileId) => Number.isFinite(tileId))
+}
+
+const normalizePlayerFromSnapshot = (
+  playerPayload: unknown,
+  fallbackIndex: number
+): Player => {
+  const playerRecord = isRecord(playerPayload) ? playerPayload : {}
+  const state = normalizePlayerState(
+    playerRecord.playerState ?? playerRecord.state
+  )
+  const stateDuration = toFiniteInt(
+    playerRecord.stateDuration ?? playerRecord.jail_turn_count,
+    0
+  )
+
+  return {
+    id: toPlayerId(playerRecord.id, fallbackIndex),
+    nickname:
+      toStringOrNull(playerRecord.nickname) ??
+      toStringOrNull(playerRecord.name) ??
+      `Player ${fallbackIndex + 1}`,
+    position: toFiniteInt(
+      playerRecord.position ??
+        playerRecord.currentTileId ??
+        playerRecord.tileId,
+      0
+    ),
+    balance: toFiniteInt(playerRecord.balance, 0),
+    owned_tiles: normalizeOwnedTileIds(
+      playerRecord.owned_tiles ?? playerRecord.ownedTiles
+    ),
+    is_in_jail:
+      Boolean(playerRecord.is_in_jail) ||
+      state === 'locked' ||
+      state === 'island',
+    jail_turn_count: stateDuration,
+    is_bankrupt: Boolean(playerRecord.is_bankrupt) || state === 'bankrupt',
+    state,
+    stateDuration,
+    color: toStringOrNull(playerRecord.color) ?? DEFAULT_PLAYER_COLOR,
+    avatar: toStringOrNull(playerRecord.avatar) ?? undefined,
+  }
+}
+
+const clampBuildingLevel = (value: unknown): Tile['building'] => {
+  const level = toFiniteInt(value, 0)
+  const clamped = Math.min(Math.max(level, 0), 7)
+  return clamped as Tile['building']
+}
+
+const normalizeTileFromSnapshot = (
+  tilePayload: unknown,
+  fallbackIndex: number
+): Tile => {
+  const tileRecord = isRecord(tilePayload) ? tilePayload : {}
+  const index = toFiniteInt(tileRecord.index ?? tileRecord.id, fallbackIndex)
+  const ownerId = tileRecord.ownerId ?? tileRecord.owner_id ?? null
+  const tileTypeRaw = tileRecord.tileType ?? tileRecord.type
+
+  return {
+    index,
+    ownerId: ownerId as Tile['ownerId'],
+    owner_id: ownerId as Tile['owner_id'],
+    building: clampBuildingLevel(
+      tileRecord.building ?? tileRecord.buildingLevel ?? 0
+    ),
+    name: toStringOrNull(tileRecord.name) ?? `Tile ${index}`,
+    type: normalizeTileType(tileTypeRaw),
+    transportType: normalizeTransportTileType(tileTypeRaw),
+    price: toFiniteNumber(tileRecord.price) ?? undefined,
+    color: toStringOrNull(tileRecord.color) ?? undefined,
+  }
+}
+
+export const normalizeSnapshotPayload = (
+  snapshotPayload: unknown,
+  options: SnapshotNormalizeOptions
+): GameSnapshot | null => {
+  if (!isRecord(snapshotPayload)) {
+    return null
+  }
+
+  const playersRaw = Array.isArray(snapshotPayload.players)
+    ? snapshotPayload.players
+    : []
+  const tilesRaw = Array.isArray(snapshotPayload.tiles)
+    ? snapshotPayload.tiles
+    : []
+  const currentPlayerId = toPlayerIdOrNull(
+    snapshotPayload.currentPlayerId ?? snapshotPayload.currentTurn ?? null
+  )
+  const roundFromTurn = toFiniteInt(snapshotPayload.turn, 1)
+
+  return {
+    roomId: toStringOrNull(snapshotPayload.roomId),
+    gameId:
+      toStringOrNull(snapshotPayload.gameId) ??
+      toStringOrNull(options.envelopeGameId) ??
+      null,
+    revision: toFiniteInt(snapshotPayload.revision, options.envelopeRevision),
+    phase: normalizePhase(snapshotPayload.phase),
+    players: playersRaw.map(normalizePlayerFromSnapshot),
+    tiles: tilesRaw.map(normalizeTileFromSnapshot),
+    currentPlayerId,
+    currentTurn: currentPlayerId,
+    round: toFiniteInt(snapshotPayload.round, roundFromTurn),
+    turnTimeoutSec: toFiniteInt(
+      snapshotPayload.turnTimeoutSec,
+      DEFAULT_TURN_TIMEOUT_SEC
+    ),
+    prompt: normalizePromptPayload(snapshotPayload.prompt),
+    gameResult:
+      snapshotPayload.gameResult && isRecord(snapshotPayload.gameResult)
+        ? (snapshotPayload.gameResult as GameSnapshot['gameResult'])
+        : null,
+    isGameOver: Boolean(snapshotPayload.isGameOver),
+    winnerId: (snapshotPayload.winnerId ?? null) as GameSnapshot['winnerId'],
+  }
+}
+
+const toPathSegments = (
+  path: GamePatchOperation['path']
+): Array<string | number> => {
+  if (Array.isArray(path)) {
+    return path
+  }
+
+  return path
+    .split('.')
+    .map((segment) =>
+      /^\d+$/.test(segment) ? Number.parseInt(segment, 10) : segment
+    )
+}
+
+const toPathLike = (
+  originalPath: GamePatchOperation['path'],
+  segments: Array<string | number>
+): GamePatchOperation['path'] => {
+  if (Array.isArray(originalPath)) {
+    return segments
+  }
+
+  return segments.map((segment) => String(segment)).join('.')
+}
+
+const normalizePathSegment = (segment: string | number): string | number => {
+  if (typeof segment !== 'string') {
+    return segment
+  }
+
+  if (segment === 'currentTileId') return 'position'
+  if (segment === 'playerState') return 'state'
+  if (segment === 'ownedTiles') return 'owned_tiles'
+  if (segment === 'buildingLevel') return 'building'
+  if (segment === 'tileType') return 'type'
+  return segment
+}
+
+const normalizePatchSetValue = (
+  pathSegments: Array<string | number>,
+  value: unknown
+) => {
+  const lastSegment = pathSegments[pathSegments.length - 1]
+  const firstSegment = pathSegments[0]
+
+  if (pathSegments.length === 1 && firstSegment === 'phase') {
+    return normalizePhase(value)
+  }
+
+  if (pathSegments.length === 1 && firstSegment === 'players') {
+    if (!Array.isArray(value)) {
+      return []
+    }
+    return value.map(normalizePlayerFromSnapshot)
+  }
+
+  if (pathSegments.length === 1 && firstSegment === 'tiles') {
+    if (!Array.isArray(value)) {
+      return []
+    }
+    return value.map(normalizeTileFromSnapshot)
+  }
+
+  if (lastSegment === 'state') {
+    return normalizePlayerState(value)
+  }
+
+  if (lastSegment === 'owned_tiles') {
+    return normalizeOwnedTileIds(value)
+  }
+
+  if (lastSegment === 'position') {
+    return toFiniteInt(value, 0)
+  }
+
+  if (lastSegment === 'building') {
+    return clampBuildingLevel(value)
+  }
+
+  if (lastSegment === 'type') {
+    return normalizeTileType(value)
+  }
+
+  return value
+}
+
+const normalizePatchOperation = (operation: GamePatchOperation) => {
+  const pathSegments = toPathSegments(operation.path).map(normalizePathSegment)
+  const path = toPathLike(operation.path, pathSegments)
+
+  if (operation.op === 'set') {
+    return {
+      ...operation,
+      path,
+      value: normalizePatchSetValue(pathSegments, operation.value),
+    } as GamePatchOperation
+  }
+
+  return {
+    ...operation,
+    path,
+  } as GamePatchOperation
+}
+
+export const normalizePatchEnvelopePayload = (
+  payload: GamePatchEnvelope
+): GamePatchEnvelope => ({
+  ...payload,
+  revision: toFiniteInt(payload.revision, 0),
+  patch: Array.isArray(payload.patch)
+    ? payload.patch.map(normalizePatchOperation)
+    : [],
+  events: Array.isArray(payload.events) ? payload.events : [],
+})


### PR DESCRIPTION
## 관련 이슈
> closes #이슈번호

---

## 작업 내용
> game socket 계약(canonical payload)과 FE 내부 상태 구조(legacy/internal shape) 사이 어댑터 레이어를 추가하고, game handler에서 단일 경로로 사용하도록 정리했습니다.

- `src/services/socket/gameContractAdapters.ts` 신규 추가
  - `game:prompt` 정규화
    - `promptId/id` 호환 처리
    - `timeoutSec/timeoutMs` 호환 처리
    - choice value canonical upper-case 정규화
  - `game:patch(snapshot)` 정규화
    - canonical snapshot 필드(`currentTileId`, `playerState`, `ownedTiles`, `buildingLevel`, `tileType`)를 내부 상태 필드로 매핑
  - `game:patch(patch)` 정규화
    - path 매핑(`currentTileId -> position`, `playerState -> state`, `ownedTiles -> owned_tiles`, `buildingLevel -> building`, `tileType -> type`)
    - set value 정규화(phase/state/building/type 등)

- `src/services/socket/game.handler.ts` 리팩터링
  - 기존 중복 normalize 로직 제거
  - snapshot/patch/prompt를 모두 어댑터 경유로 store 반영
  - 유효하지 않은 snapshot 수신 시 `INVALID_SNAPSHOT` 에러 처리 추가

- `src/services/socket/gameContractAdapters.test.ts` 신규 추가
  - prompt 호환 정규화 테스트
  - snapshot canonical -> internal 매핑 테스트
  - patch path/value 정규화 테스트

---

## 테스트/검증
- `npm run test -- src/services/socket/gameContractAdapters.test.ts src/mocks/handlers/game.handler.test.ts src/stores/game.store.test.ts`
- `npm run test -- src/components/board/gameBoardActionHandlers.test.ts src/hooks/game/useDiceRoll.test.ts`
- `npx eslint src/services/socket/game.handler.ts src/services/socket/gameContractAdapters.ts src/services/socket/gameContractAdapters.test.ts`
- `npm run build`
- pre-push gate 통과
  - `npm run lint`
  - `npm run test`
  - `npm run test:coverage`
  - `npm run e2e:ci`
  - `npm run build`

---

## 체크리스트
- [x] 불필요한 상수/함수 확인
- [x] 불필요한 console.log 제거
- [x] 간단 이슈 해결 완료
