### PR TITLE
feat: refresh cookie 기반 인증 복구와 재시도 흐름 반영

### DIFF
--- a/docs/ai/tasks/auth-refresh-cookie-flow/checklist.md
+++ b/docs/ai/tasks/auth-refresh-cookie-flow/checklist.md
@@ -1,0 +1,34 @@
+# Checklist
+
+## Planning
+
+- [x] 관련 manual과 기존 문서를 읽었다
+- [x] 백엔드 refresh 계약을 정리했다
+- [x] 영향 범위와 제외 범위를 정리했다
+- [x] 최소 검증 범위를 정리했다
+
+## Implementation
+
+- [x] refresh 응답 타입과 refresh helper를 추가한다
+- [x] `apiClient`에 `withCredentials` 기본 설정을 추가한다
+- [x] 401 응답 후 refresh + 1회 재시도 interceptor를 추가한다
+- [x] refresh 성공 시 access token 갱신과 소켓 재연결 흐름을 연결한다
+- [x] `/auth/logout` 호출 기반 logout 정리를 반영한다
+- [x] mock/real 경로를 함께 확인한다
+
+## Testing
+
+- [x] `npx vitest run src/lib/axios.test.ts`
+- [x] `npx vitest run src/features/auth/api/api.test.ts`
+- [x] `npx vitest run src/features/auth/session/hooks/useAuthBootstrap.test.tsx`
+- [x] `npx vitest run src/lib/socket.test.ts`
+- [x] 필요 시 관련 페이지 테스트를 실행한다
+- [x] 필요 시 `npm run lint`
+- [x] 필요 시 `npm run build`
+
+## Review
+
+- [x] refresh token이 프론트 상태나 body에 저장되지 않는지 확인한다
+- [x] 401 -> refresh -> 재시도 -> 실패 시 세션 정리 흐름을 확인한다
+- [x] logout과 socket reconnect 흐름을 확인한다
+- [ ] 변경 파일 / 실행한 검증 / 남은 리스크를 정리한다

--- a/docs/ai/tasks/auth-refresh-cookie-flow/context.md
+++ b/docs/ai/tasks/auth-refresh-cookie-flow/context.md
@@ -1,0 +1,54 @@
+# Context
+
+## Current Behavior
+
+- 프론트는 zustand persisted session에 저장된 `accessToken`을 Authorization 헤더에만 붙인다.
+- `apiClient`는 `withCredentials`를 기본으로 켜지 않고 있으며 401 응답 후 refresh 재시도 로직도 없다.
+- 앱 초기 bootstrap은 persisted access token이 있을 때 `/auth/session`으로 세션을 1회 복구하는 구조다.
+- logout은 `/auth/logout` API 호출 없이 `clearSession()`과 `disconnectSocketAndClearAuth()`만 수행한다.
+- 소켓은 현재 store의 access token을 `socket.auth.token`으로 동기화하고, 토큰이 바뀌면 재연결할 수 있는 유틸만 제공한다.
+
+## Related Files
+
+- `src/lib/axios.ts`
+- `src/lib/socket.ts`
+- `src/features/auth/api/api.ts`
+- `src/features/auth/session/types.ts`
+- `src/features/auth/session/store.ts`
+- `src/features/auth/session/hooks/useAuthBootstrap.ts`
+- `src/pages/KakaoLoginCallbackPage.tsx`
+- `src/pages/lobby/LobbyPage.tsx`
+- `src/pages/waiting-room/page/WaitingRoomPage.tsx`
+
+## Backend Contract Notes
+
+- refresh endpoint는 `POST /v1/auth/refresh`다.
+- refresh 성공 응답 body는 `access_token`, `token_type`, `expires_in`만 포함한다.
+- refresh token은 HttpOnly cookie only로 전달되며 body에는 포함되지 않는다.
+- refresh token TTL은 14일이고, refresh 성공 시 rotation이 적용된다.
+- logout endpoint는 `POST /v1/auth/logout`이며 refresh 무효화와 cookie 삭제를 함께 처리한다.
+- access token 만료/무효와 refresh token 만료/무효는 모두 401을 반환한다.
+- 소켓은 connect 시점에만 토큰 검증하므로 refresh 성공 후 새 access token으로 재연결하면 된다.
+
+## Constraints
+
+- access token은 현재처럼 프론트 session 상태에 유지할 수 있지만, refresh token은 프론트 상태에 저장하면 안 된다.
+- cookie 전송을 위해 refresh/logout 호출은 `withCredentials: true` 전제를 만족해야 한다.
+- 실제 cookie path는 `/v1/auth`이므로 `VITE_API_URL`과 auth endpoint 경로 정합성을 확인해야 한다.
+- mock 모드와 실제 모드가 공존하므로 mock 경로를 불필요하게 깨지 않도록 주의한다.
+- 소켓 재연결은 이미 연결 중인 room/lobby 흐름을 과하게 흔들지 않아야 한다.
+
+## Decision Notes
+
+- refresh는 별도 auth helper로 분리해 axios interceptor와 UI 코드가 refresh payload 형식을 직접 알지 않게 한다.
+- response interceptor는 무한 루프를 막기 위해 refresh 재시도를 1회로 제한한다.
+- refresh 성공 시 store access token을 갱신하고, 소켓은 기존 유틸을 활용해 인증 컨텍스트를 재동기화한다.
+- logout은 UI에서 직접 세션만 비우지 않고 API 호출 성공/실패와 상관없이 최종 정리 흐름을 한 곳으로 모은다.
+- bootstrap restore와 runtime refresh는 중복 책임이 생기지 않도록 역할을 분리한다.
+
+## Open Risks
+
+- 401 응답 메시지(`Token expired`, `Invalid token`)가 모두 refresh 대상은 아닐 수 있어, interceptor 조건이 너무 넓으면 의도치 않은 재시도가 생길 수 있다.
+- refresh 실패 시 동시에 여러 요청이 401을 받으면 중복 refresh 호출을 막는 동기화가 필요할 수 있다.
+- Kakao callback이 여전히 query `access_token`을 사용하므로, 이 흐름과 refresh 기반 세션 복구가 충돌하지 않게 순서를 맞춰야 한다.
+- logout을 waiting-room에서 호출할 때 leaveRoom 실패와 auth 정리 순서가 엇갈리면 UX가 흔들릴 수 있다.

--- a/docs/ai/tasks/auth-refresh-cookie-flow/context.md
+++ b/docs/ai/tasks/auth-refresh-cookie-flow/context.md
@@ -22,11 +22,11 @@
 
 ## Backend Contract Notes
 
-- refresh endpoint는 `POST /v1/auth/refresh`다.
+- refresh endpoint는 `POST /api/auth/refresh`다.
 - refresh 성공 응답 body는 `access_token`, `token_type`, `expires_in`만 포함한다.
 - refresh token은 HttpOnly cookie only로 전달되며 body에는 포함되지 않는다.
 - refresh token TTL은 14일이고, refresh 성공 시 rotation이 적용된다.
-- logout endpoint는 `POST /v1/auth/logout`이며 refresh 무효화와 cookie 삭제를 함께 처리한다.
+- logout endpoint는 `POST /api/auth/logout`이며 refresh 무효화와 cookie 삭제를 함께 처리한다.
 - access token 만료/무효와 refresh token 만료/무효는 모두 401을 반환한다.
 - 소켓은 connect 시점에만 토큰 검증하므로 refresh 성공 후 새 access token으로 재연결하면 된다.
 
@@ -34,7 +34,7 @@
 
 - access token은 현재처럼 프론트 session 상태에 유지할 수 있지만, refresh token은 프론트 상태에 저장하면 안 된다.
 - cookie 전송을 위해 refresh/logout 호출은 `withCredentials: true` 전제를 만족해야 한다.
-- 실제 cookie path는 `/v1/auth`이므로 `VITE_API_URL`과 auth endpoint 경로 정합성을 확인해야 한다.
+- refresh/logout 경로가 `/api/auth/*`로 확정됐으므로, cookie path와 함께 정합성을 재확인해야 한다.
 - mock 모드와 실제 모드가 공존하므로 mock 경로를 불필요하게 깨지 않도록 주의한다.
 - 소켓 재연결은 이미 연결 중인 room/lobby 흐름을 과하게 흔들지 않아야 한다.
 

--- a/docs/ai/tasks/auth-refresh-cookie-flow/plan.md
+++ b/docs/ai/tasks/auth-refresh-cookie-flow/plan.md
@@ -1,0 +1,69 @@
+# Plan
+
+## Task
+
+- 작업 이름: refresh cookie 기반 인증 복구와 재시도 흐름 반영
+- 요청 날짜: 2026-03-18
+- 담당 범위: auth api, axios interceptor, session bootstrap, logout, socket reconnect
+
+## Goal
+
+- 백엔드가 확정한 refresh 계약을 기준으로 프론트 인증 흐름을 cookie 기반 refresh 재발급 구조에 맞게 정리한다.
+- access token은 클라이언트 세션에 유지하되, refresh token은 HttpOnly cookie로만 전달받고 프론트에서는 직접 저장하지 않도록 맞춘다.
+- 401 응답 후 refresh 재시도, logout API 호출, refresh 성공 후 소켓 재연결까지 하나의 흐름으로 연결한다.
+
+## In Scope
+
+- `withCredentials: true`가 적용된 auth/axios 기본 설정
+- `POST /auth/refresh` helper와 refresh 응답 타입 정리
+- 401 응답 시 refresh 후 1회 재시도하는 axios response interceptor
+- refresh 성공 시 access token 갱신 및 소켓 인증 컨텍스트 재동기화
+- `/auth/logout` 호출 기반 logout 정리
+- bootstrap restore와 refresh 실패 시 세션 정리 흐름 점검
+- 관련 auth/axios/socket 테스트 보강
+
+## Out Of Scope
+
+- refresh token 자체를 프론트 store/localStorage에 저장하는 구조
+- 카카오 로그인 callback 계약 자체 변경
+- auth 전역 UX 리디자인
+- branch protection, AI review workflow 변경
+
+## Target Files
+
+- `src/lib/axios.ts`
+- `src/lib/axios.test.ts`
+- `src/lib/socket.ts`
+- `src/lib/socket.test.ts`
+- `src/features/auth/api/api.ts`
+- `src/features/auth/api/api.test.ts`
+- `src/features/auth/session/types.ts`
+- `src/features/auth/session/store.ts`
+- `src/features/auth/session/hooks/useAuthBootstrap.ts`
+- `src/features/auth/session/hooks/useAuthBootstrap.test.tsx`
+- `src/pages/KakaoLoginCallbackPage.tsx`
+- `src/pages/lobby/LobbyPage.tsx`
+- `src/pages/waiting-room/page/WaitingRoomPage.tsx`
+- 필요 시 logout 관련 페이지 테스트
+
+## Completion Criteria
+
+- `apiClient`가 refresh/logout 요청에 cookie를 보낼 수 있도록 `withCredentials: true`로 동작한다.
+- access token 만료로 401이 발생하면 refresh 성공 시 access token을 갱신하고 실패한 요청을 1회 재시도한다.
+- refresh 실패 시 세션 정리와 소켓 정리가 일관되게 수행된다.
+- logout은 `/auth/logout`을 호출해 refresh 무효화 + cookie 삭제 계약을 따른다.
+- refresh 성공 후 소켓은 새 access token으로 재연결된다.
+- refresh token은 프론트 store/localStorage/body에 저장되지 않는다.
+
+## Test Plan
+
+- 최소 실행 테스트
+  - `npx vitest run src/lib/axios.test.ts`
+  - `npx vitest run src/features/auth/api/api.test.ts`
+  - `npx vitest run src/features/auth/session/hooks/useAuthBootstrap.test.tsx`
+  - `npx vitest run src/lib/socket.test.ts`
+- 추가 검증
+  - 필요 시 `npx vitest run src/pages/lobby/LobbyPage.test.tsx`
+  - 필요 시 `npx vitest run src/pages/waiting-room/page/WaitingRoomPage.test.tsx`
+  - `npm run lint`
+  - `npm run build`

--- a/src/features/auth/api/api.test.ts
+++ b/src/features/auth/api/api.test.ts
@@ -1,4 +1,4 @@
-import { AxiosError } from 'axios'
+import axios, { AxiosError, AxiosHeaders } from 'axios'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { apiClient } from '../../../lib/axios'
 import {
@@ -7,7 +7,9 @@ import {
   getAuthErrorMessage,
   getMyPageProfile,
   loginAsGuest,
+  logoutAuthSession,
   mapMyPageProfile,
+  refreshAccessToken,
   restoreAuthSession,
   setNickname,
   shouldUseFallbackSessionForRestore,
@@ -176,6 +178,29 @@ describe('auth api integration helpers', () => {
     expect(restored.needsNicknameSetup).toBe(true)
   })
 
+  it('restoreAuthSession은 refresh 이후 응답 config의 Authorization 헤더를 최신 access token으로 반영한다', async () => {
+    vi.spyOn(apiClient, 'get').mockResolvedValue({
+      data: {
+        id: 11,
+        nickname: '',
+        is_guest: false,
+        profile_image_url: null,
+      },
+      config: {
+        headers: new AxiosHeaders({
+          Authorization: 'Bearer refreshed-token',
+        }),
+      },
+    } as never)
+
+    const restored = await restoreAuthSession({
+      accessToken: 'persisted-token',
+      fallbackSession: baseSession,
+    })
+
+    expect(restored.accessToken).toBe('refreshed-token')
+  })
+
   it('mock 모드에서는 persisted fallback session을 그대로 복구에 사용한다', () => {
     expect(
       shouldUseFallbackSessionForRestore({
@@ -255,6 +280,47 @@ describe('auth api integration helpers', () => {
     expect(result).toBeNull()
     expect(assignSpy).toHaveBeenCalledWith(
       'http://localhost:3000/api/auth/kakao/login'
+    )
+  })
+
+  it('refreshAccessToken은 versioned auth refresh endpoint를 withCredentials로 호출한다', async () => {
+    const postSpy = vi.spyOn(axios, 'post').mockResolvedValue({
+      data: {
+        access_token: 'refreshed-token',
+        token_type: 'Bearer',
+        expires_in: 3600,
+      },
+    } as never)
+
+    const result = await refreshAccessToken()
+
+    expect(result).toEqual({
+      access_token: 'refreshed-token',
+      token_type: 'Bearer',
+      expires_in: 3600,
+    })
+    expect(postSpy).toHaveBeenCalledWith(
+      'http://localhost:3000/v1/auth/refresh',
+      undefined,
+      expect.objectContaining({
+        withCredentials: true,
+      })
+    )
+  })
+
+  it('logoutAuthSession은 versioned auth logout endpoint를 withCredentials로 호출한다', async () => {
+    const postSpy = vi.spyOn(axios, 'post').mockResolvedValue({
+      data: null,
+    } as never)
+
+    await logoutAuthSession()
+
+    expect(postSpy).toHaveBeenCalledWith(
+      'http://localhost:3000/v1/auth/logout',
+      undefined,
+      expect.objectContaining({
+        withCredentials: true,
+      })
     )
   })
 

--- a/src/features/auth/api/api.test.ts
+++ b/src/features/auth/api/api.test.ts
@@ -283,7 +283,7 @@ describe('auth api integration helpers', () => {
     )
   })
 
-  it('refreshAccessToken은 versioned auth refresh endpoint를 withCredentials로 호출한다', async () => {
+  it('refreshAccessToken은 auth refresh endpoint를 withCredentials로 호출한다', async () => {
     const postSpy = vi.spyOn(axios, 'post').mockResolvedValue({
       data: {
         access_token: 'refreshed-token',
@@ -300,7 +300,7 @@ describe('auth api integration helpers', () => {
       expires_in: 3600,
     })
     expect(postSpy).toHaveBeenCalledWith(
-      'http://localhost:3000/v1/auth/refresh',
+      'http://localhost:3000/api/auth/refresh',
       undefined,
       expect.objectContaining({
         withCredentials: true,
@@ -308,7 +308,7 @@ describe('auth api integration helpers', () => {
     )
   })
 
-  it('logoutAuthSession은 versioned auth logout endpoint를 withCredentials로 호출한다', async () => {
+  it('logoutAuthSession은 auth logout endpoint를 withCredentials로 호출한다', async () => {
     const postSpy = vi.spyOn(axios, 'post').mockResolvedValue({
       data: null,
     } as never)
@@ -316,7 +316,7 @@ describe('auth api integration helpers', () => {
     await logoutAuthSession()
 
     expect(postSpy).toHaveBeenCalledWith(
-      'http://localhost:3000/v1/auth/logout',
+      'http://localhost:3000/api/auth/logout',
       undefined,
       expect.objectContaining({
         withCredentials: true,

--- a/src/features/auth/api/api.ts
+++ b/src/features/auth/api/api.ts
@@ -1,7 +1,12 @@
-import { isAxiosError } from 'axios'
+import { AxiosHeaders, isAxiosError } from 'axios'
 import { IS_DEMO_MOCK_ENABLED } from '../../../config/env'
 import { getParsedApiErrorMessage, parseApiError } from '../../../lib/apiError'
-import { apiClient } from '../../../lib/axios'
+import {
+  apiClient,
+  requestAccessTokenRefresh,
+  requestAuthLogout,
+  type RefreshAccessTokenResponsePayload,
+} from '../../../lib/axios'
 import {
   mockGuestLogin,
   mockGetMyPageProfile,
@@ -31,6 +36,11 @@ interface AuthResponsePayload {
   access_token: string
   user: AuthUserPayload
   is_new_user: boolean
+}
+
+interface AuthSessionResponse {
+  user: AuthUserPayload
+  accessToken: string
 }
 
 type AuthSessionPayload = AuthUserPayload
@@ -131,13 +141,25 @@ function buildApiPath(path: string) {
 }
 
 async function getAuthSessionWithToken(accessToken: string) {
-  const { data } = await apiClient.get<AuthSessionPayload>('/auth/session', {
+  const response = await apiClient.get<AuthSessionPayload>('/auth/session', {
     headers: {
       Authorization: `Bearer ${accessToken}`,
     },
   })
 
-  return data
+  const resolvedAuthorization = AxiosHeaders.from(response.config?.headers).get(
+    'Authorization'
+  )
+  const resolvedAccessToken =
+    typeof resolvedAuthorization === 'string' &&
+    resolvedAuthorization.startsWith('Bearer ')
+      ? resolvedAuthorization.slice('Bearer '.length).trim()
+      : accessToken
+
+  return {
+    user: response.data,
+    accessToken: resolvedAccessToken,
+  } satisfies AuthSessionResponse
 }
 
 export function shouldUseFallbackSessionForRestore({
@@ -158,14 +180,15 @@ export async function restoreAuthSession({
     return fallbackSession
   }
 
-  const user = await getAuthSessionWithToken(accessToken)
+  const restored = await getAuthSessionWithToken(accessToken)
 
   return buildAuthSession({
-    accessToken,
-    user,
+    accessToken: restored.accessToken,
+    user: restored.user,
     provider: fallbackSession?.provider,
     needsNicknameSetup:
-      fallbackSession?.needsNicknameSetup && user.nickname.trim().length === 0,
+      fallbackSession?.needsNicknameSetup &&
+      restored.user.nickname.trim().length === 0,
   })
 }
 
@@ -173,14 +196,26 @@ export async function completeKakaoLogin({
   accessToken,
   isNewUser,
 }: CompleteKakaoLoginParams) {
-  const user = await getAuthSessionWithToken(accessToken)
+  const restored = await getAuthSessionWithToken(accessToken)
 
   return buildAuthSession({
-    accessToken,
-    user,
+    accessToken: restored.accessToken,
+    user: restored.user,
     provider: 'kakao',
-    needsNicknameSetup: isNewUser || user.nickname.trim().length === 0,
+    needsNicknameSetup: isNewUser || restored.user.nickname.trim().length === 0,
   })
+}
+
+export async function refreshAccessToken() {
+  if (IS_AUTH_MOCK_ENABLED) {
+    return {
+      access_token: '',
+      token_type: 'Bearer',
+      expires_in: 0,
+    } satisfies RefreshAccessTokenResponsePayload
+  }
+
+  return requestAccessTokenRefresh()
 }
 
 export async function loginAsGuest() {
@@ -297,6 +332,14 @@ export async function getMyPageProfile(
       ),
     }
   }
+}
+
+export async function logoutAuthSession() {
+  if (IS_AUTH_MOCK_ENABLED) {
+    return
+  }
+
+  await requestAuthLogout()
 }
 
 export function getAuthErrorMessage(error: unknown, fallbackMessage: string) {

--- a/src/lib/axios.test.ts
+++ b/src/lib/axios.test.ts
@@ -1,13 +1,18 @@
-import { AxiosHeaders, type InternalAxiosRequestConfig } from 'axios'
-import { afterEach, describe, expect, it } from 'vitest'
+import axios, {
+  AxiosError,
+  AxiosHeaders,
+  type InternalAxiosRequestConfig,
+} from 'axios'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { useAuthStore } from '../features/auth/session/store'
-import { apiClient } from './axios'
+import { apiClient, buildVersionedAuthUrl } from './axios'
 
 interface RequestInterceptorManagerLike {
   handlers?: Array<{
     fulfilled?: (
       config: InternalAxiosRequestConfig
     ) => InternalAxiosRequestConfig | Promise<InternalAxiosRequestConfig>
+    rejected?: (error: unknown) => unknown
   }>
 }
 
@@ -35,8 +40,38 @@ function runRequestInterceptor(config: InternalAxiosRequestConfig) {
   return nextConfig
 }
 
+function runResponseErrorInterceptor(error: unknown) {
+  const responseInterceptors = apiClient.interceptors
+    .response as RequestInterceptorManagerLike
+  const rejectedHandler = responseInterceptors.handlers?.[0]?.rejected
+  if (!rejectedHandler) {
+    throw new Error('response interceptor is not registered')
+  }
+
+  return rejectedHandler(error)
+}
+
+function createAxiosError(config: InternalAxiosRequestConfig, status: number) {
+  return new AxiosError(
+    `Request failed with status code ${status}`,
+    undefined,
+    config,
+    undefined,
+    {
+      status,
+      statusText: 'error',
+      headers: {},
+      config,
+      data: {
+        detail: status === 401 ? 'Token expired' : 'error',
+      },
+    }
+  )
+}
+
 describe('apiClient request interceptor', () => {
   afterEach(() => {
+    vi.restoreAllMocks()
     useAuthStore.getState().clearSession()
   })
 
@@ -78,5 +113,77 @@ describe('apiClient request interceptor', () => {
     expect(
       AxiosHeaders.from(config.headers).get('Authorization')
     ).toBeUndefined()
+  })
+
+  it('기본적으로 withCredentials를 켠다', () => {
+    expect(apiClient.defaults.withCredentials).toBe(true)
+  })
+
+  it('401 응답이면 refresh 후 access token을 갱신하고 요청을 1회 재시도한다', async () => {
+    useAuthStore.getState().setSession({
+      accessToken: 'expired-token',
+      userId: '1',
+      nickname: '마블러',
+      profileImage: null,
+      isGuest: false,
+      needsNicknameSetup: false,
+      provider: 'kakao',
+    })
+
+    const refreshSpy = vi.spyOn(axios, 'post').mockResolvedValue({
+      data: {
+        access_token: 'refreshed-token',
+        token_type: 'Bearer',
+        expires_in: 3600,
+      },
+    } as never)
+    const retrySpy = vi.spyOn(apiClient, 'request').mockResolvedValue({
+      data: { ok: true },
+    } as never)
+
+    const result = await runResponseErrorInterceptor(
+      createAxiosError(createRequestConfig(), 401)
+    )
+
+    expect(refreshSpy).toHaveBeenCalledWith(
+      buildVersionedAuthUrl('/refresh'),
+      undefined,
+      expect.objectContaining({
+        withCredentials: true,
+      })
+    )
+    expect(retrySpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        _retry: true,
+        headers: expect.objectContaining({
+          Authorization: 'Bearer refreshed-token',
+        }),
+      })
+    )
+    expect(useAuthStore.getState().session?.accessToken).toBe('refreshed-token')
+    expect(result).toEqual({
+      data: { ok: true },
+    })
+  })
+
+  it('refresh가 실패하면 세션을 정리하고 원본 요청을 종료한다', async () => {
+    useAuthStore.getState().setSession({
+      accessToken: 'expired-token',
+      userId: '1',
+      nickname: '마블러',
+      profileImage: null,
+      isGuest: false,
+      needsNicknameSetup: false,
+      provider: 'kakao',
+    })
+
+    const refreshError = new Error('refresh failed')
+    vi.spyOn(axios, 'post').mockRejectedValue(refreshError)
+
+    await expect(
+      runResponseErrorInterceptor(createAxiosError(createRequestConfig(), 401))
+    ).rejects.toBe(refreshError)
+
+    expect(useAuthStore.getState().session).toBeNull()
   })
 })

--- a/src/lib/axios.test.ts
+++ b/src/lib/axios.test.ts
@@ -5,7 +5,7 @@ import axios, {
 } from 'axios'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { useAuthStore } from '../features/auth/session/store'
-import { apiClient, buildVersionedAuthUrl } from './axios'
+import { apiClient, buildAuthTransportUrl } from './axios'
 
 interface RequestInterceptorManagerLike {
   handlers?: Array<{
@@ -146,7 +146,7 @@ describe('apiClient request interceptor', () => {
     )
 
     expect(refreshSpy).toHaveBeenCalledWith(
-      buildVersionedAuthUrl('/refresh'),
+      buildAuthTransportUrl('/refresh'),
       undefined,
       expect.objectContaining({
         withCredentials: true,

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -44,13 +44,13 @@ function getApiOrigin(baseURL = apiClient.defaults.baseURL) {
   return new URL(String(baseURL), fallbackOrigin).origin
 }
 
-export function buildVersionedAuthUrl(path: '/refresh' | '/logout') {
-  return new URL(`/v1/auth${path}`, getApiOrigin()).toString()
+export function buildAuthTransportUrl(path: '/refresh' | '/logout') {
+  return new URL(`/api/auth${path}`, getApiOrigin()).toString()
 }
 
 export async function requestAccessTokenRefresh() {
   const { data } = await axios.post<RefreshAccessTokenResponsePayload>(
-    buildVersionedAuthUrl('/refresh'),
+    buildAuthTransportUrl('/refresh'),
     undefined,
     {
       timeout: apiClient.defaults.timeout,
@@ -65,7 +65,7 @@ export async function requestAccessTokenRefresh() {
 }
 
 export async function requestAuthLogout() {
-  await axios.post(buildVersionedAuthUrl('/logout'), undefined, {
+  await axios.post(buildAuthTransportUrl('/logout'), undefined, {
     timeout: apiClient.defaults.timeout,
     withCredentials: true,
     headers: {

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -1,14 +1,114 @@
-import axios, { AxiosHeaders } from 'axios'
+import axios, {
+  AxiosError,
+  AxiosHeaders,
+  isAxiosError,
+  type InternalAxiosRequestConfig,
+} from 'axios'
+import { IS_DEMO_MOCK_ENABLED } from '../config/env'
 import { useAuthStore } from '../features/auth/session/store'
+import {
+  disconnectSocketAndClearAuth,
+  reconnectSocketWithUpdatedAuthIfConnected,
+} from './socket'
+
+export interface RefreshAccessTokenResponsePayload {
+  access_token: string
+  token_type: string
+  expires_in: number
+}
+
+interface RetryableAuthRequestConfig extends InternalAxiosRequestConfig {
+  _retry?: boolean
+}
+
+let activeRefreshPromise: Promise<string> | null = null
 
 // 공통 API 요청에 사용할 axios 인스턴스 생성
 export const apiClient = axios.create({
   baseURL: import.meta.env.VITE_API_URL ?? '/api',
   timeout: 10000,
+  withCredentials: true,
   headers: {
     'Content-Type': 'application/json',
   },
 })
+
+function getApiOrigin(baseURL = apiClient.defaults.baseURL) {
+  const fallbackOrigin =
+    typeof window !== 'undefined' ? window.location.origin : 'http://localhost'
+
+  if (!baseURL) {
+    return fallbackOrigin
+  }
+
+  return new URL(String(baseURL), fallbackOrigin).origin
+}
+
+export function buildVersionedAuthUrl(path: '/refresh' | '/logout') {
+  return new URL(`/v1/auth${path}`, getApiOrigin()).toString()
+}
+
+export async function requestAccessTokenRefresh() {
+  const { data } = await axios.post<RefreshAccessTokenResponsePayload>(
+    buildVersionedAuthUrl('/refresh'),
+    undefined,
+    {
+      timeout: apiClient.defaults.timeout,
+      withCredentials: true,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    }
+  )
+
+  return data
+}
+
+export async function requestAuthLogout() {
+  await axios.post(buildVersionedAuthUrl('/logout'), undefined, {
+    timeout: apiClient.defaults.timeout,
+    withCredentials: true,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+}
+
+function shouldSkipRefreshRetry(url?: string) {
+  if (!url) {
+    return false
+  }
+
+  return url.includes('/auth/refresh') || url.includes('/auth/logout')
+}
+
+async function refreshAccessTokenAndSyncSession() {
+  const sessionSnapshot = useAuthStore.getState().session
+  if (!sessionSnapshot?.accessToken) {
+    throw new AxiosError('No active session for refresh')
+  }
+
+  const refreshResult = await requestAccessTokenRefresh()
+  const activeSession = useAuthStore.getState().session
+
+  if (
+    !activeSession ||
+    activeSession.userId !== sessionSnapshot.userId ||
+    activeSession.accessToken !== sessionSnapshot.accessToken
+  ) {
+    throw new AxiosError('Auth session changed before refresh completed')
+  }
+
+  if (activeSession.accessToken !== refreshResult.access_token) {
+    useAuthStore.getState().setSession({
+      ...activeSession,
+      accessToken: refreshResult.access_token,
+    })
+    reconnectSocketWithUpdatedAuthIfConnected()
+  }
+
+  return refreshResult.access_token
+}
 
 // 요청 직전에 최신 세션 토큰을 Authorization 헤더로 동기화
 apiClient.interceptors.request.use((config) => {
@@ -29,4 +129,39 @@ apiClient.interceptors.request.use((config) => {
 
   config.headers = nextHeaders
   return config
+})
+
+apiClient.interceptors.response.use(undefined, async (error) => {
+  if (IS_DEMO_MOCK_ENABLED || !isAxiosError(error)) {
+    return Promise.reject(error)
+  }
+
+  const originalRequest = error.config as RetryableAuthRequestConfig | undefined
+  if (
+    error.response?.status !== 401 ||
+    !originalRequest ||
+    originalRequest._retry ||
+    shouldSkipRefreshRetry(originalRequest.url)
+  ) {
+    return Promise.reject(error)
+  }
+
+  originalRequest._retry = true
+
+  try {
+    activeRefreshPromise ??= refreshAccessTokenAndSyncSession().finally(() => {
+      activeRefreshPromise = null
+    })
+
+    const nextAccessToken = await activeRefreshPromise
+    const nextHeaders = AxiosHeaders.from(originalRequest.headers)
+    nextHeaders.set('Authorization', `Bearer ${nextAccessToken}`)
+    originalRequest.headers = nextHeaders
+
+    return apiClient.request(originalRequest)
+  } catch (refreshError) {
+    useAuthStore.getState().clearSession()
+    disconnectSocketAndClearAuth()
+    return Promise.reject(refreshError)
+  }
 })

--- a/src/lib/socket.test.ts
+++ b/src/lib/socket.test.ts
@@ -35,6 +35,70 @@ describe('socket helpers', () => {
     expect(socket.disconnect).toHaveBeenCalledTimes(1)
   })
 
+  it('reconnectSocketWithUpdatedAuthIfConnected는 연결 중이고 토큰이 바뀌면 재연결한다', async () => {
+    vi.resetModules()
+
+    const socket: MockSocket = {
+      auth: { token: 'stale-token' },
+      connected: true,
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    }
+
+    vi.doMock('socket.io-client', () => ({
+      io: () => socket,
+    }))
+    vi.doMock('../features/auth/session/store', () => ({
+      useAuthStore: {
+        getState: () => ({
+          session: {
+            accessToken: 'fresh-token',
+          },
+        }),
+      },
+    }))
+
+    const module = await import('./socket')
+
+    module.reconnectSocketWithUpdatedAuthIfConnected()
+
+    expect(socket.auth).toEqual({ token: 'fresh-token' })
+    expect(socket.disconnect).toHaveBeenCalledTimes(1)
+    expect(socket.connect).toHaveBeenCalledTimes(1)
+  })
+
+  it('reconnectSocketWithUpdatedAuthIfConnected는 미연결 상태에서 새 연결을 만들지 않는다', async () => {
+    vi.resetModules()
+
+    const socket: MockSocket = {
+      auth: { token: 'stale-token' },
+      connected: false,
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    }
+
+    vi.doMock('socket.io-client', () => ({
+      io: () => socket,
+    }))
+    vi.doMock('../features/auth/session/store', () => ({
+      useAuthStore: {
+        getState: () => ({
+          session: {
+            accessToken: 'fresh-token',
+          },
+        }),
+      },
+    }))
+
+    const module = await import('./socket')
+
+    module.reconnectSocketWithUpdatedAuthIfConnected()
+
+    expect(socket.auth).toEqual({ token: 'fresh-token' })
+    expect(socket.disconnect).not.toHaveBeenCalled()
+    expect(socket.connect).not.toHaveBeenCalled()
+  })
+
   it('disconnectSocketAndClearAuth는 미연결 상태면 disconnect를 호출하지 않는다', async () => {
     vi.resetModules()
 

--- a/src/lib/socket.ts
+++ b/src/lib/socket.ts
@@ -43,6 +43,22 @@ export function connectSocketWithAuthIfNeeded() {
   socket.connect()
 }
 
+// 이미 연결된 소켓만 새 토큰으로 재인증하고, 비연결 상태에서는 auth 값만 동기화
+export function reconnectSocketWithUpdatedAuthIfConnected() {
+  const previousToken = getSocketAuthToken()
+  syncSocketAuthToken()
+  const nextToken = getSocketAuthToken()
+
+  if (!socket.connected) {
+    return
+  }
+
+  if (previousToken !== nextToken) {
+    socket.disconnect()
+    socket.connect()
+  }
+}
+
 // 세션 종료 시 소켓 연결과 auth 컨텍스트를 함께 초기화
 export function disconnectSocketAndClearAuth() {
   socket.auth = {}

--- a/src/pages/lobby/LobbyPage.test.tsx
+++ b/src/pages/lobby/LobbyPage.test.tsx
@@ -19,6 +19,8 @@ const {
   useDirectMessageControllerMock,
   navigateMock,
   disconnectSocketAndClearAuthMock,
+  logoutAuthSessionMock,
+  getAuthErrorMessageMock,
   createWaitingRoomMock,
   getWaitingRoomErrorMessageMock,
   isJoinPasswordMismatchErrorMock,
@@ -29,6 +31,8 @@ const {
   useDirectMessageControllerMock: vi.fn(),
   navigateMock: vi.fn(),
   disconnectSocketAndClearAuthMock: vi.fn(),
+  logoutAuthSessionMock: vi.fn(),
+  getAuthErrorMessageMock: vi.fn(),
   createWaitingRoomMock: vi.fn(),
   getWaitingRoomErrorMessageMock: vi.fn(),
   isJoinPasswordMismatchErrorMock: vi.fn(),
@@ -62,6 +66,11 @@ vi.mock(
 
 vi.mock('../../lib/socket', () => ({
   disconnectSocketAndClearAuth: disconnectSocketAndClearAuthMock,
+}))
+
+vi.mock('../../features/auth/api/api', () => ({
+  logoutAuthSession: logoutAuthSessionMock,
+  getAuthErrorMessage: getAuthErrorMessageMock,
 }))
 
 vi.mock('../waiting-room/api/api', () => ({
@@ -177,6 +186,10 @@ describe('LobbyPage filter and toggle regression', () => {
       closeDirectMessage: vi.fn(),
       sendDirectMessage: vi.fn(),
     })
+    logoutAuthSessionMock.mockResolvedValue(undefined)
+    getAuthErrorMessageMock.mockReturnValue(
+      '로그아웃 처리 중 문제가 있었지만 현재 기기 세션은 종료했어요.'
+    )
 
     createWaitingRoomMock.mockResolvedValue({
       roomId: 'room-10',
@@ -484,8 +497,11 @@ describe('LobbyPage filter and toggle regression', () => {
     await user.click(screen.getByRole('button', { name: '프로필 메뉴 열기' }))
     await user.click(screen.getByRole('button', { name: '로그아웃' }))
 
-    expect(disconnectSocketAndClearAuthMock).toHaveBeenCalledTimes(1)
-    expect(navigateMock).toHaveBeenCalledWith('/', { replace: true })
-    expect(useAuthStore.getState().session).toBeNull()
+    await waitFor(() => {
+      expect(logoutAuthSessionMock).toHaveBeenCalledTimes(1)
+      expect(disconnectSocketAndClearAuthMock).toHaveBeenCalledTimes(1)
+      expect(navigateMock).toHaveBeenCalledWith('/', { replace: true })
+      expect(useAuthStore.getState().session).toBeNull()
+    })
   })
 })

--- a/src/pages/lobby/LobbyPage.tsx
+++ b/src/pages/lobby/LobbyPage.tsx
@@ -4,6 +4,10 @@ import toast from 'react-hot-toast'
 import { useNavigate } from 'react-router-dom'
 import Header from '../../components/header/Header'
 import { useRequireActiveSession } from '../../features/auth/session/hooks/useRequireActiveSession'
+import {
+  getAuthErrorMessage,
+  logoutAuthSession,
+} from '../../features/auth/api/api'
 import { useAuthStore } from '../../features/auth/session/store'
 import {
   createProfileMenuItems,
@@ -109,9 +113,20 @@ function LobbyPage() {
     setMockOnlineUserStatus(session.userId, 'lobby', session.nickname)
   }, [session])
 
-  function handleLogout() {
+  async function handleLogout() {
     if (IS_SOCKET_MOCK_ENABLED && session) {
       removeMockOnlineUser(session.userId)
+    }
+
+    try {
+      await logoutAuthSession()
+    } catch (error) {
+      toast.error(
+        getAuthErrorMessage(
+          error,
+          '로그아웃 처리 중 문제가 있었지만 현재 기기 세션은 종료했어요.'
+        )
+      )
     }
 
     clearSession()
@@ -134,7 +149,9 @@ function LobbyPage() {
   const headerMenuItems = createProfileMenuItems({
     isGuest: session.isGuest,
     onGoMyPage: handleGoMyPage,
-    onLogout: handleLogout,
+    onLogout: () => {
+      void handleLogout()
+    },
   })
 
   return (

--- a/src/pages/waiting-room/page/WaitingRoomFlow.test.tsx
+++ b/src/pages/waiting-room/page/WaitingRoomFlow.test.tsx
@@ -9,7 +9,9 @@ import LobbyPage from '../../lobby/LobbyPage'
 import WaitingRoomPage from './WaitingRoomPage'
 
 vi.mock('../../../config/env', () => ({
+  IS_DEMO_MOCK_ENABLED: false,
   IS_SOCKET_MOCK_ENABLED: true,
+  SHOULD_ENABLE_MSW: true,
 }))
 
 const {

--- a/src/pages/waiting-room/page/WaitingRoomPage.tsx
+++ b/src/pages/waiting-room/page/WaitingRoomPage.tsx
@@ -8,6 +8,10 @@ import {
   useParams,
 } from 'react-router-dom'
 import { useRequireActiveSession } from '../../../features/auth/session/hooks/useRequireActiveSession'
+import {
+  getAuthErrorMessage,
+  logoutAuthSession,
+} from '../../../features/auth/api/api'
 import { useAuthStore } from '../../../features/auth/session/store'
 import {
   createProfileMenuItems,
@@ -188,6 +192,17 @@ function WaitingRoomPage() {
       removeMockOnlineUser(session.userId)
     }
 
+    try {
+      await logoutAuthSession()
+    } catch (error) {
+      toast.error(
+        getAuthErrorMessage(
+          error,
+          '로그아웃 처리 중 문제가 있었지만 현재 기기 세션은 종료했어요.'
+        )
+      )
+    }
+
     clearSession()
     disconnectSocketAndClearAuth()
     navigate('/', { replace: true })
@@ -241,7 +256,9 @@ function WaitingRoomPage() {
   const headerMenuItems = createProfileMenuItems({
     isGuest: session.isGuest,
     onGoMyPage: handleGoMyPage,
-    onLogout: handleLogout,
+    onLogout: () => {
+      void handleLogout()
+    },
   })
 
   return (


### PR DESCRIPTION
## 📌 관련 이슈

> closes #476

---

## 📝 작업 내용

> 백엔드 refresh/logout 계약을 기준으로, 프론트 인증 흐름을 refresh cookie 기반 재발급 구조에 맞게 정리했습니다.

### 1. refresh transport 추가

- `apiClient`에 `withCredentials: true`를 기본 적용했습니다.
- `POST /api/auth/refresh`, `POST /api/auth/logout` 호출 helper를 추가했습니다.
- 401 응답 시 refresh 성공 후 access token을 갱신하고 원래 요청을 1회 재시도하는 interceptor를 추가했습니다.
- refresh 실패 시 세션과 소켓을 함께 정리하도록 맞췄습니다.

### 2. 세션/소켓 갱신 흐름 반영

- refresh 성공 시 store의 access token을 최신 값으로 갱신하도록 정리했습니다.
- 소켓은 이미 연결 중인 경우에만 새 access token으로 재연결되도록 보완했습니다.
- refresh token은 프론트 상태/localStorage/body에 저장하지 않고, access token만 세션에 유지하는 구조를 유지했습니다.

### 3. logout UI 연동

- 로비와 대기방의 logout이 `/api/auth/logout` 호출 후 세션/소켓 정리로 이어지도록 변경했습니다.
- logout API 실패 시에도 현재 기기 세션은 정리하되, 사용자에게는 토스트로 안내하도록 했습니다.

### 4. 테스트와 작업 문서 보강

- auth/axios/socket/logout 관련 단위 테스트를 보강했습니다.
- 작업 범위와 계약 메모를 `docs/ai/tasks/auth-refresh-cookie-flow/`에 정리했습니다.

### 백엔드 최종 계약 기준

- `POST /api/auth/refresh`
- `POST /api/auth/logout`
- refresh token: HttpOnly cookie only
- refresh cookie `Path=/api/auth`

### 검증

- `npx vitest run src/lib/axios.test.ts`
- `npx vitest run src/features/auth/api/api.test.ts`
- `npx vitest run src/lib/socket.test.ts`
- `npx vitest run src/features/auth/session/hooks/useAuthBootstrap.test.tsx`
- `npx vitest run src/pages/lobby/LobbyPage.test.tsx`
- `npx vitest run src/pages/waiting-room/page/WaitingRoomPage.test.tsx`
- `npm run lint`
- `npm run build`
- `npm run ai:self-review -- --files src/lib/axios.ts src/lib/socket.ts src/features/auth/api/api.ts src/pages/lobby/LobbyPage.tsx src/pages/waiting-room/page/WaitingRoomPage.tsx src/features/auth/api/api.test.ts src/lib/axios.test.ts src/lib/socket.test.ts src/pages/lobby/LobbyPage.test.tsx docs/ai/tasks/auth-refresh-cookie-flow/plan.md docs/ai/tasks/auth-refresh-cookie-flow/context.md docs/ai/tasks/auth-refresh-cookie-flow/checklist.md`

---

## ✅ 체크리스트

- [x] refresh cookie 기반 access token 재발급 연결
- [x] 401 응답 후 refresh + 1회 재시도 반영
- [x] refresh 실패 시 세션/소켓 정리 반영
- [x] logout API 호출 기반 정리 반영
- [x] 관련 auth/axios/socket 테스트 보강

---

## 📌 추가 메모

- 현재 배포 서버 기준으로 `/api/auth/logout` 200 응답과 refresh cookie 삭제(`Path=/api/auth`)까지 확인했습니다.
- `npm run lint`는 기존 `src/components/board/GameBoard.tsx`의 `react-hooks/exhaustive-deps` warning 1건이 남아 있지만, 이번 auth 변경과는 무관합니다.