### PR TITLE
fix: 실서버 payload 기준 총자산 계산 및 patch 정규화 보정

### DIFF
--- a/src/pages/game/gameViewModel.test.ts
+++ b/src/pages/game/gameViewModel.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  calcPlayerTotalAssets,
   findBoardCurrentPlayerIndex,
   mapStorePlayersToBoardPlayers,
   mapStoreTilesToBoardTiles,
@@ -135,5 +136,62 @@ describe('game view model mapper', () => {
     )
 
     expect(boardTiles[0]?.owner_id).toBe(99)
+  })
+
+  it('calculates total assets using server tile prices when available', () => {
+    const totalAssets = calcPlayerTotalAssets(
+      {
+        id: 'player-1',
+        nickname: 'Player 1',
+        position: 0,
+        balance: 1000,
+        owned_tiles: [1],
+        is_in_jail: false,
+        jail_turn_count: 0,
+        is_bankrupt: false,
+        color: '#111111',
+      },
+      [
+        {
+          index: 1,
+          name: 'Suwon',
+          type: 'property',
+          owner_id: 'player-1',
+          building: 1,
+          price: 200,
+        },
+      ]
+    )
+
+    expect(totalAssets).toBe(1300)
+  })
+
+  it('derives owned tiles from tile owner fields even when owned_tiles is stale', () => {
+    const totalAssets = calcPlayerTotalAssets(
+      {
+        id: 'owner-1',
+        nickname: 'Owner',
+        position: 0,
+        balance: 500,
+        owned_tiles: [],
+        is_in_jail: false,
+        jail_turn_count: 0,
+        is_bankrupt: false,
+        color: '#111111',
+      },
+      [
+        {
+          index: 2,
+          name: 'Yongin',
+          type: 'property',
+          ownerId: 'owner-1',
+          owner_id: 'owner-1',
+          building: 0,
+          price: 120,
+        },
+      ]
+    )
+
+    expect(totalAssets).toBe(620)
   })
 })

--- a/src/pages/game/gameViewModel.ts
+++ b/src/pages/game/gameViewModel.ts
@@ -88,32 +88,43 @@ export const mapStoreTilesToBoardTiles = (
   })
 }
 
-/**
- * 플레이어 총자산 계산:
- * 현금 + 보유 도시 토지 가격 + 건물 레벨별 누적 건설비
- */
+const getOwnedTileIndices = (player: Player, storeTiles: Tile[]) => {
+  const ownedTileIndexSet = new Set<number>(player.owned_tiles)
+  const normalizedPlayerId = String(player.id)
+
+  for (const tile of storeTiles) {
+    const ownerId =
+      tile.ownerId !== undefined ? tile.ownerId : (tile.owner_id ?? null)
+    if (ownerId == null) {
+      continue
+    }
+
+    if (String(ownerId) === normalizedPlayerId) {
+      ownedTileIndexSet.add(tile.index)
+    }
+  }
+
+  return ownedTileIndexSet
+}
+
 export const calcPlayerTotalAssets = (
   player: Player,
   storeTiles: Tile[]
 ): number => {
+  const ownedTileIndices = getOwnedTileIndices(player, storeTiles)
   let assets = player.balance
 
-  for (const tileIndex of player.owned_tiles) {
-    // 서버 타일에서 building 레벨 조회
-    const serverTile = storeTiles.find((t) => t.index === tileIndex)
+  for (const tileIndex of ownedTileIndices) {
+    const serverTile = storeTiles.find((tile) => tile.index === tileIndex)
+    const staticTile = TILES.find((tile) => tile.id === tileIndex)
+    const landPrice = serverTile?.price ?? staticTile?.price ?? 0
     const buildingLevel: BuildingLevel =
       (serverTile?.building as BuildingLevel | undefined) ?? 0
 
-    // 정적 타일 데이터에서 토지 가격 조회
-    const staticTile = TILES.find((t) => t.id === tileIndex)
-    const landPrice = staticTile?.price ?? 0
-
-    // 토지 가격 합산
     assets += landPrice
 
-    // 건물 레벨 1~7 누적 건설비 합산
-    for (let lvl = 0 as BuildingLevel; lvl < buildingLevel; lvl++) {
-      assets += getBuildCost(landPrice, lvl as BuildingLevel)
+    for (let level = 0 as BuildingLevel; level < buildingLevel; level++) {
+      assets += getBuildCost(landPrice, level as BuildingLevel)
     }
   }
 

--- a/src/services/socket/gameContractAdapters.test.ts
+++ b/src/services/socket/gameContractAdapters.test.ts
@@ -526,4 +526,64 @@ describe('gameContractAdapters', () => {
       },
     ])
   })
+
+  it('normalizes set patches that replace a single player or tile object', () => {
+    const normalized = normalizePatchEnvelopePayload({
+      gameId: 'game-entity-set',
+      revision: 11,
+      patch: [
+        {
+          op: 'set',
+          path: 'players.player-a',
+          value: {
+            playerId: 'player-a',
+            nickname: 'Player A',
+            current_tile_id: 4,
+            money: 5200,
+            ownedTiles: [2],
+            player_state: 'NORMAL',
+          },
+        },
+        {
+          op: 'set',
+          path: ['tiles', 2],
+          value: {
+            tileId: 2,
+            owner_player_id: 'player-a',
+            tile_type: 'PROPERTY',
+            building_level: 3,
+            purchase_price: 140,
+          },
+        },
+      ],
+      events: [],
+    })
+
+    expect(normalized.patch).toEqual([
+      {
+        op: 'set',
+        path: 'players.player-a',
+        value: expect.objectContaining({
+          id: 'player-a',
+          nickname: 'Player A',
+          position: 4,
+          balance: 5200000000,
+          owned_tiles: [2],
+          state: 'normal',
+        }),
+      },
+      {
+        op: 'set',
+        path: ['tiles', 2],
+        value: expect.objectContaining({
+          index: 2,
+          ownerId: 'player-a',
+          owner_id: 'player-a',
+          type: 'property',
+          building: 3,
+          price: 140000000,
+        }),
+      },
+    ])
+  })
 })

--- a/src/services/socket/gameContractAdapters.ts
+++ b/src/services/socket/gameContractAdapters.ts
@@ -428,10 +428,12 @@ const normalizePlayerFromSnapshot = (
 ): Player => {
   const playerRecord = isRecord(playerPayload) ? playerPayload : {}
   const state = normalizePlayerState(
-    playerRecord.playerState ?? playerRecord.state
+    playerRecord.playerState ?? playerRecord.player_state ?? playerRecord.state
   )
   const stateDuration = toFiniteInt(
-    playerRecord.stateDuration ?? playerRecord.jail_turn_count,
+    playerRecord.stateDuration ??
+      playerRecord.state_duration ??
+      playerRecord.jail_turn_count,
     0
   )
 
@@ -631,6 +633,18 @@ const normalizePathSegment = (segment: string | number): string | number => {
   return segment
 }
 
+const resolvePatchEntityFallbackIndex = (segment: string | number) => {
+  if (typeof segment === 'number' && Number.isFinite(segment)) {
+    return Math.max(0, Math.trunc(segment))
+  }
+
+  if (typeof segment === 'string' && /^\d+$/.test(segment)) {
+    return Number.parseInt(segment, 10)
+  }
+
+  return 0
+}
+
 const normalizePatchSetValue = (
   pathSegments: Array<string | number>,
   value: unknown
@@ -664,6 +678,28 @@ const normalizePatchSetValue = (
 
   if (pathSegments.length === 1 && firstSegment === 'prompt') {
     return normalizePromptPayload(value)
+  }
+
+  if (
+    pathSegments.length === 2 &&
+    firstSegment === 'players' &&
+    isRecord(value)
+  ) {
+    return normalizePlayerFromSnapshot(
+      value,
+      resolvePatchEntityFallbackIndex(pathSegments[1])
+    )
+  }
+
+  if (
+    pathSegments.length === 2 &&
+    firstSegment === 'tiles' &&
+    isRecord(value)
+  ) {
+    return normalizeTileFromSnapshot(
+      value,
+      resolvePatchEntityFallbackIndex(pathSegments[1])
+    )
   }
 
   if (lastSegment === 'state') {


### PR DESCRIPTION
## 관련 이슈
> closes #없음

## 작업 내용
- `calcPlayerTotalAssets`를 서버 상태 기준으로 보정했습니다.
  - `owned_tiles`만 보지 않고 `tile.ownerId/owner_id`도 함께 사용해 소유 타일을 계산
  - 토지 가격은 정적 보드값보다 서버 `storeTiles.price`를 우선 사용
- `gameContractAdapters`의 patch 정규화를 보강했습니다.
  - `set players.<id>` / `set tiles.<id>` 형태의 객체 교체 patch도 정규화 경로로 처리
  - `player_state`, `state_duration` alias를 함께 정규화해 실서버 payload 호환 강화
- 회귀 방지를 위한 테스트를 추가했습니다.
  - 자산 계산(서버 가격 우선/owned_tiles stale 케이스)
  - 객체 단위 set patch 정규화 케이스

## 체크리스트
- [x] 불필요한 생성/수정 파일 제거
- [x] 불필요한 console.log 제거
- [x] 간단 이슈 해결 완료
- [x] 관련 테스트 통과 (`gameViewModel`, `gameContractAdapters`)
