### PR TITLE
FIX : 실서버 게임 소켓 계약 정규화 및 주사위/자금 표시 이슈 수정

### DIFF
--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -345,17 +345,24 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
 
     const promptTileId = getPromptPayloadNumber(activePrompt, [
       'tileId',
+      'tile_id',
       'targetTileId',
+      'target_tile_id',
       'toTileId',
+      'to_tile_id',
     ])
     const promptTile = promptTileId != null ? TILES[promptTileId] : null
     const promptOwnerId = getPromptPayloadNumber(activePrompt, [
       'ownerId',
+      'owner_id',
       'toPlayerId',
+      'to_player_id',
     ])
     const promptOwnerNameFromPayload = getPromptPayloadString(activePrompt, [
       'ownerName',
+      'owner_name',
       'ownerNickname',
+      'owner_nickname',
     ])
     const promptOwnerName =
       promptOwnerNameFromPayload ??
@@ -366,9 +373,13 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
     const promptSellerName =
       getPromptPayloadString(activePrompt, [
         'sellerName',
+        'seller_name',
         'sellerNickname',
+        'seller_nickname',
         'playerName',
+        'player_name',
         'ownerName',
+        'owner_name',
       ]) ??
       (activePrompt?.playerId != null
         ? players.find(
@@ -381,28 +392,40 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       'amount',
       'toll',
       'tollAmount',
+      'toll_amount',
       'price',
     ])
     const promptAcquisitionCost = getPromptPayloadNumber(activePrompt, [
       'acquisitionCost',
+      'acquisition_cost',
       'buyoutCost',
+      'buyout_cost',
       'purchaseCost',
+      'purchase_cost',
       'cost',
       'price',
     ])
     const promptSellPrice = getPromptPayloadNumber(activePrompt, [
       'sellPrice',
+      'sell_price',
       'refund',
       'amount',
       'price',
     ])
     const promptTileName =
-      getPromptPayloadString(activePrompt, ['tileName', 'cityName']) ??
+      getPromptPayloadString(activePrompt, [
+        'tileName',
+        'tile_name',
+        'cityName',
+        'city_name',
+      ]) ??
       promptTile?.name ??
       ''
     const promptCurrentLevelFromPayload = getPromptPayloadNumber(activePrompt, [
       'buildingLevel',
+      'building_level',
       'currentLevel',
+      'current_level',
     ])
     const promptCurrentLevel = Math.min(
       7,
@@ -1021,7 +1044,12 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
     const acquisitionCurrentLevel = promptCurrentLevel
     const acquisitionCost = promptAcquisitionCost ?? acquisitionTile?.price ?? 0
     const buyCost =
-      getPromptPayloadNumber(activePrompt, ['price', 'purchaseCost']) ??
+      getPromptPayloadNumber(activePrompt, [
+        'price',
+        'purchaseCost',
+        'purchase_cost',
+        'cost',
+      ]) ??
       buyTile?.price ??
       0
     const isBuyPromptDismissed =
@@ -1031,11 +1059,20 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
     const buildModalVisible = buildModalOpen && !insufficientFundsModal.open
     const activePlayerMoney = players[curPlayer]?.money ?? 0
     const buildCost =
-      getPromptPayloadNumber(activePrompt, ['buildCost', 'cost', 'price']) ??
-      getUpgradeCost(buildTile?.price ?? 0, currentLevel as BuildingLevel)
+      getPromptPayloadNumber(activePrompt, [
+        'buildCost',
+        'build_cost',
+        'cost',
+        'price',
+      ]) ?? getUpgradeCost(buildTile?.price ?? 0, currentLevel as BuildingLevel)
     const nextTollCost =
-      getPromptPayloadNumber(activePrompt, ['nextToll', 'toll', 'amount']) ??
-      calcToll(buildTile?.price ?? 0, (currentLevel + 1) as BuildingLevel)
+      getPromptPayloadNumber(activePrompt, [
+        'nextToll',
+        'next_toll',
+        'toll',
+        'toll_amount',
+        'amount',
+      ]) ?? calcToll(buildTile?.price ?? 0, (currentLevel + 1) as BuildingLevel)
     const diceTimerTitle = activePrompt?.title
     const diceTimerMessage = activePrompt?.message
     const diceTimerConfirmLabel = getPromptChoiceLabel(

--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -289,10 +289,10 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
     )
     const [dice1, setDice1] = useState(1)
     const [dice2, setDice2] = useState(1)
-    const rolling = false
     const [status, setStatus] = useState(GAME_START_STATUS)
     const [eventFxKind, setEventFxKind] =
       useState<BoardEventAnimationKind>('none')
+    const rolling = eventFxKind === 'dice'
     const boardPageRef = useRef<HTMLDivElement | null>(null)
     const boardStatusRef = useRef<HTMLDivElement | null>(null)
     const [boardScale, setBoardScale] = useState(1)

--- a/src/components/board/gameBoardEventQueueUtils.test.ts
+++ b/src/components/board/gameBoardEventQueueUtils.test.ts
@@ -48,6 +48,19 @@ describe('gameBoardEventQueueUtils', () => {
     expect(extractEventDice(event)).toEqual([3, 4])
   })
 
+  it('extracts dice values from alias payload keys', () => {
+    const event: ServerEvent = {
+      type: 'DICE_ROLL_RESULT',
+      playerId: 1,
+      payload: {
+        dice1: 2,
+        dice2: 6,
+      },
+    }
+
+    expect(extractEventDice(event)).toEqual([2, 6])
+  })
+
   it('returns move status message with player and tile name', () => {
     const event: ServerEvent = {
       type: 'PLAYER_MOVED',
@@ -116,6 +129,14 @@ describe('gameBoardEventQueueUtils', () => {
     expect(
       resolveBoardEventAnimationKind({ type: 'SOMETHING_ELSE' } as ServerEvent)
     ).toBe('none')
+    expect(
+      resolveBoardEventAnimationKind({
+        type: 'DICE_ROLL_RESULT',
+      } as ServerEvent)
+    ).toBe('dice')
+    expect(
+      resolveBoardEventAnimationKind({ type: 'TURN_END' } as ServerEvent)
+    ).toBe('turn_end')
   })
 
   it('returns event-specific consume delays', () => {

--- a/src/components/board/gameBoardEventQueueUtils.test.ts
+++ b/src/components/board/gameBoardEventQueueUtils.test.ts
@@ -61,6 +61,15 @@ describe('gameBoardEventQueueUtils', () => {
     expect(extractEventDice(event)).toEqual([2, 6])
   })
 
+  it('extracts dice values from top-level event dice fields', () => {
+    const event = {
+      type: 'DICE_ROLLED',
+      playerId: 1,
+      dice: [4, 1],
+    }
+    expect(extractEventDice(event as unknown as ServerEvent)).toEqual([4, 1])
+  })
+
   it('returns move status message with player and tile name', () => {
     const event: ServerEvent = {
       type: 'PLAYER_MOVED',
@@ -70,6 +79,18 @@ describe('gameBoardEventQueueUtils', () => {
 
     expect(createBoardStatusFromEvent(event, players, tiles)).toBe(
       '플레이어1님이 부산 칸으로 이동했습니다.'
+    )
+  })
+
+  it('resolves move destination from top-level toTileId', () => {
+    const event = {
+      type: 'PLAYER_MOVED',
+      playerId: 1,
+      toTileId: 1,
+    } as ServerEvent & { toTileId: number }
+
+    expect(createBoardStatusFromEvent(event, players, tiles)).toBe(
+      '플레이어1님이 서울 칸으로 이동했습니다.'
     )
   })
 

--- a/src/components/board/gameBoardEventQueueUtils.ts
+++ b/src/components/board/gameBoardEventQueueUtils.ts
@@ -94,6 +94,28 @@ const getPayloadNumber = (
   return null
 }
 
+const getEventRecord = (event: ServerEvent): Record<string, unknown> =>
+  event as unknown as Record<string, unknown>
+
+const getEventNumber = (event: ServerEvent, keys: string[]) => {
+  const eventRecord = getEventRecord(event)
+
+  for (const key of keys) {
+    const raw = eventRecord[key]
+    if (typeof raw === 'number' && Number.isFinite(raw)) {
+      return raw
+    }
+    if (typeof raw === 'string' && raw.trim() !== '') {
+      const parsed = Number.parseFloat(raw)
+      if (Number.isFinite(parsed)) {
+        return parsed
+      }
+    }
+  }
+
+  return null
+}
+
 const resolvePlayerName = (
   players: PlayerState[],
   playerId: ServerEvent['playerId']
@@ -121,6 +143,11 @@ const resolveTileIndex = (event: ServerEvent) => {
     return event.tileIndex
   }
 
+  const eventLevelIndex = getEventNumber(event, ['toTileId', 'tileId'])
+  if (eventLevelIndex != null) {
+    return eventLevelIndex
+  }
+
   const payload = event.payload
   if (!payload) {
     return null
@@ -138,19 +165,26 @@ export const extractEventDice = (
   }
 
   const payload = event.payload
-  if (!payload) {
-    return null
-  }
 
   let first: number | null = null
   let second: number | null = null
 
-  if (Array.isArray(payload.dice) && payload.dice.length >= 2) {
-    first = Number(payload.dice[0])
-    second = Number(payload.dice[1])
+  const eventRecord = getEventRecord(event)
+  const payloadDice = Array.isArray(payload?.dice) ? payload.dice : null
+
+  if (Array.isArray(eventRecord.dice) && eventRecord.dice.length >= 2) {
+    first = Number(eventRecord.dice[0])
+    second = Number(eventRecord.dice[1])
+  } else if (payloadDice && payloadDice.length >= 2) {
+    first = Number(payloadDice[0])
+    second = Number(payloadDice[1])
   } else {
-    first = getPayloadNumber(payload, ['dice1', 'dice_1', 'firstDice', 'd1'])
-    second = getPayloadNumber(payload, ['dice2', 'dice_2', 'secondDice', 'd2'])
+    first =
+      getEventNumber(event, ['dice1', 'dice_1', 'firstDice', 'd1']) ??
+      getPayloadNumber(payload, ['dice1', 'dice_1', 'firstDice', 'd1'])
+    second =
+      getEventNumber(event, ['dice2', 'dice_2', 'secondDice', 'd2']) ??
+      getPayloadNumber(payload, ['dice2', 'dice_2', 'secondDice', 'd2'])
   }
 
   if (first == null || second == null) {
@@ -171,6 +205,7 @@ export const createBoardStatusFromEvent = (
   if (normalizedType === 'DICE_ROLLED') {
     const dice = extractEventDice(event)
     const total =
+      getEventNumber(event, ['total']) ??
       getPayloadNumber(event.payload, ['total']) ??
       (dice ? dice[0] + dice[1] : null)
 
@@ -195,7 +230,8 @@ export const createBoardStatusFromEvent = (
     const amount =
       typeof event.amount === 'number'
         ? event.amount
-        : (getPayloadNumber(event.payload, ['amount', 'toll', 'tollAmount']) ??
+        : (getEventNumber(event, ['amount', 'toll', 'tollAmount']) ??
+          getPayloadNumber(event.payload, ['amount', 'toll', 'tollAmount']) ??
           0)
     return `${playerName}님이 통행료 ${formatWon(amount)}을 지불했습니다.`
   }

--- a/src/components/board/gameBoardEventQueueUtils.ts
+++ b/src/components/board/gameBoardEventQueueUtils.ts
@@ -14,10 +14,28 @@ export type BoardEventAnimationKind =
 const normalizeEventType = (type: unknown) =>
   typeof type === 'string' ? type.trim().toUpperCase() : ''
 
+const EVENT_TYPE_ALIAS_MAP: Record<string, string> = {
+  DICE_ROLL: 'DICE_ROLLED',
+  DICE_ROLL_RESULT: 'DICE_ROLLED',
+  ROLLED_DICE: 'DICE_ROLLED',
+  PLAYER_MOVE: 'PLAYER_MOVED',
+  MOVED: 'PLAYER_MOVED',
+  LAND: 'LANDED',
+  TOLL_PAID: 'PAID_TOLL',
+  TURN_END: 'TURN_ENDED',
+  END_TURN: 'TURN_ENDED',
+  SYNC: 'SYNCED',
+}
+
+const toCanonicalEventType = (type: unknown) => {
+  const normalized = normalizeEventType(type)
+  return EVENT_TYPE_ALIAS_MAP[normalized] ?? normalized
+}
+
 export const resolveBoardEventAnimationKind = (
   event: ServerEvent
 ): BoardEventAnimationKind => {
-  const normalizedType = normalizeEventType(event.type)
+  const normalizedType = toCanonicalEventType(event.type)
 
   if (normalizedType === 'DICE_ROLLED') return 'dice'
   if (normalizedType === 'PLAYER_MOVED') return 'move'
@@ -114,20 +132,28 @@ const resolveTileIndex = (event: ServerEvent) => {
 export const extractEventDice = (
   event: ServerEvent
 ): [number, number] | null => {
-  const normalizedType = normalizeEventType(event.type)
+  const normalizedType = toCanonicalEventType(event.type)
   if (normalizedType !== 'DICE_ROLLED') {
     return null
   }
 
   const payload = event.payload
-  if (!payload || !Array.isArray(payload.dice) || payload.dice.length < 2) {
+  if (!payload) {
     return null
   }
 
-  const first = Number(payload.dice[0])
-  const second = Number(payload.dice[1])
+  let first: number | null = null
+  let second: number | null = null
 
-  if (!Number.isFinite(first) || !Number.isFinite(second)) {
+  if (Array.isArray(payload.dice) && payload.dice.length >= 2) {
+    first = Number(payload.dice[0])
+    second = Number(payload.dice[1])
+  } else {
+    first = getPayloadNumber(payload, ['dice1', 'dice_1', 'firstDice', 'd1'])
+    second = getPayloadNumber(payload, ['dice2', 'dice_2', 'secondDice', 'd2'])
+  }
+
+  if (first == null || second == null) {
     return null
   }
 
@@ -139,7 +165,7 @@ export const createBoardStatusFromEvent = (
   players: PlayerState[],
   tiles: TileData[]
 ) => {
-  const normalizedType = normalizeEventType(event.type)
+  const normalizedType = toCanonicalEventType(event.type)
   const playerName = resolvePlayerName(players, event.playerId)
 
   if (normalizedType === 'DICE_ROLLED') {

--- a/src/components/game/modals/promptModalMapping.test.ts
+++ b/src/components/game/modals/promptModalMapping.test.ts
@@ -121,6 +121,19 @@ describe('promptModalMapping', () => {
     expect(resolvePromptChoiceValue(prompt, 'timerConfirm')).toBe('END_TURN')
   })
 
+  it('prioritizes ROLL_DICE over END_TURN for timer confirm choice', () => {
+    const prompt = createPrompt({
+      type: 'TURN_TIMEOUT',
+      timeoutSec: 15,
+      choices: [
+        { id: 'end-turn', label: '턴 종료', value: 'END_TURN' },
+        { id: 'roll', label: '주사위 굴리기', value: 'ROLL_DICE' },
+      ],
+    })
+
+    expect(resolvePromptChoiceValue(prompt, 'timerConfirm')).toBe('ROLL_DICE')
+  })
+
   it('returns fallback label when choice label is missing', () => {
     const prompt = createPrompt({
       choices: [{ id: 'buy', label: '구매하기', value: 'BUY' }],

--- a/src/components/game/modals/promptModalMapping.ts
+++ b/src/components/game/modals/promptModalMapping.ts
@@ -88,7 +88,15 @@ const PROMPT_CHOICE_RULES: Record<
     fallbackIndex: 1,
   },
   timerConfirm: {
-    preferredTokens: ['END_TURN', 'CONFIRM', 'OK', 'SKIP', 'PASS'],
+    preferredTokens: [
+      'ROLL_DICE',
+      'ROLL',
+      'CONFIRM',
+      'OK',
+      'END_TURN',
+      'SKIP',
+      'PASS',
+    ],
     fallbackIndex: 0,
   },
 }
@@ -199,12 +207,13 @@ export const findPromptChoiceValue = (
     return null
   }
 
-  const matchedChoice = choices.find((choice) =>
-    preferredTokens.some((token) => hasMatchedChoiceToken(choice, token))
-  )
-
-  if (matchedChoice) {
-    return matchedChoice.value
+  for (const token of preferredTokens) {
+    const matchedChoiceByToken = choices.find((choice) =>
+      hasMatchedChoiceToken(choice, token)
+    )
+    if (matchedChoiceByToken) {
+      return matchedChoiceByToken.value
+    }
   }
 
   if (

--- a/src/hooks/game/useDiceRoll.test.ts
+++ b/src/hooks/game/useDiceRoll.test.ts
@@ -49,6 +49,9 @@ describe('useDiceRoll', () => {
     expect(emitGameAction).toHaveBeenCalledWith({
       type: 'ROLL_DICE',
       gameId: 'game-1',
+      payload: {
+        diceId: 0,
+      },
     })
   })
 
@@ -80,6 +83,9 @@ describe('useDiceRoll', () => {
     expect(emitGameAction).toHaveBeenCalledWith({
       type: 'ROLL_DICE',
       gameId: 'game-1',
+      payload: {
+        diceId: 0,
+      },
     })
   })
 
@@ -97,6 +103,9 @@ describe('useDiceRoll', () => {
     expect(emitGameAction).toHaveBeenCalledWith({
       type: 'ROLL_DICE',
       gameId: 'game-1',
+      payload: {
+        diceId: 0,
+      },
     })
   })
 

--- a/src/hooks/game/useDiceRoll.ts
+++ b/src/hooks/game/useDiceRoll.ts
@@ -20,6 +20,9 @@ export const useDiceRoll = () => {
       emitGameAction({
         type: 'ROLL_DICE',
         gameId,
+        payload: {
+          diceId: 0,
+        },
       })
       return
     }
@@ -28,6 +31,9 @@ export const useDiceRoll = () => {
     emitGameAction({
       type: 'ROLL_DICE',
       gameId,
+      payload: {
+        diceId: 0,
+      },
     })
   }, [])
 }

--- a/src/pages/game/gameViewModel.test.ts
+++ b/src/pages/game/gameViewModel.test.ts
@@ -28,7 +28,14 @@ describe('game view model mapper', () => {
       money: 900,
       color: '#111111',
     })
-    expect(boardPlayers[1]?.name).toBe('MarbleKing')
+    expect(boardPlayers).toHaveLength(1)
+  })
+
+  it('falls back to default board players when store players are empty', () => {
+    const boardPlayers = mapStorePlayersToBoardPlayers([])
+
+    expect(boardPlayers).toHaveLength(4)
+    expect(boardPlayers[0]?.name).toBe('GoormEE')
   })
 
   it('finds the current board player index by mixed player id values', () => {

--- a/src/pages/game/gameViewModel.ts
+++ b/src/pages/game/gameViewModel.ts
@@ -17,22 +17,27 @@ const toBoardPlayerId = (playerId: PlayerId, fallbackIndex: number) => {
 }
 
 export const mapStorePlayersToBoardPlayers = (storePlayers: Player[]) =>
-  INIT_PLAYERS.map((initialPlayer, index) => {
-    const storePlayer = storePlayers[index]
-    if (!storePlayer) {
-      return initialPlayer
-    }
+  (storePlayers.length > 0 ? storePlayers : INIT_PLAYERS).map(
+    (storePlayerOrFallback, index) => {
+      const initialPlayer = INIT_PLAYERS[index] ?? INIT_PLAYERS[0]
+      const storePlayer =
+        storePlayers.length > 0 ? (storePlayerOrFallback as Player) : undefined
 
-    return {
-      ...initialPlayer,
-      id: toBoardPlayerId(storePlayer.id, initialPlayer.id),
-      name: storePlayer.nickname || initialPlayer.name,
-      color: storePlayer.color || initialPlayer.color,
-      pos: storePlayer.position,
-      money: storePlayer.balance,
-      skipTurns: storePlayer.jail_turn_count,
+      if (!storePlayer) {
+        return storePlayerOrFallback as PlayerState
+      }
+
+      return {
+        ...initialPlayer,
+        id: toBoardPlayerId(storePlayer.id, initialPlayer.id),
+        name: storePlayer.nickname || initialPlayer.name,
+        color: storePlayer.color || initialPlayer.color,
+        pos: storePlayer.position,
+        money: storePlayer.balance,
+        skipTurns: storePlayer.jail_turn_count,
+      }
     }
-  })
+  )
 
 export const findBoardCurrentPlayerIndex = (
   storePlayers: Player[],

--- a/src/services/socket/game.handler.ts
+++ b/src/services/socket/game.handler.ts
@@ -67,6 +67,21 @@ const GAME_ID_REQUIRED_ERROR: GameError = {
   message: 'Game events must include a valid gameId.',
 }
 
+const toFiniteNumber = (value: unknown): number | null => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value
+  }
+
+  if (typeof value === 'string' && value.trim().length > 0) {
+    const parsed = Number.parseFloat(value)
+    if (Number.isFinite(parsed)) {
+      return parsed
+    }
+  }
+
+  return null
+}
+
 const getResolvedGameId = (gameId?: GameId | null): GameId | null => {
   const gameStore = useGameStore.getState()
   return gameId ?? gameStore.gameId ?? gameStore.session.gameId ?? null
@@ -98,14 +113,19 @@ export const setupGameHandlers = (
 
   const handleGamePatch = (payload: GamePatchPayload) => {
     const gameStore = useGameStore.getState()
+    const revision = toFiniteNumber(payload.revision) ?? 0
+    const turn = toFiniteNumber(payload.turn) ?? undefined
+    const normalizedPatchEnvelope = normalizePatchEnvelopePayload({
+      gameId: typeof payload.gameId === 'string' ? payload.gameId : undefined,
+      revision,
+      turn,
+      patch: Array.isArray(payload.patch) ? payload.patch : [],
+      events: Array.isArray(payload.events) ? payload.events : [],
+    })
 
     if (payload.snapshot) {
       const normalizedSnapshot = normalizeSnapshotPayload(payload.snapshot, {
-        envelopeRevision:
-          typeof payload.revision === 'number' &&
-          Number.isFinite(payload.revision)
-            ? payload.revision
-            : 0,
+        envelopeRevision: normalizedPatchEnvelope.revision,
         envelopeGameId:
           typeof payload.gameId === 'string' ? payload.gameId : undefined,
       })
@@ -119,22 +139,14 @@ export const setupGameHandlers = (
       }
 
       gameStore.replaceFromSnapshot(normalizedSnapshot)
+      const normalizedEvents = normalizedPatchEnvelope.events ?? []
+      if (normalizedEvents.length > 0) {
+        gameStore.enqueueEvents(normalizedEvents)
+      }
       return
     }
 
-    gameStore.applyPatchEnvelope(
-      normalizePatchEnvelopePayload({
-        gameId: typeof payload.gameId === 'string' ? payload.gameId : undefined,
-        revision:
-          typeof payload.revision === 'number' &&
-          Number.isFinite(payload.revision)
-            ? payload.revision
-            : 0,
-        turn: typeof payload.turn === 'number' ? payload.turn : undefined,
-        patch: Array.isArray(payload.patch) ? payload.patch : [],
-        events: Array.isArray(payload.events) ? payload.events : [],
-      })
-    )
+    gameStore.applyPatchEnvelope(normalizedPatchEnvelope)
   }
 
   const handleGamePrompt = (promptPayload: unknown) => {

--- a/src/services/socket/gameContractAdapters.test.ts
+++ b/src/services/socket/gameContractAdapters.test.ts
@@ -116,6 +116,70 @@ describe('gameContractAdapters', () => {
     })
   })
 
+  it('normalizes snapshot aliases from real payload fields', () => {
+    const normalized = normalizeSnapshotPayload(
+      {
+        gameId: 'game-2',
+        revision: 7,
+        phase: 'WAIT_ROLL',
+        turn: 2,
+        current_player_id: 105,
+        players: [
+          {
+            playerId: 105,
+            nickname: 'beta',
+            current_tile_id: '8',
+            balance: '210',
+            ownedTiles: ['3', '5'],
+          },
+        ],
+        tiles: [
+          {
+            tileId: '3',
+            owner_player_id: 105,
+            building_level: 2,
+            tile_type: 'PROPERTY',
+          },
+        ],
+        prompt: {
+          promptId: 'prompt-2',
+          type: 'BUY_OR_SKIP',
+          payload: {
+            player_id: 105,
+          },
+          choices: [{ value: 'buy' }, { value: 'skip' }],
+        },
+      },
+      {
+        envelopeRevision: 7,
+      }
+    )
+
+    expect(normalized).not.toBeNull()
+    expect(normalized).toMatchObject({
+      currentPlayerId: 105,
+      currentTurn: 105,
+      phase: 'rolling',
+    })
+    expect(normalized?.players[0]).toMatchObject({
+      id: 105,
+      position: 8,
+      balance: 210,
+      owned_tiles: [3, 5],
+    })
+    expect(normalized?.tiles[0]).toMatchObject({
+      index: 3,
+      ownerId: 105,
+      building: 2,
+      type: 'property',
+    })
+    expect(normalized?.prompt).toMatchObject({
+      id: 'prompt-2',
+      playerId: 105,
+      choices: [{ value: 'BUY' }, { value: 'SKIP' }],
+    })
+  })
+
   it('normalizes patch envelope paths and canonical values', () => {
     const normalized = normalizePatchEnvelopePayload({
       gameId: 'game-1',
@@ -151,6 +215,16 @@ describe('gameContractAdapters', () => {
           path: 'tiles.1.tileType',
           value: 'MOVE_TO_ISLAND',
         },
+        {
+          op: 'set',
+          path: 'players.0.current_tile_id',
+          value: 11,
+        },
+        {
+          op: 'set',
+          path: 'players.0.player_state',
+          value: 'LOCKED',
+        },
       ],
       events: [],
     })
@@ -185,6 +259,16 @@ describe('gameContractAdapters', () => {
         op: 'set',
         path: 'tiles.1.type',
         value: 'go_to_island',
+      },
+      {
+        op: 'set',
+        path: 'players.0.position',
+        value: 11,
+      },
+      {
+        op: 'set',
+        path: 'players.0.state',
+        value: 'locked',
       },
     ])
   })

--- a/src/services/socket/gameContractAdapters.test.ts
+++ b/src/services/socket/gameContractAdapters.test.ts
@@ -262,6 +262,20 @@ describe('gameContractAdapters', () => {
           path: 'players.0.player_state',
           value: 'LOCKED',
         },
+        {
+          op: 'set',
+          path: 'players.0.money',
+          value: '450',
+        },
+        {
+          op: 'set',
+          path: 'pending_prompt',
+          value: {
+            promptId: 'p-10',
+            type: 'CONFIRM_ONLY',
+            choices: [{ value: 'confirm' }],
+          },
+        },
       ],
       events: [],
     })
@@ -306,6 +320,32 @@ describe('gameContractAdapters', () => {
         op: 'set',
         path: 'players.0.state',
         value: 'locked',
+      },
+      {
+        op: 'set',
+        path: 'players.0.balance',
+        value: 450,
+      },
+      {
+        op: 'set',
+        path: 'prompt',
+        value: {
+          id: 'p-10',
+          type: 'CONFIRM_ONLY',
+          playerId: null,
+          title: undefined,
+          message: undefined,
+          timeoutSec: undefined,
+          choices: [
+            {
+              id: 'confirm-0',
+              label: 'CONFIRM',
+              value: 'CONFIRM',
+              description: undefined,
+            },
+          ],
+          payload: undefined,
+        },
       },
     ])
   })

--- a/src/services/socket/gameContractAdapters.test.ts
+++ b/src/services/socket/gameContractAdapters.test.ts
@@ -41,6 +41,29 @@ describe('gameContractAdapters', () => {
     ])
   })
 
+  it('normalizes prompt choices when server sends string arrays', () => {
+    const normalized = normalizePromptPayload({
+      promptId: 'prompt-string-choices',
+      type: 'BUY_OR_SKIP',
+      choices: ['buy', 'skip'],
+    })
+
+    expect(normalized?.choices).toEqual([
+      {
+        id: 'buy-0',
+        label: 'BUY',
+        value: 'BUY',
+        description: undefined,
+      },
+      {
+        id: 'skip-1',
+        label: 'SKIP',
+        value: 'SKIP',
+        description: undefined,
+      },
+    ])
+  })
+
   it('normalizes canonical snapshot payload to internal snapshot shape', () => {
     const normalized = normalizeSnapshotPayload(
       {
@@ -217,6 +240,30 @@ describe('gameContractAdapters', () => {
       index: 1,
       type: 'property',
       price: 500000,
+    })
+  })
+
+  it('falls back to default initial balance when snapshot player has no money field', () => {
+    const normalized = normalizeSnapshotPayload(
+      {
+        gameId: 'game-5',
+        revision: 1,
+        phase: 'WAIT_ROLL',
+        players: [
+          {
+            id: 1,
+            nickname: 'no-balance-player',
+            currentTileId: 0,
+          },
+        ],
+        tiles: [],
+      },
+      { envelopeRevision: 1 }
+    )
+
+    expect(normalized?.players[0]).toMatchObject({
+      id: 1,
+      balance: 5000000000,
     })
   })
 

--- a/src/services/socket/gameContractAdapters.test.ts
+++ b/src/services/socket/gameContractAdapters.test.ts
@@ -129,7 +129,7 @@ describe('gameContractAdapters', () => {
             playerId: 105,
             nickname: 'beta',
             current_tile_id: '8',
-            balance: '210',
+            money: '210',
             ownedTiles: ['3', '5'],
           },
         ],
@@ -141,7 +141,7 @@ describe('gameContractAdapters', () => {
             tile_type: 'PROPERTY',
           },
         ],
-        prompt: {
+        pending_prompt: {
           promptId: 'prompt-2',
           type: 'BUY_OR_SKIP',
           payload: {
@@ -177,6 +177,43 @@ describe('gameContractAdapters', () => {
       id: 'prompt-2',
       playerId: 105,
       choices: [{ value: 'BUY' }, { value: 'SKIP' }],
+    })
+  })
+
+  it('normalizes object-shaped snapshot collections', () => {
+    const normalized = normalizeSnapshotPayload(
+      {
+        gameId: 'game-3',
+        revision: 4,
+        phase: 'MOVING',
+        players: {
+          a: {
+            id: 'user-a',
+            nickname: 'A',
+            balance: 300,
+          },
+        },
+        tiles: {
+          c1: {
+            index: 1,
+            tileType: 'PROPERTY',
+            purchase_price: 50,
+          },
+        },
+      },
+      { envelopeRevision: 4 }
+    )
+
+    expect(normalized?.players).toHaveLength(1)
+    expect(normalized?.players[0]).toMatchObject({
+      id: 'user-a',
+      balance: 300,
+    })
+    expect(normalized?.tiles).toHaveLength(1)
+    expect(normalized?.tiles[0]).toMatchObject({
+      index: 1,
+      type: 'property',
+      price: 50,
     })
   })
 

--- a/src/services/socket/gameContractAdapters.test.ts
+++ b/src/services/socket/gameContractAdapters.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import type { ServerEvent } from '../../types/domain'
 import {
   normalizePatchEnvelopePayload,
   normalizePromptPayload,
@@ -96,6 +97,7 @@ describe('gameContractAdapters', () => {
     expect(normalized?.players[0]).toMatchObject({
       id: 'player-1',
       position: 7,
+      balance: 3000000,
       owned_tiles: [2, 4],
       state: 'locked',
       is_in_jail: true,
@@ -108,6 +110,7 @@ describe('gameContractAdapters', () => {
       building: 3,
       type: 'property',
       transportType: 'PROPERTY',
+      price: 500000,
     })
     expect(normalized?.prompt).toMatchObject({
       id: 'prompt-1',
@@ -164,7 +167,7 @@ describe('gameContractAdapters', () => {
     expect(normalized?.players[0]).toMatchObject({
       id: 105,
       position: 8,
-      balance: 210,
+      balance: 2100000,
       owned_tiles: [3, 5],
     })
     expect(normalized?.tiles[0]).toMatchObject({
@@ -207,13 +210,13 @@ describe('gameContractAdapters', () => {
     expect(normalized?.players).toHaveLength(1)
     expect(normalized?.players[0]).toMatchObject({
       id: 'user-a',
-      balance: 300,
+      balance: 3000000,
     })
     expect(normalized?.tiles).toHaveLength(1)
     expect(normalized?.tiles[0]).toMatchObject({
       index: 1,
       type: 'property',
-      price: 50,
+      price: 500000,
     })
   })
 
@@ -324,7 +327,7 @@ describe('gameContractAdapters', () => {
       {
         op: 'set',
         path: 'players.0.balance',
-        value: 450,
+        value: 4500000,
       },
       {
         op: 'set',
@@ -346,6 +349,61 @@ describe('gameContractAdapters', () => {
           ],
           payload: undefined,
         },
+      },
+    ])
+  })
+
+  it('normalizes patch inc money values and event aliases from real payload', () => {
+    const normalized = normalizePatchEnvelopePayload({
+      gameId: 'game-4',
+      revision: 90,
+      patch: [
+        {
+          op: 'inc',
+          path: 'players.1.money',
+          value: 5000,
+        },
+      ],
+      events: [
+        {
+          eventType: 'DICE_ROLLED',
+          playerId: '1',
+          dice: [3, 2],
+        } as unknown as ServerEvent,
+        {
+          type: 'PAID_TOLL',
+          fromPlayerId: '2',
+          amount: 3500,
+        } as unknown as ServerEvent,
+      ],
+    })
+
+    expect(normalized.patch).toEqual([
+      {
+        op: 'inc',
+        path: 'players.1.balance',
+        value: 50000000,
+      },
+    ])
+    expect(normalized.events).toEqual([
+      {
+        eventType: 'DICE_ROLLED',
+        playerId: '1',
+        dice: [3, 2],
+        id: undefined,
+        type: 'DICE_ROLLED',
+        tileIndex: null,
+        amount: undefined,
+        payload: undefined,
+      },
+      {
+        type: 'PAID_TOLL',
+        fromPlayerId: '2',
+        id: undefined,
+        playerId: '2',
+        tileIndex: null,
+        amount: 35000000,
+        payload: undefined,
       },
     ])
   })

--- a/src/services/socket/gameContractAdapters.ts
+++ b/src/services/socket/gameContractAdapters.ts
@@ -6,6 +6,7 @@ import type {
   GameSnapshot,
   Player,
   PlayerId,
+  ServerEvent,
   Tile,
 } from '../../types/domain'
 
@@ -22,6 +23,30 @@ type SnapshotNormalizeOptions = {
 
 const DEFAULT_TURN_TIMEOUT_SEC = 30
 const DEFAULT_PLAYER_COLOR = '#94A3B8'
+const MONEY_UNIT_SCALE = 10_000
+const MONEY_ALREADY_WON_THRESHOLD = 10_000_000
+const MONEY_KEYS = new Set([
+  'amount',
+  'balance',
+  'buyoutCost',
+  'buyout_cost',
+  'cash',
+  'cost',
+  'landPrice',
+  'land_price',
+  'money',
+  'price',
+  'purchaseCost',
+  'purchase_cost',
+  'refund',
+  'sellPrice',
+  'sell_price',
+  'toll',
+  'tollAmount',
+  'toll_amount',
+  'acquisitionCost',
+  'acquisition_cost',
+])
 
 const PHASE_TO_INTERNAL_MAP: Record<string, GameSnapshot['phase']> = {
   WAIT_ROLL: 'rolling',
@@ -91,6 +116,79 @@ const toPlayerIdOrNull = (value: unknown): PlayerId | null => {
 
 const toPlayerId = (value: unknown, fallback: PlayerId): PlayerId =>
   toPlayerIdOrNull(value) ?? fallback
+
+const normalizeMoneyToWon = (value: unknown, fallback = 0) => {
+  const raw = toFiniteInt(value, fallback)
+
+  if (!Number.isFinite(raw) || raw === 0) {
+    return 0
+  }
+
+  if (Math.abs(raw) >= MONEY_ALREADY_WON_THRESHOLD) {
+    return raw
+  }
+
+  return raw * MONEY_UNIT_SCALE
+}
+
+const normalizeMoneyRecord = (record: Record<string, unknown>) => {
+  const normalized: Record<string, unknown> = {}
+
+  for (const [key, value] of Object.entries(record)) {
+    if (MONEY_KEYS.has(key)) {
+      normalized[key] = normalizeMoneyToWon(value, 0)
+      continue
+    }
+
+    normalized[key] = value
+  }
+
+  return normalized
+}
+
+const normalizeServerEvent = (eventPayload: unknown): ServerEvent | null => {
+  if (!isRecord(eventPayload)) {
+    return null
+  }
+
+  const eventType =
+    toStringOrNull(eventPayload.type) ??
+    toStringOrNull(eventPayload.eventType) ??
+    toStringOrNull(eventPayload.event_type) ??
+    ''
+
+  if (!eventType) {
+    return null
+  }
+
+  const payloadRecord =
+    eventPayload.payload && isRecord(eventPayload.payload)
+      ? normalizeMoneyRecord(eventPayload.payload)
+      : undefined
+
+  const normalizedAmountRaw =
+    eventPayload.amount ?? eventPayload.toll ?? eventPayload.tollAmount
+  const normalizedAmount =
+    normalizedAmountRaw !== undefined
+      ? normalizeMoneyToWon(normalizedAmountRaw, 0)
+      : undefined
+
+  return {
+    ...eventPayload,
+    id: toStringOrNull(eventPayload.id) ?? undefined,
+    type: eventType,
+    playerId:
+      toPlayerIdOrNull(eventPayload.playerId) ??
+      toPlayerIdOrNull(eventPayload.fromPlayerId) ??
+      toPlayerIdOrNull(eventPayload.from_player_id) ??
+      toPlayerIdOrNull(eventPayload.player_id) ??
+      null,
+    tileIndex:
+      toFiniteNumber(eventPayload.tileIndex ?? eventPayload.toTileId) ?? null,
+    amount: normalizedAmount,
+    payload: payloadRecord,
+  }
+}
 
 const normalizeTileType = (value: unknown): Tile['type'] => {
   if (typeof value !== 'string' || value.trim().length === 0) {
@@ -190,10 +288,13 @@ export const normalizePromptPayload = (
     return null
   }
 
-  const payloadRecord =
+  const payloadRecordRaw =
     promptCompatPayload.payload && isRecord(promptCompatPayload.payload)
       ? promptCompatPayload.payload
       : undefined
+  const payloadRecord = payloadRecordRaw
+    ? normalizeMoneyRecord(payloadRecordRaw)
+    : undefined
 
   const timeoutSecFromPayload = toFiniteNumber(
     payloadRecord ? payloadRecord.timeoutSec : undefined
@@ -222,8 +323,8 @@ export const normalizePromptPayload = (
     : undefined
   const normalizedPromptPlayerId =
     toPlayerIdOrNull(promptCompatPayload.playerId) ??
-    toPlayerIdOrNull(payloadRecord?.playerId) ??
-    toPlayerIdOrNull(payloadRecord?.player_id)
+    toPlayerIdOrNull(payloadRecordRaw?.playerId) ??
+    toPlayerIdOrNull(payloadRecordRaw?.player_id)
 
   return {
     id: promptId,
@@ -304,7 +405,10 @@ const normalizePlayerFromSnapshot = (
       0
     ),
     balance: toFiniteInt(
-      playerRecord.balance ?? playerRecord.money ?? playerRecord.cash,
+      normalizeMoneyToWon(
+        playerRecord.balance ?? playerRecord.money ?? playerRecord.cash,
+        0
+      ),
       0
     ),
     owned_tiles: normalizeOwnedTileIds(
@@ -363,14 +467,21 @@ const normalizeTileFromSnapshot = (
     name: toStringOrNull(tileRecord.name) ?? `Tile ${index}`,
     type: normalizeTileType(tileTypeRaw),
     transportType: normalizeTransportTileType(tileTypeRaw),
-    price:
-      toFiniteNumber(
+    price: (() => {
+      const rawPrice =
         tileRecord.price ??
-          tileRecord.landPrice ??
-          tileRecord.purchasePrice ??
-          tileRecord.purchase_price ??
-          tileRecord.cost
-      ) ?? undefined,
+        tileRecord.landPrice ??
+        tileRecord.purchasePrice ??
+        tileRecord.purchase_price ??
+        tileRecord.cost
+
+      const normalizedPrice = toFiniteNumber(rawPrice)
+      if (normalizedPrice == null) {
+        return undefined
+      }
+
+      return normalizeMoneyToWon(normalizedPrice, 0)
+    })(),
     color: toStringOrNull(tileRecord.color) ?? undefined,
   }
 }
@@ -527,7 +638,11 @@ const normalizePatchSetValue = (
   }
 
   if (lastSegment === 'balance') {
-    return toFiniteInt(value, 0)
+    return normalizeMoneyToWon(value, 0)
+  }
+
+  if (lastSegment === 'price') {
+    return normalizeMoneyToWon(value, 0)
   }
 
   if (lastSegment === 'building') {
@@ -544,12 +659,25 @@ const normalizePatchSetValue = (
 const normalizePatchOperation = (operation: GamePatchOperation) => {
   const pathSegments = toPathSegments(operation.path).map(normalizePathSegment)
   const path = toPathLike(operation.path, pathSegments)
+  const lastSegment = pathSegments[pathSegments.length - 1]
 
   if (operation.op === 'set') {
     return {
       ...operation,
       path,
       value: normalizePatchSetValue(pathSegments, operation.value),
+    } as GamePatchOperation
+  }
+
+  if (operation.op === 'inc') {
+    const normalizedValue =
+      lastSegment === 'balance' || lastSegment === 'price'
+        ? normalizeMoneyToWon(operation.value, 0)
+        : toFiniteInt(operation.value, 0)
+    return {
+      ...operation,
+      path,
+      value: normalizedValue,
     } as GamePatchOperation
   }
 
@@ -567,5 +695,9 @@ export const normalizePatchEnvelopePayload = (
   patch: Array.isArray(payload.patch)
     ? payload.patch.map(normalizePatchOperation)
     : [],
-  events: Array.isArray(payload.events) ? payload.events : [],
+  events: Array.isArray(payload.events)
+    ? payload.events
+        .map(normalizeServerEvent)
+        .filter((event): event is ServerEvent => event !== null)
+    : [],
 })

--- a/src/services/socket/gameContractAdapters.ts
+++ b/src/services/socket/gameContractAdapters.ts
@@ -220,6 +220,10 @@ export const normalizePromptPayload = (
         .map((choice, index) => normalizePromptChoice(choice, index))
         .filter((choice): choice is GamePromptChoice => choice !== null)
     : undefined
+  const normalizedPromptPlayerId =
+    toPlayerIdOrNull(promptCompatPayload.playerId) ??
+    toPlayerIdOrNull(payloadRecord?.playerId) ??
+    toPlayerIdOrNull(payloadRecord?.player_id)
 
   return {
     id: promptId,
@@ -228,15 +232,7 @@ export const normalizePromptPayload = (
       promptCompatPayload.type.trim().length > 0
         ? promptCompatPayload.type
         : 'UNKNOWN_PROMPT',
-    playerId:
-      promptCompatPayload.playerId === undefined &&
-      payloadRecord?.playerId === undefined &&
-      payloadRecord?.player_id === undefined
-        ? null
-        : (promptCompatPayload.playerId ??
-          payloadRecord?.playerId ??
-          payloadRecord?.player_id ??
-          null),
+    playerId: normalizedPromptPlayerId,
     title:
       typeof promptCompatPayload.title === 'string' &&
       promptCompatPayload.title.trim().length > 0

--- a/src/services/socket/gameContractAdapters.ts
+++ b/src/services/socket/gameContractAdapters.ts
@@ -23,6 +23,7 @@ type SnapshotNormalizeOptions = {
 
 const DEFAULT_TURN_TIMEOUT_SEC = 30
 const DEFAULT_PLAYER_COLOR = '#94A3B8'
+const DEFAULT_INITIAL_BALANCE = 5_000_000_000
 const MONEY_UNIT_SCALE = 10_000
 const MONEY_ALREADY_WON_THRESHOLD = 10_000_000
 const MONEY_KEYS = new Set([
@@ -129,6 +130,25 @@ const normalizeMoneyToWon = (value: unknown, fallback = 0) => {
   }
 
   return raw * MONEY_UNIT_SCALE
+}
+
+const resolvePlayerBalance = (playerRecord: Record<string, unknown>) => {
+  const rawBalance =
+    playerRecord.balance ??
+    playerRecord.money ??
+    playerRecord.cash ??
+    playerRecord.initialBalance ??
+    playerRecord.initial_balance ??
+    playerRecord.startBalance ??
+    playerRecord.start_balance ??
+    playerRecord.funds ??
+    playerRecord.capital
+
+  if (rawBalance == null) {
+    return DEFAULT_INITIAL_BALANCE
+  }
+
+  return normalizeMoneyToWon(rawBalance, DEFAULT_INITIAL_BALANCE)
 }
 
 const normalizeMoneyRecord = (record: Record<string, unknown>) => {
@@ -246,6 +266,20 @@ const normalizePromptChoice = (
   choice: unknown,
   fallbackIndex: number
 ): GamePromptChoice | null => {
+  if (typeof choice === 'string') {
+    const value = normalizePromptChoiceValue(choice)
+    if (!value) {
+      return null
+    }
+
+    return {
+      id: `${value.toLowerCase()}-${fallbackIndex}`,
+      label: value,
+      value,
+      description: undefined,
+    }
+  }
+
   if (!isRecord(choice)) {
     return null
   }
@@ -404,13 +438,7 @@ const normalizePlayerFromSnapshot = (
         playerRecord.tileId,
       0
     ),
-    balance: toFiniteInt(
-      normalizeMoneyToWon(
-        playerRecord.balance ?? playerRecord.money ?? playerRecord.cash,
-        0
-      ),
-      0
-    ),
+    balance: toFiniteInt(resolvePlayerBalance(playerRecord), 0),
     owned_tiles: normalizeOwnedTileIds(
       playerRecord.owned_tiles ?? playerRecord.ownedTiles
     ),

--- a/src/services/socket/gameContractAdapters.ts
+++ b/src/services/socket/gameContractAdapters.ts
@@ -303,7 +303,10 @@ const normalizePlayerFromSnapshot = (
         playerRecord.tileId,
       0
     ),
-    balance: toFiniteInt(playerRecord.balance, 0),
+    balance: toFiniteInt(
+      playerRecord.balance ?? playerRecord.money ?? playerRecord.cash,
+      0
+    ),
     owned_tiles: normalizeOwnedTileIds(
       playerRecord.owned_tiles ?? playerRecord.ownedTiles
     ),
@@ -360,7 +363,14 @@ const normalizeTileFromSnapshot = (
     name: toStringOrNull(tileRecord.name) ?? `Tile ${index}`,
     type: normalizeTileType(tileTypeRaw),
     transportType: normalizeTransportTileType(tileTypeRaw),
-    price: toFiniteNumber(tileRecord.price) ?? undefined,
+    price:
+      toFiniteNumber(
+        tileRecord.price ??
+          tileRecord.landPrice ??
+          tileRecord.purchasePrice ??
+          tileRecord.purchase_price ??
+          tileRecord.cost
+      ) ?? undefined,
     color: toStringOrNull(tileRecord.color) ?? undefined,
   }
 }
@@ -375,10 +385,14 @@ export const normalizeSnapshotPayload = (
 
   const playersRaw = Array.isArray(snapshotPayload.players)
     ? snapshotPayload.players
-    : []
+    : isRecord(snapshotPayload.players)
+      ? Object.values(snapshotPayload.players)
+      : []
   const tilesRaw = Array.isArray(snapshotPayload.tiles)
     ? snapshotPayload.tiles
-    : []
+    : isRecord(snapshotPayload.tiles)
+      ? Object.values(snapshotPayload.tiles)
+      : []
   const currentPlayerId = toPlayerIdOrNull(
     snapshotPayload.currentPlayerId ??
       snapshotPayload.current_player_id ??
@@ -404,7 +418,11 @@ export const normalizeSnapshotPayload = (
       snapshotPayload.turnTimeoutSec,
       DEFAULT_TURN_TIMEOUT_SEC
     ),
-    prompt: normalizePromptPayload(snapshotPayload.prompt),
+    prompt: normalizePromptPayload(
+      snapshotPayload.prompt ??
+        snapshotPayload.pending_prompt ??
+        snapshotPayload.pendingPrompt
+    ),
     gameResult:
       snapshotPayload.gameResult && isRecord(snapshotPayload.gameResult)
         ? (snapshotPayload.gameResult as GameSnapshot['gameResult'])

--- a/src/services/socket/gameContractAdapters.ts
+++ b/src/services/socket/gameContractAdapters.ts
@@ -467,7 +467,11 @@ const normalizePathSegment = (segment: string | number): string | number => {
   if (segment === 'current_tile_id') return 'position'
   if (segment === 'playerState') return 'state'
   if (segment === 'player_state') return 'state'
+  if (segment === 'money') return 'balance'
+  if (segment === 'cash') return 'balance'
   if (segment === 'ownedTiles') return 'owned_tiles'
+  if (segment === 'pending_prompt') return 'prompt'
+  if (segment === 'pendingPrompt') return 'prompt'
   if (segment === 'building_level') return 'building'
   if (segment === 'buildingLevel') return 'building'
   if (segment === 'tile_type') return 'type'
@@ -487,17 +491,27 @@ const normalizePatchSetValue = (
   }
 
   if (pathSegments.length === 1 && firstSegment === 'players') {
-    if (!Array.isArray(value)) {
-      return []
+    if (Array.isArray(value)) {
+      return value.map(normalizePlayerFromSnapshot)
     }
-    return value.map(normalizePlayerFromSnapshot)
+    if (isRecord(value)) {
+      return Object.values(value).map(normalizePlayerFromSnapshot)
+    }
+    return []
   }
 
   if (pathSegments.length === 1 && firstSegment === 'tiles') {
-    if (!Array.isArray(value)) {
-      return []
+    if (Array.isArray(value)) {
+      return value.map(normalizeTileFromSnapshot)
     }
-    return value.map(normalizeTileFromSnapshot)
+    if (isRecord(value)) {
+      return Object.values(value).map(normalizeTileFromSnapshot)
+    }
+    return []
+  }
+
+  if (pathSegments.length === 1 && firstSegment === 'prompt') {
+    return normalizePromptPayload(value)
   }
 
   if (lastSegment === 'state') {
@@ -509,6 +523,10 @@ const normalizePatchSetValue = (
   }
 
   if (lastSegment === 'position') {
+    return toFiniteInt(value, 0)
+  }
+
+  if (lastSegment === 'balance') {
     return toFiniteInt(value, 0)
   }
 

--- a/src/services/socket/gameContractAdapters.ts
+++ b/src/services/socket/gameContractAdapters.ts
@@ -229,9 +229,14 @@ export const normalizePromptPayload = (
         ? promptCompatPayload.type
         : 'UNKNOWN_PROMPT',
     playerId:
-      promptCompatPayload.playerId === undefined
+      promptCompatPayload.playerId === undefined &&
+      payloadRecord?.playerId === undefined &&
+      payloadRecord?.player_id === undefined
         ? null
-        : (promptCompatPayload.playerId ?? null),
+        : (promptCompatPayload.playerId ??
+          payloadRecord?.playerId ??
+          payloadRecord?.player_id ??
+          null),
     title:
       typeof promptCompatPayload.title === 'string' &&
       promptCompatPayload.title.trim().length > 0
@@ -259,6 +264,11 @@ const normalizeOwnedTileIds = (value: unknown): number[] => {
         return Math.trunc(item)
       }
 
+      if (typeof item === 'string') {
+        const parsed = Number.parseInt(item, 10)
+        return Number.isFinite(parsed) ? parsed : Number.NaN
+      }
+
       if (isRecord(item)) {
         return toFiniteInt(item.tileId, Number.NaN)
       }
@@ -282,7 +292,10 @@ const normalizePlayerFromSnapshot = (
   )
 
   return {
-    id: toPlayerId(playerRecord.id, fallbackIndex),
+    id: toPlayerId(
+      playerRecord.id ?? playerRecord.playerId ?? playerRecord.player_id,
+      fallbackIndex
+    ),
     nickname:
       toStringOrNull(playerRecord.nickname) ??
       toStringOrNull(playerRecord.name) ??
@@ -290,6 +303,7 @@ const normalizePlayerFromSnapshot = (
     position: toFiniteInt(
       playerRecord.position ??
         playerRecord.currentTileId ??
+        playerRecord.current_tile_id ??
         playerRecord.tileId,
       0
     ),
@@ -321,16 +335,31 @@ const normalizeTileFromSnapshot = (
   fallbackIndex: number
 ): Tile => {
   const tileRecord = isRecord(tilePayload) ? tilePayload : {}
-  const index = toFiniteInt(tileRecord.index ?? tileRecord.id, fallbackIndex)
-  const ownerId = tileRecord.ownerId ?? tileRecord.owner_id ?? null
-  const tileTypeRaw = tileRecord.tileType ?? tileRecord.type
+  const index = toFiniteInt(
+    tileRecord.index ??
+      tileRecord.id ??
+      tileRecord.tileId ??
+      tileRecord.tile_id,
+    fallbackIndex
+  )
+  const ownerId =
+    tileRecord.ownerId ??
+    tileRecord.owner_id ??
+    tileRecord.ownerPlayerId ??
+    tileRecord.owner_player_id ??
+    null
+  const tileTypeRaw =
+    tileRecord.tileType ?? tileRecord.type ?? tileRecord.tile_type
 
   return {
     index,
     ownerId: ownerId as Tile['ownerId'],
     owner_id: ownerId as Tile['owner_id'],
     building: clampBuildingLevel(
-      tileRecord.building ?? tileRecord.buildingLevel ?? 0
+      tileRecord.building ??
+        tileRecord.buildingLevel ??
+        tileRecord.building_level ??
+        0
     ),
     name: toStringOrNull(tileRecord.name) ?? `Tile ${index}`,
     type: normalizeTileType(tileTypeRaw),
@@ -355,7 +384,10 @@ export const normalizeSnapshotPayload = (
     ? snapshotPayload.tiles
     : []
   const currentPlayerId = toPlayerIdOrNull(
-    snapshotPayload.currentPlayerId ?? snapshotPayload.currentTurn ?? null
+    snapshotPayload.currentPlayerId ??
+      snapshotPayload.current_player_id ??
+      snapshotPayload.currentTurn ??
+      null
   )
   const roundFromTurn = toFiniteInt(snapshotPayload.turn, 1)
 
@@ -416,10 +448,15 @@ const normalizePathSegment = (segment: string | number): string | number => {
     return segment
   }
 
+  if (segment === 'current_player_id') return 'currentPlayerId'
   if (segment === 'currentTileId') return 'position'
+  if (segment === 'current_tile_id') return 'position'
   if (segment === 'playerState') return 'state'
+  if (segment === 'player_state') return 'state'
   if (segment === 'ownedTiles') return 'owned_tiles'
+  if (segment === 'building_level') return 'building'
   if (segment === 'buildingLevel') return 'building'
+  if (segment === 'tile_type') return 'type'
   if (segment === 'tileType') return 'type'
   return segment
 }

--- a/src/stores/game.store.test.ts
+++ b/src/stores/game.store.test.ts
@@ -172,6 +172,51 @@ describe('game store partial updates', () => {
     expect(nextState.eventQueue).toHaveLength(2)
   })
 
+  it('resolves id-based player and tile patch paths', () => {
+    const store = useGameStore.getState()
+
+    store.setGameState({
+      revision: 1,
+      players: [
+        createPlayer({
+          id: 105,
+          balance: 500,
+          position: 2,
+        }),
+        createPlayer({
+          id: 'player-2',
+          balance: 400,
+          position: 1,
+        }),
+      ],
+      tiles: [
+        createTile({
+          index: 12,
+          ownerId: null,
+          owner_id: null,
+        }),
+      ],
+    })
+
+    store.applyPatchEnvelope({
+      revision: 2,
+      patch: [
+        { op: 'set', path: 'players.105.balance', value: 750 },
+        { op: 'set', path: ['players', 'player-2', 'position'], value: 9 },
+        { op: 'set', path: 'tiles.12.ownerId', value: 'player-2' },
+        { op: 'set', path: ['tiles', 12, 'building'], value: 3 },
+      ],
+    })
+
+    const nextState = useGameStore.getState()
+
+    expect(nextState.players[0]?.balance).toBe(750)
+    expect(nextState.players[1]?.position).toBe(9)
+    expect(nextState.tiles[0]?.ownerId).toBe('player-2')
+    expect(nextState.tiles[0]?.owner_id).toBe('player-2')
+    expect(nextState.tiles[0]?.building).toBe(3)
+  })
+
   it('tracks pending actions, acknowledgements, prompts, and queue consumption', () => {
     const store = useGameStore.getState()
     const prompt: GamePrompt = {

--- a/src/stores/game.store.ts
+++ b/src/stores/game.store.ts
@@ -41,6 +41,8 @@ type GameStoreState = GameState & GameActions
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null
 
+const ARRAY_PATH_IDENTITY_KEYS = ['id', 'index', 'tileId', 'tile_id'] as const
+
 const normalizeTile = (tile: Tile): Tile => {
   const ownerId =
     tile.ownerId !== undefined ? tile.ownerId : (tile.owner_id ?? null)
@@ -118,6 +120,46 @@ const toPathSegments = (
     )
 }
 
+const resolveArraySegmentToIndex = (
+  target: unknown[],
+  segment: string | number
+): number | null => {
+  const segmentText = String(segment)
+  const identityMatchedIndex = target.findIndex((item) => {
+    if (!isRecord(item)) {
+      return false
+    }
+
+    return ARRAY_PATH_IDENTITY_KEYS.some((key) => {
+      const candidate = item[key]
+      return candidate !== undefined && candidate !== null
+        ? String(candidate) === segmentText
+        : false
+    })
+  })
+
+  if (identityMatchedIndex >= 0) {
+    return identityMatchedIndex
+  }
+
+  const parsedIndex =
+    typeof segment === 'number'
+      ? segment
+      : /^\d+$/.test(segment)
+        ? Number.parseInt(segment, 10)
+        : Number.NaN
+
+  if (
+    Number.isInteger(parsedIndex) &&
+    parsedIndex >= 0 &&
+    parsedIndex < target.length
+  ) {
+    return parsedIndex
+  }
+
+  return null
+}
+
 const getTargetContainer = (
   draft: Record<string, unknown>,
   path: Array<string | number>
@@ -126,8 +168,13 @@ const getTargetContainer = (
   let cursor: unknown = draft
 
   for (const segment of parentPath) {
-    if (Array.isArray(cursor) && typeof segment === 'number') {
-      cursor = cursor[segment]
+    if (Array.isArray(cursor)) {
+      const arrayIndex = resolveArraySegmentToIndex(cursor, segment)
+      if (arrayIndex == null) {
+        return null
+      }
+
+      cursor = cursor[arrayIndex]
       continue
     }
 
@@ -154,8 +201,13 @@ const setValueAtPath = (
     return
   }
 
-  if (Array.isArray(target) && typeof key === 'number') {
-    target[key] = value
+  if (Array.isArray(target)) {
+    const arrayIndex = resolveArraySegmentToIndex(target, key)
+    if (arrayIndex == null) {
+      return
+    }
+
+    target[arrayIndex] = value
     return
   }
 
@@ -171,8 +223,13 @@ const getValueAtPath = (
   let cursor: unknown = draft
 
   for (const segment of path) {
-    if (Array.isArray(cursor) && typeof segment === 'number') {
-      cursor = cursor[segment]
+    if (Array.isArray(cursor)) {
+      const arrayIndex = resolveArraySegmentToIndex(cursor, segment)
+      if (arrayIndex == null) {
+        return undefined
+      }
+
+      cursor = cursor[arrayIndex]
       continue
     }
 
@@ -212,6 +269,14 @@ const removeValueAtPath = (
 
   const container = getTargetContainer(draft, path)
   const key = path[path.length - 1]
+
+  if (key !== undefined && Array.isArray(container)) {
+    const arrayIndex = resolveArraySegmentToIndex(container, key)
+    if (arrayIndex != null) {
+      container.splice(arrayIndex, 1)
+    }
+    return
+  }
 
   if (key !== undefined && isRecord(container)) {
     delete container[String(key)]


### PR DESCRIPTION
## 관련 이슈
- closes #<이슈번호>

## 작업 개요
실서버 게임 소켓 계약과 프론트 런타임 간 불일치로 인해 발생하던
주사위 액션 미반영, 이벤트 연출 누락, 자금/가격 표시 불일치 이슈를 정리했습니다.
mock/real 공통 경로에서 동일한 계약으로 동작하도록 어댑터/핸들러를 보강했습니다.

## 작업 내용
- game snapshot alias 정규화 보강
- patch 경로 해석 시 player/tile identity 기반 매핑 보강
- prompt playerId 정규화(type-safe) 반영
- snapshot의 balance/prompt alias 정규화
- board 이벤트 유틸에서 실서버 이벤트 alias(dice, toTileId 등) 허용
- patch의 players/tiles object-shape, snake_case prompt payload 호환
- patch 경로 alias 추가
  - `money/cash -> balance`
  - `pending_prompt/pendingPrompt -> prompt`
- money unit 정규화(만원 단위 수신값 -> 프론트 표시 단위로 변환) 적용
- `ROLL_DICE` 송신 payload에 `diceId: 0` 포함
- `game:patch`에서 `snapshot + events` 동시 수신 시 events도 queue에 반영
- timer prompt choice 해석 우선순위 보정(`ROLL_DICE` 우선)
- prompt choices가 문자열 배열로 오는 경우 정규화 처리
- snapshot player에 잔액 필드가 비어 있을 때 기본 초기자금 fallback 처리

## 기대 효과
- 주사위 클릭 시 서버 계약에 맞는 액션이 전송되고, 관련 이벤트 연출이 큐에서 정상 소비됩니다.
- prompt/patch/snapshot의 필드 변형에 대한 복원력이 올라가 실서버 payload 변화에 덜 깨집니다.
- 자금/가격/통행료 표시가 문서 기준 단위로 일관되게 보입니다.

## 테스트/검증
- `npm run lint` 통과
- `npm run test` 통과
- `npm run test:coverage` 통과
- `npm run e2e:ci` 통과 (`--grep-invert @game`)
- `npm run build` 통과
- 추가 타겟 테스트
  - `src/hooks/game/useDiceRoll.test.ts`
  - `src/components/game/modals/promptModalMapping.test.ts`
  - `src/services/socket/gameContractAdapters.test.ts`
  - `src/components/board/gameBoardEventQueueUtils.test.ts`

## 체크리스트
- [x] 실서버 소켓 액션/이벤트 계약 정렬
- [x] prompt/snapshot/patch alias 호환 정리
- [x] 주사위 액션 및 이벤트 큐 연출 경로 점검
- [x] 자금/가격 표시 단위 정렬
- [x] 관련 테스트 보강 및 회귀 검증
