### PR TITLE
refactor: waiting-room 기능 폴더 구조 정리

### DIFF
--- a/docs/ai/tasks/waiting-room-folder-structure/checklist.md
+++ b/docs/ai/tasks/waiting-room-folder-structure/checklist.md
@@ -1,0 +1,7 @@
+- [x] `waiting-room-folder-structure` 작업 범위와 제외 범위를 문서로 고정했다
+- [x] `src/pages/waiting-room` 파일을 책임 단위 폴더로 재배치했다
+- [x] 관련 import / `vi.mock()` / dynamic import 경로를 모두 갱신했다
+- [x] 관련 Vitest를 실행했다
+- [x] `npm run lint` 대상 범위를 실행했다
+- [x] `npm run build`를 실행했다
+- [x] 기능 변경 없이 구조만 바뀌었는지 최종 확인했다

--- a/docs/ai/tasks/waiting-room-folder-structure/context.md
+++ b/docs/ai/tasks/waiting-room-folder-structure/context.md
@@ -1,0 +1,71 @@
+# 현재 구조
+
+`src/pages/waiting-room`에는 아래 파일이 한 디렉토리에 많이 섞여 있다.
+
+- `WaitingRoomPage.tsx`, `WaitingRoomPage.test.tsx`, `WaitingRoomFlow.test.tsx`
+- `api.ts`, `api.test.ts`, `types.ts`
+- `socket.ts`
+- `mockGateway.ts`, `mockGateway.test.ts`, `mockSeed.ts`
+- `hooks.ts`
+- `controller/*`
+- `components/*`
+
+현재도 `components/`, `controller/`는 나뉘어 있지만, page root에 여전히 api / socket / mock / test가 함께 있어 파일 탐색 시 맥락 전환이 잦다.
+
+# 정리 방향
+
+- 테스트를 전역 `tests/` 폴더로 이동하지 않는다.
+- 대신 waiting-room 내부에 책임 기준 폴더를 추가한다.
+- `WaitingRoomPage`는 page entry 성격을 유지한다.
+- `controller/`는 현재 구조를 유지한다.
+- `api`, `socket/mock`, `page test`를 더 분리해 page root의 밀도를 낮춘다.
+
+# 목표 구조
+
+```text
+src/pages/waiting-room/
+  page/
+    WaitingRoomPage.tsx
+    WaitingRoomPage.test.tsx
+    WaitingRoomFlow.test.tsx
+  components/
+    DevControlPanel.tsx
+    WaitingRoomActionPanel.tsx
+    WaitingRoomChatBox.tsx
+    WaitingRoomHeader.tsx
+    WaitingRoomSidePanel.tsx
+    WaitingSeatCard.tsx
+  controller/
+    actions.ts
+    actions.test.ts
+    lifecycle.ts
+    lifecycle.test.ts
+    socketSync.ts
+    socketSync.test.ts
+    state.ts
+    state.test.ts
+  api/
+    api.ts
+    api.test.ts
+    types.ts
+  socket/
+    socket.ts
+    mockGateway.ts
+    mockGateway.test.ts
+    mockSeed.ts
+  hooks/
+    hooks.ts
+```
+
+# 결정 이유
+
+- `page/`는 화면 조합과 page-level test를 함께 묶어 읽기 쉽게 한다.
+- `api/`는 snapshot payload, API 호출, 타입이 함께 바뀌는 경계다.
+- `socket/`는 emit/subscribe와 mock gateway가 함께 바뀌는 경계다.
+- `controller/`는 이미 잘 나뉘어 있어 유지하는 편이 안전하다.
+
+# 주의할 점
+
+- `WaitingRoomPage`는 presence, auth, lobby 경로와도 연결된다.
+- `mockSeed`는 presence mock data와도 연결돼 있어 import 이동 시 상대 경로를 조심해야 한다.
+- game start navigate, cleanup leave, preJoinedSnapshot 같은 경계 로직은 구조만 바꾸고 동작은 건드리지 않는다.

--- a/docs/ai/tasks/waiting-room-folder-structure/plan.md
+++ b/docs/ai/tasks/waiting-room-folder-structure/plan.md
@@ -1,0 +1,42 @@
+# 목표
+
+`src/pages/waiting-room` 내부 파일을 책임 단위 폴더로 재배치해 page / controller / api / socket / mock 경계를 더 명확하게 만든다.
+
+# 범위
+
+- `src/pages/waiting-room/**`
+- 관련 import를 사용하는 `src/pages/lobby/**`, `src/features/presence/**`, `src/mocks/**`
+- waiting-room 테스트 파일 위치 재정리
+
+# 제외 범위
+
+- waiting-room 기능 동작 변경
+- 준비/시작/퇴장 정책 변경
+- socket payload/contract 변경
+- `presence` 구조 추가 개편
+
+# 완료 기준
+
+- `WaitingRoomPage`, `controller`, `api`, `socket/mock` 관련 파일이 기능별 폴더로 재배치된다.
+- 테스트 파일은 대상 코드와 같은 폴더 또는 인접 폴더에 유지된다.
+- 기능 변화 없이 import 경로만 안정적으로 갱신된다.
+- 관련 Vitest, lint, build가 통과한다.
+
+# 타깃 파일
+
+- `src/pages/waiting-room/**`
+- `src/pages/lobby/**` 중 waiting-room import 경로를 가진 파일
+- `src/features/auth/mock/session.ts`
+- `src/mocks/handlers.ts`
+
+# 검증 계획
+
+1. `npx vitest run src/pages/waiting-room src/pages/lobby/LobbyPage.test.tsx`
+2. `npm run lint -- src/pages/waiting-room src/pages/lobby`
+3. `npm run build`
+
+# 리스크
+
+- waiting-room은 lifecycle / cleanup / socket sync가 강하게 연결돼 있어 경로 변경 중 import 누락이 생기기 쉽다.
+- `vi.mock()` 경로와 dynamic import 경로가 실제 이동과 같이 바뀌지 않으면 테스트만 깨질 수 있다.
+- `mockGateway`, `mockSeed`, `socket`, `api`는 서로 순환 의존처럼 보이는 경계가 있어 과한 공통화는 피해야 한다.

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -48,7 +48,7 @@ vi.mock('./pages/MyPage', () => ({
   default: () => <div>마이페이지</div>,
 }))
 
-vi.mock('./pages/waiting-room/WaitingRoomPage', () => ({
+vi.mock('./pages/waiting-room/page/WaitingRoomPage', () => ({
   default: () => <div>대기방 페이지</div>,
 }))
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,7 @@ const KakaoLoginCallbackPage = lazy(
 const NicknameSetupPage = lazy(() => import('./pages/NicknameSetupPage'))
 const MyPage = lazy(() => import('./pages/MyPage'))
 const WaitingRoomPage = lazy(
-  () => import('./pages/waiting-room/WaitingRoomPage')
+  () => import('./pages/waiting-room/page/WaitingRoomPage')
 )
 
 function RouteLoadingScreen() {

--- a/src/features/auth/mock/session.ts
+++ b/src/features/auth/mock/session.ts
@@ -1,6 +1,6 @@
 import type { AuthSession } from '../types'
 import { resetMockOnlineUsers } from '../../presence/mock/mockData'
-import { resetMockWaitingRooms } from '../../../pages/waiting-room/mockGateway'
+import { resetMockWaitingRooms } from '../../../pages/waiting-room/socket/mockGateway'
 import { MOCK_AUTH_DELAY_MS } from './constants'
 import { createMockUuid, delay } from './helpers'
 import {

--- a/src/features/presence/mock/mockData.test.ts
+++ b/src/features/presence/mock/mockData.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it, vi } from 'vitest'
-import { createSeededRoomPlayers } from '../../../pages/waiting-room/mockSeed'
+import { createSeededRoomPlayers } from '../../../pages/waiting-room/socket/mockSeed'
 
 type PresenceMockDataModule = typeof import('./mockData')
 type WaitingRoomMockGatewayModule =
-  typeof import('../../../pages/waiting-room/mockGateway')
+  typeof import('../../../pages/waiting-room/socket/mockGateway')
 
 interface LoadedMockModules {
   presence: PresenceMockDataModule
@@ -16,7 +16,7 @@ async function loadMockModules(): Promise<LoadedMockModules> {
 
   const [presence, gateway] = await Promise.all([
     import('./mockData'),
-    import('../../../pages/waiting-room/mockGateway'),
+    import('../../../pages/waiting-room/socket/mockGateway'),
   ])
 
   return {

--- a/src/features/presence/mock/mockData.ts
+++ b/src/features/presence/mock/mockData.ts
@@ -1,5 +1,5 @@
 import type { OnlineUserPayload } from '../types'
-import { createInitialSeededOnlineUsers } from '../../../pages/waiting-room/mockSeed'
+import { createInitialSeededOnlineUsers } from '../../../pages/waiting-room/socket/mockSeed'
 
 // 대기방 시드와 동일한 규칙으로 접속자 초기 데이터를 생성
 const INITIAL_MOCK_ONLINE_USERS: OnlineUserPayload[] =

--- a/src/features/room-chat/DevRoomChatControlPanel.tsx
+++ b/src/features/room-chat/DevRoomChatControlPanel.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { IS_SOCKET_MOCK_ENABLED } from '../../config/env'
 import { cn } from '../../lib/utils'
-import { sendWaitingRoomChat } from '../../pages/waiting-room/socket'
+import { sendWaitingRoomChat } from '../../pages/waiting-room/socket/socket'
 
 const IS_DEV_ROOM_CHAT_CONTROL_ENABLED = IS_SOCKET_MOCK_ENABLED
 

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,7 +1,7 @@
 import { delay, http, HttpResponse } from 'msw'
 import { getMockOnlineUsersSnapshot } from '../features/presence/mock/mockData'
 import type { LobbyRoomPayload, LobbyRoomStatus } from '../pages/lobby/types'
-import { getMockLobbyRooms } from '../pages/waiting-room/mockGateway'
+import { getMockLobbyRooms } from '../pages/waiting-room/socket/mockGateway'
 import { gameHandlers } from './handlers/game.handler'
 
 // 로비 방 모델을 API 응답 payload 포맷으로 변환

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -25,8 +25,8 @@ import {
   mapStoreTilesToBoardTiles,
   calcPlayerTotalAssets,
 } from './game/gameViewModel'
-import { sendWaitingRoomChat } from './waiting-room/socket'
-import type { ChatEventPayload } from './waiting-room/types'
+import { sendWaitingRoomChat } from './waiting-room/socket/socket'
+import type { ChatEventPayload } from './waiting-room/api/types'
 
 const USE_GAME_SOCKET_MOCK = IS_SOCKET_MOCK_ENABLED
 const ALLOW_ALL_MOCK_TURNS =

--- a/src/pages/lobby/LobbyPage.test.tsx
+++ b/src/pages/lobby/LobbyPage.test.tsx
@@ -11,7 +11,7 @@ import { renderWithProviders } from '../../test/renderWithProviders'
 import LobbyPage from './LobbyPage'
 import type { GetLobbyRoomsParams } from './api'
 import type { LobbyRoom } from './types'
-import type { WaitingRoomSnapshot } from '../waiting-room/types'
+import type { WaitingRoomSnapshot } from '../waiting-room/api/types'
 
 const {
   useLobbyRoomsQueryMock,
@@ -64,7 +64,7 @@ vi.mock('../../lib/socket', () => ({
   disconnectSocketAndClearAuth: disconnectSocketAndClearAuthMock,
 }))
 
-vi.mock('../waiting-room/api', () => ({
+vi.mock('../waiting-room/api/api', () => ({
   createWaitingRoom: createWaitingRoomMock,
   getWaitingRoomErrorMessage: getWaitingRoomErrorMessageMock,
   isJoinPasswordMismatchError: isJoinPasswordMismatchErrorMock,

--- a/src/pages/lobby/useLobbyRoomActions.ts
+++ b/src/pages/lobby/useLobbyRoomActions.ts
@@ -8,9 +8,9 @@ import {
   getWaitingRoomErrorMessage,
   isJoinPasswordMismatchError,
   joinWaitingRoom,
-} from '../waiting-room/api'
+} from '../waiting-room/api/api'
 import type { LobbyRoom } from './types'
-import type { WaitingRoomSnapshot } from '../waiting-room/types'
+import type { WaitingRoomSnapshot } from '../waiting-room/api/types'
 
 // 로비 방 생성/입장 액션 훅 입력값 타입
 interface UseLobbyRoomActionsParams {

--- a/src/pages/waiting-room/api/api.test.ts
+++ b/src/pages/waiting-room/api/api.test.ts
@@ -5,7 +5,7 @@ import {
   parseJoinWaitingRoomPayload,
   WaitingRoomContractError,
 } from './api'
-import { WaitingRoomMockError } from './mockGateway'
+import { WaitingRoomMockError } from '../socket/mockGateway'
 
 // axios 에러 형태를 테스트에서 간단히 재현
 function createAxiosLikeError(options: {

--- a/src/pages/waiting-room/api/api.ts
+++ b/src/pages/waiting-room/api/api.ts
@@ -1,13 +1,13 @@
-import { apiClient } from '../../lib/axios'
-import { getParsedApiErrorMessage, parseApiError } from '../../lib/apiError'
-import { IS_SOCKET_MOCK_ENABLED } from '../../config/env'
+import { apiClient } from '../../../lib/axios'
+import { getParsedApiErrorMessage, parseApiError } from '../../../lib/apiError'
+import { IS_SOCKET_MOCK_ENABLED } from '../../../config/env'
 import {
   mockCreateWaitingRoom,
   mockJoinWaitingRoom,
   mockLeaveWaitingRoom,
   mockStartWaitingGame,
   mockToggleWaitingReady,
-} from './mockGateway'
+} from '../socket/mockGateway'
 import type {
   CreateRoomResponsePayload,
   JoinWaitingRoomResponsePayload,

--- a/src/pages/waiting-room/api/types.ts
+++ b/src/pages/waiting-room/api/types.ts
@@ -1,4 +1,4 @@
-import type { LobbyRoomStatus } from '../lobby/types'
+import type { LobbyRoomStatus } from '../../lobby/types'
 
 // 대기방 플레이어 화면 모델
 export interface WaitingRoomPlayer {

--- a/src/pages/waiting-room/components/DevControlPanel.tsx
+++ b/src/pages/waiting-room/components/DevControlPanel.tsx
@@ -7,7 +7,7 @@ import { emitDirectMessageReceiveMockForDev } from '../../../features/presence/d
 import { setMockOnlineUserStatus } from '../../../features/presence/mock/mockData'
 import { emitMockOnlineUsersSnapshot } from '../../../features/presence/online-users/onlineUsersSocket'
 import { cn } from '../../../lib/utils'
-import { getWaitingRoomErrorMessage } from '../api'
+import { getWaitingRoomErrorMessage } from '../api/api'
 import {
   mockDevAddWaitingRoomParticipant,
   mockDevGetWaitingRoomSnapshot,
@@ -16,9 +16,9 @@ import {
   mockDevSeedStartCondition,
   mockDevSetAllNonHostReady,
   mockDevTransferWaitingRoomHost,
-} from '../mockGateway'
-import { sendWaitingRoomChat } from '../socket'
-import type { WaitingRoomPlayer, WaitingRoomSnapshot } from '../types'
+} from '../socket/mockGateway'
+import { sendWaitingRoomChat } from '../socket/socket'
+import type { WaitingRoomPlayer, WaitingRoomSnapshot } from '../api/types'
 import { IS_SOCKET_MOCK_ENABLED } from '../../../config/env'
 
 const IS_DEV_CONTROL_ENABLED = IS_SOCKET_MOCK_ENABLED

--- a/src/pages/waiting-room/components/WaitingRoomChatBox.tsx
+++ b/src/pages/waiting-room/components/WaitingRoomChatBox.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import RoomChat from '../../../features/room-chat/RoomChat'
 import type { ChatMessage } from '../../../types/domain'
-import type { WaitingRoomChatMessage } from '../types'
+import type { WaitingRoomChatMessage } from '../api/types'
 
 // 대기방 채팅 박스 렌더링 입력값 타입
 interface WaitingRoomChatBoxProps {

--- a/src/pages/waiting-room/components/WaitingRoomSidePanel.tsx
+++ b/src/pages/waiting-room/components/WaitingRoomSidePanel.tsx
@@ -1,6 +1,6 @@
 import { WaitingRoomActionPanel } from './WaitingRoomActionPanel'
 import { WaitingRoomChatBox } from './WaitingRoomChatBox'
-import type { WaitingRoomChatMessage } from '../types'
+import type { WaitingRoomChatMessage } from '../api/types'
 
 // 우측 사이드 패널 렌더링 입력값 타입
 interface WaitingRoomSidePanelProps {

--- a/src/pages/waiting-room/components/WaitingSeatCard.tsx
+++ b/src/pages/waiting-room/components/WaitingSeatCard.tsx
@@ -1,7 +1,7 @@
 import { CheckCircle2, Clock3, Crown, UserRound } from 'lucide-react'
 import { Avatar } from '../../../components/avatar/Avatar'
 import { cn } from '../../../lib/utils'
-import type { WaitingRoomSeat } from '../types'
+import type { WaitingRoomSeat } from '../api/types'
 
 // 좌석 카드 렌더링 입력값 타입
 interface WaitingSeatCardProps {

--- a/src/pages/waiting-room/controller/actions.test.ts
+++ b/src/pages/waiting-room/controller/actions.test.ts
@@ -2,7 +2,7 @@ import { act, renderHook } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createAuthSessionFixture } from '../../../test/fixtures'
 import { useWaitingRoomActions } from './actions'
-import type { WaitingRoomSnapshot } from '../types'
+import type { WaitingRoomSnapshot } from '../api/types'
 import type { WaitingRoomActionResult } from './state'
 
 const {
@@ -21,14 +21,14 @@ const {
   sendWaitingRoomChatMock: vi.fn(),
 }))
 
-vi.mock('../api', () => ({
+vi.mock('../api/api', () => ({
   leaveWaitingRoom: leaveWaitingRoomMock,
   startWaitingGame: startWaitingGameMock,
   toggleWaitingReady: toggleWaitingReadyMock,
   getWaitingRoomErrorMessage: getWaitingRoomErrorMessageMock,
 }))
 
-vi.mock('../socket', () => ({
+vi.mock('../socket/socket', () => ({
   leaveWaitingRoomSocket: leaveWaitingRoomSocketMock,
   sendWaitingRoomChat: sendWaitingRoomChatMock,
 }))

--- a/src/pages/waiting-room/controller/actions.ts
+++ b/src/pages/waiting-room/controller/actions.ts
@@ -6,9 +6,9 @@ import {
   leaveWaitingRoom,
   startWaitingGame,
   toggleWaitingReady,
-} from '../api'
-import { leaveWaitingRoomSocket, sendWaitingRoomChat } from '../socket'
-import type { WaitingRoomSnapshot } from '../types'
+} from '../api/api'
+import { leaveWaitingRoomSocket, sendWaitingRoomChat } from '../socket/socket'
+import type { WaitingRoomSnapshot } from '../api/types'
 import type { LeaveRoomSequenceParams, WaitingRoomActionResult } from './state'
 
 // 액션 훅 입력 파라미터 타입

--- a/src/pages/waiting-room/controller/lifecycle.test.ts
+++ b/src/pages/waiting-room/controller/lifecycle.test.ts
@@ -2,7 +2,7 @@ import { renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createAuthSessionFixture } from '../../../test/fixtures'
 import { useWaitingRoomLifecycle } from './lifecycle'
-import type { WaitingRoomSnapshot } from '../types'
+import type { WaitingRoomSnapshot } from '../api/types'
 
 const {
   joinWaitingRoomMock,
@@ -16,12 +16,12 @@ const {
   requestOnlineUsersSnapshotSyncMock: vi.fn(),
 }))
 
-vi.mock('../api', () => ({
+vi.mock('../api/api', () => ({
   joinWaitingRoom: joinWaitingRoomMock,
   getWaitingRoomErrorMessage: getWaitingRoomErrorMessageMock,
 }))
 
-vi.mock('../socket', () => ({
+vi.mock('../socket/socket', () => ({
   enterWaitingRoomSocket: enterWaitingRoomSocketMock,
 }))
 

--- a/src/pages/waiting-room/controller/lifecycle.ts
+++ b/src/pages/waiting-room/controller/lifecycle.ts
@@ -2,9 +2,9 @@ import { useEffect } from 'react'
 import type { Dispatch, MutableRefObject, SetStateAction } from 'react'
 import type { AuthSession } from '../../../features/auth/types'
 import { requestOnlineUsersSnapshotSync } from '../../../features/presence/online-users/onlineUsersSocket'
-import { getWaitingRoomErrorMessage, joinWaitingRoom } from '../api'
-import { enterWaitingRoomSocket } from '../socket'
-import type { WaitingRoomChatMessage, WaitingRoomSnapshot } from '../types'
+import { getWaitingRoomErrorMessage, joinWaitingRoom } from '../api/api'
+import { enterWaitingRoomSocket } from '../socket/socket'
+import type { WaitingRoomChatMessage, WaitingRoomSnapshot } from '../api/types'
 
 // 입장/초기화 훅 입력 파라미터 타입
 interface UseWaitingRoomLifecycleParams {

--- a/src/pages/waiting-room/controller/socketSync.test.ts
+++ b/src/pages/waiting-room/controller/socketSync.test.ts
@@ -11,7 +11,7 @@ import type {
   PlayerReadyEventPayload,
   RoomUpdatedEventPayload,
   WaitingRoomSnapshot,
-} from '../types'
+} from '../api/types'
 
 const {
   subscribeWaitingRoomSocketEventsMock,
@@ -25,11 +25,11 @@ const {
   requestOnlineUsersSnapshotSyncMock: vi.fn(),
 }))
 
-vi.mock('../socket', () => ({
+vi.mock('../socket/socket', () => ({
   subscribeWaitingRoomSocketEvents: subscribeWaitingRoomSocketEventsMock,
 }))
 
-vi.mock('../api', () => ({
+vi.mock('../api/api', () => ({
   mapWaitingRoomSnapshotPayload: mapWaitingRoomSnapshotPayloadMock,
 }))
 

--- a/src/pages/waiting-room/controller/socketSync.ts
+++ b/src/pages/waiting-room/controller/socketSync.ts
@@ -2,15 +2,15 @@ import { useEffect } from 'react'
 import type { Dispatch, MutableRefObject, SetStateAction } from 'react'
 import type { AuthSession } from '../../../features/auth/types'
 import { requestOnlineUsersSnapshotSync } from '../../../features/presence/online-users/onlineUsersSocket'
-import { mapWaitingRoomSnapshotPayload } from '../api'
-import { subscribeWaitingRoomSocketEvents } from '../socket'
+import { mapWaitingRoomSnapshotPayload } from '../api/api'
+import { subscribeWaitingRoomSocketEvents } from '../socket/socket'
 import type {
   GameStartEventPayload,
   LobbyUpdatedEventPayload,
   RoomUpdatedEventPayload,
   WaitingRoomChatMessage,
   WaitingRoomSnapshot,
-} from '../types'
+} from '../api/types'
 import { mapChatPayloadToMessage } from './state'
 
 // 소켓 동기화 훅 입력 파라미터 타입

--- a/src/pages/waiting-room/controller/state.test.ts
+++ b/src/pages/waiting-room/controller/state.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { buildWaitingRoomSeats, getStartConditionMet } from './state'
-import type { WaitingRoomSnapshot } from '../types'
+import type { WaitingRoomSnapshot } from '../api/types'
 
 // 테스트 기본 대기방 스냅샷 생성
 function createWaitingRoomSnapshot(

--- a/src/pages/waiting-room/controller/state.ts
+++ b/src/pages/waiting-room/controller/state.ts
@@ -3,7 +3,7 @@ import type {
   WaitingRoomChatMessage,
   WaitingRoomSeat,
   WaitingRoomSnapshot,
-} from '../types'
+} from '../api/types'
 import { getAvatarBackgroundColor } from '../../../components/avatar/avatarModel'
 
 // 대기방 액션 함수 공통 반환 타입

--- a/src/pages/waiting-room/hooks/hooks.ts
+++ b/src/pages/waiting-room/hooks/hooks.ts
@@ -1,18 +1,18 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import type { AuthSession } from '../../features/auth/types'
+import type { AuthSession } from '../../../features/auth/types'
 import type {
   GameStartEventPayload,
   WaitingRoomChatMessage,
   WaitingRoomSnapshot,
-} from './types'
-import { useWaitingRoomActions } from './controller/actions'
-import { useWaitingRoomLifecycle } from './controller/lifecycle'
+} from '../api/types'
+import { useWaitingRoomActions } from '../controller/actions'
+import { useWaitingRoomLifecycle } from '../controller/lifecycle'
 import {
   buildWaitingRoomSeats,
   getStartConditionMet,
   type WaitingRoomActionResult,
-} from './controller/state'
-import { useWaitingRoomSocketSync } from './controller/socketSync'
+} from '../controller/state'
+import { useWaitingRoomSocketSync } from '../controller/socketSync'
 
 // 대기방 컨트롤러 훅 입력값 타입
 interface UseWaitingRoomControllerParams {

--- a/src/pages/waiting-room/page/WaitingRoomFlow.test.tsx
+++ b/src/pages/waiting-room/page/WaitingRoomFlow.test.tsx
@@ -2,13 +2,13 @@ import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Route, Routes, useParams } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { useAuthStore } from '../../features/auth/store'
-import { createAuthSessionFixture } from '../../test/fixtures'
-import { renderWithProviders } from '../../test/renderWithProviders'
-import LobbyPage from '../lobby/LobbyPage'
+import { useAuthStore } from '../../../features/auth/store'
+import { createAuthSessionFixture } from '../../../test/fixtures'
+import { renderWithProviders } from '../../../test/renderWithProviders'
+import LobbyPage from '../../lobby/LobbyPage'
 import WaitingRoomPage from './WaitingRoomPage'
 
-vi.mock('../../config/env', () => ({
+vi.mock('../../../config/env', () => ({
   IS_SOCKET_MOCK_ENABLED: true,
 }))
 
@@ -22,16 +22,16 @@ const {
   useDirectMessageControllerMock: vi.fn(),
 }))
 
-vi.mock('../lobby/hooks', () => ({
+vi.mock('../../lobby/hooks', () => ({
   useLobbyRoomsQuery: useLobbyRoomsQueryMock,
 }))
 
-vi.mock('../../features/presence/online-users/useOnlineUsersSocket', () => ({
+vi.mock('../../../features/presence/online-users/useOnlineUsersSocket', () => ({
   useOnlineUsersSocket: useOnlineUsersSocketMock,
 }))
 
 vi.mock(
-  '../../features/presence/direct-message/useDirectMessageController',
+  '../../../features/presence/direct-message/useDirectMessageController',
   () => ({
     useDirectMessageController: useDirectMessageControllerMock,
   })

--- a/src/pages/waiting-room/page/WaitingRoomPage.test.tsx
+++ b/src/pages/waiting-room/page/WaitingRoomPage.test.tsx
@@ -3,16 +3,16 @@ import userEvent from '@testing-library/user-event'
 import type { MemoryRouterProps } from 'react-router-dom'
 import { Route, Routes } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { useAuthStore } from '../../features/auth/store'
-import { createAuthSessionFixture } from '../../test/fixtures'
-import { renderWithProviders } from '../../test/renderWithProviders'
+import { useAuthStore } from '../../../features/auth/store'
+import { createAuthSessionFixture } from '../../../test/fixtures'
+import { renderWithProviders } from '../../../test/renderWithProviders'
 import WaitingRoomPage from './WaitingRoomPage'
 import type {
   GameStartEventPayload,
   WaitingRoomChatMessage,
   WaitingRoomSeat,
   WaitingRoomSnapshot,
-} from './types'
+} from '../api/types'
 
 type WaitingRoomControllerResult = {
   room: WaitingRoomSnapshot | null
@@ -75,16 +75,16 @@ vi.mock('react-router-dom', async () => {
   }
 })
 
-vi.mock('./hooks', () => ({
+vi.mock('../hooks/hooks', () => ({
   useWaitingRoomController: useWaitingRoomControllerMock,
 }))
 
-vi.mock('../../features/presence/online-users/useOnlineUsersSocket', () => ({
+vi.mock('../../../features/presence/online-users/useOnlineUsersSocket', () => ({
   useOnlineUsersSocket: useOnlineUsersSocketMock,
 }))
 
 vi.mock(
-  '../../features/presence/direct-message/useDirectMessageController',
+  '../../../features/presence/direct-message/useDirectMessageController',
   () => ({
     useDirectMessageController: useDirectMessageControllerMock,
   })

--- a/src/pages/waiting-room/page/WaitingRoomPage.tsx
+++ b/src/pages/waiting-room/page/WaitingRoomPage.tsx
@@ -7,28 +7,28 @@ import {
   useNavigationType,
   useParams,
 } from 'react-router-dom'
-import { useRequireActiveSession } from '../../features/auth/hooks/useRequireActiveSession'
-import { useAuthStore } from '../../features/auth/store'
+import { useRequireActiveSession } from '../../../features/auth/hooks/useRequireActiveSession'
+import { useAuthStore } from '../../../features/auth/store'
 import {
   createProfileMenuItems,
   getAvatarBackground,
   getAvatarText,
-} from '../../components/header/profileMenu'
-import { DirectMessagePanel } from '../../features/presence/components/DirectMessagePanel'
-import { UserListPanel } from '../../features/presence/components/UserListPanel'
-import { useDirectMessageController } from '../../features/presence/direct-message/useDirectMessageController'
-import { removeMockOnlineUser } from '../../features/presence/mock/mockData'
-import { mergeOnlineUsersWithRoomPlayers } from '../../features/presence/online-users/onlineUsersModel'
-import { useOnlineUsersSocket } from '../../features/presence/online-users/useOnlineUsersSocket'
-import { cn } from '../../lib/utils'
-import { disconnectSocketAndClearAuth } from '../../lib/socket'
-import { IS_SOCKET_MOCK_ENABLED } from '../../config/env'
-import { WaitingRoomHeader } from './components/WaitingRoomHeader'
-import { WaitingSeatCard } from './components/WaitingSeatCard'
-import { WaitingRoomSidePanel } from './components/WaitingRoomSidePanel'
-import { DevControlPanel } from './components/DevControlPanel'
-import { useWaitingRoomController } from './hooks'
-import type { GameStartEventPayload, WaitingRoomSnapshot } from './types'
+} from '../../../components/header/profileMenu'
+import { DirectMessagePanel } from '../../../features/presence/components/DirectMessagePanel'
+import { UserListPanel } from '../../../features/presence/components/UserListPanel'
+import { useDirectMessageController } from '../../../features/presence/direct-message/useDirectMessageController'
+import { removeMockOnlineUser } from '../../../features/presence/mock/mockData'
+import { mergeOnlineUsersWithRoomPlayers } from '../../../features/presence/online-users/onlineUsersModel'
+import { useOnlineUsersSocket } from '../../../features/presence/online-users/useOnlineUsersSocket'
+import { cn } from '../../../lib/utils'
+import { disconnectSocketAndClearAuth } from '../../../lib/socket'
+import { IS_SOCKET_MOCK_ENABLED } from '../../../config/env'
+import { WaitingRoomHeader } from '../components/WaitingRoomHeader'
+import { WaitingSeatCard } from '../components/WaitingSeatCard'
+import { WaitingRoomSidePanel } from '../components/WaitingRoomSidePanel'
+import { DevControlPanel } from '../components/DevControlPanel'
+import { useWaitingRoomController } from '../hooks/hooks'
+import type { GameStartEventPayload, WaitingRoomSnapshot } from '../api/types'
 
 interface WaitingRoomLocationState {
   roomId?: string

--- a/src/pages/waiting-room/socket/mockGateway.test.ts
+++ b/src/pages/waiting-room/socket/mockGateway.test.ts
@@ -194,7 +194,7 @@ describe('mockGateway waiting-room action sequence', () => {
 
   it('입장과 퇴장 시 접속자 목록 상태가 in_room -> lobby로 동기화된다', async () => {
     const gateway = await loadMockGateway()
-    const presence = await import('../../features/presence/mock/mockData')
+    const presence = await import('../../../features/presence/mock/mockData')
     const userId = 'presence-sync-user'
     const nickname = '동기화테스터'
 

--- a/src/pages/waiting-room/socket/mockGateway.ts
+++ b/src/pages/waiting-room/socket/mockGateway.ts
@@ -1,8 +1,8 @@
-import { socket } from '../../lib/socket'
-import { ROOM_PASSWORD_PATTERN } from '../../constants/room'
-import { setMockOnlineUserStatus } from '../../features/presence/mock/mockData'
-import { mockLobbyRooms } from '../lobby/mockData'
-import type { LobbyRoom, LobbyRoomStatus } from '../lobby/types'
+import { socket } from '../../../lib/socket'
+import { ROOM_PASSWORD_PATTERN } from '../../../constants/room'
+import { setMockOnlineUserStatus } from '../../../features/presence/mock/mockData'
+import { mockLobbyRooms } from '../../lobby/mockData'
+import type { LobbyRoom, LobbyRoomStatus } from '../../lobby/types'
 import { createSeededRoomPlayers } from './mockSeed'
 import type {
   ChatEventPayload,
@@ -14,7 +14,7 @@ import type {
   WaitingRoomChatMessage,
   WaitingRoomChatPayload,
   WaitingRoomSnapshot,
-} from './types'
+} from '../api/types'
 
 // 목 게이트웨이 네트워크 지연/비밀방 기본 비밀번호
 const MOCK_NETWORK_DELAY_MS = 220

--- a/src/pages/waiting-room/socket/mockSeed.ts
+++ b/src/pages/waiting-room/socket/mockSeed.ts
@@ -1,9 +1,9 @@
 import type {
   OnlineUserPayload,
   OnlineUserStatus,
-} from '../../features/presence/types'
-import { mockLobbyRooms } from '../lobby/mockData'
-import type { LobbyRoom, LobbyRoomStatus } from '../lobby/types'
+} from '../../../features/presence/types'
+import { mockLobbyRooms } from '../../lobby/mockData'
+import type { LobbyRoom, LobbyRoomStatus } from '../../lobby/types'
 
 // 목 시드 플레이어의 공통 기본 정보 타입
 interface SeededRoomPlayer {

--- a/src/pages/waiting-room/socket/socket.ts
+++ b/src/pages/waiting-room/socket/socket.ts
@@ -1,5 +1,5 @@
-import { connectSocketWithAuthIfNeeded, socket } from '../../lib/socket'
-import { IS_SOCKET_MOCK_ENABLED } from '../../config/env'
+import { connectSocketWithAuthIfNeeded, socket } from '../../../lib/socket'
+import { IS_SOCKET_MOCK_ENABLED } from '../../../config/env'
 import {
   mockEnterWaitingRoomSocket,
   mockLeaveWaitingRoomSocket,
@@ -15,7 +15,7 @@ import type {
   PlayerReadyEventPayload,
   RoomUpdatedEventPayload,
   SendChatSocketPayload,
-} from './types'
+} from '../api/types'
 
 // 대기방 소켓 이벤트 이름 맵
 const WAITING_ROOM_EVENT_NAMES = {


### PR DESCRIPTION
## 📌 관련 이슈

> closes #450 

---

## 📝 작업 내용

> `src/pages/waiting-room` 내부 파일을 책임 단위 폴더로 재배치해 page / api / socket / hooks 경계를 더 명확하게 정리했습니다.

### 1. waiting-room 구조 재배치

- `page/` 폴더로 `WaitingRoomPage`, `WaitingRoomPage.test.tsx`, `WaitingRoomFlow.test.tsx`를 이동했습니다.
- `api/` 폴더로 `api.ts`, `api.test.ts`, `types.ts`를 이동했습니다.
- `socket/` 폴더로 `socket.ts`, `mockGateway.ts`, `mockGateway.test.ts`, `mockSeed.ts`를 이동했습니다.
- `hooks/` 폴더로 `hooks.ts`를 이동했습니다.
- 기존 `controller/`, `components/` 구조는 유지해 lifecycle / action / socket sync 책임은 그대로 보존했습니다.

### 2. import / mock 경로 정리

- waiting-room 내부에서 바뀐 상대 경로를 모두 갱신했습니다.
- `vi.mock()` 경로도 새 파일 위치에 맞게 같이 정리했습니다.
- `LobbyPage`, `GamePage`, `App`, mock handler, presence mock, auth mock session, room-chat dev panel 등 외부 참조 파일도 새 경로를 보도록 업데이트했습니다.

### 3. 구조만 변경, 동작은 유지

- 이번 PR은 folder structure 정리가 목적입니다.
- `preJoinedSnapshot`, cleanup leave, ready/start, room_updated sync, mock gateway 동작은 그대로 유지했습니다.
- route-level lazy loading도 새 `page/WaitingRoomPage` 경로만 보도록 갱신했고 동작 의미는 바꾸지 않았습니다.

### 검증

- `npx vitest run src/pages/waiting-room src/pages/lobby/LobbyPage.test.tsx src/features/presence/mock/mockData.test.ts src/App.test.tsx`
- `npm run lint -- src/pages/waiting-room src/pages/lobby/LobbyPage.test.tsx src/pages/GamePage.tsx src/features/presence/mock/mockData.ts src/features/presence/mock/mockData.test.ts src/features/room-chat/DevRoomChatControlPanel.tsx src/mocks/handlers.ts src/features/auth/mock/session.ts src/App.tsx src/App.test.tsx`
- `npm run build`

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)

> UI 변경보다 파일 구조 정리 리팩토링이 중심이라 스크린샷은 생략했습니다.

## 📌 추가 메모

- 테스트 파일은 전역 `tests/` 폴더로 모으지 않고, 대상 코드와 같은 폴더 또는 인접 폴더에 유지했습니다.
- `controller/`와 `components/`는 이미 역할이 잘 나뉘어 있어 이번 PR에서는 유지했습니다.
- PR 범위에는 로컬 `.env` 변경과 임시 task 문서(`backend-api-contract-adoption`)를 포함하지 않습니다.
