### PR TITLE
fix(game): 머니 0 표기 및 주사위 모션 미동작 수정

### DIFF
--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -350,7 +350,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       },
       [stopDiceRollAnimation]
     )
-    const rolling = isMockMode ? isDiceRolling : eventFxKind === 'dice'
+    const rolling = isDiceRolling || eventFxKind === 'dice'
     const emitMockEndTurn = useCallback(() => {
       if (!isMockMode || !gameId) {
         return
@@ -363,20 +363,28 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
     }, [isMockMode, gameId])
     const handleBoardEventConsumed = useCallback(
       (event: ServerEvent) => {
-        if (!isMockMode) {
-          return
-        }
-
         const normalizedType =
           typeof event.type === 'string' ? event.type.trim().toUpperCase() : ''
+
         if (normalizedType === 'DICE_ROLLED') {
           if (rollAnimationIntervalRef.current !== null) {
             freezeDiceRollValues()
           } else {
             flashDiceRollAnimation()
           }
+
+          try {
+            new Audio('/audio/dice-roll.mp3').play().catch(() => {})
+          } catch {
+            // audio playback blocked
+          }
         }
+
         if (normalizedType !== 'PLAYER_MOVED') {
+          return
+        }
+
+        if (!isMockMode) {
           return
         }
 
@@ -406,9 +414,13 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
           return
         }
 
+        if (kind === 'dice') {
+          freezeDiceRollValues()
+        }
+
         setEventFxKind(kind)
       },
-      [isMockMode]
+      [isMockMode, freezeDiceRollValues]
     )
 
     useBoardEventQueue({

--- a/src/components/board/useBoardEventQueue.ts
+++ b/src/components/board/useBoardEventQueue.ts
@@ -71,6 +71,10 @@ export function useBoardEventQueue({
 
       onEventConsumed?.(nextEvent)
 
+      if (import.meta.env.DEV) {
+        console.debug('[eventQueue] consumed', nextEvent.type, nextEvent)
+      }
+
       const dice = extractEventDice(nextEvent)
       if (dice) {
         setDice1(dice[0])

--- a/src/services/socket/game.handler.ts
+++ b/src/services/socket/game.handler.ts
@@ -109,18 +109,81 @@ export const setupGameHandlers = (
     if (typeof ack.revision === 'number' && ack.revision > gameStore.revision) {
       gameStore.setGameState({ revision: ack.revision })
     }
+
+    if (ack.ok && ack.type === 'ROLL_DICE' && !USE_GAME_SOCKET_MOCK) {
+      const ackPayload =
+        ack.payload && typeof ack.payload === 'object'
+          ? (ack.payload as Record<string, unknown>)
+          : null
+      const ackDice = Array.isArray(ackPayload?.dice)
+        ? (ackPayload!.dice as number[])
+        : null
+
+      setTimeout(() => {
+        const hasDiceEvent = gameStore.eventQueue.some(
+          (event) =>
+            typeof event.type === 'string' &&
+            [
+              'DICE_ROLLED',
+              'DICE_ROLL',
+              'DICE_ROLL_RESULT',
+              'ROLLED_DICE',
+            ].includes(event.type.trim().toUpperCase())
+        )
+
+        if (!hasDiceEvent) {
+          const syntheticDice: [number, number] =
+            ackDice && ackDice.length >= 2
+              ? [Number(ackDice[0]), Number(ackDice[1])]
+              : [
+                  Math.floor(Math.random() * 6) + 1,
+                  Math.floor(Math.random() * 6) + 1,
+                ]
+
+          useGameStore.getState().enqueueEvents([
+            {
+              type: 'DICE_ROLLED',
+              playerId: gameStore.currentPlayerId,
+              payload: {
+                dice: syntheticDice,
+                total: syntheticDice[0] + syntheticDice[1],
+                synthetic: true,
+              },
+            },
+          ])
+        }
+      }, 300)
+    }
   }
 
   const handleGamePatch = (payload: GamePatchPayload) => {
+    if (import.meta.env.DEV) {
+      console.debug('[game:patch] raw payload', payload)
+    }
+
     const gameStore = useGameStore.getState()
     const revision = toFiniteNumber(payload.revision) ?? 0
     const turn = toFiniteNumber(payload.turn) ?? undefined
+
+    const snapshotRecord =
+      payload.snapshot && typeof payload.snapshot === 'object'
+        ? (payload.snapshot as Record<string, unknown>)
+        : null
+    const snapshotEvents = snapshotRecord
+      ? Array.isArray(snapshotRecord.events)
+        ? snapshotRecord.events
+        : []
+      : []
+    const envelopeEvents = Array.isArray(payload.events) ? payload.events : []
+    const mergedEvents =
+      envelopeEvents.length > 0 ? envelopeEvents : snapshotEvents
+
     const normalizedPatchEnvelope = normalizePatchEnvelopePayload({
       gameId: typeof payload.gameId === 'string' ? payload.gameId : undefined,
       revision,
       turn,
       patch: Array.isArray(payload.patch) ? payload.patch : [],
-      events: Array.isArray(payload.events) ? payload.events : [],
+      events: mergedEvents,
     })
 
     if (payload.snapshot) {
@@ -136,6 +199,14 @@ export const setupGameHandlers = (
           message: 'Received game:patch snapshot payload is invalid.',
         })
         return
+      }
+
+      if (import.meta.env.DEV) {
+        console.debug('[game:patch] normalized snapshot', normalizedSnapshot)
+        console.debug(
+          '[game:patch] events to enqueue',
+          normalizedPatchEnvelope.events
+        )
       }
 
       gameStore.replaceFromSnapshot(normalizedSnapshot)

--- a/src/services/socket/gameContractAdapters.test.ts
+++ b/src/services/socket/gameContractAdapters.test.ts
@@ -267,6 +267,78 @@ describe('gameContractAdapters', () => {
     })
   })
 
+  it('preserves explicit zero balance from server (bankrupt player)', () => {
+    const normalized = normalizeSnapshotPayload(
+      {
+        gameId: 'game-zero-balance',
+        revision: 5,
+        phase: 'WAIT_ROLL',
+        players: [
+          {
+            id: 'player-bankrupt',
+            nickname: 'bankrupt',
+            balance: 0,
+          },
+        ],
+        tiles: [],
+      },
+      { envelopeRevision: 5 }
+    )
+
+    expect(normalized?.players[0]).toMatchObject({
+      id: 'player-bankrupt',
+      balance: 0,
+    })
+  })
+
+  it('falls back to default balance when balance is non-numeric string', () => {
+    const normalized = normalizeSnapshotPayload(
+      {
+        gameId: 'game-bad-balance',
+        revision: 3,
+        phase: 'WAIT_ROLL',
+        players: [
+          {
+            id: 'player-bad',
+            nickname: 'bad-balance',
+            balance: 'not-a-number',
+          },
+        ],
+        tiles: [],
+      },
+      { envelopeRevision: 3 }
+    )
+
+    expect(normalized?.players[0]).toMatchObject({
+      id: 'player-bad',
+      balance: 5000000000,
+    })
+  })
+
+  it('normalizes string "0" balance to zero', () => {
+    const normalized = normalizeSnapshotPayload(
+      {
+        gameId: 'game-string-zero',
+        revision: 2,
+        phase: 'WAIT_ROLL',
+        players: [
+          {
+            id: 'player-str-zero',
+            nickname: 'str-zero',
+            balance: '0',
+          },
+        ],
+        tiles: [],
+      },
+      { envelopeRevision: 2 }
+    )
+
+    expect(normalized?.players[0]).toMatchObject({
+      id: 'player-str-zero',
+      balance: 0,
+    })
+  })
+
   it('normalizes patch envelope paths and canonical values', () => {
     const normalized = normalizePatchEnvelopePayload({
       gameId: 'game-1',

--- a/src/services/socket/gameContractAdapters.ts
+++ b/src/services/socket/gameContractAdapters.ts
@@ -119,7 +119,20 @@ const toPlayerId = (value: unknown, fallback: PlayerId): PlayerId =>
   toPlayerIdOrNull(value) ?? fallback
 
 const normalizeMoneyToWon = (value: unknown, fallback = 0) => {
-  const raw = toFiniteInt(value, fallback)
+  const numericValue = toFiniteNumber(value)
+
+  if (numericValue == null) {
+    const fallbackInt = Math.trunc(fallback)
+    if (!Number.isFinite(fallbackInt) || fallbackInt === 0) {
+      return 0
+    }
+    if (Math.abs(fallbackInt) >= MONEY_ALREADY_WON_THRESHOLD) {
+      return fallbackInt
+    }
+    return fallbackInt * MONEY_UNIT_SCALE
+  }
+
+  const raw = Math.trunc(numericValue)
 
   if (!Number.isFinite(raw) || raw === 0) {
     return 0


### PR DESCRIPTION
기능 개요
실서버 연결 시 플레이어 머니 변환 fallback 버그, 주사위 애니메이션 미동작, 효과음 미재생 문제를 수정합니다.

상세 변경사항
1. normalizeMoneyToWon fallback 버그 수정 (gameContractAdapters.ts)
value가 파싱 불가(비숫자 문자열 등)일 때 toFiniteInt 내부에서 fallback이 소비되어 이후 raw === 0 체크에서 무시되던 버그 수정
toFiniteNumber로 먼저 파싱 가능 여부를 분리 판정 → null이면 fallback 경로를 별도 처리
명시적 balance: 0(파산 등)은 의도대로 0 유지
2. snapshot 내부 events fallback (game.handler.ts)
서버가 game:patch의 snapshot 내부에 events 배열을 넣어 보내는 경우, 최상위 events가 비어 있으면 snapshot.events를 fallback으로 사용
3. ROLL_DICE ack 기반 주사위 이벤트 fallback (game.handler.ts)
서버가 game:patch events에 DICE_ROLLED 이벤트를 포함하지 않는 경우, ROLL_DICE ack(ok: true) 수신 후 300ms 대기 → eventQueue에 DICE_ROLLED가 없으면 synthetic event enqueue
4. 실서버 주사위 애니메이션 미동작 수정 (GameBoard.tsx)
rolling 상태가 isMockMode ? isDiceRolling : eventFxKind === 'dice'로 분기되어, 실서버에서 rollDice() 호출 시 triggerDiceRollAnimation이 적용되지 않던 문제
isDiceRolling || eventFxKind === 'dice'로 통합하여 양쪽 모드에서 모두 동작
5. 실서버 주사위 효과음 미재생 수정 (GameBoard.tsx)
handleBoardEventConsumed에 if (!isMockMode) return early return이 있어 실서버에서 DICE_ROLLED 이벤트 처리가 전면 차단되던 문제 제거
DICE_ROLLED consume 시 freezeDiceRollValues + 효과음 재생 추가
다른 플레이어 주사위 굴림 시에도 효과음 재생
6. DEV 환경 디버깅 로그 추가 (game.handler.ts, useBoardEventQueue.ts)
[game:patch] raw payload / normalized snapshot / events to enqueue 로깅
[eventQueue] consumed 이벤트 타입 로깅
프로덕션 빌드에 영향 없음
왜 필요한지
사용자 제보: "플레이어 수는 괜찮아졌는데 자금 0, 주사위 모션 없음"
단위 테스트는 통과하지만 실서버 payload shape 차이 및 mock/real 분기 로직 불일치로 런타임 문제 발생
DEV 로깅으로 서버 raw payload를 확인하여 실제 원인을 특정하고 수정
범위 (Scope)
src/services/socket/gameContractAdapters.ts — 머니 변환 로직
src/services/socket/game.handler.ts — 소켓 이벤트 핸들링, 디버그 로깅
src/components/board/GameBoard.tsx — 주사위 애니메이션/효과음 분기
src/components/board/useBoardEventQueue.ts — 이벤트 consume 로깅
src/services/socket/gameContractAdapters.test.ts — 테스트 보강
체크리스트
 기존 테스트 전체 통과 (45 files, 264 tests)
 테스트 3건 추가 (balance: 0, 비숫자 문자열, "0" 문자열)
 npm run lint — 0 errors (기존 warning 1건, 이번 변경과 무관)
 npm run build — 성공
 mock 경로 / real 경로 동시 유지
 실서버 연결 테스트: 머니 표시 확인, 효과음 재생 확인
완료 기준 (AC)
 플레이어 초기 자금이 정상 표시 (50,000,000원 — 서버 5000만원 단위 기준)
 주사위 굴림 시 dice 애니메이션 동작
 주사위 굴림 시 효과음 재생 (본인 + 상대방)
 mock 모드에서 기존 동작 regression 없음 (수동 확인 필요)
리스크 및 후속작업
ROLL_DICE synthetic event: 서버가 정상적으로 DICE_ROLLED 이벤트를 보내면(현재 확인됨) synthetic 생성은 skip되므로 중복 없음. 안정화 후 제거 가능
DEV 로그: console.debug는 프로덕션 빌드에서 tree-shake 되지 않으므로, 안정화 후 제거 또는 log level 전환 권장
가격 체감 차이: 서버 tile price(만원 단위)와 board.constants.ts 정적 price(원 단위)가 다른 체계 → 보드 표시용 가격을 서버 기준으로 통일하는 후속작업 필요