### PR TITLE
refactor: AI 워크플로우 리뷰 품질과 task 생성 흐름 개선

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -47,29 +47,18 @@ jobs:
         if: steps.changed-files.outputs.count != '0'
         run: |
           mapfile -t changed_files < /tmp/changed-files.txt
-          npm run ai:self-review -- --files "${changed_files[@]}" | tee /tmp/ai-self-review.txt
+          node scripts/ai/self-review.mjs --files "${changed_files[@]}" > /tmp/ai-self-review.txt
 
       - name: Write empty self review fallback
         if: steps.changed-files.outputs.count == '0'
         run: |
           echo "No changed files detected for this pull request." > /tmp/ai-self-review.txt
 
-      - name: Run AI UI check plan
-        if: steps.changed-files.outputs.count != '0'
-        run: |
-          mapfile -t changed_files < /tmp/changed-files.txt
-          npm run ai:check:ui -- --plan --files "${changed_files[@]}" | tee /tmp/ai-ui-check-plan.txt
-
       - name: Run AI validation orchestration plan
         if: steps.changed-files.outputs.count != '0'
         run: |
           mapfile -t changed_files < /tmp/changed-files.txt
-          npm run ai:validation-plan -- --files "${changed_files[@]}" | tee /tmp/ai-validation-plan.txt
-
-      - name: Write empty UI plan fallback
-        if: steps.changed-files.outputs.count == '0'
-        run: |
-          echo "No UI checks selected because there are no changed files." > /tmp/ai-ui-check-plan.txt
+          node scripts/ai/validation-plan.mjs --files "${changed_files[@]}" > /tmp/ai-validation-plan.txt
 
       - name: Write empty validation plan fallback
         if: steps.changed-files.outputs.count == '0'
@@ -113,8 +102,65 @@ jobs:
               return `${value.slice(0, maxSectionLength)}\n\n...truncated`
             }
 
+            function escapeRegExp(value) {
+              return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+            }
+
+            function extractScriptSection(text, heading, nextHeadings = []) {
+              if (!text) {
+                return ''
+              }
+
+              const escapedHeading = escapeRegExp(heading)
+              const escapedNextHeadings = nextHeadings.map(escapeRegExp).join('|')
+              const boundary = escapedNextHeadings
+                ? `(?:\\n(?:${escapedNextHeadings})\\n|$)`
+                : '$'
+              const pattern = new RegExp(
+                `${escapedHeading}\\n([\\s\\S]*?)${boundary}`
+              )
+              const match = text.match(pattern)
+
+              return match?.[1]?.trim() ?? ''
+            }
+
+            function extractBulletLines(section) {
+              if (!section) {
+                return []
+              }
+
+              return section
+                .split('\n')
+                .map((line) => line.trim())
+                .filter((line) => line.startsWith('- '))
+            }
+
+            function formatBulletSection(lines, emptyFallback = '- none') {
+              if (!lines.length) {
+                return emptyFallback
+              }
+
+              return lines.join('\n')
+            }
+
+            function formatChangedFiles(files, maxItems = 8) {
+              if (!files.length) {
+                return '- none'
+              }
+
+              const visibleFiles = files
+                .slice(0, maxItems)
+                .map((file) => `- \`${file}\``)
+              const remainingCount = files.length - maxItems
+
+              if (remainingCount > 0) {
+                visibleFiles.push(`- ...and ${remainingCount} more`)
+              }
+
+              return visibleFiles.join('\n')
+            }
+
             const selfReview = truncate(readFile('/tmp/ai-self-review.txt'))
-            const uiPlan = truncate(readFile('/tmp/ai-ui-check-plan.txt'))
             const validationPlan = truncate(readFile('/tmp/ai-validation-plan.txt'))
             const changedFiles = readFile('/tmp/changed-files.txt')
             const changedFileArray = changedFiles
@@ -143,6 +189,36 @@ jobs:
                 /docs\/ai\/tasks\/[^\s)]+\/context\.md/,
                 /docs\/ai\/tasks\/[^\s)]+\/checklist\.md/,
               ].every((pattern) => pattern.test(body))
+            }
+
+            function hasTaskDocumentTripletInChangedFiles(files) {
+              if (!Array.isArray(files) || files.length === 0) {
+                return false
+              }
+
+              const groupedKindsBySlug = new Map()
+
+              for (const file of files) {
+                const match = file.match(
+                  /^docs\/ai\/tasks\/([^/]+)\/(plan|context|checklist)\.md$/
+                )
+
+                if (!match) {
+                  continue
+                }
+
+                const [, slug, kind] = match
+                const kinds = groupedKindsBySlug.get(slug) ?? new Set()
+                kinds.add(kind)
+                groupedKindsBySlug.set(slug, kinds)
+              }
+
+              return Array.from(groupedKindsBySlug.values()).some(
+                (kinds) =>
+                  kinds.has('plan') &&
+                  kinds.has('context') &&
+                  kinds.has('checklist')
+              )
             }
 
             function hasMeaningfulValidationContent(section) {
@@ -200,9 +276,6 @@ jobs:
                 })
             }
 
-            const changedFileList = changedFileArray.length
-              ? changedFileArray.map((file) => `- \`${file}\``).join('\n')
-              : '- none'
             const pullRequestBody = context.payload.pull_request?.body ?? ''
             const taskSection = extractSection(
               pullRequestBody,
@@ -221,11 +294,14 @@ jobs:
               changedFileArray.some((file) =>
                 startsWithAnyPrefix(file, highRiskPrefixes)
               )
+            const hasTaskDocumentEvidence =
+              hasTaskDocumentLinks(taskSection) ||
+              hasTaskDocumentTripletInChangedFiles(changedFileArray)
             const workflowWarnings = []
 
-            if (isLargeChange && !hasTaskDocumentLinks(taskSection)) {
+            if (isLargeChange && !hasTaskDocumentEvidence) {
               workflowWarnings.push(
-                `큰 변경으로 보이지만 task 문서 링크(plan/context/checklist)가 PR 본문에 없습니다. 기준: 파일 ${largeChangeFileCountThreshold}개 이상 또는 고위험 경로 변경.`
+                `큰 변경으로 보이지만 task 문서 근거(plan/context/checklist)가 없습니다. PR 본문 Task 섹션 또는 changed files 안의 task 문서 3종 세트가 필요합니다. 기준: 파일 ${largeChangeFileCountThreshold}개 이상 또는 고위험 경로 변경.`
               )
             }
 
@@ -244,34 +320,77 @@ jobs:
             const warningSection = workflowWarnings.length
               ? workflowWarnings.map((warning) => `- ${warning}`).join('\n')
               : '- none'
+            const validationRequired = formatBulletSection(
+              extractBulletLines(
+                extractScriptSection(validationPlan, 'Required checks:', [
+                  'Suggested checks:',
+                ])
+              )
+            )
+            const validationSuggested = formatBulletSection(
+              extractBulletLines(
+                extractScriptSection(validationPlan, 'Suggested checks:')
+              )
+            )
+            const relevantManuals = formatBulletSection(
+              extractBulletLines(
+                extractScriptSection(selfReview, 'Relevant Manuals', [
+                  'Findings',
+                ])
+              )
+            )
+            const selfReviewFindings = formatBulletSection(
+              extractBulletLines(
+                extractScriptSection(selfReview, 'Findings', ['Test Gaps'])
+              )
+            )
+            const selfReviewTestGaps = formatBulletSection(
+              extractBulletLines(
+                extractScriptSection(selfReview, 'Test Gaps', ['Warnings'])
+              )
+            )
+            const selfReviewWarnings = formatBulletSection(
+              extractBulletLines(
+                extractScriptSection(selfReview, 'Warnings', [
+                  'Suggested Validation Commands',
+                ])
+              )
+            )
+            const changedFilesSection = `- Total: ${changedFileArray.length}\n${formatChangedFiles(
+              changedFileArray
+            )}`
 
             const body = `${marker}
             ## 🤖 AI Review
 
             이 코멘트는 PR 변경 파일 기준으로 자동 갱신됩니다.
-            기존 CI를 대체하지 않고, deterministic warning / validation / self-review 결과를 요약합니다.
+            기존 CI를 대체하지 않고, deterministic warning / validation 결과를 짧게 요약합니다.
             생성형 PR summary와 code review는 Gemini Code Assist가 담당합니다.
 
             ### Changed Files
-            ${changedFileList}
+            ${changedFilesSection}
 
             ### Workflow Warnings
             ${warningSection}
 
-            ### Validation Orchestration
-            \`\`\`text
-            ${validationPlan || 'No validation orchestration output.'}
-            \`\`\`
+            ### Findings
+            ${selfReviewFindings}
 
-            ### Self Review
-            \`\`\`text
-            ${selfReview || 'No self-review output.'}
-            \`\`\`
+            ### Test Gaps
+            ${selfReviewTestGaps}
 
-            ### UI Check Plan
-            \`\`\`text
-            ${uiPlan || 'No UI check output.'}
-            \`\`\`
+            ### Required Checks
+            ${validationRequired}
+
+            ### Suggested Checks
+            ${validationSuggested}
+
+            ### Self Review Notes
+            Relevant manuals:
+            ${relevantManuals}
+
+            Review warnings:
+            ${selfReviewWarnings}
             `
 
             const comments = await github.paginate(github.rest.issues.listComments, {

--- a/docs/ai/tasks/README.md
+++ b/docs/ai/tasks/README.md
@@ -30,6 +30,16 @@ docs/ai/tasks/game-prompt-normalization/
 4. `checklist.md`에 구현/테스트/리뷰 체크박스를 만든다.
 5. 새 세션에서 해당 문서 3개를 다시 읽고 구현을 시작한다.
 
+수동 복사가 번거로우면 아래 스크립트로 초안을 만들 수 있다.
+
+```bash
+npm run ai:task:new -- auth-refresh-cookie-flow
+npm run ai:task:new -- auth-refresh-cookie-flow --files src/lib/axios.ts src/features/auth/api/api.ts
+```
+
+- `--files`를 주면 관련 manual과 최소 검증 명령 초안을 함께 채운다.
+- 이미 같은 slug가 있으면 실패하고, 의도적으로 덮어쓰려면 `--force`를 사용한다.
+
 ## example-\* 디렉토리
 
 `example-*` 디렉토리는 실제 작업 방식 예시를 보여주기 위한 샘플이다.

--- a/docs/ai/tasks/ai-review-findings-upgrade/checklist.md
+++ b/docs/ai/tasks/ai-review-findings-upgrade/checklist.md
@@ -1,0 +1,21 @@
+# Checklist
+
+## Implementation
+
+- [x] self-review 출력에 `Findings`, `Test Gaps` 섹션을 추가한다
+- [x] auth transport 변경 시 기본 계약/테스트 누락 규칙을 추가한다
+- [x] lobby / waiting-room / game / socket 변경 시 영역별 테스트 누락 규칙을 추가한다
+- [x] PR 코멘트가 findings/test gaps 중심으로 보이도록 workflow를 갱신한다
+- [x] review 품질이 길이 대비 신호가 높아지도록 중복 출력을 줄인다
+
+## Testing
+
+- [x] `npx vitest run scripts/ai/lib.test.ts`
+- [x] `npx prettier --check ...`
+- [x] `npm run ai:self-review -- --files ...`
+
+## Review
+
+- [x] Gemini summary와 역할이 겹치지 않는지 확인한다
+- [x] false positive가 과도하지 않은지 확인한다
+- [x] findings가 없을 때도 코멘트가 지나치게 길어지지 않는지 확인한다

--- a/docs/ai/tasks/ai-review-findings-upgrade/context.md
+++ b/docs/ai/tasks/ai-review-findings-upgrade/context.md
@@ -1,0 +1,21 @@
+# Context
+
+## 현재 상태
+
+- `AI Review`는 warning, validation, self-review 결과를 PR 코멘트에 자동으로 남긴다.
+- 하지만 self-review는 관련 manual과 고정 체크리스트 중심이라, 실제 diff에서 무엇이 위험한지 바로 읽히지 않는다.
+- validation과 UI check의 중복은 줄였지만, 여전히 "리뷰"보다 "체크 계획"에 가깝다는 피드백이 있다.
+
+## 판단
+
+- 생성형 리뷰는 Gemini가 맡고 있으므로, 저장소 안 `AI Review`는 repo 전용 deterministic risk detector 역할에 더 집중하는 편이 맞다.
+- 따라서 코멘트 품질을 높이려면 체크리스트를 더 늘리는 것보다, 현재 diff에서 걸리는 `Findings`와 `Test Gaps`를 우선 보여줘야 한다.
+- 1차 규칙은 auth transport, lobby, waiting-room, game, socket 변경에서 자주 놓치는 회귀와 테스트 누락을 잡는 수준으로 제한한다.
+
+## 제외 범위
+
+- 생성형 코드 요약/리뷰
+- inline code comment 자동 생성
+- 복잡한 정적 분석기 또는 AST 기반 규칙 엔진
+
+이번 단계에서는 파일 분류 + 일부 파일 내용 확인 기반의 실용적인 deterministic 규칙만 추가한다.

--- a/docs/ai/tasks/ai-review-findings-upgrade/plan.md
+++ b/docs/ai/tasks/ai-review-findings-upgrade/plan.md
@@ -1,0 +1,27 @@
+# Plan
+
+## 목표
+
+- `AI Review` 코멘트가 단순 체크 계획 출력이 아니라, diff 기준의 `Findings`와 `Test Gaps`를 먼저 보여주도록 바꾼다.
+- 기존 warning gate와 validation plan은 유지하되, 중복 로그보다 실제 위험 신호가 먼저 읽히게 만든다.
+- repo 전용 deterministic 리뷰어 역할을 강화해 Gemini summary와 역할이 겹치지 않게 한다.
+
+## 대상 파일
+
+- `scripts/ai/lib.mjs`
+- `scripts/ai/self-review.mjs`
+- `.github/workflows/ai-review.yml`
+- `scripts/ai/lib.test.ts`
+
+## 완료 기준
+
+- self-review 출력에 `Findings`, `Test Gaps` 섹션이 추가된다.
+- auth transport / lobby / waiting-room / game / socket 변경에 대해 최소한의 deterministic review 규칙이 동작한다.
+- PR 코멘트가 `Workflow Warnings -> Findings -> Test Gaps -> Required/Suggested Checks` 순서로 짧게 읽힌다.
+- 관련 테스트가 추가되어 review 규칙의 기본 동작을 검증한다.
+
+## 최소 검증
+
+- `npx vitest run scripts/ai/lib.test.ts`
+- `npx prettier --check scripts/ai/lib.mjs scripts/ai/self-review.mjs scripts/ai/lib.test.ts .github/workflows/ai-review.yml docs/ai/tasks/ai-review-findings-upgrade/plan.md docs/ai/tasks/ai-review-findings-upgrade/context.md docs/ai/tasks/ai-review-findings-upgrade/checklist.md`
+- `npm run ai:self-review -- --files scripts/ai/lib.mjs scripts/ai/self-review.mjs .github/workflows/ai-review.yml scripts/ai/lib.test.ts docs/ai/tasks/ai-review-findings-upgrade/plan.md docs/ai/tasks/ai-review-findings-upgrade/context.md docs/ai/tasks/ai-review-findings-upgrade/checklist.md`

--- a/docs/ai/tasks/ai-task-workspace-generator/checklist.md
+++ b/docs/ai/tasks/ai-task-workspace-generator/checklist.md
@@ -1,0 +1,22 @@
+# Checklist
+
+## Implementation
+
+- [x] task workspace 생성 스크립트를 추가했다
+- [x] slug와 optional `--files` 입력을 처리한다
+- [x] template 기반 문서 3종을 생성한다
+- [x] manual / target files / validation 초안을 자동 채운다
+- [x] `package.json`에 실행 스크립트를 추가했다
+- [x] README 사용 예시를 보강했다
+
+## Testing
+
+- [x] `npx vitest run scripts/ai/task-new.test.ts`
+- [x] `npx prettier --check ...`
+- [x] `npm run ai:self-review -- --files ...`
+
+## Review
+
+- [x] 생성 결과가 바로 수정 가능한 수준인지 확인했다
+- [x] 기존 template 구조를 깨지 않는지 확인했다
+- [x] 기존 manual/validation 분류 로직과 충돌하지 않는지 확인했다

--- a/docs/ai/tasks/ai-task-workspace-generator/context.md
+++ b/docs/ai/tasks/ai-task-workspace-generator/context.md
@@ -1,0 +1,31 @@
+# Context
+
+## Current Behavior
+
+- 현재 task 문서는 `docs/ai/tasks/_template/`를 수동 복사해서 시작한다.
+- 경로를 만들고 템플릿을 복사한 뒤, 목표/대상 파일/검증 계획을 직접 채워야 해서 실제 사용 마찰이 있다.
+- 문서 기반 AI 워크플로우를 강조하고 있지만, 작업 시작 자동화는 아직 없다.
+
+## Related Files
+
+- `docs/ai/tasks/README.md`
+- `docs/ai/tasks/_template/*`
+- `scripts/ai/lib.mjs`
+- `package.json`
+
+## Constraints
+
+- `_template/`는 원본으로 유지해야 한다.
+- 생성기는 기존 문서 구조(`plan.md`, `context.md`, `checklist.md`)를 그대로 따라야 한다.
+- 입력 파일이 있으면 관련 manual과 최소 검증 명령을 자동으로 제안하되, 과도한 추론은 피한다.
+
+## Decision Notes
+
+- 스크립트는 `scripts/ai/task-new.mjs` 하나로 시작하고, 테스트 가능한 helper를 같이 export한다.
+- 파일 분류와 검증 추천은 기존 `scripts/ai/lib.mjs`의 manual / suggested scripts 로직을 재사용한다.
+- 이미 같은 slug 폴더가 있으면 기본적으로 실패시키고, 의도적 덮어쓰기는 `--force`로만 허용한다.
+
+## Open Risks
+
+- 자동 생성 문구가 실제 작업 맥락을 완전히 대체할 수는 없다. 생성 후 직접 수정이 필요하다.
+- `--files`를 주지 않으면 manual/검증 추천은 비어 있을 수 있다.

--- a/docs/ai/tasks/ai-task-workspace-generator/plan.md
+++ b/docs/ai/tasks/ai-task-workspace-generator/plan.md
@@ -1,0 +1,45 @@
+# Plan
+
+## Task
+
+- 작업 이름: AI task workspace generator
+- 요청 날짜: 2026-03-18
+- 담당 범위: `scripts/ai`, `package.json`, `docs/ai/tasks`
+
+## Goal
+
+- `docs/ai/tasks/<slug>/plan.md`, `context.md`, `checklist.md`를 빠르게 만들 수 있는 생성 스크립트를 추가한다.
+- 단순 템플릿 복사에 그치지 않고, 입력 파일 기준 manual/검증 초안을 함께 넣어 실제 사용 마찰을 줄인다.
+
+## In Scope
+
+- `npm run ai:task:new -- <slug> [--files ...]` 스크립트 추가
+- template 기반 task 문서 3종 생성
+- 입력 파일 기준 Target Files, Related Files, 최소 검증 명령 초안 생성
+- 관련 테스트와 문서 보강
+
+## Out Of Scope
+
+- 이미 존재하는 task 문서를 자동 병합/업데이트하는 기능
+- PR 본문 자동 작성
+- git 브랜치/이슈 자동 생성
+
+## Target Files
+
+- `scripts/ai/task-new.mjs`
+- `scripts/ai/task-new.test.ts`
+- `package.json`
+- `docs/ai/tasks/README.md`
+- `docs/ai/tasks/ai-task-workspace-generator/*`
+
+## Completion Criteria
+
+- `npm run ai:task:new -- example-slug` 실행 시 task 문서 3종이 생성된다.
+- `--files`를 주면 관련 manual과 최소 검증 명령 초안이 문서에 반영된다.
+- 기존 template 구조를 유지하면서도 바로 편집 가능한 문서가 나온다.
+
+## Test Plan
+
+- `npx vitest run scripts/ai/task-new.test.ts`
+- `npx prettier --check scripts/ai/task-new.mjs scripts/ai/task-new.test.ts package.json docs/ai/tasks/README.md docs/ai/tasks/ai-task-workspace-generator/plan.md docs/ai/tasks/ai-task-workspace-generator/context.md docs/ai/tasks/ai-task-workspace-generator/checklist.md`
+- `npm run ai:self-review -- --files scripts/ai/task-new.mjs scripts/ai/task-new.test.ts package.json docs/ai/tasks/README.md docs/ai/tasks/ai-task-workspace-generator/plan.md docs/ai/tasks/ai-task-workspace-generator/context.md docs/ai/tasks/ai-task-workspace-generator/checklist.md`

--- a/docs/ai/tasks/ai-workflow-warning-gates/checklist.md
+++ b/docs/ai/tasks/ai-workflow-warning-gates/checklist.md
@@ -7,6 +7,8 @@
 - [x] `실행한 검증` 섹션이 비어 있거나 placeholder 그대로면 warning을 추가했다
 - [x] `남은 리스크` 섹션이 비어 있거나 placeholder 그대로면 warning을 추가했다
 - [x] warning 결과를 `AI Review` 코멘트에 함께 표시했다
+- [x] PR 본문에 링크가 없더라도 changed files 안의 task 문서 3종 세트를 fallback으로 인식하도록 보완했다
+- [x] raw script 출력과 중복 섹션을 줄이고, warning/required/suggested checks 중심으로 코멘트를 축약했다
 
 ## Testing
 
@@ -17,4 +19,4 @@
 
 - [x] warning은 advisory only로 유지했다
 - [x] 기준이 과도하게 엄격하지 않은지 확인했다
-- [x] 기존 self-review / UI plan 코멘트 구조를 해치지 않는지 확인했다
+- [x] 코멘트가 길이 대비 신호가 더 높아졌는지 확인했다

--- a/docs/ai/tasks/ai-workflow-warning-gates/context.md
+++ b/docs/ai/tasks/ai-workflow-warning-gates/context.md
@@ -2,7 +2,7 @@
 
 ## 현재 상태
 
-- `AI Review`는 changed files, self-review, UI check plan을 PR 코멘트에 자동으로 남긴다.
+- `AI Review`는 changed files, warning, validation, self-review 결과를 PR 코멘트에 자동으로 남긴다.
 - 하지만 큰 변경에 task 문서 링크가 없는지, PR 본문에 검증/리스크가 비어 있는지는 자동으로 보지 않는다.
 - PR 템플릿은 보강됐지만, 실제 작성 누락을 드러내는 장치가 아직 없다.
 
@@ -11,6 +11,8 @@
 - 1차 경량 도입 다음 단계는 생성형 리뷰보다 먼저 "문서/검증/리스크 누락을 보이게 만드는 warning 게이트"가 맞다.
 - 이 단계는 비용이 들지 않고 팀 적용력을 높이며, 이력서/블로그에서 "문서 기반 워크플로우를 PR 프로세스에 강제했다"는 설명으로 이어진다.
 - merge blocker까지 올리기 전에 advisory warning으로 운영하는 편이 안정적이다.
+- 다만 task 문서를 실제로 만들었는데 PR 본문 링크만 빠져도 warning이 뜨면 노이즈가 커지므로, changed files 안의 `plan/context/checklist` 3종 세트를 fallback 증거로 인정하는 편이 실용적이다.
+- 현재 코멘트는 raw script 출력과 중복 섹션이 길어 읽기 부담이 있어, warning과 required/suggested checks 위주로 줄이는 편이 실용적이다.
 
 ## 제외 범위
 

--- a/docs/ai/tasks/ai-workflow-warning-gates/plan.md
+++ b/docs/ai/tasks/ai-workflow-warning-gates/plan.md
@@ -3,7 +3,8 @@
 ## 목표
 
 - PR changed files와 PR 본문을 기준으로 문서 기반 워크플로우 누락을 warning으로 노출한다.
-- 큰 변경인데 task 문서 링크가 없거나, PR 본문에 검증/리스크 섹션이 비어 있으면 `AI Review` 코멘트에 함께 표시한다.
+- 큰 변경인데 task 문서 링크가 없고 changed files 안에도 task 문서 3종 세트가 없거나, PR 본문에 검증/리스크 섹션이 비어 있으면 `AI Review` 코멘트에 함께 표시한다.
+- `AI Review` 코멘트는 중복 로그를 줄이고, warning/required checks/suggested checks 중심으로 짧게 읽히도록 유지한다.
 - warning은 advisory only로 유지하고 기존 CI 게이트를 대체하지 않는다.
 
 ## 대상 파일
@@ -14,9 +15,9 @@
 ## 완료 기준
 
 - 큰 변경 기준이 workflow에 정의된다.
-- 큰 변경인데 task 문서 링크가 없으면 warning이 코멘트에 표시된다.
+- 큰 변경인데 PR 본문 Task 섹션과 changed files 어디에도 task 문서 근거가 없으면 warning이 코멘트에 표시된다.
 - `실행한 검증`, `남은 리스크` 섹션이 비어 있거나 placeholder 그대로면 warning이 표시된다.
-- 기존 self-review / UI check plan 코멘트와 함께 한 번에 볼 수 있다.
+- validation/self-review 결과가 중복 없이 짧은 요약으로 코멘트에 표시된다.
 
 ## 최소 검증
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "ai:check:build": "npm run build",
     "ai:self-review": "node scripts/ai/self-review.mjs",
     "ai:validation-plan": "node scripts/ai/validation-plan.mjs",
+    "ai:task:new": "node scripts/ai/task-new.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/scripts/ai/lib.mjs
+++ b/scripts/ai/lib.mjs
@@ -1,3 +1,4 @@
+import fs from 'node:fs'
 import { execSync, spawnSync } from 'node:child_process'
 import process from 'node:process'
 
@@ -23,6 +24,14 @@ function splitLines(value) {
 
 function unique(values) {
   return [...new Set(values)]
+}
+
+function readWorkspaceFile(path) {
+  try {
+    return fs.readFileSync(path, 'utf8')
+  } catch {
+    return ''
+  }
 }
 
 export function parseScriptArgs(argv) {
@@ -234,6 +243,156 @@ export function getSuggestedScripts(files, options = {}) {
   }
 
   return unique(scripts)
+}
+
+function hasMatchingTest(files, matcher) {
+  return files.some((file) => isTestFile(file) && matcher(file))
+}
+
+export function getReviewInsights(files, options = {}) {
+  const diffText = options.diffText ?? getDiffText()
+  const readFile = options.readFile ?? readWorkspaceFile
+  const classified = classifyFiles(files)
+  const findings = []
+  const testGaps = []
+  const warnings = []
+
+  const authTransportChanged = files.some((file) =>
+    [
+      'src/lib/axios.ts',
+      'src/features/auth/api/api.ts',
+      'src/lib/socket.ts',
+      'src/features/auth/session/hooks/useAuthBootstrap.ts',
+    ].includes(file)
+  )
+
+  const authTransportTestsChanged = files.some((file) =>
+    [
+      'src/lib/axios.test.ts',
+      'src/features/auth/api/api.test.ts',
+      'src/lib/socket.test.ts',
+      'src/features/auth/session/hooks/useAuthBootstrap.test.tsx',
+      'src/pages/lobby/LobbyPage.test.tsx',
+      'src/pages/waiting-room/page/WaitingRoomPage.test.tsx',
+      'src/pages/waiting-room/page/WaitingRoomFlow.test.tsx',
+    ].includes(file)
+  )
+
+  if (authTransportChanged) {
+    const axiosSource = readFile('src/lib/axios.ts')
+
+    if (axiosSource && !axiosSource.includes('withCredentials: true')) {
+      findings.push(
+        'auth transport 변경이 있지만 `withCredentials: true` 설정이 보이지 않습니다.'
+      )
+    }
+
+    if (
+      axiosSource &&
+      (!axiosSource.includes('/api/auth/refresh') ||
+        !axiosSource.includes('/api/auth/logout'))
+    ) {
+      findings.push(
+        'auth refresh/logout 경로가 현재 `/api/auth/*` 계약과 다를 수 있습니다.'
+      )
+    }
+
+    if (!authTransportTestsChanged) {
+      testGaps.push(
+        'auth transport 변경이 있지만 axios/api/socket/session 관련 테스트 변경이 diff에 없습니다.'
+      )
+    }
+  }
+
+  if (
+    classified.hasLobby &&
+    !hasMatchingTest(
+      files,
+      (file) =>
+        file.startsWith('src/pages/lobby/') ||
+        file.startsWith('src/features/presence/') ||
+        file.startsWith('src/features/room-chat/')
+    )
+  ) {
+    testGaps.push(
+      'lobby/presence/room-chat 변경이 있지만 관련 테스트 변경이 diff에 없습니다.'
+    )
+  }
+
+  if (
+    classified.hasWaitingRoom &&
+    !hasMatchingTest(files, (file) =>
+      file.startsWith('src/pages/waiting-room/')
+    )
+  ) {
+    testGaps.push(
+      'waiting-room 변경이 있지만 관련 테스트 변경이 diff에 없습니다.'
+    )
+  }
+
+  if (
+    classified.hasGame &&
+    !hasMatchingTest(
+      files,
+      (file) =>
+        file.startsWith('src/components/game/') ||
+        file.startsWith('src/components/board/') ||
+        file.startsWith('src/hooks/game/') ||
+        file === 'src/pages/GamePage.test.tsx' ||
+        file === 'src/mocks/handlers/game.handler.test.ts'
+    )
+  ) {
+    testGaps.push(
+      'game runtime 변경이 있지만 관련 테스트 변경이 diff에 없습니다.'
+    )
+  }
+
+  if (
+    classified.hasSocketInfra &&
+    !hasMatchingTest(
+      files,
+      (file) =>
+        file.startsWith('src/lib/socket.test.') ||
+        file.startsWith('src/services/socket/') ||
+        file.startsWith('src/contracts/socket/')
+    )
+  ) {
+    testGaps.push(
+      'socket infra 변경이 있지만 subscribe/cleanup 또는 계약 테스트 변경이 diff에 없습니다.'
+    )
+  }
+
+  if (
+    classified.hasSourceChanges &&
+    !classified.hasTestChanges &&
+    testGaps.length === 0
+  ) {
+    testGaps.push(
+      '소스 파일이 바뀌었지만 이번 diff에는 테스트 파일 변경이 없습니다.'
+    )
+  }
+
+  if (
+    classified.hasSocketInfra &&
+    /\+.*\bsocket\.on\(/.test(diffText) &&
+    !/\+.*\bsocket\.off\(/.test(diffText)
+  ) {
+    warnings.push(
+      'socket subscribe 변경 흔적은 있지만 cleanup 짝이 diff에서 바로 보이지 않습니다.'
+    )
+  }
+
+  if (classified.docsOnly) {
+    warnings.push(
+      '현재 diff는 문서 중심입니다. 코드 품질 체크보다 문서-코드 정합성 검토가 우선입니다.'
+    )
+  }
+
+  return {
+    findings: unique(findings),
+    testGaps: unique(testGaps),
+    warnings: unique(warnings),
+  }
 }
 
 export function getValidationOrchestration(files) {

--- a/scripts/ai/lib.test.ts
+++ b/scripts/ai/lib.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+
+import { getReviewInsights } from './lib.mjs'
+
+describe('getReviewInsights', () => {
+  it('reports auth contract findings and missing tests', () => {
+    const insights = getReviewInsights(['src/lib/axios.ts'], {
+      diffText: '',
+      readFile: (path) => {
+        if (path === 'src/lib/axios.ts') {
+          return `
+              export const apiClient = axios.create({})
+              export function requestAccessTokenRefresh() {
+                return '/v1/auth/refresh'
+              }
+            `
+        }
+
+        return ''
+      },
+    })
+
+    expect(insights.findings).toContain(
+      'auth transport 변경이 있지만 `withCredentials: true` 설정이 보이지 않습니다.'
+    )
+    expect(insights.findings).toContain(
+      'auth refresh/logout 경로가 현재 `/api/auth/*` 계약과 다를 수 있습니다.'
+    )
+    expect(insights.testGaps).toContain(
+      'auth transport 변경이 있지만 axios/api/socket/session 관련 테스트 변경이 diff에 없습니다.'
+    )
+  })
+
+  it('reports area-specific test gaps for waiting-room changes', () => {
+    const insights = getReviewInsights(
+      ['src/pages/waiting-room/page/WaitingRoomPage.tsx'],
+      {
+        diffText: '',
+        readFile: () => '',
+      }
+    )
+
+    expect(insights.testGaps).toContain(
+      'waiting-room 변경이 있지만 관련 테스트 변경이 diff에 없습니다.'
+    )
+  })
+
+  it('stays quiet when auth transport change has matching config and tests', () => {
+    const insights = getReviewInsights(
+      [
+        'src/lib/axios.ts',
+        'src/lib/axios.test.ts',
+        'src/features/auth/api/api.test.ts',
+      ],
+      {
+        diffText: '',
+        readFile: (path) => {
+          if (path === 'src/lib/axios.ts') {
+            return `
+              export const apiClient = axios.create({
+                withCredentials: true,
+              })
+              export function requestAccessTokenRefresh() {
+                return '/api/auth/refresh'
+              }
+              export function requestAuthLogout() {
+                return '/api/auth/logout'
+              }
+            `
+          }
+
+          return ''
+        },
+      }
+    )
+
+    expect(insights.findings).toEqual([])
+    expect(insights.testGaps).toEqual([])
+  })
+})

--- a/scripts/ai/self-review.mjs
+++ b/scripts/ai/self-review.mjs
@@ -6,6 +6,7 @@ import {
   getChangedFiles,
   getDiffText,
   getManualsForFiles,
+  getReviewInsights,
   getSuggestedScripts,
   parseScriptArgs,
 } from './lib.mjs'
@@ -28,55 +29,7 @@ const diffText = getDiffText()
 const classified = classifyFiles(files)
 const manuals = getManualsForFiles(files)
 const suggestedScripts = getSuggestedScripts(files, { includeUiChecks: true })
-
-const checklist = [
-  'R5: 핵심 플로우가 위에서 아래로 읽히는가, 시점 이동이 늘지 않았는가?',
-]
-const warnings = []
-
-if (classified.hasHooks) {
-  checklist.push('Hook 반환 형태와 네이밍이 기존 규칙과 달라지지 않았는가?')
-}
-
-if (classified.hasSocketInfra || /\bsocket\.(on|off|emit)\(/.test(diffText)) {
-  checklist.push(
-    'Socket subscribe/unsubscribe, emit 경로, cleanup 타이밍이 모두 짝을 이루는가?'
-  )
-}
-
-if (
-  classified.hasSocketInfra ||
-  files.some((file) => file.startsWith('src/contracts/socket/'))
-) {
-  checklist.push('Mock, socket contract, 관련 테스트가 함께 갱신됐는가?')
-}
-
-if (classified.hasUiFiles || /\buseNavigate\b|\bnavigate\(/.test(diffText)) {
-  checklist.push(
-    'Redirect, modal close, cleanup, pending state 흐름이 사용자 동선 기준으로 일관적인가?'
-  )
-}
-
-if (classified.hasSourceChanges) {
-  checklist.push('변경 기능을 직접 검증하는 테스트가 최소 1개 이상 존재하는가?')
-}
-
-if (classified.hasSourceChanges && !classified.hasTestChanges) {
-  warnings.push('소스 파일이 바뀌었지만 이번 diff에는 테스트 파일 변경이 없습니다.')
-}
-
-if (
-  (classified.hasSocketInfra || classified.hasWaitingRoom || classified.hasGame) &&
-  !classified.hasTestChanges
-) {
-  warnings.push(
-    '실시간/런타임 경로가 바뀌었는데 테스트 보강 흔적이 없습니다. 회귀 가능성을 다시 확인하세요.'
-  )
-}
-
-if (classified.docsOnly) {
-  warnings.push('현재 diff는 문서 중심입니다. 코드 품질 체크보다 문서-코드 정합성 검토가 우선입니다.')
-}
+const reviewInsights = getReviewInsights(files, { diffText })
 
 console.log('AI Self Review')
 console.log('')
@@ -88,8 +41,9 @@ if (files.length === 0) {
 
 printList('Changed Files', files)
 printList('Relevant Manuals', manuals)
-printList('Review Checklist', checklist)
-printList('Warnings', warnings)
+printList('Findings', reviewInsights.findings)
+printList('Test Gaps', reviewInsights.testGaps)
+printList('Warnings', reviewInsights.warnings)
 
 printList(
   'Suggested Validation Commands',

--- a/scripts/ai/task-new.mjs
+++ b/scripts/ai/task-new.mjs
@@ -1,0 +1,243 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+import { getManualsForFiles, getSuggestedScripts } from './lib.mjs'
+
+const TASKS_ROOT = path.join('docs', 'ai', 'tasks')
+const TEMPLATE_ROOT = path.join(TASKS_ROOT, '_template')
+
+export function humanizeSlug(slug) {
+  return slug
+    .split('-')
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(' ')
+}
+
+export function getTodayDate() {
+  return new Date().toISOString().slice(0, 10)
+}
+
+export function parseTaskNewArgs(argv) {
+  const args = argv.slice(2)
+  const force = args.includes('--force')
+  const filesIndex = args.indexOf('--files')
+  const slug = args.find((value) => !value.startsWith('--'))
+
+  let files = []
+
+  if (filesIndex !== -1) {
+    files = args
+      .slice(filesIndex + 1)
+      .filter((value) => !value.startsWith('--'))
+  }
+
+  return {
+    slug,
+    files,
+    force,
+  }
+}
+
+function formatBulletList(items, fallback = '- 직접 채워주세요') {
+  if (!items.length) {
+    return fallback
+  }
+
+  return items.map((item) => `- ${item}`).join('\n')
+}
+
+function formatCodeBulletList(items, fallback = '- 직접 채워주세요') {
+  if (!items.length) {
+    return fallback
+  }
+
+  return items.map((item) => `- \`${item}\``).join('\n')
+}
+
+export function buildTaskFileContents({ slug, files, date = getTodayDate() }) {
+  const manuals = getManualsForFiles(files)
+  const suggestedScripts = getSuggestedScripts(files, {
+    includeUiChecks: true,
+  }).map((scriptName) => `npm run ${scriptName}`)
+  const taskName = humanizeSlug(slug)
+  const targetFiles = formatCodeBulletList(files)
+  const relatedFiles = formatCodeBulletList([...manuals, ...files])
+  const manualNotes = formatCodeBulletList(
+    manuals,
+    '- 관련 manual을 직접 추가해주세요'
+  )
+  const validationCommands = formatCodeBulletList(
+    suggestedScripts,
+    '- 최소 검증 명령을 직접 채워주세요'
+  )
+
+  return {
+    plan: `# Plan
+
+## Task
+
+- 작업 이름: ${taskName}
+- 요청 날짜: ${date}
+- 담당 범위: ${files.length ? '입력 파일 기준 초안 생성' : '직접 채워주세요'}
+
+## Goal
+
+- ${taskName} 작업의 목표를 직접 채워주세요
+
+## In Scope
+
+${targetFiles}
+
+## Out Of Scope
+
+- 이번 작업에서 일부러 다루지 않을 범위를 직접 채워주세요
+
+## Target Files
+
+${targetFiles}
+
+## Completion Criteria
+
+- 사용자 관점에서 완료 기준을 직접 채워주세요
+- 관련 코드, 문서, 테스트 범위를 직접 확인해주세요
+
+## Test Plan
+
+${validationCommands}
+`,
+    context: `# Context
+
+## Current Behavior
+
+- 지금 어떤 흐름으로 동작하는지 직접 정리해주세요
+- 어디서 문제가 발생하는지 직접 정리해주세요
+
+## Related Files
+
+${relatedFiles}
+
+## Constraints
+
+${manualNotes}
+
+## Decision Notes
+
+- 선택한 접근 방식과 이유를 직접 정리해주세요
+- 버린 대안과 이유를 직접 정리해주세요
+
+## Open Risks
+
+- 아직 확인이 덜 된 부분을 직접 정리해주세요
+- 구현 후 꼭 다시 볼 경계 조건을 직접 정리해주세요
+`,
+    checklist: `# Checklist
+
+## Implementation
+
+- [ ] 관련 manual과 기존 문서를 읽었다
+- [ ] 영향 범위를 정리했다
+- [ ] 최소 범위로 구현했다
+- [ ] mock/real 경로를 함께 확인했다
+- [ ] 타입/contract 변경이 있으면 관련 코드도 같이 수정했다
+
+## Testing
+
+${
+  suggestedScripts.length
+    ? suggestedScripts.map((script) => `- [ ] \`${script}\``).join('\n')
+    : '- [ ] 최소 검증 명령을 직접 추가했다'
+}
+
+## Review
+
+- [ ] \`docs/rules.md\` 기준으로 셀프 리뷰했다
+- [ ] 리다이렉트, cleanup, 중복 구독, 에러 처리 경계를 확인했다
+- [ ] 변경 파일 / 실행한 검증 / 남은 리스크를 정리했다
+`,
+  }
+}
+
+export function createTaskWorkspace({
+  slug,
+  files = [],
+  force = false,
+  cwd = process.cwd(),
+  date,
+}) {
+  if (!slug) {
+    throw new Error(
+      'task slug가 필요합니다. 예: npm run ai:task:new -- auth-refresh-cookie-flow'
+    )
+  }
+
+  const taskDir = path.join(cwd, TASKS_ROOT, slug)
+
+  if (fs.existsSync(taskDir) && !force) {
+    throw new Error(
+      `이미 같은 task 디렉토리가 있습니다: ${taskDir}\n덮어쓰려면 --force 를 사용하세요.`
+    )
+  }
+
+  fs.mkdirSync(taskDir, {
+    recursive: true,
+  })
+
+  const contents = buildTaskFileContents({
+    slug,
+    files,
+    date,
+  })
+
+  fs.writeFileSync(path.join(taskDir, 'plan.md'), contents.plan)
+  fs.writeFileSync(path.join(taskDir, 'context.md'), contents.context)
+  fs.writeFileSync(path.join(taskDir, 'checklist.md'), contents.checklist)
+
+  return {
+    taskDir,
+    createdFiles: [
+      path.join(taskDir, 'plan.md'),
+      path.join(taskDir, 'context.md'),
+      path.join(taskDir, 'checklist.md'),
+    ],
+  }
+}
+
+function validateEnvironment() {
+  if (!fs.existsSync(TEMPLATE_ROOT)) {
+    throw new Error(`task template 경로를 찾을 수 없습니다: ${TEMPLATE_ROOT}`)
+  }
+}
+
+export function main(argv = process.argv) {
+  validateEnvironment()
+
+  const { slug, files, force } = parseTaskNewArgs(argv)
+  const result = createTaskWorkspace({
+    slug,
+    files,
+    force,
+  })
+
+  console.log('AI task workspace created:')
+  for (const file of result.createdFiles) {
+    console.log(`- ${path.relative(process.cwd(), file)}`)
+  }
+}
+
+const executedPath = process.argv[1]
+const modulePath = fileURLToPath(import.meta.url)
+
+if (executedPath && path.resolve(executedPath) === modulePath) {
+  try {
+    main()
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    console.error(message)
+    process.exit(1)
+  }
+}

--- a/scripts/ai/task-new.test.ts
+++ b/scripts/ai/task-new.test.ts
@@ -1,0 +1,96 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  buildTaskFileContents,
+  createTaskWorkspace,
+  humanizeSlug,
+  parseTaskNewArgs,
+} from './task-new.mjs'
+
+const tempDirs = []
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, {
+      recursive: true,
+      force: true,
+    })
+  }
+})
+
+describe('task-new', () => {
+  it('parses slug, files, and force flag', () => {
+    const parsed = parseTaskNewArgs([
+      'node',
+      'task-new.mjs',
+      'auth-refresh-cookie-flow',
+      '--files',
+      'src/lib/axios.ts',
+      'src/features/auth/api/api.ts',
+      '--force',
+    ])
+
+    expect(parsed).toEqual({
+      slug: 'auth-refresh-cookie-flow',
+      files: ['src/lib/axios.ts', 'src/features/auth/api/api.ts'],
+      force: true,
+    })
+  })
+
+  it('builds populated task file contents from files', () => {
+    const contents = buildTaskFileContents({
+      slug: 'auth-refresh-cookie-flow',
+      files: ['src/lib/axios.ts', 'src/features/auth/api/api.ts'],
+      date: '2026-03-18',
+    })
+
+    expect(humanizeSlug('auth-refresh-cookie-flow')).toBe(
+      'Auth Refresh Cookie Flow'
+    )
+    expect(contents.plan).toContain('작업 이름: Auth Refresh Cookie Flow')
+    expect(contents.plan).toContain('`src/lib/axios.ts`')
+    expect(contents.context).toContain('`docs/ai/manuals/common.md`')
+    expect(contents.checklist).toContain('`npm run lint`')
+  })
+
+  it('creates a task workspace and blocks overwrite by default', () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'bm-task-new-'))
+    tempDirs.push(cwd)
+    fs.mkdirSync(path.join(cwd, 'docs', 'ai', 'tasks', '_template'), {
+      recursive: true,
+    })
+
+    const created = createTaskWorkspace({
+      cwd,
+      slug: 'socket-session-clear',
+      files: ['src/lib/socket.ts'],
+      date: '2026-03-18',
+    })
+
+    expect(created.createdFiles).toHaveLength(3)
+    expect(
+      fs.readFileSync(
+        path.join(
+          cwd,
+          'docs',
+          'ai',
+          'tasks',
+          'socket-session-clear',
+          'plan.md'
+        ),
+        'utf8'
+      )
+    ).toContain('Socket Session Clear')
+
+    expect(() =>
+      createTaskWorkspace({
+        cwd,
+        slug: 'socket-session-clear',
+      })
+    ).toThrow(/이미 같은 task 디렉토리가 있습니다/)
+  })
+})


### PR DESCRIPTION
## 📌 관련 이슈

> closes #479 

---

## 📝 작업 내용

> 문서 기반 AI 워크플로우의 실제 사용성을 높이기 위해, PR의 `AI Review` 코멘트를 finding 중심으로 정리하고 task 문서 생성 스크립트를 추가했습니다.

### 1. AI Review 코멘트 개선

- `AI Review` 코멘트에서 중복되는 changed files/raw 로그/UI check plan 출력을 줄였습니다.
- `self-review`는 고정 체크리스트 출력 대신 `Findings`, `Test Gaps`, `Warnings`를 중심으로 보이도록 정리했습니다.
- auth / lobby / waiting-room / game / socket 변경에 대해 deterministic한 review 규칙을 추가했습니다.
- PR 코멘트는 `Workflow Warnings -> Findings -> Test Gaps -> Required Checks -> Suggested Checks` 순서로 짧게 읽히도록 정리했습니다.

### 2. AI task 문서 생성 스크립트 추가

- `npm run ai:task:new -- <slug> [--files ...]` 스크립트를 추가했습니다.
- `docs/ai/tasks/<slug>/plan.md`, `context.md`, `checklist.md`를 자동 생성할 수 있게 했습니다.
- `--files`를 주면 관련 manual, target files, 최소 검증 명령 초안을 함께 채우도록 했습니다.
- `docs/ai/tasks/README.md`에 사용 예시를 추가했습니다.

### 3. 문서 기반 워크플로우 사용 마찰 감소

- task 문서를 수동 복사하던 흐름을 명령어 기반으로 줄여 실제 사용성을 높였습니다.
- 생성형 리뷰는 Gemini가, deterministic review는 repo 내부 `AI Review`가 맡는 구조를 더 분명하게 정리했습니다.

### 🧠 Task 문서 (큰 작업이면 필수)

- `docs/ai/tasks/ai-review-findings-upgrade/plan.md`
- `docs/ai/tasks/ai-review-findings-upgrade/context.md`
- `docs/ai/tasks/ai-review-findings-upgrade/checklist.md`
- `docs/ai/tasks/ai-task-workspace-generator/plan.md`
- `docs/ai/tasks/ai-task-workspace-generator/context.md`
- `docs/ai/tasks/ai-task-workspace-generator/checklist.md`

### 🧪 실행한 검증

- `npx vitest run scripts/ai/lib.test.ts`
- `npx vitest run scripts/ai/task-new.test.ts`
- `npx prettier --check .github/workflows/ai-review.yml scripts/ai/lib.mjs scripts/ai/self-review.mjs scripts/ai/lib.test.ts scripts/ai/task-new.mjs scripts/ai/task-new.test.ts package.json docs/ai/tasks/README.md docs/ai/tasks/ai-workflow-warning-gates/plan.md docs/ai/tasks/ai-workflow-warning-gates/context.md docs/ai/tasks/ai-workflow-warning-gates/checklist.md docs/ai/tasks/ai-review-findings-upgrade/plan.md docs/ai/tasks/ai-review-findings-upgrade/context.md docs/ai/tasks/ai-review-findings-upgrade/checklist.md docs/ai/tasks/ai-task-workspace-generator/plan.md docs/ai/tasks/ai-task-workspace-generator/context.md docs/ai/tasks/ai-task-workspace-generator/checklist.md`
- `npm run ai:self-review -- --files .github/workflows/ai-review.yml scripts/ai/lib.mjs scripts/ai/self-review.mjs scripts/ai/lib.test.ts scripts/ai/task-new.mjs scripts/ai/task-new.test.ts package.json docs/ai/tasks/README.md docs/ai/tasks/ai-workflow-warning-gates/plan.md docs/ai/tasks/ai-workflow-warning-gates/context.md docs/ai/tasks/ai-workflow-warning-gates/checklist.md docs/ai/tasks/ai-review-findings-upgrade/plan.md docs/ai/tasks/ai-review-findings-upgrade/context.md docs/ai/tasks/ai-review-findings-upgrade/checklist.md docs/ai/tasks/ai-task-workspace-generator/plan.md docs/ai/tasks/ai-task-workspace-generator/context.md docs/ai/tasks/ai-task-workspace-generator/checklist.md`

### ⚠️ 남은 리스크

- `AI Review`의 deterministic findings는 1차 규칙만 들어간 상태라, false positive / false negative를 실제 PR 몇 개로 더 보면서 조정할 필요가 있습니다.
- `ai:task:new`는 초안을 만드는 도구라 `Goal`, `Current Behavior`, `Open Risks` 같은 내용은 생성 후 직접 보강해야 합니다.
- `AI Review` 코멘트 형태는 workflow 재실행 후 실제 PR에서 한 번 더 확인이 필요합니다.

---

## ✅ 체크리스트

- [x] AI Review 코멘트를 finding 중심으로 정리
- [x] deterministic review 규칙 추가
- [x] `npm run ai:task:new` 스크립트 추가
- [x] task 문서 자동 생성 및 README 예시 추가
- [x] 관련 테스트와 self-review 실행

---

## 📌 추가 메모

- 이번 PR은 생성형 리뷰를 늘리는 작업이 아니라, 기존 문서 기반 AI
