### PR TITLE
Refactor :  gameStore.eventQueue 소비 트리거 보강 및 useBoardEventQueue 테스트 추가

### DIFF
--- a/src/components/board/useBoardEventQueue.test.tsx
+++ b/src/components/board/useBoardEventQueue.test.tsx
@@ -1,0 +1,147 @@
+import { renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useGameStore } from '../../stores/game.store'
+import type { PlayerState } from './board.constants'
+import { useBoardEventQueue } from './useBoardEventQueue'
+
+const playersRef: { current: PlayerState[] } = {
+  current: [
+    {
+      id: 1,
+      name: '플레이어1',
+      color: '#f00',
+      pos: 0,
+      money: 1000,
+      skipTurns: 0,
+    },
+    {
+      id: 2,
+      name: '플레이어2',
+      color: '#0f0',
+      pos: 0,
+      money: 1000,
+      skipTurns: 0,
+    },
+  ],
+}
+
+const setupHook = (enabled = true) => {
+  const setStatus = vi.fn()
+  const setDice1 = vi.fn()
+  const setDice2 = vi.fn()
+  const onEventAnimation = vi.fn()
+
+  renderHook(() =>
+    useBoardEventQueue({
+      enabled,
+      playersRef,
+      setStatus,
+      setDice1,
+      setDice2,
+      onEventAnimation,
+    })
+  )
+
+  return {
+    setStatus,
+    setDice1,
+    setDice2,
+    onEventAnimation,
+  }
+}
+
+describe('useBoardEventQueue', () => {
+  beforeEach(() => {
+    useGameStore.getState().resetGame()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers()
+    vi.useRealTimers()
+    useGameStore.getState().resetGame()
+  })
+
+  it('consumes queued events in order and applies dice/status/animation updates', () => {
+    useGameStore.getState().enqueueEvents([
+      {
+        type: 'DICE_ROLLED',
+        playerId: 1,
+        payload: { dice: [2, 5], total: 7 },
+      },
+      {
+        type: 'TURN_ENDED',
+        playerId: 1,
+      },
+    ])
+
+    const { setStatus, setDice1, setDice2, onEventAnimation } = setupHook()
+
+    expect(setDice1).toHaveBeenCalledWith(2)
+    expect(setDice2).toHaveBeenCalledWith(5)
+    expect(setStatus).toHaveBeenCalledWith(
+      expect.stringContaining('플레이어1님이 주사위를 굴렸습니다')
+    )
+    expect(onEventAnimation).toHaveBeenCalledWith('dice')
+    expect(useGameStore.getState().eventQueue).toHaveLength(1)
+
+    vi.advanceTimersByTime(420)
+
+    expect(setStatus).toHaveBeenCalledWith('플레이어1님 턴이 종료되었습니다.')
+    expect(onEventAnimation).toHaveBeenLastCalledWith('turn_end')
+    expect(useGameStore.getState().eventQueue).toHaveLength(0)
+  })
+
+  it('drains newly enqueued events after current consume delay finishes', () => {
+    useGameStore.getState().enqueueEvents([
+      {
+        type: 'PLAYER_MOVED',
+        playerId: 1,
+        tileIndex: 1,
+      },
+    ])
+
+    const { setStatus, onEventAnimation } = setupHook()
+    expect(setStatus).toHaveBeenCalledTimes(1)
+    expect(onEventAnimation).toHaveBeenCalledWith('move')
+
+    useGameStore.getState().enqueueEvents([
+      {
+        type: 'LANDED',
+        playerId: 1,
+        tileIndex: 1,
+      },
+    ])
+    expect(useGameStore.getState().eventQueue).toHaveLength(1)
+
+    vi.advanceTimersByTime(520)
+
+    expect(setStatus).toHaveBeenCalledTimes(2)
+    expect(setStatus).toHaveBeenLastCalledWith(
+      expect.stringContaining('플레이어1님이')
+    )
+    expect(setStatus).toHaveBeenLastCalledWith(
+      expect.stringContaining('칸에 도착했습니다.')
+    )
+    expect(onEventAnimation).toHaveBeenLastCalledWith('land')
+    expect(useGameStore.getState().eventQueue).toHaveLength(0)
+  })
+
+  it('does not consume events when disabled', () => {
+    useGameStore.getState().enqueueEvents([
+      {
+        type: 'DICE_ROLLED',
+        playerId: 1,
+        payload: { dice: [1, 1], total: 2 },
+      },
+    ])
+
+    const { setStatus, setDice1, setDice2, onEventAnimation } = setupHook(false)
+
+    expect(setStatus).not.toHaveBeenCalled()
+    expect(setDice1).not.toHaveBeenCalled()
+    expect(setDice2).not.toHaveBeenCalled()
+    expect(onEventAnimation).not.toHaveBeenCalled()
+    expect(useGameStore.getState().eventQueue).toHaveLength(1)
+  })
+})

--- a/src/components/board/useBoardEventQueue.ts
+++ b/src/components/board/useBoardEventQueue.ts
@@ -92,10 +92,17 @@ export function useBoardEventQueue({
     }
 
     const unsubscribe = useGameStore.subscribe((state, prevState) => {
-      if (
-        state.eventQueue.length === prevState.eventQueue.length ||
-        state.eventQueue.length <= 0
-      ) {
+      const hasQueueItems = state.eventQueue.length > 0
+      if (!hasQueueItems) {
+        return
+      }
+
+      const queueLengthChanged =
+        state.eventQueue.length !== prevState.eventQueue.length
+      const queueHeadChanged = state.eventQueue[0] !== prevState.eventQueue[0]
+      const queueReferenceChanged = state.eventQueue !== prevState.eventQueue
+
+      if (!queueLengthChanged && !queueHeadChanged && !queueReferenceChanged) {
         return
       }
 


### PR DESCRIPTION
## 📌 관련 이슈

> closes #410

---

## 📝 작업 내용

- `useBoardEventQueue`의 구독 트리거 조건을 보강했습니다.
- `eventQueue` 길이 변화뿐 아니라, 큐 헤드 변경/배열 참조 변경도 감지하도록 수정해 이벤트 소비 누락 가능성을 줄였습니다.
- `useBoardEventQueue` 훅 테스트를 신규 추가했습니다.
  - 큐 순차 소비(`DICE_ROLLED` → `TURN_ENDED`) 검증
  - 소비 지연 중 신규 enqueue 이벤트 후속 소비 검증
  - `enabled=false`일 때 이벤트 미소비 검증

검증:
- `npx vitest run src/components/board/useBoardEventQueue.test.tsx src/components/board/gameBoardEventQueueUtils.test.ts`
- pre-push 게이트 통과: `lint`, `test`, `test:coverage`, `e2e:ci`, `build`

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

- UI 변경 없음
