### PR TITLE
fix: 로그아웃과 세션 만료 시 접속자 목록 stale 상태 정리

### DIFF
--- a/docs/ai/tasks/socket-session-clear/checklist.md
+++ b/docs/ai/tasks/socket-session-clear/checklist.md
@@ -1,0 +1,18 @@
+# Checklist
+
+## Implementation
+
+- [x] 소켓 정리 helper를 추가했다
+- [x] 로비/대기방 로그아웃 경로에서 helper를 호출한다
+- [x] bootstrap/카카오 실패 경로에서도 helper를 호출한다
+
+## Testing
+
+- [x] `src/lib/socket.test.ts`
+- [x] `src/pages/lobby/LobbyPage.test.tsx`
+- [x] 관련 범위 lint
+
+## Review
+
+- [x] 세션 clear와 socket disconnect 책임이 섞이지 않는지 확인했다
+- [x] mock/real 모드에서 helper 의미가 같은지 확인했다

--- a/docs/ai/tasks/socket-session-clear/context.md
+++ b/docs/ai/tasks/socket-session-clear/context.md
@@ -1,0 +1,11 @@
+# Context
+
+## 배경
+
+- 현재 `clearSession()`은 zustand 세션만 지우고 socket.io 연결은 그대로 둔다.
+- 그 결과 다른 브라우저에서 접속자 목록을 볼 때, 로그아웃한 사용자가 잠시 또는 계속 online으로 남을 수 있다.
+
+## 판단
+
+- 이 문제는 백엔드 cleanup이 아니라 프론트 logout cleanup 경계로 설명된다.
+- 소켓 정리는 store 내부보다 `lib/socket` helper와 실제 세션 종료 경로에서 호출하는 방식이 현재 구조에 더 맞다.

--- a/docs/ai/tasks/socket-session-clear/plan.md
+++ b/docs/ai/tasks/socket-session-clear/plan.md
@@ -1,0 +1,21 @@
+# Plan
+
+## 목표
+
+- 세션 종료 시 소켓 연결과 auth 컨텍스트를 함께 정리한다.
+- 로그아웃 후 다른 클라이언트 접속자 목록에 stale online 상태가 남지 않게 한다.
+
+## 범위
+
+- `src/lib/socket.ts`
+- `src/pages/lobby/LobbyPage.tsx`
+- `src/pages/waiting-room/WaitingRoomPage.tsx`
+- `src/pages/KakaoLoginCallbackPage.tsx`
+- `src/features/auth/hooks/useAuthBootstrap.ts`
+- 관련 단위 테스트
+
+## 구현 단계
+
+1. 소켓 연결 종료 + auth 초기화 helper를 추가한다.
+2. 실제 세션 clear 경로에서 helper를 함께 호출한다.
+3. 로비 로그아웃 클릭 테스트와 socket helper 테스트를 추가한다.

--- a/src/features/auth/hooks/useAuthBootstrap.ts
+++ b/src/features/auth/hooks/useAuthBootstrap.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { restoreAuthSession, shouldClearAuthSession } from '../api'
 import { useAuthStore } from '../store'
+import { disconnectSocketAndClearAuth } from '../../../lib/socket'
 
 interface UseAuthBootstrapParams {
   skip?: boolean
@@ -79,6 +80,7 @@ export function useAuthBootstrap({
 
         if (shouldClearAuthSession(error)) {
           clearSession()
+          disconnectSocketAndClearAuth()
         }
       })
       .finally(() => {

--- a/src/lib/socket.test.ts
+++ b/src/lib/socket.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+interface MockSocket {
+  auth: Record<string, unknown>
+  connected: boolean
+  connect: ReturnType<typeof vi.fn>
+  disconnect: ReturnType<typeof vi.fn>
+}
+
+describe('socket helpers', () => {
+  afterEach(() => {
+    vi.resetModules()
+    vi.unstubAllEnvs()
+  })
+
+  it('disconnectSocketAndClearAuth는 auth를 비우고 연결 중이면 disconnect한다', async () => {
+    vi.resetModules()
+
+    const socket: MockSocket = {
+      auth: { token: 'session-token' },
+      connected: true,
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    }
+
+    vi.doMock('socket.io-client', () => ({
+      io: () => socket,
+    }))
+
+    const module = await import('./socket')
+
+    module.disconnectSocketAndClearAuth()
+
+    expect(socket.auth).toEqual({})
+    expect(socket.disconnect).toHaveBeenCalledTimes(1)
+  })
+
+  it('disconnectSocketAndClearAuth는 미연결 상태면 disconnect를 호출하지 않는다', async () => {
+    vi.resetModules()
+
+    const socket: MockSocket = {
+      auth: { token: 'session-token' },
+      connected: false,
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    }
+
+    vi.doMock('socket.io-client', () => ({
+      io: () => socket,
+    }))
+
+    const module = await import('./socket')
+
+    module.disconnectSocketAndClearAuth()
+
+    expect(socket.auth).toEqual({})
+    expect(socket.disconnect).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/socket.ts
+++ b/src/lib/socket.ts
@@ -42,3 +42,12 @@ export function connectSocketWithAuthIfNeeded() {
 
   socket.connect()
 }
+
+// 세션 종료 시 소켓 연결과 auth 컨텍스트를 함께 초기화
+export function disconnectSocketAndClearAuth() {
+  socket.auth = {}
+
+  if (socket.connected) {
+    socket.disconnect()
+  }
+}

--- a/src/pages/KakaoLoginCallbackPage.tsx
+++ b/src/pages/KakaoLoginCallbackPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { completeKakaoLogin, getAuthErrorMessage } from '../features/auth/api'
 import { useAuthStore } from '../features/auth/store'
+import { disconnectSocketAndClearAuth } from '../lib/socket'
 
 // 카카오 로그인 redirect query를 받아 세션 저장과 후속 이동을 처리
 function KakaoLoginCallbackPage() {
@@ -43,6 +44,7 @@ function KakaoLoginCallbackPage() {
         }
 
         clearSession()
+        disconnectSocketAndClearAuth()
         setErrorMessage(
           getAuthErrorMessage(error, '카카오 로그인 처리에 실패했습니다.')
         )

--- a/src/pages/lobby/LobbyPage.test.tsx
+++ b/src/pages/lobby/LobbyPage.test.tsx
@@ -18,6 +18,7 @@ const {
   useOnlineUsersSocketMock,
   useDirectMessageControllerMock,
   navigateMock,
+  disconnectSocketAndClearAuthMock,
   createWaitingRoomMock,
   getWaitingRoomErrorMessageMock,
   isJoinPasswordMismatchErrorMock,
@@ -27,6 +28,7 @@ const {
   useOnlineUsersSocketMock: vi.fn(),
   useDirectMessageControllerMock: vi.fn(),
   navigateMock: vi.fn(),
+  disconnectSocketAndClearAuthMock: vi.fn(),
   createWaitingRoomMock: vi.fn(),
   getWaitingRoomErrorMessageMock: vi.fn(),
   isJoinPasswordMismatchErrorMock: vi.fn(),
@@ -53,6 +55,10 @@ vi.mock('../../features/presence/useOnlineUsersSocket', () => ({
 
 vi.mock('../../features/presence/useDirectMessageController', () => ({
   useDirectMessageController: useDirectMessageControllerMock,
+}))
+
+vi.mock('../../lib/socket', () => ({
+  disconnectSocketAndClearAuth: disconnectSocketAndClearAuthMock,
 }))
 
 vi.mock('../waiting-room/api', () => ({
@@ -466,5 +472,17 @@ describe('LobbyPage filter and toggle regression', () => {
       '비밀번호 입력'
     ) as HTMLInputElement
     expect(reopenedPasswordInput.value).toBe('')
+  })
+
+  it('로그아웃 클릭 시 세션과 소켓 연결을 함께 정리한다', async () => {
+    const user = userEvent.setup()
+    renderLobbyPage()
+
+    await user.click(screen.getByRole('button', { name: '프로필 메뉴 열기' }))
+    await user.click(screen.getByRole('button', { name: '로그아웃' }))
+
+    expect(disconnectSocketAndClearAuthMock).toHaveBeenCalledTimes(1)
+    expect(navigateMock).toHaveBeenCalledWith('/', { replace: true })
+    expect(useAuthStore.getState().session).toBeNull()
   })
 })

--- a/src/pages/lobby/LobbyPage.tsx
+++ b/src/pages/lobby/LobbyPage.tsx
@@ -28,6 +28,7 @@ import { PrivateRoomJoinModal } from './PrivateRoomJoinModal'
 import { CreateRoomModal } from './CreateRoomModal'
 import { useLobbyRoomActions } from './useLobbyRoomActions'
 import { IS_SOCKET_MOCK_ENABLED } from '../../config/env'
+import { disconnectSocketAndClearAuth } from '../../lib/socket'
 
 // 로비 화면 상태 관리와 방/접속자/DM 상호작용 통합 처리
 function LobbyPage() {
@@ -114,6 +115,7 @@ function LobbyPage() {
     }
 
     clearSession()
+    disconnectSocketAndClearAuth()
     navigate('/', { replace: true })
   }
 

--- a/src/pages/waiting-room/WaitingRoomPage.tsx
+++ b/src/pages/waiting-room/WaitingRoomPage.tsx
@@ -21,6 +21,7 @@ import { useOnlineUsersSocket } from '../../features/presence/useOnlineUsersSock
 import { useDirectMessageController } from '../../features/presence/useDirectMessageController'
 import { removeMockOnlineUser } from '../../features/presence/mockData'
 import { cn } from '../../lib/utils'
+import { disconnectSocketAndClearAuth } from '../../lib/socket'
 import { IS_SOCKET_MOCK_ENABLED } from '../../config/env'
 import { WaitingRoomHeader } from './components/WaitingRoomHeader'
 import { WaitingSeatCard } from './components/WaitingSeatCard'
@@ -188,6 +189,7 @@ function WaitingRoomPage() {
     }
 
     clearSession()
+    disconnectSocketAndClearAuth()
     navigate('/', { replace: true })
   }, [clearSession, leaveRoom, navigate, session])
 


### PR DESCRIPTION
## 📌 관련 이슈

> closes #442 

---

## 📝 작업 내용

> 세션은 지워졌지만 socket 연결이 남아 있어 다른 클라이언트 접속자 목록에 사용자가 계속 보이던 문제를 수정했습니다.

### 1. 세션 종료용 socket cleanup 추가

- `src/lib/socket.ts`에 `disconnectSocketAndClearAuth()`를 추가했습니다.
- 이 helper는 socket auth payload를 비우고, 연결 중이면 `disconnect()`까지 수행합니다.
- 세션 종료와 socket 인증 컨텍스트 정리를 함께 다루되, store 내부에 넣지 않고 socket 경계에 유지했습니다.

### 2. 실제 세션 종료 경로 반영

- 로비 로그아웃 시 `clearSession()`과 함께 socket cleanup을 수행하도록 변경했습니다.
- 대기방 로그아웃 시에도 동일하게 socket cleanup을 수행하도록 맞췄습니다.
- 카카오 로그인 콜백 실패 시 세션 clear 후 socket cleanup을 추가했습니다.
- bootstrap 중 세션 복구 실패로 `clearSession()`이 일어나는 경우에도 socket cleanup을 함께 수행하도록 정리했습니다.

### 3. 회귀 테스트 추가

- `src/lib/socket.test.ts`에 socket cleanup helper 테스트를 추가했습니다.
- `src/pages/lobby/LobbyPage.test.tsx`에 로그아웃 클릭 시 세션과 socket이 함께 정리되는지 검증하는 테스트를 추가했습니다.

### 재현하던 문제

- 일반 브라우저와 시크릿 브라우저로 각각 로그인
- 한쪽에서 로그아웃
- 다른 쪽 접속자 목록에서 해당 사용자가 즉시 사라지지 않고 계속 남아 있음

### 기대 결과

- 로그아웃/세션 만료 시 socket 연결과 auth 컨텍스트가 함께 정리된다
- 다른 클라이언트 접속자 목록에서 해당 사용자가 즉시 사라진다

### 검증

- `npx vitest run src/lib/socket.test.ts src/pages/lobby/LobbyPage.test.tsx`
- `npm run lint -- src/lib/socket.ts src/lib/socket.test.ts src/pages/lobby/LobbyPage.tsx src/pages/lobby/LobbyPage.test.tsx src/pages/waiting-room/WaitingRoomPage.tsx src/pages/KakaoLoginCallbackPage.tsx src/features/auth/hooks/useAuthBootstrap.ts`
- `npm run build`

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

> UI 변경보다 세션 종료/소켓 cleanup 경계 수정이 중심이라 스크린샷은 생략했습니다.

## 📌 추가 메모

- 이번 수정은 `정상 로그아웃` 및 세션 만료 경계를 다룹니다.
- 브라우저 강제 종료 후 stale room/player가 남는 문제는 별도 backend cleanup 이슈로 추적 중입니다.
- PR 범위에는 로컬 `.env` 변경과 임시 task 문서를 포함하지 않습니다.
