### PR TITLE
fix: 여행 모달 fallback 중복 표시 및 주사위 값 불일치 수정

### DIFF
--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -490,6 +490,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
     const isTollPromptOpen = promptModalKind === 'toll'
     const isSellPromptOpen = promptModalKind === 'sell'
     const isAcquisitionPromptOpen = promptModalKind === 'acquisition'
+    const isTravelPromptOpen = promptModalKind === 'travel'
     const isDiceTimerPromptOpen = promptModalKind === 'dice_timer'
 
     const promptTileId = getPromptPayloadNumber(activePrompt, [
@@ -621,6 +622,14 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
     const promptAcquisitionCancelChoiceValue = resolvePromptChoiceValue(
       activePrompt,
       'acquisitionCancel'
+    )
+    const promptTravelConfirmChoiceValue = resolvePromptChoiceValue(
+      activePrompt,
+      'travelConfirm'
+    )
+    const promptTravelCancelChoiceValue = resolvePromptChoiceValue(
+      activePrompt,
+      'travelCancel'
     )
     const promptTimerConfirmChoiceValue = resolvePromptChoiceValue(
       activePrompt,
@@ -813,6 +822,13 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
     const [travelSelection, setTravelSelection] = useState(
       INITIAL_TRAVEL_SELECTION_STATE
     )
+
+    useEffect(() => {
+      if (isTravelPromptOpen && !travelModal.open && !travelSelection.active) {
+        setTravelModal({ open: true })
+      }
+    }, [isTravelPromptOpen, travelModal.open, travelSelection.active])
+
     const [tollModal, setTollModal] = useState<TollModalState>({
       open: false,
       tileId: null,
@@ -1085,11 +1101,17 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
     function handleTravelConfirm() {
       const { onDoneCallback } = travelModal
       setTravelModal({ open: false })
+      submitPromptChoice(promptTravelConfirmChoiceValue)
       setTravelSelection({
         active: true,
         onDoneCallback,
       })
       setStatus('국내여행: 이동할 칸을 클릭하세요.')
+    }
+
+    function handleTravelCancel() {
+      setTravelModal({ open: false })
+      submitPromptChoice(promptTravelCancelChoiceValue)
     }
 
     function handleTravelDestinationSelect(tileId: number) {
@@ -1732,7 +1754,12 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
           variant={cardModal.variant}
           onConfirm={handleCardConfirm}
         />
-        <TravelModal open={travelModal.open} onConfirm={handleTravelConfirm} />
+        <TravelModal
+          open={travelModal.open}
+          onConfirm={handleTravelConfirm}
+          onCancel={handleTravelCancel}
+          showCancel={isTravelPromptOpen && !!promptTravelCancelChoiceValue}
+        />
         <AIPenaltyModal
           open={aiModal.open}
           status={aiModal.status}

--- a/src/components/game/modals/TravelModal.tsx
+++ b/src/components/game/modals/TravelModal.tsx
@@ -5,19 +5,26 @@ interface TravelModalProps {
   title?: string
   description?: string
   confirmLabel?: string
+  cancelLabel?: string
+  showCancel?: boolean
   onConfirm?: () => void
+  onCancel?: () => void
 }
 
 const DEFAULT_TITLE = '국내여행'
 const DEFAULT_DESCRIPTION = '원하는 도시를 클릭하여 이동할 수 있습니다'
 const DEFAULT_CONFIRM_LABEL = '확인'
+const DEFAULT_CANCEL_LABEL = '건너뛰기'
 
 const TravelModal: React.FC<TravelModalProps> = ({
   open,
   title = DEFAULT_TITLE,
   description = DEFAULT_DESCRIPTION,
   confirmLabel = DEFAULT_CONFIRM_LABEL,
+  cancelLabel = DEFAULT_CANCEL_LABEL,
+  showCancel = false,
   onConfirm,
+  onCancel,
 }) => {
   if (!open) {
     return null
@@ -49,6 +56,16 @@ const TravelModal: React.FC<TravelModalProps> = ({
         >
           {confirmLabel}
         </button>
+
+        {showCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            className="mx-auto mt-3 flex h-18.5 w-full max-w-102 items-center justify-center rounded-[22px] border border-[#D0D7E2] bg-white text-[24px] font-black tracking-tight text-[#5A6D8A] transition-colors hover:bg-[#F8FAFC]"
+          >
+            {cancelLabel}
+          </button>
+        )}
       </div>
     </div>
   )

--- a/src/components/game/modals/promptModalMapping.ts
+++ b/src/components/game/modals/promptModalMapping.ts
@@ -7,6 +7,7 @@ export type PromptModalKind =
   | 'sell'
   | 'acquisition'
   | 'dice_timer'
+  | 'travel'
   | 'unknown'
 
 export type PromptChoiceRuleKey =
@@ -19,6 +20,8 @@ export type PromptChoiceRuleKey =
   | 'sellCancel'
   | 'acquisitionConfirm'
   | 'acquisitionCancel'
+  | 'travelConfirm'
+  | 'travelCancel'
   | 'timerConfirm'
 
 const BUY_TYPE_TOKENS = ['BUY_OR_SKIP', 'BUY_PROPERTY', 'BUY_PROMPT']
@@ -40,6 +43,12 @@ const ACQUISITION_TYPE_TOKENS = [
   'ACQUIRE_CITY',
   'PURCHASE_CITY',
   'TAKEOVER_CITY',
+]
+const TRAVEL_TYPE_TOKENS = [
+  'TRAVEL',
+  'DOMESTIC_TRAVEL',
+  'TRAVEL_PROMPT',
+  'MOVE_TO',
 ]
 const DICE_TIMER_TYPE_TOKENS = [
   'DICE_TIMEOUT',
@@ -88,6 +97,14 @@ const PROMPT_CHOICE_RULES: Record<
     fallbackIndex: 0,
   },
   acquisitionCancel: {
+    preferredTokens: ['SKIP', 'PASS', 'CANCEL', 'NO'],
+    fallbackIndex: 1,
+  },
+  travelConfirm: {
+    preferredTokens: ['TRAVEL', 'DESTINATION', 'SELECT', 'CONFIRM', 'YES'],
+    fallbackIndex: 0,
+  },
+  travelCancel: {
     preferredTokens: ['SKIP', 'PASS', 'CANCEL', 'NO'],
     fallbackIndex: 1,
   },
@@ -180,6 +197,13 @@ export const resolvePromptModalKind = (
       hasChoiceToken(prompt, ['SKIP', 'PASS', 'CANCEL']))
   ) {
     return 'acquisition'
+  }
+
+  if (
+    hasTypeToken(prompt, TRAVEL_TYPE_TOKENS) ||
+    hasChoiceToken(prompt, ['TRAVEL', 'DESTINATION'])
+  ) {
+    return 'travel'
   }
 
   if (

--- a/src/services/socket/game.handler.ts
+++ b/src/services/socket/game.handler.ts
@@ -54,6 +54,7 @@ type PromptResponsePayload = GamePromptResponse & {
 
 let teardownGameHandlersRef: Teardown | null = null
 const USE_GAME_SOCKET_MOCK = IS_SOCKET_MOCK_ENABLED
+let lastDiceRolledEnqueuedAt = 0
 
 const createActionId = () => `game-action-${Date.now()}`
 
@@ -119,17 +120,23 @@ export const setupGameHandlers = (
         ? (ackPayload!.dice as number[])
         : null
 
+      const ackReceivedAt = Date.now()
+
       setTimeout(() => {
-        const hasDiceEvent = gameStore.eventQueue.some(
-          (event) =>
-            typeof event.type === 'string' &&
-            [
-              'DICE_ROLLED',
-              'DICE_ROLL',
-              'DICE_ROLL_RESULT',
-              'ROLLED_DICE',
-            ].includes(event.type.trim().toUpperCase())
-        )
+        const hasDiceEvent =
+          lastDiceRolledEnqueuedAt >= ackReceivedAt ||
+          useGameStore
+            .getState()
+            .eventQueue.some(
+              (event) =>
+                typeof event.type === 'string' &&
+                [
+                  'DICE_ROLLED',
+                  'DICE_ROLL',
+                  'DICE_ROLL_RESULT',
+                  'ROLLED_DICE',
+                ].includes(event.type.trim().toUpperCase())
+            )
 
         if (!hasDiceEvent) {
           const syntheticDice: [number, number] =
@@ -177,6 +184,19 @@ export const setupGameHandlers = (
     const envelopeEvents = Array.isArray(payload.events) ? payload.events : []
     const mergedEvents =
       envelopeEvents.length > 0 ? envelopeEvents : snapshotEvents
+
+    const hasDiceRolledInEvents = mergedEvents.some(
+      (e: unknown) =>
+        e != null &&
+        typeof e === 'object' &&
+        'type' in e &&
+        typeof (e as { type: unknown }).type === 'string' &&
+        ((e as { type: string }).type.trim().toUpperCase() === 'DICE_ROLLED' ||
+          (e as { type: string }).type.trim().toUpperCase() === 'DICE_ROLL')
+    )
+    if (hasDiceRolledInEvents) {
+      lastDiceRolledEnqueuedAt = Date.now()
+    }
 
     const normalizedPatchEnvelope = normalizePatchEnvelopePayload({
       gameId: typeof payload.gameId === 'string' ? payload.gameId : undefined,


### PR DESCRIPTION
📌 관련 이슈
게임 런타임 버그 (여행 모달 중복 / 주사위 값 불일치)

📝 작업 내용
1. 여행(TRAVEL) 프롬프트 → fallback 모달 중복 표시 수정

서버가 TRAVEL 타입 prompt를 보내면 promptModalMapping에 매핑이 없어 unknown → GamePage fallback UI(라디오 버튼)가 기존 TravelModal과 동시에 렌더링되는 문제
promptModalMapping.ts에 'travel' kind + TRAVEL 토큰 추가 → fallback 차단
GameBoard.tsx에서 travel prompt 도착 시 기존 TravelModal 열기 + prompt confirm/cancel 응답 연결
TravelModal.tsx에 건너뛰기(cancel) 버튼 추가 (서버 prompt에 skip 선택지가 있을 때만 표시)
2. 주사위 값과 실제 이동 칸수 불일치 수정

ACK 후 300ms 뒤 큐를 체크할 때, 서버의 실제 DICE_ROLLED는 이미 소비(dequeue)되어 없으므로 hasDiceEvent = false → synthetic DICE_ROLLED(랜덤 dice)가 중복 생성 → 화면에 잘못된 주사위 값 표시
lastDiceRolledEnqueuedAt 타임스탬프로 enqueue 이력을 추적하여 중복 synthetic 생성 방지
🧪 실행한 검증
 npm run lint
 npm run test (267 passed)
 npm run build (pre-push hook)
⚠️ 남은 리스크
서버 ACK에 dice가 없고 game:patch에도 DICE_ROLLED 이벤트가 없는 극단적 케이스에서는 여전히 synthetic fallback이 생성됨 (현재 서버는 항상 DICE_ROLLED를 events에 포함하므로 실제 발생 가능성 낮음)
✅ 체크리스트
 로컬에서 정상 동작 확인
 불필요한 console.log 제거
 관련 이슈 연결 완료
 실행한 검증과 남은 리스크를 PR 본문에 적었다