### PR TITLE
fix: 새로고침과 로비 복귀 시 접속자 목록 상태 동기화 보정

### DIFF
--- a/src/features/presence/useOnlineUsersSocket.test.tsx
+++ b/src/features/presence/useOnlineUsersSocket.test.tsx
@@ -160,6 +160,48 @@ describe('useOnlineUsersSocket', () => {
     })
   })
 
+  it('disconnect 이벤트는 재연결 대기 상태로 취급하고 즉시 에러로 표시하지 않는다', async () => {
+    getOnlineUsersSnapshotMock.mockResolvedValue([
+      createOnlineUserPayloadFixture({
+        id: 'user-4',
+        nickname: 'WaitingRoom',
+        status: 'in_room',
+      }),
+    ])
+
+    const { result } = renderHook(() => useOnlineUsersSocket())
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    act(() => {
+      emitSocketEvent(socketOnMock, 'disconnect', undefined)
+    })
+
+    expect(result.current.isError).toBe(false)
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.data).toHaveLength(1)
+  })
+
+  it('connect_error 이벤트도 일시 재연결 경계로 취급하고 에러 문구를 띄우지 않는다', async () => {
+    getOnlineUsersSnapshotMock.mockResolvedValue([])
+
+    const { result } = renderHook(() => useOnlineUsersSocket())
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    act(() => {
+      emitSocketEvent(socketOnMock, 'connect_error', undefined)
+    })
+
+    expect(result.current.isError).toBe(false)
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.data).toEqual([])
+  })
+
   it('refresh request 이벤트 수신 시 최신 REST snapshot으로 다시 동기화한다', async () => {
     getOnlineUsersSnapshotMock.mockResolvedValueOnce([]).mockResolvedValueOnce([
       createOnlineUserPayloadFixture({

--- a/src/features/presence/useOnlineUsersSocket.ts
+++ b/src/features/presence/useOnlineUsersSocket.ts
@@ -28,6 +28,7 @@ export function useOnlineUsersSocket() {
   useEffect(() => {
     let isActive = true
     let latestSnapshotRequestId = 0
+    let latestUsersCount = 0
 
     async function syncOnlineUsersSnapshot() {
       const requestId = latestSnapshotRequestId + 1
@@ -39,7 +40,9 @@ export function useOnlineUsersSocket() {
           return
         }
 
-        setUsers(mapOnlineUsersToViewModel(payloadUsers))
+        const nextUsers = mapOnlineUsersToViewModel(payloadUsers)
+        latestUsersCount = nextUsers.length
+        setUsers(nextUsers)
         setIsLoading(false)
         setIsError(false)
       } catch {
@@ -58,23 +61,23 @@ export function useOnlineUsersSocket() {
         return
       }
 
-      setUsers(
-        mapOnlineUsersToViewModel(
-          normalizeOnlineUsersPayload(readOnlineUsersEventPayloadUsers(payload))
-        )
+      const nextUsers = mapOnlineUsersToViewModel(
+        normalizeOnlineUsersPayload(readOnlineUsersEventPayloadUsers(payload))
       )
+      latestUsersCount = nextUsers.length
+      setUsers(nextUsers)
       setIsLoading(false)
       setIsError(false)
     }
 
-    // 소켓 연결 오류를 에러 상태로 반영
+    // 새로고침/재인증 경계의 connect_error는 일시 상태일 수 있어 즉시 hard error로 노출하지 않는다.
     const handleConnectError = () => {
       if (!isActive) {
         return
       }
 
       setIsLoading(false)
-      setIsError(true)
+      setIsError(false)
     }
 
     // 실제 연결 성공 뒤 최신 snapshot을 다시 읽어 현재 사용자 포함 여부를 맞춘다
@@ -95,13 +98,16 @@ export function useOnlineUsersSocket() {
       void syncOnlineUsersSnapshot()
     }
 
-    // 연결 종료 상태를 에러로 표시
+    // 새로고침/재연결 중 disconnect는 hard error 대신 재동기화 대기 상태로 처리
     const handleDisconnect = () => {
       if (!isActive) {
         return
       }
 
-      setIsError(true)
+      if (latestUsersCount === 0) {
+        setIsLoading(true)
+      }
+      setIsError(false)
     }
 
     socket.on(ONLINE_USERS_EVENT_NAME, handleOnlineUsers)

--- a/src/pages/lobby/LobbyPage.test.tsx
+++ b/src/pages/lobby/LobbyPage.test.tsx
@@ -263,6 +263,29 @@ describe('LobbyPage filter and toggle regression', () => {
     ).toBeInTheDocument()
   })
 
+  it('현재 사용자가 접속자 스냅샷에 없어도 로비 접속자로 보정한다', () => {
+    useOnlineUsersSocketMock.mockReturnValue({
+      data: [
+        createOnlineUserFixture({
+          id: 'user-2',
+          nickname: '상대방',
+          status: 'in_room',
+          avatarText: '상',
+          avatarBackground: '#fde68a',
+        }),
+      ],
+      isLoading: false,
+      isError: false,
+    })
+
+    renderLobbyPage()
+
+    expect(screen.getAllByText('테스터').length).toBeGreaterThan(0)
+    expect(screen.getByText('상대방')).toBeInTheDocument()
+    expect(screen.getByText('2명')).toBeInTheDocument()
+    expect(screen.getByText('로비')).toBeInTheDocument()
+  })
+
   it('비밀방 입장하기 클릭 시 비밀번호 모달이 열리고 성공하면 대기방 이동이 호출된다', async () => {
     const user = userEvent.setup()
     renderLobbyPage()

--- a/src/pages/lobby/LobbyPage.tsx
+++ b/src/pages/lobby/LobbyPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { AnimatePresence } from 'framer-motion'
 import toast from 'react-hot-toast'
 import { useNavigate } from 'react-router-dom'
@@ -13,6 +13,11 @@ import {
 import { UserListPanel } from '../../features/presence/components/UserListPanel'
 import { DirectMessagePanel } from '../../features/presence/components/DirectMessagePanel'
 import { DevPresenceControlPanel } from '../../features/presence/components/DevPresenceControlPanel'
+import {
+  getOnlineUserAvatarBackground,
+  getOnlineUserAvatarText,
+} from '../../features/presence/onlineUsersModel'
+import type { OnlineUser } from '../../features/presence/types'
 import { useOnlineUsersSocket } from '../../features/presence/useOnlineUsersSocket'
 import { useDirectMessageController } from '../../features/presence/useDirectMessageController'
 import {
@@ -71,6 +76,35 @@ function LobbyPage() {
     isError: isUsersError,
   } = useOnlineUsersSocket()
 
+  const lobbyUsers = useMemo(() => {
+    if (!session) {
+      return users
+    }
+
+    const usersById = new Map<string, OnlineUser>(
+      users.map((user) => [user.id, user])
+    )
+    const currentUser = usersById.get(session.userId)
+
+    if (currentUser) {
+      usersById.set(session.userId, {
+        ...currentUser,
+        nickname: session.nickname,
+        status: 'lobby',
+      })
+    } else {
+      usersById.set(session.userId, {
+        id: session.userId,
+        nickname: session.nickname,
+        status: 'lobby',
+        avatarText: getOnlineUserAvatarText(session.nickname),
+        avatarBackground: getOnlineUserAvatarBackground(session.userId),
+      })
+    }
+
+    return Array.from(usersById.values())
+  }, [session, users])
+
   const {
     dmTargetUser,
     directMessagesByUserId,
@@ -80,7 +114,7 @@ function LobbyPage() {
     sendDirectMessage,
   } = useDirectMessageController({
     session,
-    users,
+    users: lobbyUsers,
     onBlockedByPlaying: () => {
       toast.error('게임중인 유저에게는 DM을 보낼 수 없습니다.')
     },
@@ -164,7 +198,7 @@ function LobbyPage() {
 
         <div className="xl:sticky xl:top-20 xl:self-start">
           <UserListPanel
-            users={users}
+            users={lobbyUsers}
             isLoading={isUsersLoading}
             isError={isUsersError}
             isOpen={isUserListOpen}
@@ -214,7 +248,10 @@ function LobbyPage() {
         ) : null}
       </AnimatePresence>
 
-      <DevPresenceControlPanel users={users} currentUserId={session.userId} />
+      <DevPresenceControlPanel
+        users={lobbyUsers}
+        currentUserId={session.userId}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## 📌 관련 이슈

> closes #433 

---

## 📝 작업 내용

> 대기방 새로고침과 로비 복귀 경계에서 접속자 목록 상태가 잘못 보이던 문제를 정리했습니다.

### 1. 새로고침 중 접속자 목록 false error 완화

- `useOnlineUsersSocket`에서 `disconnect`와 `connect_error`를 새로고침/재연결 중의 일시 상태로 보고, 곧바로 `접속자 목록을 불러오지 못했습니다.`를 띄우지 않도록 조정했습니다.
- 기존 사용자 목록이 있으면 그대로 유지하고, 재연결 이후 최신 snapshot으로 다시 동기화되도록 했습니다.
- 관련 hook 테스트를 추가/보강해 재연결 경계에서 false error가 보이지 않는지 검증했습니다.

### 2. 로비 복귀 시 현재 사용자 누락 보정

- 대기방에서 뒤로가기로 로비에 복귀했을 때 `/users/online` snapshot 반영이 한 템포 늦더라도, 현재 세션 사용자는 로비 접속자로 즉시 보이도록 보정했습니다.
- 로비 접속자 목록/DM 소비 경로 모두 같은 보정된 사용자 목록을 사용하도록 맞췄습니다.
- 관련 로비 테스트를 추가해 현재 사용자가 snapshot에 없어도 목록에 보이는지 검증했습니다.

### 재현하던 문제

- 대기방 새로고침 시 접속자 목록에 `접속자 목록을 불러오지 못했습니다.`가 일시적으로 표시됨
- 대기방에서 뒤로가기로 로비에 복귀하면 현재 사용자가 접속자 목록에서 빠짐
- 새로고침해야 다시 보임

### 검증

- `npx vitest run src/features/presence/useOnlineUsersSocket.test.tsx`
- `npx vitest run src/pages/lobby/LobbyPage.test.tsx`
- `npm run lint -- src/features/presence/useOnlineUsersSocket.ts src/features/presence/useOnlineUsersSocket.test.tsx`
- `npm run lint -- src/pages/lobby/LobbyPage.tsx src/pages/lobby/LobbyPage.test.tsx`

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

> 시각 변경보다 새로고침/복귀 경계의 상태 보정이 중심이라 스크린샷은 생략했습니다.

## 📌 추가 메모

- 이번 작업은 접속자 목록 상태 보정 범위입니다.
- `room cleanup / stale membership`처럼 브라우저 강제 종료 후 서버 상태가 남는 문제는 별도 백엔드 이슈로 추적 중입니다.