### PR TITLE
refactor: App과 카카오 로그인 로딩 UI 톤 정리

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import { LoaderCircle } from 'lucide-react'
 import { Suspense, lazy } from 'react'
 import { Routes, Route, useLocation } from 'react-router-dom'
 import { DesktopViewportGuard } from './components/DesktopViewportGuard'
@@ -20,9 +21,26 @@ const WaitingRoomPage = lazy(
 function RouteLoadingScreen() {
   return (
     <div className="flex min-h-screen items-center justify-center bg-ui-app-bg px-4">
-      <p className="text-sm font-medium text-ui-text-muted">
-        화면을 불러오고 있습니다.
-      </p>
+      <div className="w-full max-w-sm rounded-[28px] border border-ui-border bg-ui-surface px-6 py-8 text-center shadow-[0_14px_34px_rgba(15,23,42,0.08)]">
+        <div
+          className="flex flex-col items-center"
+          role="status"
+          aria-live="polite"
+        >
+          <div className="flex size-16 items-center justify-center rounded-full bg-ui-brand/12 ring-1 ring-ui-brand/20">
+            <LoaderCircle
+              className="size-8 animate-spin text-ui-brand"
+              strokeWidth={2.25}
+            />
+          </div>
+          <h1 className="mt-5 text-xl font-bold text-ui-text-strong">
+            화면을 준비하고 있어요
+          </h1>
+          <p className="mt-2 text-sm font-medium text-ui-text-muted">
+            필요한 화면을 불러온 뒤 바로 보여드릴게요.
+          </p>
+        </div>
+      </div>
     </div>
   )
 }

--- a/src/pages/KakaoLoginCallbackPage.tsx
+++ b/src/pages/KakaoLoginCallbackPage.tsx
@@ -1,3 +1,4 @@
+import { LoaderCircle } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import {
@@ -63,23 +64,43 @@ function KakaoLoginCallbackPage() {
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-ui-app-bg px-4">
-      <div className="w-full max-w-md rounded-3xl border border-ui-border bg-ui-surface px-6 py-8 text-center shadow-[0_14px_34px_rgba(15,23,42,0.08)]">
-        <h1 className="text-2xl font-bold text-ui-text-strong">
-          카카오 로그인 처리 중
-        </h1>
-        <p className="mt-3 text-sm font-medium text-ui-text-muted">
-          {errorMessage ??
-            '인증 정보를 확인하고 있습니다. 잠시만 기다려 주세요.'}
-        </p>
+      <div className="w-full max-w-sm rounded-[28px] border border-ui-border bg-ui-surface px-6 py-8 text-center shadow-[0_14px_34px_rgba(15,23,42,0.08)]">
         {errorMessage ? (
-          <button
-            type="button"
-            onClick={() => navigate('/', { replace: true })}
-            className="mt-6 inline-flex h-11 items-center justify-center rounded-xl bg-ui-brand px-4 text-sm font-semibold text-white transition-colors hover:bg-ui-brand-strong"
+          <>
+            <h1 className="text-xl font-bold text-ui-text-strong">
+              카카오 로그인에 실패했어요
+            </h1>
+            <p className="mt-3 text-sm font-medium leading-relaxed text-ui-text-muted">
+              {errorMessage}
+            </p>
+            <button
+              type="button"
+              onClick={() => navigate('/', { replace: true })}
+              className="mt-6 inline-flex h-11 items-center justify-center rounded-xl bg-ui-brand px-4 text-sm font-semibold text-white transition-colors hover:bg-ui-brand-strong"
+            >
+              홈으로 돌아가기
+            </button>
+          </>
+        ) : (
+          <div
+            className="flex flex-col items-center"
+            role="status"
+            aria-live="polite"
           >
-            홈으로 돌아가기
-          </button>
-        ) : null}
+            <div className="flex size-16 items-center justify-center rounded-full bg-[#fee500]/20 ring-1 ring-[#fee500]/50">
+              <LoaderCircle
+                className="size-8 animate-spin text-[#3b2a10]"
+                strokeWidth={2.25}
+              />
+            </div>
+            <h1 className="mt-5 text-xl font-bold text-ui-text-strong">
+              로그인 정보를 확인하고 있어요
+            </h1>
+            <p className="mt-2 text-sm font-medium text-ui-text-muted">
+              카카오 계정을 확인한 뒤 바로 입장할게요.
+            </p>
+          </div>
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
## 📌 관련 이슈

> closes #463

---

## 📝 작업 내용

> App lazy fallback과 카카오 로그인 콜백 로딩 화면을 스피너 중심 UI로 정리해 전반적인 로딩 상태 톤을 맞췄습니다.

### 1. App lazy fallback 로딩 UI 정리

- `App.tsx`의 `RouteLoadingScreen()`이 기존 텍스트-only 상태로 보이던 부분을 카드형 로딩 UI로 변경했습니다.
- 스피너, 제목, 보조 문구를 함께 배치해 “처리 중” 상태가 더 직관적으로 보이도록 정리했습니다.

### 2. 카카오 로그인 콜백 로딩 UI 정리

- `KakaoLoginCallbackPage.tsx`의 정상 처리 상태를 스피너 중심 레이아웃으로 바꿨습니다.
- 기존의 큰 제목형 텍스트 상태 대신, 짧은 문구와 진행 표시가 먼저 보이도록 정리했습니다.
- 실패 상태는 버튼을 유지하면서 문구를 더 자연스럽게 정리했습니다.

### 3. 시각 톤 일관성 개선

- 일반 route loading과 카카오 로그인 loading이 모두 카드형 + 스피너 중심 구조를 사용하도록 맞췄습니다.
- 사용자가 서로 다른 로딩 종류를 별개 화면처럼 느끼지 않도록 시각적 밀도와 문구 톤을 맞췄습니다.

### 검증

- `npx vitest run src/App.test.tsx`
- `npm run lint -- src/App.tsx`
- `npm run lint -- src/pages/KakaoLoginCallbackPage.tsx`

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료

---

## 📸 스크린샷 (선택)


https://github.com/user-attachments/assets/5bc00e92-beaf-413b-809e-d120aa25953b


https://github.com/user-attachments/assets/75bf53a8-ac88-4ba0-8c75-1b3d2509004a



## 📌 추가 메모

- 이번 PR은 로딩 상태 UI 정리에 한정합니다.
- 인증 정책이나 카카오 로그인 처리 로직 자체는 변경하지 않았습니다.