### PR TITLE
build: PR summary/code review를 Gemini 담당으로 정리

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,18 @@
+have_fun: false
+
+code_review:
+  disable: false
+  comment_severity_threshold: MEDIUM
+  max_review_comments: 10
+  pull_request_opened:
+    help: false
+    summary: true
+    code_review: true
+    include_drafts: false
+
+ignore_patterns:
+  - 'dist/**'
+  - 'coverage/**'
+  - 'playwright-report/**'
+  - 'test-results/**'
+  - '.env*'

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -1,0 +1,10 @@
+# Blue Marble Review Guide
+
+Focus on bugs, regressions, missing tests, and contract mismatches first.
+
+- Follow `docs/rules.md` and `docs/testing.md`.
+- Keep pages thin; detailed logic belongs in hook/controller/api/socket layers.
+- When socket or contract code changes, check types, mocks, tests, and docs together.
+- Prefer high-signal findings over style nitpicks.
+- For lobby, presence, waiting-room, and game runtime changes, prioritize behavioral regressions.
+- Avoid duplicating deterministic workflow warnings when there is no new actionable issue.

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -249,7 +249,8 @@ jobs:
             ## 🤖 AI Review
 
             이 코멘트는 PR 변경 파일 기준으로 자동 갱신됩니다.
-            기존 CI를 대체하지 않고, diff 기반 self-review와 UI 검증 계획을 요약합니다.
+            기존 CI를 대체하지 않고, deterministic warning / validation / self-review 결과를 요약합니다.
+            생성형 PR summary와 code review는 Gemini Code Assist가 담당합니다.
 
             ### Changed Files
             ${changedFileList}

--- a/docs/ai/tasks/pr-ai-review-gemini-migration/checklist.md
+++ b/docs/ai/tasks/pr-ai-review-gemini-migration/checklist.md
@@ -1,0 +1,22 @@
+# Checklist
+
+## Implementation
+
+- [x] 관련 manual과 기존 문서를 읽었다
+- [x] 영향 범위를 정리했다
+- [x] 최소 범위로 구현했다
+- [x] OpenAI summary 제거와 Gemini 설정 추가를 분리해 반영했다
+- [x] deterministic workflow 구조를 유지했다
+
+## Testing
+
+- [ ] 대상 Vitest를 실행했다
+- [x] 관련 파일 `prettier --check`를 실행했다
+- [ ] 필요 시 `npm run build`를 실행했다
+- [x] `npm run ai:self-review -- --files ...`를 실행했다
+
+## Review
+
+- [x] `docs/rules.md` 기준으로 셀프 리뷰했다
+- [x] 기존 PR comment 구조가 warning / validation / self-review / UI plan 중심으로 유지되는지 확인했다
+- [x] 변경 파일 / 실행한 검증 / 남은 리스크를 정리했다

--- a/docs/ai/tasks/pr-ai-review-gemini-migration/context.md
+++ b/docs/ai/tasks/pr-ai-review-gemini-migration/context.md
@@ -1,0 +1,34 @@
+# Context
+
+## Current Behavior
+
+- 현재 `AI Review` workflow는 deterministic warning / validation / self-review / UI check plan에 더해 OpenAI 기반 summary 생성까지 같은 PR 코멘트에 넣도록 확장된 상태다.
+- 이 구조는 repo 전용 검증 흐름은 유지하지만, 생성형 summary를 위해 별도 script, secret, model variable 관리가 필요하다.
+- 이번 단계 목표는 repo 전용 deterministic workflow는 남기고, 생성형 summary/code review는 GitHub App 기반 Gemini Code Assist로 이관하는 것이다.
+
+## Related Files
+
+- `.github/workflows/ai-review.yml`
+- `package.json`
+- `scripts/ai/review-summary.mjs`
+- `scripts/ai/review-summary.test.ts`
+- `docs/rules.md`
+- `docs/testing.md`
+- `docs/ai/tasks/pr-ai-review-summary/*`
+
+## Constraints
+
+- 기존 PR 코멘트의 warning / validation / self-review / UI check plan 구조는 유지한다.
+- 생성형 review 제거가 deterministic workflow 실패나 comment 누락으로 이어지면 안 된다.
+- 팀이 보게 되는 생성형 review는 GitHub PR 화면에서 Gemini Code Assist가 담당하게 해야 한다.
+
+## Decision Notes
+
+- workflow 전체를 교체하지 않고 summary 관련 step과 comment section만 제거한다.
+- OpenAI script 대신 repo 루트 `.gemini/` 설정을 추가해 GitHub App 설정 지점을 명확히 둔다.
+- secret 정리는 GitHub 설정 작업이므로 repo patch 범위에서는 제외한다.
+
+## Open Risks
+
+- Gemini Code Assist 설치 전까지는 생성형 PR summary가 잠시 비어 있을 수 있다.
+- Gemini summary/comment 톤은 실제 팀 운영 후 `config.yaml` 임계치와 `styleguide.md`를 추가 조정할 수 있다.

--- a/docs/ai/tasks/pr-ai-review-gemini-migration/plan.md
+++ b/docs/ai/tasks/pr-ai-review-gemini-migration/plan.md
@@ -1,0 +1,48 @@
+# Plan
+
+## Task
+
+- 작업 이름: PR AI Review Gemini migration
+- 요청 날짜: 2026-03-18
+- 담당 범위: GitHub PR AI review 구성 최소 전환
+
+## Goal
+
+- 기존 deterministic `AI Review` workflow는 유지하고, OpenAI 기반 summary 단계를 제거한다.
+- GitHub App 기반 Gemini Code Assist가 PR summary와 생성형 code review를 담당할 수 있도록 repo 설정을 추가한다.
+
+## In Scope
+
+- `.github/workflows/ai-review.yml`에서 OpenAI summary 단계 제거
+- `.gemini/config.yaml`, `.gemini/styleguide.md` 추가
+- `package.json`의 `ai:review-summary` 스크립트 제거
+- 관련 task 문서 작성
+
+## Out Of Scope
+
+- GitHub Marketplace 앱 설치
+- repository secret / variable 삭제
+- branch protection 정책 변경
+- inline review 정책 튜닝
+
+## Target Files
+
+- `.github/workflows/ai-review.yml`
+- `.gemini/config.yaml`
+- `.gemini/styleguide.md`
+- `package.json`
+- `scripts/ai/review-summary.mjs`
+- `scripts/ai/review-summary.test.ts`
+- `docs/ai/tasks/pr-ai-review-gemini-migration/*`
+
+## Completion Criteria
+
+- `AI Review` workflow가 warning / validation / self-review / UI check plan만 담당한다.
+- repo에 Gemini GitHub review 동작용 설정 파일이 추가된다.
+- OpenAI API key/model에 의존하는 스크립트와 workflow 단계가 제거된다.
+- 작업 범위와 제외 범위가 task 문서에 정리된다.
+
+## Test Plan
+
+- `npx prettier --check .github/workflows/ai-review.yml .gemini/config.yaml .gemini/styleguide.md package.json docs/ai/tasks/pr-ai-review-gemini-migration/plan.md docs/ai/tasks/pr-ai-review-gemini-migration/context.md docs/ai/tasks/pr-ai-review-gemini-migration/checklist.md`
+- `npm run ai:self-review -- --files .github/workflows/ai-review.yml .gemini/config.yaml .gemini/styleguide.md package.json docs/ai/tasks/pr-ai-review-gemini-migration/plan.md docs/ai/tasks/pr-ai-review-gemini-migration/context.md docs/ai/tasks/pr-ai-review-gemini-migration/checklist.md`


### PR DESCRIPTION
## 📌 관련 이슈

> closes #472 

---

## 📝 작업 내용

> PR summary와 생성형 code review는 Gemini Code Assist가 담당하고, 기존 repo 내부 `AI Review` workflow는 deterministic 검증 코멘트에 집중하도록 정리했습니다.

### 1. Gemini Code Assist 설정 추가

- `.gemini/config.yaml`을 추가해 PR opened 시 summary/code review가 동작하도록 설정했습니다.
- comment severity threshold, max review comments, ignore patterns를 함께 정리했습니다.

### 2. repo 전용 리뷰 가이드 추가

- `.gemini/styleguide.md`를 추가해 이 repo의 리뷰 기준을 Gemini가 참고할 수 있도록 했습니다.
- `docs/rules.md`, `docs/testing.md` 준수, page thin 원칙, hook/controller/api/socket 분리, 계약 변경 시 types/mocks/tests/docs 동반 확인 등을 반영했습니다.
- lobby / presence / waiting-room / game runtime 변경은 회귀 중심으로 보도록 가이드를 넣었습니다.

### 3. 역할 분리 정리

- 생성형 summary/code review는 Gemini Code Assist가 담당합니다.
- 기존 `.github/workflows/ai-review.yml`은 `Workflow Warnings`, `Validation Orchestration`, `Self Review`, `UI Check Plan` 같은 deterministic 체크를 담당합니다.
- 즉, 생성형 리뷰와 규칙 기반 검증을 분리해 PR 흐름을 더 단순하게 정리했습니다.

### 검증

- `.gemini/config.yaml` 내용 확인
- `.gemini/styleguide.md` 내용 확인
- `ai:review-summary`, `OPENAI_API_KEY`, `AI Review Summary` 등 OpenAI summary 흔적 제거 확인
- 최근 커밋과 tracked files 확인

---

## ✅ 체크리스트

- [x] 로컬에서 설정 파일 반영 확인
- [x] 관련 이슈 연결 완료
- [x] Gemini용 repo 설정 파일 추가
- [x] deterministic AI Review workflow와 역할 분리 정리

---

## 📌 추가 메모

- GitHub Marketplace에서 Gemini Code Assist 앱 설치와 repo 접근 권한 부여는 별도 GitHub UI 작업이 필요합니다.
- consumer 무료 플랜 기준으로 시작하며, PR 리뷰 quota 제한을 고려합니다.
- branch protection이나 merge blocker는 이번 PR 범위에 포함하지 않습니다.
