### PR TITLE
fix: 타 플레이어 턴에 모달이 뜨는 문제 수정

### DIFF
--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -69,7 +69,7 @@ import type {
 } from './gameBoard.types'
 import '../../styles/board.css'
 import { formatWon } from '../../lib/utils'
-import type { GamePrompt, ServerEvent } from '../../types/domain'
+import type { GamePrompt, PlayerId, ServerEvent } from '../../types/domain'
 import { playLongSfx, stopLongSfx } from '../../lib/bgm'
 import { IS_SOCKET_MOCK_ENABLED } from '../../config/env'
 import { emitGameAction } from '../../services/socket/game.handler'
@@ -405,7 +405,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
           return
         }
 
-        handleArrival(tileIndex, emitMockEndTurn)
+        handleArrival(tileIndex, emitMockEndTurn, event.playerId ?? null)
       },
       [
         handleArrival,
@@ -1158,8 +1158,17 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       }, 300)
     }
 
-    function handleArrival(tileId: number, onDone?: () => void) {
+    function handleArrival(
+      tileId: number,
+      onDone?: () => void,
+      eventPlayerId?: PlayerId | null
+    ) {
       const tile = TILES[tileId]
+
+      const isLocalPlayerTurn =
+        localPlayerId == null ||
+        eventPlayerId == null ||
+        String(eventPlayerId) === String(localPlayerId)
 
       if (tile.type === 'START') {
         setStatus('시작 칸에 도착!')
@@ -1169,18 +1178,23 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
 
       if (tile.type === 'MOVE_TO_ISLAND') {
         setStatus('무인도로 이동!')
-        setGoToIslandModal({ open: true, onDoneCallback: onDone })
-        // 🏝️ 무인도 칸 도착 소리 재생
-        new Audio('/audio/island-trap.mp3').play().catch(() => {})
+        if (isLocalPlayerTurn) {
+          setGoToIslandModal({ open: true, onDoneCallback: onDone })
+          new Audio('/audio/island-trap.mp3').play().catch(() => {})
+        } else {
+          onDone?.()
+        }
         return
       }
 
       if (tile.type === 'ISLAND') {
         setStatus('무인도 칸에 도착!')
-        // 🏝️ 무인도(직접 도착) 칸 소리 재생
-        new Audio('/audio/island-trap.mp3').play().catch(() => {})
-
-        setIslandModal({ open: true, onDoneCallback: onDone })
+        if (isLocalPlayerTurn) {
+          new Audio('/audio/island-trap.mp3').play().catch(() => {})
+          setIslandModal({ open: true, onDoneCallback: onDone })
+        } else {
+          onDone?.()
+        }
         return
       }
 
@@ -1191,10 +1205,14 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       }
 
       if (tile.type === 'TRAVEL') {
-        setTravelModal({
-          open: true,
-          onDoneCallback: onDone,
-        })
+        if (isLocalPlayerTurn) {
+          setTravelModal({
+            open: true,
+            onDoneCallback: onDone,
+          })
+        } else {
+          onDone?.()
+        }
         return
       }
 
@@ -1202,25 +1220,29 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
         tile.type === 'AI' ||
         (tile.type === 'EVENT' && tile.emoji === '🤖')
       ) {
-        // 🤖 AI 칸 도착 소리 재생
-        playLongSfx('/audio/AI.mp3')
-
-        handleAITile(onDone)
+        if (isLocalPlayerTurn) {
+          playLongSfx('/audio/AI.mp3')
+          handleAITile(onDone)
+        } else {
+          onDone?.()
+        }
         return
       }
 
       if (tile.type === 'CHANCE' || tile.type === 'EVENT') {
-        setCardModal({
-          open: true,
-          variant: tile.type === 'CHANCE' ? 'CHANCE' : 'EVENT',
-          onDoneCallback: onDone,
-        })
-
-        // 🃏 찬스/강화 이벤트 소리 재생
-        if (tile.type === 'CHANCE') {
-          new Audio('/audio/chance.mp3').play().catch(() => {})
+        if (isLocalPlayerTurn) {
+          setCardModal({
+            open: true,
+            variant: tile.type === 'CHANCE' ? 'CHANCE' : 'EVENT',
+            onDoneCallback: onDone,
+          })
+          if (tile.type === 'CHANCE') {
+            new Audio('/audio/chance.mp3').play().catch(() => {})
+          } else {
+            new Audio('/audio/event.mp3').play().catch(() => {})
+          }
         } else {
-          new Audio('/audio/event.mp3').play().catch(() => {})
+          onDone?.()
         }
         return
       }


### PR DESCRIPTION
## 📌 관련 이슈

> 없음 (플레이 테스트 중 발견된 버그)

---

## 📝 작업 내용

> 다른 플레이어가 무인도/AI/찬스/이벤트/여행 칸에 도착했을 때, 턴 당사자가 아닌 클라이언트에서도 모달이 표시되는 문제를 수정했습니다.

### 원인
- `handleArrival`에서 현재 턴 당사자를 판별할 때 `curPlayerRef.current`를 사용하고 있었음
- 서버 스냅샷이 이벤트 큐보다 먼저 적용되기 때문에, `handleArrival` 실행 시점에 `curPlayerRef`는 이미 **다음 턴 플레이어**를 가리키고 있었음
- 결과적으로 턴 당사자에겐 모달이 안 뜨고, 다른 플레이어에게 모달이 뜨는 현상 발생

### 수정
- `PLAYER_MOVED` 이벤트의 `event.playerId`를 `handleArrival`에 전달하도록 변경
- `handleArrival` 내부에서 `event.playerId`와 `localPlayerId`(현재 접속 유저 ID)를 비교하여 턴 당사자 여부를 판별
- 턴 당사자가 아닌 경우 모달을 열지 않고 `onDone?.()` 으로 바로 다음 흐름으로 진행
- 적용 대상 타일: `MOVE_TO_ISLAND`, `ISLAND`, `TRAVEL`, `AI`, `CHANCE`, `EVENT`
- `localPlayerId == null`(mock 모드)일 때는 기존 동작 그대로 유지

---

## 🧠 Task 문서 (큰 작업이면 필수)

> 단일 파일 수정이므로 생략합니다.

---

## 🧪 실행한 검증

- [x] `npm run lint`
- [x] `npm run test`
- [x] `npm run build`
- [x] 기타: `npx tsc --noEmit` 타입 체크 통과, pre-push hook 전체 통과

---

## ⚠️ 남은 리스크

- AI 칸 모달(`handleAITile`)은 서버 연동 없이 1.5초 후 무조건 error 상태로 전환되는 stub 구현 상태 — 서버 AI API 연동 필요
- `TRAVEL` 액션은 서버에서 `UNKNOWN_ACTION`으로 거부됨 — BE 쪽 액션 핸들러 구현 필요
- 게임 채팅은 대기방 소켓 이벤트(`send_chat`/`chat`)를 재사용 중이라 플레이 중 동작 여부는 서버 계약에 의존

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [ ] 관련 이슈 연결 완료
- [x] 큰 작업이면 task 문서 링크를 남겼다
- [x] 실행한 검증과 남은 리스크를 PR 본문에 적었다

---

## 📸 스크린샷 (선택)

> 없음
