### PR TITLE
refactor: 접속자 목록 보정 로직을 presence 경계로 정리

### DIFF
--- a/docs/ai/tasks/presence-user-merge-flow/checklist.md
+++ b/docs/ai/tasks/presence-user-merge-flow/checklist.md
@@ -1,0 +1,24 @@
+# Checklist
+
+## Implementation
+
+- [x] 관련 manual과 기존 문서를 읽었다
+- [x] 로비용 현재 사용자 보정 로직을 `presence` helper로 옮겼다
+- [x] 대기방용 `room.players` 상태 보정 로직을 `presence` helper로 옮겼다
+- [x] `LobbyPage`는 helper 결과만 사용하도록 정리했다
+- [x] `WaitingRoomPage`는 helper 결과만 사용하도록 정리했다
+- [x] helper 이름과 반환 형태가 기존 `OnlineUser` 규칙과 어긋나지 않게 정리했다
+
+## Testing
+
+- [x] `src/pages/lobby/LobbyPage.test.tsx`를 실행했다
+- [x] 필요 시 `src/pages/waiting-room/WaitingRoomPage.test.tsx`를 실행했다
+- [x] 필요 시 관련 presence 테스트를 실행했다
+- [x] `npm run lint` 또는 범위 lint를 실행했다
+
+## Review
+
+- [x] 페이지가 보정 로직보다 화면 조합 중심으로 더 읽히는지 확인했다
+- [x] helper 추출이 과도한 공통화가 아닌지 확인했다
+- [x] mock/real 경로에서 같은 사용자 경험을 유지하는지 확인했다
+- [x] 변경 파일 / 실행한 검증 / 남은 리스크를 정리했다

--- a/docs/ai/tasks/presence-user-merge-flow/context.md
+++ b/docs/ai/tasks/presence-user-merge-flow/context.md
@@ -1,0 +1,37 @@
+# Context
+
+## Current Behavior
+
+- 로비는 `/users/online` 결과에 현재 세션 사용자가 빠질 때, 페이지 내부에서 직접 `lobby` 상태로 보정하고 있다.
+- 대기방은 `/users/online` 결과와 `room.players`를 섞어 현재 room 참가자를 `in_room/playing` 상태로 직접 보정하고 있다.
+- 두 로직은 모두 “접속자 목록 최종 표시 모델 보정”이라는 같은 책임이지만, 현재는 각 페이지에 흩어져 있다.
+
+## Related Files
+
+- `src/features/presence/onlineUsersModel.ts`
+- `src/features/presence/types.ts`
+- `src/pages/lobby/LobbyPage.tsx`
+- `src/pages/waiting-room/WaitingRoomPage.tsx`
+- `src/pages/lobby/LobbyPage.test.tsx`
+- `src/pages/waiting-room/WaitingRoomPage.test.tsx`
+- `docs/ai/manuals/lobby.md`
+- `docs/ai/manuals/waiting-room.md`
+
+## Constraints
+
+- mock/real 모드 모두 같은 사용자 경험을 유지해야 한다.
+- `OnlineUser` 반환 형태와 기존 `useOnlineUsersSocket` 반환 형태는 유지한다.
+- DM 정책이나 unread badge 규칙은 건드리지 않는다.
+- 최근 회귀를 막기 위해 현재 사용자 누락 방지와 `room.players` 기반 보정은 동작을 바꾸지 않는다.
+
+## Decision Notes
+
+- 공통화는 “정말 함께 바뀌는가”가 확인되는 범위만 한다. 이번 작업은 status 보정 규칙이 로비와 대기방에서 함께 바뀌는 성격이므로 helper 추출 근거가 충분하다.
+- helper는 `presence` feature에 두고, 페이지에서는 source data와 session/room 정보를 넘겨 결과만 받는 형태가 가장 읽기 쉽다.
+- waiting-room lifecycle/socket/action 구조는 그대로 두고, user list 표시 모델 계산만 이동한다.
+
+## Open Risks
+
+- helper 추출 과정에서 로비와 대기방의 미세한 상태 규칙 차이를 과도하게 공통화하면 오히려 결합도가 올라갈 수 있다.
+- waiting-room은 `room.players`가 source of truth에 더 가깝고, 로비는 session 보정이 핵심이라, helper API를 너무 일반화하면 읽기 어려워질 수 있다.
+- 백엔드 room cleanup 이슈는 이번 작업으로 해결되지 않는다.

--- a/docs/ai/tasks/presence-user-merge-flow/plan.md
+++ b/docs/ai/tasks/presence-user-merge-flow/plan.md
@@ -1,0 +1,52 @@
+# Plan
+
+## Task
+
+- 작업 이름: 접속자 목록 보정 로직 공통화
+- 요청 날짜: 2026-03-17
+- 담당 범위: lobby / waiting-room / presence user merge helper
+
+## Goal
+
+- 로비와 대기방이 각자 직접 계산하는 접속자 목록 보정 로직을 `presence` feature helper로 이동한다.
+- 페이지 컴포넌트는 보정 규칙 자체보다 화면 조합에 집중하도록 정리한다.
+- 현재 사용자 누락, `room.players` 기반 상태 보정 같은 최근 회귀 방지 로직은 유지한다.
+
+## In Scope
+
+- `src/features/presence/**`에 online user merge helper 추가 또는 기존 model 확장
+- 로비의 현재 사용자 `lobby` 상태 보정 로직 이전
+- 대기방의 `room.players` 기반 `in_room/playing` 상태 보정 로직 이전
+- 로비/대기방이 helper 결과만 소비하도록 단순화
+- 관련 Vitest 보강
+
+## Out Of Scope
+
+- `useOnlineUsersSocket` reconnect/error 정책 재수정
+- room cleanup / stale membership 서버 이슈 대응
+- DM unread 정책 변경
+- waiting-room leave/start lifecycle 구조 변경
+
+## Target Files
+
+- `src/features/presence/onlineUsersModel.ts`
+- 필요 시 `src/features/presence/types.ts`
+- `src/pages/lobby/LobbyPage.tsx`
+- `src/pages/waiting-room/WaitingRoomPage.tsx`
+- `src/pages/lobby/LobbyPage.test.tsx`
+- 필요 시 `src/pages/waiting-room/WaitingRoomPage.test.tsx`
+
+## Completion Criteria
+
+- 로비와 대기방 모두 접속자 목록 보정 규칙을 page inline 로직이 아니라 `presence` helper를 통해 계산한다.
+- 현재 사용자 누락 방지와 waiting-room player 상태 보정이 기존과 동일하게 유지된다.
+- 페이지 파일은 보정 규칙보다 화면 조합이 더 먼저 보이도록 단순화된다.
+- 관련 Vitest와 최소 lint가 통과한다.
+
+## Test Plan
+
+- 최소 실행 테스트
+  - `npx vitest run src/pages/lobby/LobbyPage.test.tsx`
+- 추가 검증
+  - 필요 시 `npx vitest run src/pages/waiting-room/WaitingRoomPage.test.tsx`
+  - `npm run lint -- src/pages/lobby/LobbyPage.tsx src/pages/waiting-room/WaitingRoomPage.tsx src/features/presence/onlineUsersModel.ts`

--- a/src/features/presence/onlineUsersModel.test.ts
+++ b/src/features/presence/onlineUsersModel.test.ts
@@ -3,7 +3,10 @@ import {
   getOnlineUserAvatarBackground,
   getOnlineUserAvatarText,
   mapOnlineUsersToViewModel,
+  mergeOnlineUsersWithCurrentUser,
+  mergeOnlineUsersWithRoomPlayers,
 } from './onlineUsersModel'
+import { createOnlineUserFixture } from '../../test/fixtures'
 
 describe('getOnlineUserAvatarText', () => {
   it('앞뒤 공백을 제거한 닉네임 첫 글자를 대문자로 반환한다', () => {
@@ -46,5 +49,77 @@ describe('mapOnlineUsersToViewModel', () => {
     })
     expect(mapped[0].avatarBackground).toBeTruthy()
     expect(mapped[1].avatarBackground).toBeTruthy()
+  })
+})
+
+describe('mergeOnlineUsersWithCurrentUser', () => {
+  it('현재 사용자가 snapshot에 없으면 lobby 상태로 추가한다', () => {
+    const merged = mergeOnlineUsersWithCurrentUser(
+      [
+        createOnlineUserFixture({
+          id: 'user-2',
+          nickname: '상대방',
+          status: 'in_room',
+        }),
+      ],
+      {
+        id: 'user-1',
+        nickname: '테스터',
+        status: 'lobby',
+      }
+    )
+
+    expect(merged).toHaveLength(2)
+    expect(merged).toContainEqual(
+      expect.objectContaining({
+        id: 'user-1',
+        nickname: '테스터',
+        status: 'lobby',
+        avatarText: '테',
+      })
+    )
+  })
+})
+
+describe('mergeOnlineUsersWithRoomPlayers', () => {
+  it('room.players 기준으로 참가자 상태와 닉네임을 덮어쓴다', () => {
+    const merged = mergeOnlineUsersWithRoomPlayers(
+      [
+        createOnlineUserFixture({
+          id: 'user-1',
+          nickname: '이전닉네임',
+          status: 'lobby',
+          avatarText: '이',
+        }),
+        createOnlineUserFixture({
+          id: 'user-2',
+          nickname: '상대방',
+          status: 'lobby',
+        }),
+      ],
+      [
+        {
+          id: 'user-1',
+          nickname: '방장',
+        },
+      ],
+      'in_room'
+    )
+
+    expect(merged).toContainEqual(
+      expect.objectContaining({
+        id: 'user-1',
+        nickname: '방장',
+        status: 'in_room',
+        avatarText: '방',
+      })
+    )
+    expect(merged).toContainEqual(
+      expect.objectContaining({
+        id: 'user-2',
+        nickname: '상대방',
+        status: 'lobby',
+      })
+    )
   })
 })

--- a/src/features/presence/onlineUsersModel.ts
+++ b/src/features/presence/onlineUsersModel.ts
@@ -14,13 +14,69 @@ export function getOnlineUserAvatarBackground(userId: string) {
   return getAvatarBackgroundColor(userId)
 }
 
+function createOnlineUserViewModel(user: OnlineUserPayload): OnlineUser {
+  return {
+    ...user,
+    avatarText: getOnlineUserAvatarText(user.nickname),
+    avatarBackground: getOnlineUserAvatarBackground(user.id),
+  }
+}
+
 // 접속자 payload를 UI 전용 접속자 모델로 매핑
 export function mapOnlineUsersToViewModel(
   payloadUsers: OnlineUserPayload[]
 ): OnlineUser[] {
-  return payloadUsers.map((user) => ({
-    ...user,
-    avatarText: getOnlineUserAvatarText(user.nickname),
-    avatarBackground: getOnlineUserAvatarBackground(user.id),
-  }))
+  return payloadUsers.map((user) => createOnlineUserViewModel(user))
+}
+
+// 현재 사용자가 snapshot에 없더라도 원하는 상태로 보정한 접속자 목록을 반환
+export function mergeOnlineUsersWithCurrentUser(
+  users: OnlineUser[],
+  currentUser: {
+    id: string
+    nickname: string
+    status: OnlineUserPayload['status']
+  }
+) {
+  const usersById = new Map<string, OnlineUser>(
+    users.map((user) => [user.id, user])
+  )
+
+  usersById.set(
+    currentUser.id,
+    createOnlineUserViewModel({
+      id: currentUser.id,
+      nickname: currentUser.nickname,
+      status: currentUser.status,
+    })
+  )
+
+  return Array.from(usersById.values())
+}
+
+// room.players를 기준으로 현재 방 참가자의 상태를 접속자 목록에 반영한다
+export function mergeOnlineUsersWithRoomPlayers(
+  users: OnlineUser[],
+  players: Array<{
+    id: string
+    nickname: string
+  }>,
+  status: Extract<OnlineUserPayload['status'], 'in_room' | 'playing'>
+) {
+  const usersById = new Map<string, OnlineUser>(
+    users.map((user) => [user.id, user])
+  )
+
+  players.forEach((player) => {
+    usersById.set(
+      player.id,
+      createOnlineUserViewModel({
+        id: player.id,
+        nickname: player.nickname,
+        status,
+      })
+    )
+  })
+
+  return Array.from(usersById.values())
 }

--- a/src/pages/lobby/LobbyPage.tsx
+++ b/src/pages/lobby/LobbyPage.tsx
@@ -13,11 +13,7 @@ import {
 import { UserListPanel } from '../../features/presence/components/UserListPanel'
 import { DirectMessagePanel } from '../../features/presence/components/DirectMessagePanel'
 import { DevPresenceControlPanel } from '../../features/presence/components/DevPresenceControlPanel'
-import {
-  getOnlineUserAvatarBackground,
-  getOnlineUserAvatarText,
-} from '../../features/presence/onlineUsersModel'
-import type { OnlineUser } from '../../features/presence/types'
+import { mergeOnlineUsersWithCurrentUser } from '../../features/presence/onlineUsersModel'
 import { useOnlineUsersSocket } from '../../features/presence/useOnlineUsersSocket'
 import { useDirectMessageController } from '../../features/presence/useDirectMessageController'
 import {
@@ -81,28 +77,11 @@ function LobbyPage() {
       return users
     }
 
-    const usersById = new Map<string, OnlineUser>(
-      users.map((user) => [user.id, user])
-    )
-    const currentUser = usersById.get(session.userId)
-
-    if (currentUser) {
-      usersById.set(session.userId, {
-        ...currentUser,
-        nickname: session.nickname,
-        status: 'lobby',
-      })
-    } else {
-      usersById.set(session.userId, {
-        id: session.userId,
-        nickname: session.nickname,
-        status: 'lobby',
-        avatarText: getOnlineUserAvatarText(session.nickname),
-        avatarBackground: getOnlineUserAvatarBackground(session.userId),
-      })
-    }
-
-    return Array.from(usersById.values())
+    return mergeOnlineUsersWithCurrentUser(users, {
+      id: session.userId,
+      nickname: session.nickname,
+      status: 'lobby',
+    })
   }, [session, users])
 
   const {

--- a/src/pages/waiting-room/WaitingRoomPage.tsx
+++ b/src/pages/waiting-room/WaitingRoomPage.tsx
@@ -16,11 +16,7 @@ import {
 } from '../../components/header/profileMenu'
 import { DirectMessagePanel } from '../../features/presence/components/DirectMessagePanel'
 import { UserListPanel } from '../../features/presence/components/UserListPanel'
-import {
-  getOnlineUserAvatarBackground,
-  getOnlineUserAvatarText,
-} from '../../features/presence/onlineUsersModel'
-import type { OnlineUser } from '../../features/presence/types'
+import { mergeOnlineUsersWithRoomPlayers } from '../../features/presence/onlineUsersModel'
 import { useOnlineUsersSocket } from '../../features/presence/useOnlineUsersSocket'
 import { useDirectMessageController } from '../../features/presence/useDirectMessageController'
 import { removeMockOnlineUser } from '../../features/presence/mockData'
@@ -127,33 +123,11 @@ function WaitingRoomPage() {
       return users
     }
 
-    const currentRoomStatus = room.status === 'playing' ? 'playing' : 'in_room'
-    const mergedUsersById = new Map<string, OnlineUser>(
-      users.map((user) => [user.id, user])
+    return mergeOnlineUsersWithRoomPlayers(
+      users,
+      room.players,
+      room.status === 'playing' ? 'playing' : 'in_room'
     )
-
-    room.players.forEach((player) => {
-      const existingUser = mergedUsersById.get(player.id)
-
-      if (existingUser) {
-        mergedUsersById.set(player.id, {
-          ...existingUser,
-          nickname: player.nickname,
-          status: currentRoomStatus,
-        })
-        return
-      }
-
-      mergedUsersById.set(player.id, {
-        id: player.id,
-        nickname: player.nickname,
-        status: currentRoomStatus,
-        avatarText: getOnlineUserAvatarText(player.nickname),
-        avatarBackground: getOnlineUserAvatarBackground(player.id),
-      })
-    })
-
-    return Array.from(mergedUsersById.values())
   }, [room, users])
 
   const {


### PR DESCRIPTION
## 📌 관련 이슈

> closes #436 

---

## 📝 작업 내용

> 로비와 대기방이 각각 직접 계산하던 접속자 목록 보정 로직을 `presence` feature helper로 정리했습니다.

### 1. presence helper 정리

- `src/features/presence/onlineUsersModel.ts`에 접속자 목록 보정 helper를 추가했습니다.
- 현재 사용자 누락 시 로비 접속자로 보정하는 `mergeOnlineUsersWithCurrentUser`를 추가했습니다.
- `room.players`를 기준으로 현재 방 참가자를 `in_room / playing` 상태로 보정하는 `mergeOnlineUsersWithRoomPlayers`를 추가했습니다.
- 관련 단위 테스트를 보강해 현재 사용자 추가와 waiting-room 참가자 상태 덮어쓰기 규칙을 검증했습니다.

### 2. 페이지 소비 단순화

- `LobbyPage`는 더 이상 현재 사용자 보정 로직을 직접 들고 있지 않고, presence helper 결과만 소비하도록 정리했습니다.
- `WaitingRoomPage`도 `room.players` 기반 상태 보정 로직을 직접 계산하지 않고, presence helper 결과만 사용하도록 바꿨습니다.
- 그 결과 페이지는 접속자 목록 표시 규칙보다 화면 조합과 액션 흐름이 더 먼저 읽히도록 정리됐습니다.

### 3. 작업 문서 추가

- 이번 리팩토링 범위와 목표, 검증 기준을 `docs/ai/tasks/presence-user-merge-flow/` 아래 `plan/context/checklist`로 기록했습니다.

### 검증

- `npx vitest run src/features/presence/onlineUsersModel.test.ts src/pages/lobby/LobbyPage.test.tsx src/pages/waiting-room/WaitingRoomPage.test.tsx`
- `npm run lint -- src/features/presence/onlineUsersModel.ts src/features/presence/onlineUsersModel.test.ts src/pages/lobby/LobbyPage.tsx src/pages/waiting-room/WaitingRoomPage.tsx`
- `npm run build`
- `npm run ai:self-review -- --files src/features/presence/onlineUsersModel.ts src/features/presence/onlineUsersModel.test.ts src/pages/lobby/LobbyPage.tsx src/pages/lobby/LobbyPage.test.tsx src/pages/waiting-room/WaitingRoomPage.tsx`
- `npm run ai:check:lobby`
- `npm run ai:check:waiting-room`

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

> UI 변경보다 로직 정리 중심의 리팩토링이라 스크린샷은 생략했습니다.

## 📌 추가 메모

- 이번 PR은 구조 개선이 목적이며, 사용자 기능/정책 변경은 없습니다.
- `room cleanup / stale membership` 같은 백엔드 이슈는 이번 범위와 별도입니다.
