### PR TITLE
Fix : mock 주사위 입력 경로 no-op 수정

### DIFF
--- a/src/hooks/game/useDiceRoll.test.ts
+++ b/src/hooks/game/useDiceRoll.test.ts
@@ -1,7 +1,5 @@
 import { act, renderHook } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type { RefObject } from 'react'
-import type { BoardGameHandle } from '../../components/board/GameBoard'
 
 type SetupOptions = {
   mockEnabled: boolean
@@ -55,13 +53,7 @@ describe('useDiceRoll', () => {
       socketConnected: true,
       currentTurn: 'player-1',
     })
-    const localRollDice = vi.fn()
-    const boardRef = {
-      current: {
-        rollDice: localRollDice,
-      },
-    } as RefObject<BoardGameHandle | null>
-    const { result } = renderHook(() => useDiceRoll(boardRef))
+    const { result } = renderHook(() => useDiceRoll())
 
     act(() => {
       result.current('game-1')
@@ -71,7 +63,6 @@ describe('useDiceRoll', () => {
       type: 'ROLL_DICE',
       gameId: 'game-1',
     })
-    expect(localRollDice).not.toHaveBeenCalled()
   })
 
   it('non-mock 모드에서 소켓 미연결이면 아무 동작도 하지 않는다', async () => {
@@ -80,20 +71,13 @@ describe('useDiceRoll', () => {
       socketConnected: false,
       currentTurn: 'player-1',
     })
-    const localRollDice = vi.fn()
-    const boardRef = {
-      current: {
-        rollDice: localRollDice,
-      },
-    } as RefObject<BoardGameHandle | null>
-    const { result } = renderHook(() => useDiceRoll(boardRef))
+    const { result } = renderHook(() => useDiceRoll())
 
     act(() => {
       result.current('game-1')
     })
 
     expect(emitGameAction).not.toHaveBeenCalled()
-    expect(localRollDice).not.toHaveBeenCalled()
   })
 
   it('non-mock 모드에서 currentTurn이 null이면 아무 동작도 하지 않는다', async () => {
@@ -102,41 +86,45 @@ describe('useDiceRoll', () => {
       socketConnected: true,
       currentTurn: null,
     })
-    const localRollDice = vi.fn()
-    const boardRef = {
-      current: {
-        rollDice: localRollDice,
-      },
-    } as RefObject<BoardGameHandle | null>
-    const { result } = renderHook(() => useDiceRoll(boardRef))
+    const { result } = renderHook(() => useDiceRoll())
 
     act(() => {
       result.current('game-1')
     })
 
     expect(emitGameAction).not.toHaveBeenCalled()
-    expect(localRollDice).not.toHaveBeenCalled()
   })
 
-  it('mock 모드에서는 로컬 rollDice를 실행한다', async () => {
+  it('mock 모드에서는 game:action(ROLL_DICE) 경로를 사용한다', async () => {
     const { useDiceRoll, emitGameAction } = await setupUseDiceRoll({
       mockEnabled: true,
       socketConnected: false,
       currentTurn: null,
     })
-    const localRollDice = vi.fn()
-    const boardRef = {
-      current: {
-        rollDice: localRollDice,
-      },
-    } as RefObject<BoardGameHandle | null>
-    const { result } = renderHook(() => useDiceRoll(boardRef))
+    const { result } = renderHook(() => useDiceRoll())
 
     act(() => {
       result.current('game-1')
     })
 
-    expect(localRollDice).toHaveBeenCalledTimes(1)
+    expect(emitGameAction).toHaveBeenCalledWith({
+      type: 'ROLL_DICE',
+      gameId: 'game-1',
+    })
+  })
+
+  it('gameId가 없으면 어떤 모드에서도 전송하지 않는다', async () => {
+    const { useDiceRoll, emitGameAction } = await setupUseDiceRoll({
+      mockEnabled: true,
+      socketConnected: true,
+      currentTurn: 'player-1',
+    })
+    const { result } = renderHook(() => useDiceRoll())
+
+    act(() => {
+      result.current(null)
+    })
+
     expect(emitGameAction).not.toHaveBeenCalled()
   })
 })

--- a/src/hooks/game/useDiceRoll.ts
+++ b/src/hooks/game/useDiceRoll.ts
@@ -1,5 +1,4 @@
-import { RefObject, useCallback } from 'react'
-import type { BoardGameHandle } from '../../components/board/GameBoard'
+import { useCallback } from 'react'
 import { IS_SOCKET_MOCK_ENABLED } from '../../config/env'
 import { socket } from '../../lib/socket'
 import { emitGameAction } from '../../services/socket/game.handler'
@@ -7,7 +6,7 @@ import { useGameStore } from '../../stores/game.store'
 
 const USE_GAME_SOCKET_MOCK = IS_SOCKET_MOCK_ENABLED
 
-export const useDiceRoll = (boardRef: RefObject<BoardGameHandle | null>) => {
+export const useDiceRoll = () => {
   const currentTurn = useGameStore((state) => state.currentTurn)
 
   return useCallback(
@@ -29,9 +28,12 @@ export const useDiceRoll = (boardRef: RefObject<BoardGameHandle | null>) => {
         return
       }
 
-      // Local roll is allowed only in socket-mock mode.
-      boardRef.current?.rollDice()
+      // Mock mode also goes through game:action to keep one contract path.
+      emitGameAction({
+        type: 'ROLL_DICE',
+        gameId,
+      })
     },
-    [boardRef, currentTurn]
+    [currentTurn]
   )
 }

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -220,7 +220,7 @@ const GamePage: React.FC = () => {
     })
   }
 
-  const diceRoll = useDiceRoll(boardRef)
+  const diceRoll = useDiceRoll()
 
   const maxMoney = Math.max(...boardPlayers.map((player) => player.money))
   const currentPlayerState = boardPlayers[boardCurPlayer]


### PR DESCRIPTION
## 📌 관련 이슈

> closes #이슈번호

---

## ✅ 작업 내용

- mock 모드 주사위 입력 경로를 `boardRef` 로컬 처리에서 `game:action(ROLL_DICE)` emit 경로로 통일
- `useDiceRoll(boardRef)` 시그니처를 `useDiceRoll()`로 단순화하고 `GamePage` 호출부 정리
- 테스트를 새 계약에 맞게 수정:
  - mock 모드에서 `emitGameAction` 호출 검증
  - `gameId`가 없으면 emit하지 않는 케이스 추가
- real socket 모드 가드(`socket.connected`, `currentTurn`)는 기존 동작 유지

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 `console.log` 제거
- [x] 관련 이슈 연결 완료

---

## 🖼️ 스크린샷 (선택)

> UI 변경 없음
