### PR TITLE
fix: 실서버 게임 주사위 송신 가드 수정 및 real env 전환 안정화

### DIFF
--- a/.env.development.real
+++ b/.env.development.real
@@ -1,6 +1,6 @@
 # 실백엔드 연결용 예시
-VITE_API_URL=http://localhost:3000/api
-VITE_SOCKET_URL=http://localhost:3000
+VITE_API_URL=http://13.209.49.56:8000/api
+VITE_SOCKET_URL=http://13.209.49.56:8000
 VITE_USE_SOCKET_MOCK=false
 VITE_ENABLE_DEMO_MOCK=false
 VITE_ALLOW_ALL_MOCK_TURNS=false

--- a/scripts/dev/switch-env.mjs
+++ b/scripts/dev/switch-env.mjs
@@ -5,6 +5,7 @@ import process from 'node:process'
 const mode = process.argv[2]
 const rootDir = process.cwd()
 const targetPath = path.join(rootDir, '.env.development')
+const localOverridePath = path.join(rootDir, '.env.development.local')
 
 const templates = {
   mock: path.join(rootDir, '.env.development.mock'),
@@ -39,6 +40,71 @@ async function showCurrentMode() {
   }
 }
 
+function parseBooleanFlag(content, key) {
+  const matched = content.match(new RegExp(`^${key}=(true|false)$`, 'm'))
+  return matched ? matched[1] : null
+}
+
+function upsertBooleanFlag(content, key, value) {
+  const nextLine = `${key}=${value}`
+  const pattern = new RegExp(`^${key}=.*$`, 'm')
+
+  if (pattern.test(content)) {
+    return content.replace(pattern, nextLine)
+  }
+
+  const suffix = content.endsWith('\n') || content.length === 0 ? '' : '\n'
+  return `${content}${suffix}${nextLine}\n`
+}
+
+async function syncLocalOverrideFlags(templateContent) {
+  try {
+    let localContent = await fs.readFile(localOverridePath, 'utf8')
+    const useSocketMock = parseBooleanFlag(templateContent, 'VITE_USE_SOCKET_MOCK')
+    const enableDemoMock = parseBooleanFlag(
+      templateContent,
+      'VITE_ENABLE_DEMO_MOCK'
+    )
+    const allowAllMockTurns = parseBooleanFlag(
+      templateContent,
+      'VITE_ALLOW_ALL_MOCK_TURNS'
+    )
+
+    if (useSocketMock !== null) {
+      localContent = upsertBooleanFlag(
+        localContent,
+        'VITE_USE_SOCKET_MOCK',
+        useSocketMock
+      )
+    }
+
+    if (enableDemoMock !== null) {
+      localContent = upsertBooleanFlag(
+        localContent,
+        'VITE_ENABLE_DEMO_MOCK',
+        enableDemoMock
+      )
+    }
+
+    if (allowAllMockTurns !== null) {
+      localContent = upsertBooleanFlag(
+        localContent,
+        'VITE_ALLOW_ALL_MOCK_TURNS',
+        allowAllMockTurns
+      )
+    }
+
+    await fs.writeFile(localOverridePath, localContent)
+    console.log(`Synced .env.development.local mock flags -> ${mode}`)
+  } catch (error) {
+    if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+      return
+    }
+
+    throw error
+  }
+}
+
 if (!mode || !['mock', 'real', 'show'].includes(mode)) {
   console.error('Usage: node scripts/dev/switch-env.mjs <mock|real|show>')
   process.exit(1)
@@ -53,5 +119,6 @@ const templatePath = templates[mode]
 const template = await fs.readFile(templatePath, 'utf8')
 
 await fs.writeFile(targetPath, template)
+await syncLocalOverrideFlags(template)
 
 console.log(`Updated .env.development -> ${mode}`)

--- a/src/hooks/game/useDiceRoll.test.ts
+++ b/src/hooks/game/useDiceRoll.test.ts
@@ -4,21 +4,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 type SetupOptions = {
   mockEnabled: boolean
   socketConnected: boolean
-  currentTurn: string | number | null
 }
 
 async function setupUseDiceRoll(options: SetupOptions) {
   vi.resetModules()
 
   const emitGameAction = vi.fn()
-  const useGameStore = vi.fn(
-    (
-      selector: (state: { currentTurn: SetupOptions['currentTurn'] }) => unknown
-    ) =>
-      selector({
-        currentTurn: options.currentTurn,
-      })
-  )
 
   vi.doMock('../../config/env', () => ({
     IS_SOCKET_MOCK_ENABLED: options.mockEnabled,
@@ -30,9 +21,6 @@ async function setupUseDiceRoll(options: SetupOptions) {
   }))
   vi.doMock('../../services/socket/game.handler', () => ({
     emitGameAction,
-  }))
-  vi.doMock('../../stores/game.store', () => ({
-    useGameStore,
   }))
 
   const { useDiceRoll } = await import('./useDiceRoll')
@@ -47,11 +35,10 @@ describe('useDiceRoll', () => {
     vi.clearAllMocks()
   })
 
-  it('non-mock 모드에서 소켓 연결/턴 유효 시 game:action(ROLL_DICE)만 전송한다', async () => {
+  it('non-mock 모드에서 소켓 연결 시 game:action(ROLL_DICE)만 전송한다', async () => {
     const { useDiceRoll, emitGameAction } = await setupUseDiceRoll({
       mockEnabled: false,
       socketConnected: true,
-      currentTurn: 'player-1',
     })
     const { result } = renderHook(() => useDiceRoll())
 
@@ -69,7 +56,6 @@ describe('useDiceRoll', () => {
     const { useDiceRoll, emitGameAction } = await setupUseDiceRoll({
       mockEnabled: false,
       socketConnected: false,
-      currentTurn: 'player-1',
     })
     const { result } = renderHook(() => useDiceRoll())
 
@@ -80,11 +66,10 @@ describe('useDiceRoll', () => {
     expect(emitGameAction).not.toHaveBeenCalled()
   })
 
-  it('non-mock 모드에서 currentTurn이 null이면 아무 동작도 하지 않는다', async () => {
+  it('non-mock 모드에서 currentTurn과 무관하게 소켓 연결 시 전송한다', async () => {
     const { useDiceRoll, emitGameAction } = await setupUseDiceRoll({
       mockEnabled: false,
       socketConnected: true,
-      currentTurn: null,
     })
     const { result } = renderHook(() => useDiceRoll())
 
@@ -92,14 +77,16 @@ describe('useDiceRoll', () => {
       result.current('game-1')
     })
 
-    expect(emitGameAction).not.toHaveBeenCalled()
+    expect(emitGameAction).toHaveBeenCalledWith({
+      type: 'ROLL_DICE',
+      gameId: 'game-1',
+    })
   })
 
   it('mock 모드에서는 game:action(ROLL_DICE) 경로를 사용한다', async () => {
     const { useDiceRoll, emitGameAction } = await setupUseDiceRoll({
       mockEnabled: true,
       socketConnected: false,
-      currentTurn: null,
     })
     const { result } = renderHook(() => useDiceRoll())
 
@@ -117,7 +104,6 @@ describe('useDiceRoll', () => {
     const { useDiceRoll, emitGameAction } = await setupUseDiceRoll({
       mockEnabled: true,
       socketConnected: true,
-      currentTurn: 'player-1',
     })
     const { result } = renderHook(() => useDiceRoll())
 

--- a/src/hooks/game/useDiceRoll.ts
+++ b/src/hooks/game/useDiceRoll.ts
@@ -2,38 +2,32 @@ import { useCallback } from 'react'
 import { IS_SOCKET_MOCK_ENABLED } from '../../config/env'
 import { socket } from '../../lib/socket'
 import { emitGameAction } from '../../services/socket/game.handler'
-import { useGameStore } from '../../stores/game.store'
 
 const USE_GAME_SOCKET_MOCK = IS_SOCKET_MOCK_ENABLED
 
 export const useDiceRoll = () => {
-  const currentTurn = useGameStore((state) => state.currentTurn)
+  return useCallback((gameId: string | null) => {
+    if (!gameId) {
+      return
+    }
 
-  return useCallback(
-    (gameId: string | null) => {
-      if (!gameId) {
+    if (!USE_GAME_SOCKET_MOCK) {
+      // Real server mode must stay authoritative; never fallback to local roll.
+      if (!socket.connected) {
         return
       }
 
-      if (!USE_GAME_SOCKET_MOCK) {
-        // Real server mode must stay authoritative; never fallback to local roll.
-        if (!socket.connected || currentTurn === null) {
-          return
-        }
-
-        emitGameAction({
-          type: 'ROLL_DICE',
-          gameId,
-        })
-        return
-      }
-
-      // Mock mode also goes through game:action to keep one contract path.
       emitGameAction({
         type: 'ROLL_DICE',
         gameId,
       })
-    },
-    [currentTurn]
-  )
+      return
+    }
+
+    // Mock mode also goes through game:action to keep one contract path.
+    emitGameAction({
+      type: 'ROLL_DICE',
+      gameId,
+    })
+  }, [])
 }


### PR DESCRIPTION
## 📌 관련 이슈

> closes #이슈번호

---

## ✅ 작업 내용

- real 모드에서 주사위 입력이 무반응이던 원인(`currentTurn === null` 가드) 제거
- `useDiceRoll`이 소켓 연결 상태만 확인하고 `game:action(ROLL_DICE)`를 송신하도록 수정
- 관련 단위 테스트를 새 동작 기준으로 정리
- `.env.development.real`을 실서버 기준으로 갱신
  - `VITE_API_URL=http://13.209.49.56:8000/api`
  - `VITE_SOCKET_URL=http://13.209.49.56:8000`
- `scripts/dev/switch-env.mjs` 개선
  - `env:real` / `env:mock` 실행 시 `.env.development.local`의 mock 관련 플래그도 동기화하여
    로컬 오버라이드로 모드 전환이 무효화되는 문제 방지

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📷 스크린샷 (선택)

> UI 변경 없음
