### PR TITLE
refactor: useOnlineUsersSocket 흐름을 단계별 helper로 분리

### DIFF
--- a/docs/ai/tasks/online-users-socket-flow/checklist.md
+++ b/docs/ai/tasks/online-users-socket-flow/checklist.md
@@ -1,0 +1,24 @@
+# Checklist
+
+## Implementation
+
+- [x] 관련 manual과 기존 문서를 읽었다
+- [x] snapshot sync 로직을 작은 helper 또는 명확한 단계로 분리했다
+- [x] `online_users` 이벤트 처리와 상태 반영 경계를 드러나게 정리했다
+- [x] `connect`, `disconnect`, `connect_error` 정책 코드를 읽기 쉽게 정리했다
+- [x] refresh request 이벤트 처리 흐름을 정리했다
+- [x] 반환 형태와 mock/real 사용자 경험을 유지했다
+
+## Testing
+
+- [x] `src/features/presence/useOnlineUsersSocket.test.tsx`를 실행했다
+- [x] 필요 시 `src/features/presence/onlineUsersSocket.test.ts`를 실행했다
+- [x] `npm run lint` 또는 범위 lint를 실행했다
+- [x] 필요 시 `npm run build`를 실행했다
+
+## Review
+
+- [x] 핵심 흐름이 위에서 아래로 읽히는지 확인했다
+- [x] helper 분리로 시점 이동이 과도하게 늘지 않았는지 확인했다
+- [x] reconnect false error 정책이 의도대로 유지되는지 확인했다
+- [x] 변경 파일 / 실행한 검증 / 남은 리스크를 정리했다

--- a/docs/ai/tasks/online-users-socket-flow/context.md
+++ b/docs/ai/tasks/online-users-socket-flow/context.md
@@ -1,0 +1,35 @@
+# Context
+
+## Current Behavior
+
+- `useOnlineUsersSocket`는 초기 `/users/online` REST snapshot 조회와 `online_users` socket 이벤트 구독을 함께 담당한다.
+- 같은 훅 안에서 `connect`, `disconnect`, `connect_error`, window refresh request까지 같이 처리하고 있다.
+- 최근 새로고침/로비 복귀 문제를 수정하면서 reconnect false error 정책이 여기에 추가되어, 현재는 흐름 파악이 다소 어려운 상태다.
+
+## Related Files
+
+- `src/features/presence/useOnlineUsersSocket.ts`
+- `src/features/presence/useOnlineUsersSocket.test.tsx`
+- `src/features/presence/onlineUsersSocket.ts`
+- `src/features/presence/onlineUsersSocket.test.ts`
+- `src/features/presence/api.ts`
+- `docs/ai/manuals/lobby.md`
+
+## Constraints
+
+- `useOnlineUsersSocket`의 반환 형태는 유지해야 한다.
+- mock 모드와 real 모드의 visible behavior는 동일해야 한다.
+- reconnect 경계에서의 false error 완화 정책은 유지하되, 로직만 읽기 쉽게 정리한다.
+- snapshot source of truth는 여전히 `/users/online` + `online_users` 조합이다.
+
+## Decision Notes
+
+- 이번 작업은 정책 재정의가 아니라, 현재 정책을 더 작은 책임 단위로 나누는 리팩토링이다.
+- `connect_error`나 `disconnect`를 언제 hard error로 볼지에 대한 의미는 바꾸지 않고, 그 의도를 함수 이름/배치로 드러내는 쪽이 맞다.
+- `onlineUsersSocket.ts`는 socket 연결과 refresh event 이름 같은 transport 경계를 유지하고, `useOnlineUsersSocket.ts`는 state 조합 중심으로 읽히게 정리하는 방향이 적절하다.
+
+## Open Risks
+
+- reconnect 경계는 비동기 타이밍이 많아서, 작은 구조 변경도 테스트 없이 하면 회귀가 나기 쉽다.
+- helper 분리를 과도하게 하면 오히려 시점 이동이 늘어 읽기 어려워질 수 있다.
+- backend cleanup/stale membership 문제는 이 리팩토링으로 해결되지 않는다.

--- a/docs/ai/tasks/online-users-socket-flow/plan.md
+++ b/docs/ai/tasks/online-users-socket-flow/plan.md
@@ -1,0 +1,51 @@
+# Plan
+
+## Task
+
+- 작업 이름: useOnlineUsersSocket 책임 분리
+- 요청 날짜: 2026-03-17
+- 담당 범위: presence snapshot / socket / reconnect 흐름 정리
+
+## Goal
+
+- `useOnlineUsersSocket`가 동시에 들고 있는 초기 REST snapshot, socket 구독, reconnect 이벤트 처리, refresh request 처리를 읽기 쉬운 구조로 정리한다.
+- 현재 반환 형태(`{ data, isLoading, isError }`)와 사용자 경험은 유지하되, 이후 reconnect 정책 수정이 쉬운 형태로 바꾼다.
+- mock/real 모드 모두 현재와 같은 visible behavior를 유지한다.
+
+## In Scope
+
+- `useOnlineUsersSocket.ts` 내부 helper 함수 또는 작은 상태 전이 단위 분리
+- snapshot sync 흐름과 `online_users` 이벤트 반영 경계 명확화
+- `connect`, `disconnect`, `connect_error` 처리 의도 정리
+- refresh request 이벤트 처리 흐름 정리
+- 관련 테스트 보강 및 구조 정리
+
+## Out Of Scope
+
+- `/users/online` API contract 변경
+- 접속자 상태 보정 helper 정책 변경
+- DM 정책 또는 unread badge 규칙 변경
+- room cleanup / stale membership 서버 이슈 대응
+
+## Target Files
+
+- `src/features/presence/useOnlineUsersSocket.ts`
+- `src/features/presence/useOnlineUsersSocket.test.tsx`
+- 필요 시 `src/features/presence/onlineUsersSocket.ts`
+- 필요 시 `src/features/presence/onlineUsersSocket.test.ts`
+
+## Completion Criteria
+
+- `useOnlineUsersSocket`의 핵심 흐름이 위에서 아래로 자연스럽게 읽힌다.
+- snapshot / socket event / reconnect 처리 / refresh request가 서로 다른 책임으로 구분된다.
+- mock/real 분기와 기존 반환 형태는 유지된다.
+- 관련 Vitest, 최소 lint, 필요 시 build가 통과한다.
+
+## Test Plan
+
+- 최소 실행 테스트
+  - `npx vitest run src/features/presence/useOnlineUsersSocket.test.tsx`
+- 추가 검증
+  - 필요 시 `npx vitest run src/features/presence/onlineUsersSocket.test.ts`
+  - `npm run lint -- src/features/presence/useOnlineUsersSocket.ts src/features/presence/useOnlineUsersSocket.test.tsx`
+  - 필요 시 `npm run build`

--- a/src/features/presence/useOnlineUsersSocket.ts
+++ b/src/features/presence/useOnlineUsersSocket.ts
@@ -11,12 +11,77 @@ import {
 } from './onlineUsersSocket'
 import type { OnlineUser, OnlineUsersEventPayload } from './types'
 
+interface OnlineUsersSyncState {
+  latestSnapshotRequestId: number
+  latestUsersCount: number
+}
+
 function readOnlineUsersEventPayloadUsers(payload: unknown) {
   if (!payload || typeof payload !== 'object' || !('users' in payload)) {
     return []
   }
 
   return (payload as { users: unknown }).users
+}
+
+function createOnlineUsersSyncState(): OnlineUsersSyncState {
+  return {
+    latestSnapshotRequestId: 0,
+    latestUsersCount: 0,
+  }
+}
+
+function startSnapshotRequest(syncState: OnlineUsersSyncState) {
+  syncState.latestSnapshotRequestId += 1
+  return syncState.latestSnapshotRequestId
+}
+
+function isStaleSnapshotResult(
+  syncState: OnlineUsersSyncState,
+  requestId: number
+) {
+  return requestId !== syncState.latestSnapshotRequestId
+}
+
+function applyOnlineUsersState(
+  syncState: OnlineUsersSyncState,
+  nextUsers: OnlineUser[],
+  setUsers: (users: OnlineUser[]) => void,
+  setIsLoading: (isLoading: boolean) => void,
+  setIsError: (isError: boolean) => void
+) {
+  syncState.latestUsersCount = nextUsers.length
+  setUsers(nextUsers)
+  setIsLoading(false)
+  setIsError(false)
+}
+
+function mapOnlineUsersEventPayloadToViewModel(
+  payload: OnlineUsersEventPayload | unknown
+) {
+  return mapOnlineUsersToViewModel(
+    normalizeOnlineUsersPayload(readOnlineUsersEventPayloadUsers(payload))
+  )
+}
+
+function applyReconnectPendingState(
+  syncState: OnlineUsersSyncState,
+  setIsLoading: (isLoading: boolean) => void,
+  setIsError: (isError: boolean) => void
+) {
+  if (syncState.latestUsersCount === 0) {
+    setIsLoading(true)
+  }
+
+  setIsError(false)
+}
+
+function clearTransientSocketError(
+  setIsLoading: (isLoading: boolean) => void,
+  setIsError: (isError: boolean) => void
+) {
+  setIsLoading(false)
+  setIsError(false)
 }
 
 // 접속자 목록 소켓 구독과 로딩/에러 상태를 관리
@@ -27,27 +92,31 @@ export function useOnlineUsersSocket() {
 
   useEffect(() => {
     let isActive = true
-    let latestSnapshotRequestId = 0
-    let latestUsersCount = 0
+    const syncState = createOnlineUsersSyncState()
+
+    const applyNextUsers = (nextUsers: OnlineUser[]) => {
+      applyOnlineUsersState(
+        syncState,
+        nextUsers,
+        setUsers,
+        setIsLoading,
+        setIsError
+      )
+    }
 
     async function syncOnlineUsersSnapshot() {
-      const requestId = latestSnapshotRequestId + 1
-      latestSnapshotRequestId = requestId
+      const requestId = startSnapshotRequest(syncState)
 
       try {
         const payloadUsers = await getOnlineUsersSnapshot()
-        if (!isActive || requestId !== latestSnapshotRequestId) {
+        if (!isActive || isStaleSnapshotResult(syncState, requestId)) {
           return
         }
 
-        const nextUsers = mapOnlineUsersToViewModel(payloadUsers)
-        latestUsersCount = nextUsers.length
-        setUsers(nextUsers)
-        setIsLoading(false)
-        setIsError(false)
+        applyNextUsers(mapOnlineUsersToViewModel(payloadUsers))
       } catch {
         // REST 초기화 실패 시 소켓 실시간 수신으로 복구를 시도
-        if (!isActive || requestId !== latestSnapshotRequestId) {
+        if (!isActive || isStaleSnapshotResult(syncState, requestId)) {
           return
         }
 
@@ -61,13 +130,7 @@ export function useOnlineUsersSocket() {
         return
       }
 
-      const nextUsers = mapOnlineUsersToViewModel(
-        normalizeOnlineUsersPayload(readOnlineUsersEventPayloadUsers(payload))
-      )
-      latestUsersCount = nextUsers.length
-      setUsers(nextUsers)
-      setIsLoading(false)
-      setIsError(false)
+      applyNextUsers(mapOnlineUsersEventPayloadToViewModel(payload))
     }
 
     // 새로고침/재인증 경계의 connect_error는 일시 상태일 수 있어 즉시 hard error로 노출하지 않는다.
@@ -76,8 +139,7 @@ export function useOnlineUsersSocket() {
         return
       }
 
-      setIsLoading(false)
-      setIsError(false)
+      clearTransientSocketError(setIsLoading, setIsError)
     }
 
     // 실제 연결 성공 뒤 최신 snapshot을 다시 읽어 현재 사용자 포함 여부를 맞춘다
@@ -104,10 +166,7 @@ export function useOnlineUsersSocket() {
         return
       }
 
-      if (latestUsersCount === 0) {
-        setIsLoading(true)
-      }
-      setIsError(false)
+      applyReconnectPendingState(syncState, setIsLoading, setIsError)
     }
 
     socket.on(ONLINE_USERS_EVENT_NAME, handleOnlineUsers)


### PR DESCRIPTION
## 📌 관련 이슈

> closes #438 

---

## 📝 작업 내용

> `useOnlineUsersSocket` 내부에 섞여 있던 snapshot 동기화, 소켓 이벤트 반영, reconnect 정책 처리를 단계별 helper로 분리해 읽기 쉽고 수정 안전한 구조로 정리했습니다.

### 1. snapshot 동기화 책임 분리

- snapshot request id 증가와 stale response 판정을 별도 helper로 분리했습니다.
- 최신 snapshot만 상태에 반영되는 규칙이 훅 본문 밖에서도 바로 읽히도록 정리했습니다.
- users/isLoading/isError를 함께 적용하는 상태 반영 로직도 별도 helper로 묶었습니다.

### 2. socket 이벤트 처리 흐름 정리

- `online_users` 이벤트 payload를 view model로 변환하는 로직을 helper로 분리했습니다.
- reconnect 시 pending/loading 상태 처리와 일시적인 소켓 오류 정리 로직을 별도 helper로 정리했습니다.
- `connect`, `disconnect`, `connect_error` 정책이 effect 안에서 한눈에 읽히도록 구조를 단순화했습니다.

### 3. 사용자 정책 유지

- 기존 반환 형태(`{ data, isLoading, isError }`)는 그대로 유지했습니다.
- 새로고침/재연결 경계에서 `disconnect`, `connect_error`를 즉시 hard error로 보지 않는 현재 정책도 그대로 유지했습니다.
- mock/real 모드의 동작 의미는 바꾸지 않고, 내부 구조만 정리했습니다.

### 검증

- `npx vitest run src/features/presence/useOnlineUsersSocket.test.tsx src/features/presence/onlineUsersSocket.test.ts`
- `npm run lint -- src/features/presence/useOnlineUsersSocket.ts src/features/presence/useOnlineUsersSocket.test.tsx src/features/presence/onlineUsersSocket.ts src/features/presence/onlineUsersSocket.test.ts`
- `npm run build`
- `npm run ai:self-review -- --files src/features/presence/useOnlineUsersSocket.ts src/features/presence/useOnlineUsersSocket.test.tsx src/features/presence/onlineUsersSocket.ts src/features/presence/onlineUsersSocket.test.ts`
- `npm run ai:check:lobby`

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

> UI 변경이 아니라 내부 구조 정리 리팩토링이라 스크린샷은 생략했습니다.

## 📌 추가 메모

- 이번 PR은 기능 변경보다 구조 개선이 목적입니다.
- reconnect false error 정책 자체를 바꾸지 않고, 현재 정책을 읽기 쉽게 정리하는 데 집중했습니다.
- `room cleanup / stale membership` 같은 backend 이슈는 이번 범위와 별도입니다.
- PR 범위에는 로컬 `.env` 변경과 임시 task 문서를 포함하지 않습니다.
