### PR TITLE
fix: 마이페이지 배경과 전적 카드 아이콘 정리

### DIFF
--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, Gamepad2, Shield, Trophy } from 'lucide-react'
+import { ArrowLeft, Frown, Gamepad2, Trophy } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import { useRequireActiveSession } from '../features/auth/hooks/useRequireActiveSession'
 import { useAuthStore } from '../features/auth/store'
@@ -25,7 +25,7 @@ const myPageStatsCardMeta = [
   {
     key: 'losses' as const,
     label: '패배',
-    icon: Shield,
+    icon: Frown,
     iconClassName: 'text-[#ef4444]',
     iconBackgroundClassName: 'bg-[#fee2e2]',
   },

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -46,8 +46,18 @@ function MyPage() {
   const isGuest = session.isGuest
 
   return (
-    <div className="min-h-screen bg-ui-app-bg">
-      <header className="flex h-14 items-center border-b border-ui-border bg-ui-surface px-4 sm:px-6">
+    <div className="relative min-h-screen overflow-hidden bg-ui-app-bg">
+      <div className="pointer-events-none absolute inset-x-0 bottom-0 top-14">
+        <img
+          src="/LobbyPage_background.webp"
+          alt=""
+          aria-hidden="true"
+          className="absolute inset-0 h-full w-full object-cover object-center"
+        />
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_28%,rgba(255,255,255,0.34),transparent_30%),linear-gradient(180deg,rgba(250,248,240,0.38),rgba(250,248,240,0.5))]" />
+      </div>
+
+      <header className="relative flex h-14 items-center border-b border-ui-border bg-ui-surface px-4 sm:px-6">
         <button
           type="button"
           onClick={() => navigate('/lobby')}
@@ -62,7 +72,7 @@ function MyPage() {
         </button>
       </header>
 
-      <main className="mx-auto max-w-5xl px-4 py-8 sm:px-6">
+      <main className="relative mx-auto max-w-5xl px-4 py-8 sm:px-6">
         {isGuest ? (
           <section className="rounded-3xl border border-ui-border bg-ui-surface p-7 shadow-[0_12px_30px_rgba(15,23,42,0.08)]">
             <h2 className="text-xl font-bold text-ui-text-strong">


### PR DESCRIPTION
## 📌 관련 이슈

> closes #429

---

## 📝 작업 내용

> 마이페이지의 시각 톤을 로비와 맞추고, 전적 카드의 패배 아이콘을 더 자연스럽게 조정했습니다.

- 마이페이지 배경에 로비와 동일한 `LobbyPage_background.webp` 레이어와 오버레이를 적용해 화면 톤이 자연스럽게 이어지도록 정리했습니다.
- 기존 마이페이지 레이아웃과 카드 구조는 유지하고, 배경만 최소 범위로 보강했습니다.
- 전적 카드의 `패배` 아이콘을 `Shield`에서 `Frown`으로 변경해 현재 화면 분위기와 의미가 더 자연스럽게 보이도록 조정했습니다.

### 검증

- 각 커밋에서 `lint-staged` 통과
- `npm run lint -- src/pages/MyPage.tsx`

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

<img width="1912" height="1242" alt="스크린샷 2026-03-17 오전 10 33 05" src="https://github.com/user-attachments/assets/9741cdcc-3035-496f-980a-d47cc789b7de" />

## 📌 추가 메모

- PR 범위에는 로컬 환경 파일(`.env.development`, `.env.development.real`)과 임시 task 문서를 포함하지 않습니다.
