### PR TITLE
fix: 로비 접속자 목록 패널 sticky 스크롤 동작 보정

### DIFF
--- a/src/pages/lobby/LobbyPage.tsx
+++ b/src/pages/lobby/LobbyPage.tsx
@@ -138,7 +138,7 @@ function LobbyPage() {
   })
 
   return (
-    <div className="relative min-h-screen overflow-hidden bg-ui-app-bg">
+    <div className="relative min-h-screen bg-ui-app-bg">
       <div className="pointer-events-none absolute inset-x-0 bottom-0 top-14">
         <img
           src="/LobbyPage_background.webp"


### PR DESCRIPTION
## 📌 관련 이슈

> closes #458 

---

## 📝 작업 내용

> 로비 우측 접속자 목록 패널이 스크롤 시 sticky로 고정되지 않던 문제를 수정했습니다.

### 1. sticky를 막던 상위 overflow 제거

- `LobbyPage` 루트 컨테이너에 있던 overflow 설정이 우측 접속자 목록 패널의 `xl:sticky xl:top-20` 동작을 방해하고 있었습니다.
- 루트 overflow를 제거해 접속자 목록 패널이 viewport 기준으로 정상적으로 sticky 동작하도록 수정했습니다.

### 2. 동작 범위 유지

- 접속자 목록 패널 자체의 구조나 높이 계산은 변경하지 않았습니다.
- 로비 레이아웃과 접속자 목록 토글/DM 동작은 그대로 유지했습니다.

### 검증

- `npx vitest run src/pages/lobby/LobbyPage.test.tsx`
- `npm run lint -- src/pages/lobby/LobbyPage.tsx`

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)


https://github.com/user-attachments/assets/7e94251c-ced4-42bb-8495-dc64cfc01746



## 📌 추가 메모

- 이번 수정은 로비 페이지의 sticky 스크롤 동작만 다룹니다.
- waiting-room은 별도 레이아웃 구조라 이번 PR 범위에 포함하지 않았습니다.