### PR TITLE
refactor: 게임 보드 렌더링 최적화 및 스토어 버그 수정

### DIFF
--- a/src/components/board/BoardTile.tsx
+++ b/src/components/board/BoardTile.tsx
@@ -129,7 +129,7 @@ interface BoardTileProps {
   dir: TileDir
   tokens: PlayerState[]
   tileOwner?: TileOwner
-  timeLeft?: number
+  isUrgent?: boolean
   isActivePlayerTile?: boolean
 }
 
@@ -138,7 +138,7 @@ const BoardTile: React.FC<BoardTileProps> = ({
   dir,
   tokens,
   tileOwner,
-  timeLeft = 0,
+  isUrgent: isUrgentProp = false,
   isActivePlayerTile = false,
 }) => {
   const isProperty = tile.type === 'PROPERTY'
@@ -168,8 +168,7 @@ const BoardTile: React.FC<BoardTileProps> = ({
   const tileBg = ownerStyle ? ownerStyle.bg : '#FFFFFF'
   const outerBorderColor = ownerStyle ? ownerStyle.strip : '#E2E8F0'
 
-  // 턴 진행 중인 플레이어가 위치한 칸이고 시간이 10초 이하일 때 애니메이션 강조
-  const isUrgent = isActivePlayerTile && timeLeft <= 10 && timeLeft > 0
+  const isUrgent = isActivePlayerTile && isUrgentProp
 
   // ── 실제 코너 (START, ISLAND, MOVE_TO_ISLAND) ─────────────────────
   const isActualCorner = ['START', 'ISLAND', 'MOVE_TO_ISLAND'].includes(
@@ -470,4 +469,4 @@ const BoardTile: React.FC<BoardTileProps> = ({
   )
 }
 
-export default BoardTile
+export default React.memo(BoardTile)

--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -43,6 +43,7 @@ import {
   TileOwner,
   BuildingLevel,
   DICE_TIMEOUT,
+  type TileData,
 } from './board.constants'
 
 import { getBoardSellFallbackRefund } from './gameBoardActionUtils'
@@ -98,6 +99,7 @@ function calcToll(price: number, level: BuildingLevel): number {
 }
 
 const DEFAULT_OPPONENT_NAME = '상대방'
+const EMPTY_TOKENS: PlayerState[] = []
 const GAME_START_STATUS = '게임 시작!'
 const BOARD_GRID_BASE_SIZE = CORNER_SIZE * 2 + STRAIGHT_SIZE * 7 + GRID_GAP * 8
 const BOARD_INNER_PADDING = 10 * 2
@@ -290,8 +292,8 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
     },
     ref
   ) => {
-    const [localTimeLeft, setLocalTimeLeft] = useState(DICE_TIMEOUT)
-    const [showTimerModal, setShowTimerModal] = useState(false)
+    const localTimeLeftRef = useRef(DICE_TIMEOUT)
+    const [isTimerUrgent, setIsTimerUrgent] = useState(false)
     const [promptTimerLeftSec, setPromptTimerLeftSec] = useState<number | null>(
       null
     )
@@ -467,22 +469,19 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       [tiles, players]
     )
     const tileOwners = derivedTileOwners
-    const serverTilePriceMap = useMemo(() => {
-      const map: Record<number, number> = {}
+    const tilesWithServerPrice = useMemo(() => {
+      const priceMap: Record<number, number> = {}
       for (const t of tiles) {
         if (typeof t.index === 'number' && typeof t.price === 'number') {
-          map[t.index] = t.price
+          priceMap[t.index] = t.price
         }
+      }
+      const map: Record<number, TileData> = {}
+      for (let i = 0; i < TILES.length; i++) {
+        map[i] = i in priceMap ? { ...TILES[i], price: priceMap[i] } : TILES[i]
       }
       return map
     }, [tiles])
-    const getTileWithServerPrice = (id: number) => {
-      const base = TILES[id]
-      if (id in serverTilePriceMap) {
-        return { ...base, price: serverTilePriceMap[id] }
-      }
-      return base
-    }
     const tileOwnersRef = useRef<Record<number, TileOwner>>(tileOwners)
     const promptModalKind = resolvePromptModalKind(activePrompt)
     const isBuyPromptOpen = promptModalKind === 'buy'
@@ -710,8 +709,8 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
 
     // 타이머 관리
     useEffect(() => {
-      setLocalTimeLeft(DICE_TIMEOUT)
-      setShowTimerModal(false)
+      localTimeLeftRef.current = DICE_TIMEOUT
+      setIsTimerUrgent(false)
       setPromptTimerLeftSec(null)
 
       // Close all other modals when turn changes
@@ -747,13 +746,20 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       if (rolling) return
 
       const timer = setInterval(() => {
-        setLocalTimeLeft((prev) => {
-          if (prev <= 1) {
-            clearInterval(timer) // Stop once triggered
-            return 0
-          }
-          return prev - 1
-        })
+        const prev = localTimeLeftRef.current
+        if (prev <= 1) {
+          localTimeLeftRef.current = 0
+          clearInterval(timer)
+          setIsTimerUrgent(false)
+          return
+        }
+        const next = prev - 1
+        localTimeLeftRef.current = next
+        const wasUrgent = prev <= 10 && prev > 0
+        const isNowUrgent = next <= 10 && next > 0
+        if (wasUrgent !== isNowUrgent) {
+          setIsTimerUrgent(isNowUrgent)
+        }
       }, 1000)
 
       return () => clearInterval(timer)
@@ -1042,8 +1048,6 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
         return
       }
 
-      setShowTimerModal(false)
-
       const hasUnderlyingModal =
         buyModal.open ||
         buildModal.open ||
@@ -1250,12 +1254,15 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       advanceTurn(onDone)
     }
 
-    const byTile: Record<number, PlayerState[]> = {}
-    players.forEach((p) => {
-      if (p.state === 'bankrupt' || p.money <= 0) return
-      if (!byTile[p.pos]) byTile[p.pos] = []
-      byTile[p.pos].push(p)
-    })
+    const byTile = useMemo(() => {
+      const map: Record<number, PlayerState[]> = {}
+      players.forEach((p) => {
+        if (p.state === 'bankrupt' || p.money <= 0) return
+        if (!map[p.pos]) map[p.pos] = []
+        map[p.pos].push(p)
+      })
+      return map
+    }, [players])
 
     const CS = CORNER_SIZE
     const SS = STRAIGHT_SIZE
@@ -1334,8 +1341,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       '확인'
     )
     const scaledBoardSize = BOARD_RENDER_BASE_SIZE * boardScale
-    const diceTimerModalOpen =
-      !suppressDiceTimerModal && (showTimerModal || isDiceTimerPromptOpen)
+    const diceTimerModalOpen = !suppressDiceTimerModal && isDiceTimerPromptOpen
     const hasBlockingModal =
       buyModalVisible ||
       buildModalVisible ||
@@ -1471,11 +1477,11 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
                     }}
                   >
                     <BoardTile
-                      tile={getTileWithServerPrice(id)}
+                      tile={tilesWithServerPrice[id]}
                       dir={isCornerTile ? 'corner' : 'top'}
-                      tokens={byTile[id] ?? []}
+                      tokens={byTile[id] ?? EMPTY_TOKENS}
                       tileOwner={tileOwners[id]}
-                      timeLeft={localTimeLeft}
+                      isUrgent={isTimerUrgent}
                       isActivePlayerTile={id === players[curPlayer]?.pos}
                     />
                   </div>
@@ -1506,11 +1512,11 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
                     }}
                   >
                     <BoardTile
-                      tile={getTileWithServerPrice(id)}
+                      tile={tilesWithServerPrice[id]}
                       dir={isCornerTile ? 'corner' : 'bottom'}
-                      tokens={byTile[id] ?? []}
+                      tokens={byTile[id] ?? EMPTY_TOKENS}
                       tileOwner={tileOwners[id]}
-                      timeLeft={localTimeLeft}
+                      isUrgent={isTimerUrgent}
                       isActivePlayerTile={id === players[curPlayer]?.pos}
                     />
                   </div>
@@ -1540,11 +1546,11 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
                     }}
                   >
                     <BoardTile
-                      tile={getTileWithServerPrice(id)}
+                      tile={tilesWithServerPrice[id]}
                       dir="left"
-                      tokens={byTile[id] ?? []}
+                      tokens={byTile[id] ?? EMPTY_TOKENS}
                       tileOwner={tileOwners[id]}
-                      timeLeft={localTimeLeft}
+                      isUrgent={isTimerUrgent}
                       isActivePlayerTile={id === players[curPlayer]?.pos}
                     />
                   </div>
@@ -1574,11 +1580,11 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
                     }}
                   >
                     <BoardTile
-                      tile={getTileWithServerPrice(id)}
+                      tile={tilesWithServerPrice[id]}
                       dir="right"
-                      tokens={byTile[id] ?? []}
+                      tokens={byTile[id] ?? EMPTY_TOKENS}
                       tileOwner={tileOwners[id]}
-                      timeLeft={localTimeLeft}
+                      isUrgent={isTimerUrgent}
                       isActivePlayerTile={id === players[curPlayer]?.pos}
                     />
                   </div>

--- a/src/components/game/controls/RollButton.tsx
+++ b/src/components/game/controls/RollButton.tsx
@@ -1,18 +1,22 @@
 import React, { useEffect, useRef, useState } from 'react'
+import { useGameStore } from '../../../stores/game.store'
+import { useGameTimer } from '../../../hooks/game/useGameTimer'
 
 interface RollControlProps {
-  timeLeft: number
   isMyTurn: boolean
   onRoll: () => void
 }
 
-const RollControl: React.FC<RollControlProps> = ({
-  timeLeft,
-  isMyTurn,
-  onRoll,
-}) => {
+const RollControl: React.FC<RollControlProps> = ({ isMyTurn, onRoll }) => {
+  const turnTimeoutSec = useGameStore((s) => s.turnTimeoutSec)
+  const turnTimerKey = useGameStore((s) => s.turnTimerKey)
+  const [timeLeft] = useGameTimer({
+    initialTime: turnTimeoutSec,
+    resetSignal: turnTimerKey,
+  })
+
   const dashArray = 251 // Approx circumference for r=40
-  const dashOffset = dashArray * (1 - timeLeft / 30)
+  const dashOffset = dashArray * (1 - timeLeft / (turnTimeoutSec || 30))
   const previousTimeLeftRef = useRef<number | null>(null)
   const [shouldAnimate, setShouldAnimate] = useState(false)
 

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -12,7 +12,6 @@ import { DevRoomChatControlPanel } from '../features/room-chat/DevRoomChatContro
 import RoomChat from '../features/room-chat/RoomChat'
 import { useDiceRoll } from '../hooks/game/useDiceRoll'
 import { useGameState } from '../hooks/game/useGameState'
-import { useGameTimer } from '../hooks/game/useGameTimer'
 import { useTurn } from '../hooks/game/useTurn'
 import { playBgm, stopBgm } from '../lib/bgm'
 import { socket } from '../lib/socket'
@@ -67,23 +66,19 @@ const GamePage: React.FC = () => {
   const location = useLocation()
   const locationState = location.state as GamePageLocationState | null
   const authSession = useAuthStore((state) => state.session)
-  const {
-    currentTurn,
-    phase,
-    messages,
-    turnTimeoutSec,
-    turnTimerKey,
-    players: storePlayers,
-    tiles: storeTiles,
-    prompt,
-    pendingAction,
-    lastAck,
-    lastError,
-    session: gameSession,
-    gameId: storeGameId,
-    clearPrompt,
-    setLastError,
-  } = useGameStore()
+  const currentTurn = useGameStore((s) => s.currentTurn)
+  const phase = useGameStore((s) => s.phase)
+  const messages = useGameStore((s) => s.messages)
+  const storePlayers = useGameStore((s) => s.players)
+  const storeTiles = useGameStore((s) => s.tiles)
+  const prompt = useGameStore((s) => s.prompt)
+  const pendingAction = useGameStore((s) => s.pendingAction)
+  const lastAck = useGameStore((s) => s.lastAck)
+  const lastError = useGameStore((s) => s.lastError)
+  const gameSession = useGameStore((s) => s.session)
+  const storeGameId = useGameStore((s) => s.gameId)
+  const clearPrompt = useGameStore((s) => s.clearPrompt)
+  const setLastError = useGameStore((s) => s.setLastError)
   const activeGameId =
     locationState?.gameId ??
     routeGameId ??
@@ -95,10 +90,6 @@ const GamePage: React.FC = () => {
     string | null
   >(null)
   const [isExitModalOpen, setIsExitModalOpen] = useState(false)
-  const [timeLeft] = useGameTimer({
-    initialTime: turnTimeoutSec,
-    resetSignal: turnTimerKey,
-  })
   const boardRef = useRef<BoardGameHandle>(null)
 
   // 🎵 배경음악 (BGM) — 게임 진입 시 즉시 재생, 퇴장 시 정지
@@ -265,6 +256,17 @@ const GamePage: React.FC = () => {
     diceRoll(activeGameId)
   }
 
+  const isWaitingForServerState =
+    !USE_GAME_SOCKET_MOCK && storePlayers.length === 0
+
+  if (isWaitingForServerState) {
+    return (
+      <div className="flex h-screen w-full items-center justify-center bg-ui-app-bg font-['Inter']">
+        <div className="text-lg font-bold text-[#45556C]">게임 로딩 중...</div>
+      </div>
+    )
+  }
+
   return (
     <div className="relative flex h-screen w-full items-center justify-center overflow-hidden bg-ui-app-bg px-6 font-['Inter']">
       <div className="pointer-events-none absolute inset-0 z-0">
@@ -397,7 +399,6 @@ const GamePage: React.FC = () => {
       <div className="absolute bottom-10 right-10 z-20">
         {!isCurrentPlayerSkipped && !isCurrentPlayerBankrupt && (
           <RollButton
-            timeLeft={timeLeft}
             isMyTurn={isMyTurn && !isActionPending && !isPromptVisible}
             onRoll={handleRollClick}
           />

--- a/src/stores/game.store.ts
+++ b/src/stores/game.store.ts
@@ -366,6 +366,12 @@ export const useGameStore = create<GameStoreState>()(
     replaceFromSnapshot: (snapshot) =>
       set((draft) => {
         Object.assign(draft, normalizeState(snapshot))
+        if (!('prompt' in snapshot)) {
+          draft.prompt = null
+        }
+        if (!('pendingAction' in snapshot)) {
+          draft.pendingAction = null
+        }
         draft.session.roomId = snapshot.roomId ?? draft.session.roomId
         draft.session.gameId = snapshot.gameId ?? draft.session.gameId
         draft.session.transport = 'event-socket'
@@ -375,7 +381,8 @@ export const useGameStore = create<GameStoreState>()(
 
     applyPatchEnvelope: (envelope) =>
       set((draft) => {
-        if (envelope.revision < draft.revision) {
+        const hasRevision = envelope.revision > 0
+        if (hasRevision && envelope.revision < draft.revision) {
           return
         }
 
@@ -425,7 +432,9 @@ export const useGameStore = create<GameStoreState>()(
           }
         }
 
-        draft.revision = envelope.revision
+        if (hasRevision) {
+          draft.revision = envelope.revision
+        }
         draft.eventQueue.push(...(envelope.events ?? []))
         Object.assign(draft, normalizeState(draft))
       }),


### PR DESCRIPTION

Summary
게임 보드의 불필요한 리렌더를 제거하고, 스냅샷/패치 처리 시 발생하던 버그를 수정합니다.

렌더링 최적화
GamePage.tsx — Zustand 개별 셀렉터 분리
useGameStore() 통구독 → 15개 개별 셀렉터로 분리
useGameTimer 로직을 RollButton 내부로 이동
RollButton.tsx — 타이머 자체 관리
timeLeft prop 제거, 내부에서 useGameStore + useGameTimer 직접 사용
dashOffset 계산 시 스토어의 turnTimeoutSec 사용
GameBoard.tsx — 참조 안정성 및 메모이제이션
localTimeLeft useState → useRef (매초 리렌더 제거)
isTimerUrgent: 10초 경계에서만 상태 전환
byTile, tilesWithServerPrice useMemo 캐싱
EMPTY_TOKENS 모듈 레벨 상수로 빈 배열 참조 안정화
showTimerModal dead state 제거
BoardTile.tsx — React.memo
timeLeft: number → isUrgent: boolean prop
React.memo 래핑
버그 수정
game.store.ts
replaceFromSnapshot: 스냅샷에 prompt/pendingAction 키 없으면 null 초기화 (주사위 버튼 잠김 수정)
applyPatchEnvelope: revision=0 이벤트 전용 패치 무시되던 문제 수정
GamePage.tsx — 로딩 가드
서버 상태 수신 전 로딩 화면 표시 (4명 더미 플레이어 표시 방지)
Test plan
 tsc, vite build, 테스트 275개, E2E 3개 통과
 2인 게임 진입 시 플레이어 수 정상 표시 확인
 주사위 버튼 잠김 없이 턴 진행 확인
 타이머 10초 이하 타일 긴급 애니메이션 확인