### PR TITLE
fix : GamePage Tailwind canonical 클래스 경고 2건 정리

### DIFF
--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -267,7 +267,7 @@ const GamePage: React.FC = () => {
         />
         <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_28%,rgba(255,255,255,0.34),transparent_30%),linear-gradient(180deg,rgba(250,248,240,0.38),rgba(250,248,240,0.5))]" />
       </div>
-      <div className="absolute left-6 top-6 z-[70]">
+      <div className="absolute left-6 top-6 z-70">
         <button
           type="button"
           aria-label="나가기"
@@ -277,7 +277,7 @@ const GamePage: React.FC = () => {
           <ArrowLeft size={20} />
         </button>
       </div>
-      <div className="absolute right-6 top-6 z-20 flex w-[340px] flex-col gap-2">
+      <div className="absolute right-6 top-6 z-20 flex w-85 flex-col gap-2">
         {isActionPending && (
           <div className="rounded-xl border border-[#BFDBFE] bg-[#EFF6FF] px-3 py-2 text-xs font-semibold text-[#1D4ED8]">
             Pending action: {pendingAction.type}


### PR DESCRIPTION
## 📌 관련 이슈

> closes #이슈번호

---

## 📝 작업 내용

- GamePage Tailwind canonical 클래스 경고 2건 수정
- `z-[70]` → `z-70`
- `w-[340px]` → `w-85`
- 동작 변경 없이 스타일 유틸 표기만 정리

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

- UI 변경 없음
