### PR TITLE
refactor: AI 워크플로우에 역할·기준 문서·검증 증빙 연결

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,6 +21,28 @@
 
 ---
 
+## 📚 참고한 기준 문서
+
+> 이번 작업에서 실제로 읽고 기준으로 삼은 문서를 적어주세요.
+
+- `AGENTS.md`
+- `docs/rules.md`
+- `docs/testing.md`
+- 추가 manual / 문서:
+
+---
+
+## 👥 역할 수행
+
+> 큰 변경이면 Planner / Reviewer / Tester 흔적이 PR에서 보여야 합니다.
+
+- [ ] Planner
+- [ ] Implementer
+- [ ] Reviewer
+- [ ] Tester
+
+---
+
 ## 🧪 실행한 검증
 
 > 실제로 실행한 명령만 적어주세요.
@@ -46,6 +68,8 @@
 - [ ] 불필요한 console.log 제거
 - [ ] 관련 이슈 연결 완료
 - [ ] 큰 작업이면 task 문서 링크를 남겼다
+- [ ] 참고한 기준 문서를 PR 본문에 남겼다
+- [ ] 큰 작업이면 Planner / Reviewer / Tester 역할 흔적을 남겼다
 - [ ] 실행한 검증과 남은 리스크를 PR 본문에 적었다
 
 ---

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -276,10 +276,128 @@ jobs:
                 })
             }
 
+            function hasRequiredManualEvidence(section, files) {
+              const manualLines = section
+                .split('\n')
+                .map((line) => line.trim())
+                .filter((line) => line.startsWith('- '))
+
+              if (manualLines.length === 0) {
+                return false
+              }
+
+              const requiredManuals = []
+
+              if (
+                files.some((file) =>
+                  startsWithAnyPrefix(file, [
+                    'src/pages/lobby/',
+                    'src/features/presence/',
+                    'src/features/room-chat/',
+                  ])
+                )
+              ) {
+                requiredManuals.push('docs/ai/manuals/lobby.md')
+              }
+
+              if (files.some((file) => file.startsWith('src/pages/waiting-room/'))) {
+                requiredManuals.push('docs/ai/manuals/waiting-room.md')
+              }
+
+              if (
+                files.some((file) =>
+                  startsWithAnyPrefix(file, [
+                    'src/pages/GamePage.tsx',
+                    'src/components/game/',
+                    'src/components/board/',
+                    'src/hooks/game/',
+                    'src/services/socket/game.handler.ts',
+                    'src/stores/game.store.ts',
+                    'src/mocks/handlers/game.handler.ts',
+                  ])
+                )
+              ) {
+                requiredManuals.push('docs/ai/manuals/game-runtime.md')
+              }
+
+              if (
+                files.some((file) =>
+                  startsWithAnyPrefix(file, [
+                    'src/contracts/socket/',
+                    'mock-socket-server/',
+                    'src/lib/socket.ts',
+                  ])
+                )
+              ) {
+                requiredManuals.push('docs/socket-mock-server.md')
+              }
+
+              if (requiredManuals.length === 0) {
+                return true
+              }
+
+              return requiredManuals.every((manual) =>
+                manualLines.some((line) => line.includes(manual))
+              )
+            }
+
+            function hasCheckedRole(section, roleName) {
+              if (!section) {
+                return false
+              }
+
+              const rolePattern = new RegExp(`- \\[x\\] ${escapeRegExp(roleName)}\\b`)
+              return rolePattern.test(section)
+            }
+
+            function extractCommandMentions(section) {
+              if (!section) {
+                return new Set()
+              }
+
+              const commands = section
+                .split('\n')
+                .map((line) => line.trim())
+                .filter(Boolean)
+                .flatMap((line) => {
+                  const checkedQuotedMatch = line.match(
+                    /^- \[x\]\s+`([^`]+)`$/i
+                  )
+                  if (checkedQuotedMatch) {
+                    return [checkedQuotedMatch[1]]
+                  }
+
+                  if (/^- \[ \]\s+`[^`]+`$/.test(line)) {
+                    return []
+                  }
+
+                  const quotedMatches = [...line.matchAll(/`([^`]+)`/g)].map(
+                    (match) => match[1]
+                  )
+
+                  if (quotedMatches.length > 0) {
+                    return quotedMatches
+                  }
+
+                  const commandMatch = line.match(/^- (npm run .+)$/)
+                  return commandMatch ? [commandMatch[1]] : []
+                })
+
+              return new Set(commands)
+            }
+
             const pullRequestBody = context.payload.pull_request?.body ?? ''
             const taskSection = extractSection(
               pullRequestBody,
               '## 🧠 Task 문서 (큰 작업이면 필수)'
+            )
+            const manualSection = extractSection(
+              pullRequestBody,
+              '## 📚 참고한 기준 문서'
+            )
+            const roleSection = extractSection(
+              pullRequestBody,
+              '## 👥 역할 수행'
             )
             const validationSection = extractSection(
               pullRequestBody,
@@ -317,15 +435,51 @@ jobs:
               )
             }
 
+            const requiredValidationCommands = extractBulletLines(
+              extractScriptSection(validationPlan, 'Required checks:', [
+                'Suggested checks:',
+              ])
+            ).map((line) => line.replace(/^- /, ''))
+            const mentionedValidationCommands =
+              extractCommandMentions(validationSection)
+
+            if (
+              isLargeChange &&
+              !hasRequiredManualEvidence(manualSection, changedFileArray)
+            ) {
+              workflowWarnings.push(
+                '고위험 변경으로 보이지만 참고한 기준 문서 섹션에 필요한 manual 근거가 없습니다.'
+              )
+            }
+
+            if (
+              isLargeChange &&
+              !['Planner', 'Reviewer', 'Tester'].every((role) =>
+                hasCheckedRole(roleSection, role)
+              )
+            ) {
+              workflowWarnings.push(
+                '큰 변경으로 보이지만 Planner / Reviewer / Tester 역할 수행 흔적이 충분하지 않습니다.'
+              )
+            }
+
+            if (hasMeaningfulValidationContent(validationSection)) {
+              const missingRequiredChecks = requiredValidationCommands.filter(
+                (command) => !mentionedValidationCommands.has(command)
+              )
+
+              if (missingRequiredChecks.length > 0) {
+                workflowWarnings.push(
+                  `Required check 중 PR 본문 실행한 검증에 보이지 않는 항목이 있습니다: ${missingRequiredChecks.join(', ')}`
+                )
+              }
+            }
+
             const warningSection = workflowWarnings.length
               ? workflowWarnings.map((warning) => `- ${warning}`).join('\n')
               : '- none'
             const validationRequired = formatBulletSection(
-              extractBulletLines(
-                extractScriptSection(validationPlan, 'Required checks:', [
-                  'Suggested checks:',
-                ])
-              )
+              requiredValidationCommands.map((command) => `- ${command}`)
             )
             const validationSuggested = formatBulletSection(
               extractBulletLines(

--- a/docs/ai/tasks/README.md
+++ b/docs/ai/tasks/README.md
@@ -38,6 +38,7 @@ npm run ai:task:new -- auth-refresh-cookie-flow --files src/lib/axios.ts src/fea
 ```
 
 - `--files`를 주면 관련 manual과 최소 검증 명령 초안을 함께 채운다.
+- 생성 문서에는 `Relevant Manuals`, `Role Plan`, `Review/Tester` 체크 초안이 함께 들어간다.
 - 이미 같은 slug가 있으면 실패하고, 의도적으로 덮어쓰려면 `--force`를 사용한다.
 
 ## example-\* 디렉토리

--- a/docs/ai/tasks/ai-workflow-role-linking/checklist.md
+++ b/docs/ai/tasks/ai-workflow-role-linking/checklist.md
@@ -1,0 +1,22 @@
+# Checklist
+
+## Implementation
+
+- [x] 관련 manual과 기존 문서를 읽었다
+- [x] 영향 범위를 정리했다
+- [x] PR 템플릿에 기준 문서 / 역할 수행 섹션을 추가했다
+- [x] `ai:task:new`에 role plan / relevant manuals / review 역할 체크를 추가했다
+- [x] `AI Review`에 기준 문서 / Reviewer/Tester / required checks 증빙 warning을 연결했다
+
+## Testing
+
+- [x] `npx vitest run scripts/ai/task-new.test.ts`
+- [x] `npx prettier --check ...`
+- [x] `npm run ai:self-review -- --files ...`
+- [x] `npm run lint`
+
+## Review
+
+- [x] PR 본문이 과하게 길어지지 않는지 확인했다
+- [x] warning이 advisory only로 유지되는지 확인했다
+- [x] 변경 파일 / 실행한 검증 / 남은 리스크를 정리했다

--- a/docs/ai/tasks/ai-workflow-role-linking/context.md
+++ b/docs/ai/tasks/ai-workflow-role-linking/context.md
@@ -1,0 +1,40 @@
+# Context
+
+## Current Behavior
+
+- PR 본문에는 task 문서, 실행한 검증, 남은 리스크 섹션은 있지만 참고한 기준 문서와 역할 수행 흔적은 없다.
+- `ai:task:new`는 target files와 validation 초안은 채우지만 role plan / relevant manuals / review 역할 체크는 아직 없다.
+- `AI Review`는 task 문서, 검증, 리스크 누락은 보지만 기준 문서와 Reviewer/Tester 흔적, required check 증빙은 보지 않는다.
+
+## Related Files
+
+- `docs/ai/manuals/common.md`
+- `docs/rules.md`
+- `docs/testing.md`
+- `.github/PULL_REQUEST_TEMPLATE.md`
+- `.github/workflows/ai-review.yml`
+- `scripts/ai/task-new.mjs`
+- `package.json`
+- `docs/ai/tasks/README.md`
+
+## Relevant Manuals
+
+- `docs/ai/manuals/common.md`
+- `docs/rules.md`
+- `docs/testing.md`
+
+## Constraints
+
+- 큰 변경이어도 PR 본문이 지나치게 길어지지 않도록 해야 한다.
+- Reviewer/Tester warning은 advisory only로 유지해야 한다.
+- task 생성기는 초안을 만드는 도구이므로 실제 작업 맥락을 과도하게 추론하지 않는다.
+
+## Decision Notes
+
+- PR 템플릿 -> task 생성기 -> AI Review warning 순서로 연결하는 편이 가장 덜 꼬인다.
+- roles 전용 별도 시스템보다, 기존 task 문서와 PR 본문에 역할 흔적을 남기는 방식이 현재 단계에 더 적합하다.
+
+## Open Risks
+
+- required checks와 PR 본문 `실행한 검증` 비교는 문자열 기반이라 완전하지 않을 수 있다.
+- 역할 수행 체크가 형식적 체크박스로만 남지 않도록 실제 팀 운영에서 사례가 더 필요하다.

--- a/docs/ai/tasks/ai-workflow-role-linking/plan.md
+++ b/docs/ai/tasks/ai-workflow-role-linking/plan.md
@@ -1,0 +1,54 @@
+# Plan
+
+## Task
+
+- 작업 이름: Ai Workflow Role Linking
+- 요청 날짜: 2026-03-18
+- 담당 범위: 입력 파일 기준 초안 생성
+
+## Goal
+
+- PR 본문에서 참고한 기준 문서, 역할 수행, 검증 증빙이 같이 보이도록 구조를 보강한다.
+- `ai:task:new`가 같은 구조를 미리 채워 task 문서 작성 마찰을 줄이게 한다.
+- `AI Review`가 큰 변경에서 해당 흔적이 비어 있으면 warning으로 드러내도록 연결한다.
+
+## In Scope
+
+- `.github/PULL_REQUEST_TEMPLATE.md`
+- `.github/workflows/ai-review.yml`
+- `scripts/ai/task-new.mjs`
+- `package.json`
+- `docs/ai/tasks/README.md`
+
+## Out Of Scope
+
+- 생성형 리뷰 확장
+- branch protection 강제
+- roles 전용 별도 실행 엔진
+
+## Target Files
+
+- `.github/PULL_REQUEST_TEMPLATE.md`
+- `.github/workflows/ai-review.yml`
+- `scripts/ai/task-new.mjs`
+- `package.json`
+- `docs/ai/tasks/README.md`
+
+## Completion Criteria
+
+- PR 템플릿에 참고한 기준 문서 / 역할 수행 섹션이 추가된다.
+- `ai:task:new`가 role plan / relevant manuals / review 역할 체크를 포함한 문서를 생성한다.
+- `AI Review`가 큰 변경에서 기준 문서, Reviewer/Tester 흔적, required check 증빙 누락을 warning으로 표시한다.
+
+## Role Plan
+
+- Planner: PR 템플릿과 workflow가 검사할 기준을 먼저 정의
+- Implementer: task 생성기와 workflow 연결 구현
+- Reviewer: warning 기준과 코멘트 노이즈 확인
+- Tester: 관련 테스트와 self-review 실행
+
+## Test Plan
+
+- `npx vitest run scripts/ai/task-new.test.ts`
+- `npx prettier --check .github/PULL_REQUEST_TEMPLATE.md .github/workflows/ai-review.yml scripts/ai/task-new.mjs scripts/ai/task-new.test.ts docs/ai/tasks/README.md docs/ai/tasks/ai-workflow-role-linking/plan.md docs/ai/tasks/ai-workflow-role-linking/context.md docs/ai/tasks/ai-workflow-role-linking/checklist.md`
+- `npm run ai:self-review -- --files .github/PULL_REQUEST_TEMPLATE.md .github/workflows/ai-review.yml scripts/ai/task-new.mjs scripts/ai/task-new.test.ts docs/ai/tasks/README.md docs/ai/tasks/ai-workflow-role-linking/plan.md docs/ai/tasks/ai-workflow-role-linking/context.md docs/ai/tasks/ai-workflow-role-linking/checklist.md`

--- a/scripts/ai/task-new.mjs
+++ b/scripts/ai/task-new.mjs
@@ -10,6 +10,46 @@ import { getManualsForFiles, getSuggestedScripts } from './lib.mjs'
 const TASKS_ROOT = path.join('docs', 'ai', 'tasks')
 const TEMPLATE_ROOT = path.join(TASKS_ROOT, '_template')
 
+/**
+ * @typedef {Object} ParsedTaskNewArgs
+ * @property {string | undefined} slug
+ * @property {string[]} files
+ * @property {boolean} force
+ */
+
+/**
+ * @typedef {Object} TaskFileContentsOptions
+ * @property {string} slug
+ * @property {string[]} files
+ * @property {string} [date]
+ */
+
+/**
+ * @typedef {Object} TaskFileContents
+ * @property {string} plan
+ * @property {string} context
+ * @property {string} checklist
+ */
+
+/**
+ * @typedef {Object} CreateTaskWorkspaceOptions
+ * @property {string} slug
+ * @property {string[]} [files]
+ * @property {boolean} [force]
+ * @property {string} [cwd]
+ * @property {string} [date]
+ */
+
+/**
+ * @typedef {Object} CreateTaskWorkspaceResult
+ * @property {string} taskDir
+ * @property {string[]} createdFiles
+ */
+
+/**
+ * @param {string} slug
+ * @returns {string}
+ */
 export function humanizeSlug(slug) {
   return slug
     .split('-')
@@ -18,16 +58,24 @@ export function humanizeSlug(slug) {
     .join(' ')
 }
 
+/**
+ * @returns {string}
+ */
 export function getTodayDate() {
   return new Date().toISOString().slice(0, 10)
 }
 
+/**
+ * @param {string[]} argv
+ * @returns {ParsedTaskNewArgs}
+ */
 export function parseTaskNewArgs(argv) {
   const args = argv.slice(2)
   const force = args.includes('--force')
   const filesIndex = args.indexOf('--files')
   const slug = args.find((value) => !value.startsWith('--'))
 
+  /** @type {string[]} */
   let files = []
 
   if (filesIndex !== -1) {
@@ -43,14 +91,11 @@ export function parseTaskNewArgs(argv) {
   }
 }
 
-function formatBulletList(items, fallback = '- 직접 채워주세요') {
-  if (!items.length) {
-    return fallback
-  }
-
-  return items.map((item) => `- ${item}`).join('\n')
-}
-
+/**
+ * @param {string[]} items
+ * @param {string} [fallback='- 직접 채워주세요']
+ * @returns {string}
+ */
 function formatCodeBulletList(items, fallback = '- 직접 채워주세요') {
   if (!items.length) {
     return fallback
@@ -59,6 +104,10 @@ function formatCodeBulletList(items, fallback = '- 직접 채워주세요') {
   return items.map((item) => `- \`${item}\``).join('\n')
 }
 
+/**
+ * @param {TaskFileContentsOptions} options
+ * @returns {TaskFileContents}
+ */
 export function buildTaskFileContents({ slug, files, date = getTodayDate() }) {
   const manuals = getManualsForFiles(files)
   const suggestedScripts = getSuggestedScripts(files, {
@@ -106,6 +155,13 @@ ${targetFiles}
 - 사용자 관점에서 완료 기준을 직접 채워주세요
 - 관련 코드, 문서, 테스트 범위를 직접 확인해주세요
 
+## Role Plan
+
+- Planner: 범위 / 완료 기준 / 참고 문서 정리
+- Implementer: 최소 범위 구현
+- Reviewer: diff / self-review / 위험 신호 확인
+- Tester: 검증 명령 실행과 결과 정리
+
 ## Test Plan
 
 ${validationCommands}
@@ -121,9 +177,13 @@ ${validationCommands}
 
 ${relatedFiles}
 
-## Constraints
+## Relevant Manuals
 
 ${manualNotes}
+
+## Constraints
+
+- 유지해야 하는 계약과 제약을 직접 정리해주세요
 
 ## Decision Notes
 
@@ -155,6 +215,10 @@ ${
 
 ## Review
 
+- [ ] Planner 기준 정리 완료
+- [ ] Implementer 범위 구현 완료
+- [ ] Reviewer self-review 확인
+- [ ] Tester 검증 실행
 - [ ] \`docs/rules.md\` 기준으로 셀프 리뷰했다
 - [ ] 리다이렉트, cleanup, 중복 구독, 에러 처리 경계를 확인했다
 - [ ] 변경 파일 / 실행한 검증 / 남은 리스크를 정리했다
@@ -162,6 +226,10 @@ ${
   }
 }
 
+/**
+ * @param {CreateTaskWorkspaceOptions} options
+ * @returns {CreateTaskWorkspaceResult}
+ */
 export function createTaskWorkspace({
   slug,
   files = [],
@@ -207,12 +275,19 @@ export function createTaskWorkspace({
   }
 }
 
+/**
+ * @returns {void}
+ */
 function validateEnvironment() {
   if (!fs.existsSync(TEMPLATE_ROOT)) {
     throw new Error(`task template 경로를 찾을 수 없습니다: ${TEMPLATE_ROOT}`)
   }
 }
 
+/**
+ * @param {string[]} [argv=process.argv]
+ * @returns {void}
+ */
 export function main(argv = process.argv) {
   validateEnvironment()
 

--- a/scripts/ai/task-new.test.ts
+++ b/scripts/ai/task-new.test.ts
@@ -11,7 +11,7 @@ import {
   parseTaskNewArgs,
 } from './task-new.mjs'
 
-const tempDirs = []
+const tempDirs: string[] = []
 
 afterEach(() => {
   for (const dir of tempDirs.splice(0)) {
@@ -53,8 +53,11 @@ describe('task-new', () => {
     )
     expect(contents.plan).toContain('작업 이름: Auth Refresh Cookie Flow')
     expect(contents.plan).toContain('`src/lib/axios.ts`')
+    expect(contents.plan).toContain('## Role Plan')
     expect(contents.context).toContain('`docs/ai/manuals/common.md`')
+    expect(contents.context).toContain('## Relevant Manuals')
     expect(contents.checklist).toContain('`npm run lint`')
+    expect(contents.checklist).toContain('Planner 기준 정리 완료')
   })
 
   it('creates a task workspace and blocks overwrite by default', () => {


### PR DESCRIPTION
## 📌 관련 이슈

> closes #482 

---

## 📝 작업 내용

> 문서 기반 AI 워크플로우에서 아직 약하게 연결돼 있던 역할 분리, 기준 문서 근거, 검증 증빙을 PR 흐름에 더 직접 연결했습니다.

### 1. PR 템플릿 보강

- `참고한 기준 문서` 섹션을 추가해 실제로 읽고 기준으로 삼은 문서를 PR 본문에 남기도록 했습니다.
- `역할 수행` 섹션을 추가해 Planner / Implementer / Reviewer / Tester 흔적을 PR에서 확인할 수 있게 했습니다.
- 체크리스트에도 기준 문서 / 역할 흔적을 남겼는지 확인 항목을 추가했습니다.

### 2. AI task 생성기 보강

- `npm run ai:task:new`로 생성되는 task 문서에 `Role Plan`, `Relevant Manuals`, 역할 기반 review/test 체크를 함께 넣도록 바꿨습니다.
- 큰 작업을 시작할 때 역할 분리와 참고 manual을 문서 초안부터 자연스럽게 남길 수 있게 했습니다.
- `docs/ai/tasks/README.md`에도 생성 결과 설명을 추가했습니다.

### 3. AI Review warning 연결

- 큰 변경에서 PR 본문 `참고한 기준 문서` 섹션에 필요한 manual 근거가 없으면 warning을 남기도록 했습니다.
- 큰 변경인데 Planner / Reviewer / Tester 흔적이 부족하면 warning을 남기도록 했습니다.
- `Required Checks`가 있는데 PR 본문 `실행한 검증`에 보이지 않는 항목이 있으면 warning으로 드러내도록 했습니다.
- 전체적으로 문서 규칙이 PR 단계에서 실제 운영 흐름으로 보이게 연결했습니다.

### 🧠 Task 문서

- `docs/ai/tasks/ai-workflow-role-linking/plan.md`
- `docs/ai/tasks/ai-workflow-role-linking/context.md`
- `docs/ai/tasks/ai-workflow-role-linking/checklist.md`

### 🧪 실행한 검증

- `npx vitest run scripts/ai/task-new.test.ts`
- `npx prettier --check .github/PULL_REQUEST_TEMPLATE.md .github/workflows/ai-review.yml scripts/ai/task-new.mjs scripts/ai/task-new.test.ts docs/ai/tasks/README.md docs/ai/tasks/ai-workflow-role-linking/plan.md docs/ai/tasks/ai-workflow-role-linking/context.md docs/ai/tasks/ai-workflow-role-linking/checklist.md`
- workflow `github-script` 블록 문법 확인
- `npm run ai:self-review -- --files .github/PULL_REQUEST_TEMPLATE.md .github/workflows/ai-review.yml scripts/ai/task-new.mjs scripts/ai/task-new.test.ts docs/ai/tasks/README.md docs/ai/tasks/ai-workflow-role-linking/plan.md docs/ai/tasks/ai-workflow-role-linking/context.md docs/ai/tasks/ai-workflow-role-linking/checklist.md`
- `npm run lint`

### ⚠️ 남은 리스크

- `실행한 검증`과 required checks 비교는 문자열 기반이라 완전한 매칭은 아닙니다.
- 역할 체크는 advisory라 형식적으로만 체크될 가능성은 남아 있습니다.
- `npm run lint`는 이번 변경과 무관한 기존 경고 1건이 남아 있습니다. (`src/components/board/GameBoard.tsx`의 `react-hooks/exhaustive-deps`)

---

## ✅ 체크리스트

- [x] PR 템플릿에 기준 문서 / 역할 수행 섹션 추가
- [x] `ai:task:new`에 role plan / relevant manuals / review 역할 체크 추가
- [x] `AI Review`에 기준 문서 / 역할 / required checks 증빙 warning 연결
- [x] 관련 테스트 / self-review / lint 실행

---

## 📌 추가 메모

- 이번 작업은 생성형 리뷰를 늘리는 것이 아니라, 기존 문서 기반 AI 워크플로우를 실제 PR 운영 흐름에 더 강하게 연결하는 범위입니다.
- Gemini는 summary / code review를 계속 담당하고, repo 내부 `AI Review`는 deterministic warning / review 역할에 집중합니다.
