### PR TITLE
fix : 실서버 턴/무인도 주사위 버튼 가드 정합성 수정 및 GameBoard 콜백 안정화

### DIFF
--- a/scripts/ai/task-new.mjs
+++ b/scripts/ai/task-new.mjs
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 import fs from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'

--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -313,6 +313,13 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
     playersRef.current = players
 
     const isMockMode = IS_SOCKET_MOCK_ENABLED
+    const handleArrivalRef = useRef<
+      (
+        tileId: number,
+        onDone?: () => void,
+        eventPlayerId?: PlayerId | null
+      ) => void
+    >(() => {})
     const rollAnimationIntervalRef = useRef<number | null>(null)
     const rollAnimationTimeoutRef = useRef<number | null>(null)
     const freezeDiceRollValues = useCallback(() => {
@@ -407,14 +414,13 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
           return
         }
 
-        handleArrival(tileIndex, emitMockEndTurn, event.playerId ?? null)
+        handleArrivalRef.current(
+          tileIndex,
+          emitMockEndTurn,
+          event.playerId ?? null
+        )
       },
-      [
-        handleArrival,
-        emitMockEndTurn,
-        freezeDiceRollValues,
-        flashDiceRollAnimation,
-      ]
+      [emitMockEndTurn, freezeDiceRollValues, flashDiceRollAnimation]
     )
     const handleEventAnimation = useCallback(
       (kind: BoardEventAnimationKind) => {
@@ -1253,6 +1259,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
 
       advanceTurn(onDone)
     }
+    handleArrivalRef.current = handleArrival
 
     const byTile = useMemo(() => {
       const map: Record<number, PlayerState[]> = {}

--- a/src/components/game/controls/RollButton.tsx
+++ b/src/components/game/controls/RollButton.tsx
@@ -73,7 +73,7 @@ const RollControl: React.FC<RollControlProps> = ({ isMyTurn, onRoll }) => {
       <button
         onClick={onRoll}
         disabled={!isMyTurn}
-        className="group relative flex h-24 w-24 flex-col items-center justify-center gap-0.5 rounded-3xl bg-linear-to-br from-[#2B7FFF] to-[#4F39F6] border-4 border-[#BEDBFF] text-white shadow-[0_0_0_4px_rgba(255,255,255,0.5),0_20px_25px_-5px_rgba(142,197,255,0.5)] transition-all hover:translate-y-[-2px] hover:shadow-2xl active:translate-y-[2px] active:scale-95 disabled:grayscale disabled:opacity-50"
+        className="group relative flex h-24 w-24 flex-col items-center justify-center gap-0.5 rounded-3xl border-4 border-[#BEDBFF] bg-linear-to-br from-[#2B7FFF] to-[#4F39F6] text-white shadow-[0_0_0_4px_rgba(255,255,255,0.5),0_20px_25px_-5px_rgba(142,197,255,0.5)] transition-all hover:-translate-y-0.5 hover:shadow-2xl active:translate-y-0.5 active:scale-95 disabled:grayscale disabled:opacity-50"
       >
         <span className="text-3xl leading-none drop-shadow-md">🎲</span>
         <span className="text-[10px] font-black tracking-widest opacity-90 uppercase">

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -66,8 +66,8 @@ const GamePage: React.FC = () => {
   const location = useLocation()
   const locationState = location.state as GamePageLocationState | null
   const authSession = useAuthStore((state) => state.session)
+  const currentPlayerId = useGameStore((s) => s.currentPlayerId)
   const currentTurn = useGameStore((s) => s.currentTurn)
-  const phase = useGameStore((s) => s.phase)
   const messages = useGameStore((s) => s.messages)
   const storePlayers = useGameStore((s) => s.players)
   const storeTiles = useGameStore((s) => s.tiles)
@@ -108,12 +108,14 @@ const GamePage: React.FC = () => {
   const currentNickname =
     authSession?.nickname ??
     (USE_GAME_SOCKET_MOCK ? DEFAULT_MOCK_NICKNAME : 'Guest')
+  const effectiveCurrentTurn = currentPlayerId ?? currentTurn
   const normalizedCurrentTurn =
     USE_GAME_SOCKET_MOCK &&
-    (currentTurn === 'me' || currentTurn === DEFAULT_MOCK_PLAYER_ID) &&
+    (effectiveCurrentTurn === 'me' ||
+      effectiveCurrentTurn === DEFAULT_MOCK_PLAYER_ID) &&
     currentUserId
       ? currentUserId
-      : currentTurn
+      : effectiveCurrentTurn
 
   const boardPlayers = useMemo(
     () => mapStorePlayersToBoardPlayers(storePlayers),
@@ -130,9 +132,7 @@ const GamePage: React.FC = () => {
   const isMyTurnFromStore = useTurn(normalizedCurrentTurn, currentUserId)
   const isMyTurn = USE_GAME_SOCKET_MOCK
     ? ALLOW_ALL_MOCK_TURNS || boardCurPlayer === MOCK_LOCAL_PLAYER_INDEX
-    : normalizedCurrentTurn === null
-      ? true
-      : isMyTurnFromStore
+    : isMyTurnFromStore
   const isPromptTargetedToCurrentUser =
     prompt?.playerId == null ||
     (currentUserId != null && String(prompt.playerId) === String(currentUserId))
@@ -216,11 +216,12 @@ const GamePage: React.FC = () => {
 
   const maxMoney = Math.max(...boardPlayers.map((player) => player.money))
   const currentPlayerState = boardPlayers[boardCurPlayer]
-  const isCurrentPlayerBankrupt = currentPlayerState?.money <= 0
+  const isCurrentPlayerBankrupt =
+    currentPlayerState?.money <= 0 || currentPlayerState?.state === 'bankrupt'
   const isCurrentPlayerSkipped =
-    !USE_GAME_SOCKET_MOCK && phase === 'rolling'
-      ? false
-      : (currentPlayerState?.skipTurns ?? 0) > 0
+    (currentPlayerState?.skipTurns ?? 0) > 0 ||
+    currentPlayerState?.state === 'locked' ||
+    currentPlayerState?.state === 'island'
   const roomChatSenderOptions = useMemo(
     () =>
       storePlayers.map((player) => ({

--- a/src/pages/game/gameViewModel.test.ts
+++ b/src/pages/game/gameViewModel.test.ts
@@ -15,9 +15,11 @@ describe('game view model mapper', () => {
         position: 4,
         balance: 900,
         owned_tiles: [],
-        is_in_jail: false,
-        jail_turn_count: 0,
+        is_in_jail: true,
+        jail_turn_count: 2,
         is_bankrupt: false,
+        state: 'locked',
+        stateDuration: 2,
         color: '#111111',
       },
     ])
@@ -28,6 +30,9 @@ describe('game view model mapper', () => {
       pos: 4,
       money: 900,
       color: '#111111',
+      skipTurns: 2,
+      state: 'locked',
+      stateDuration: 2,
     })
     expect(boardPlayers).toHaveLength(1)
   })

--- a/src/pages/game/gameViewModel.ts
+++ b/src/pages/game/gameViewModel.ts
@@ -35,6 +35,8 @@ export const mapStorePlayersToBoardPlayers = (storePlayers: Player[]) =>
         pos: storePlayer.position,
         money: storePlayer.balance,
         skipTurns: storePlayer.jail_turn_count,
+        state: storePlayer.state ?? initialPlayer.state,
+        stateDuration: storePlayer.stateDuration ?? initialPlayer.stateDuration,
       }
     }
   )

--- a/src/stores/game.store.test.ts
+++ b/src/stores/game.store.test.ts
@@ -217,6 +217,30 @@ describe('game store partial updates', () => {
     expect(nextState.tiles[0]?.building).toBe(3)
   })
 
+  it('synchronizes currentTurn alias when currentPlayerId is patched', () => {
+    const store = useGameStore.getState()
+
+    store.setGameState({
+      revision: 1,
+      currentTurn: 'player-1',
+      currentPlayerId: 'player-1',
+      players: [
+        createPlayer({ id: 'player-1' }),
+        createPlayer({ id: 'player-2' }),
+      ],
+    })
+
+    store.applyPatchEnvelope({
+      revision: 2,
+      patch: [{ op: 'set', path: 'currentPlayerId', value: 'player-2' }],
+    })
+
+    const nextState = useGameStore.getState()
+
+    expect(nextState.currentPlayerId).toBe('player-2')
+    expect(nextState.currentTurn).toBe('player-2')
+  })
+
   it('tracks pending actions, acknowledgements, prompts, and queue consumption', () => {
     const store = useGameStore.getState()
     const prompt: GamePrompt = {

--- a/src/stores/game.store.ts
+++ b/src/stores/game.store.ts
@@ -65,14 +65,13 @@ const normalizeState = (state: Partial<GameState>): Partial<GameState> => {
   const normalizedState: Partial<GameState> = { ...state }
 
   if ('currentPlayerId' in state || 'currentTurn' in state) {
-    const currentPlayerId =
+    const canonicalCurrentPlayerId =
       state.currentPlayerId !== undefined
         ? state.currentPlayerId
         : (state.currentTurn ?? null)
 
-    normalizedState.currentPlayerId = currentPlayerId
-    normalizedState.currentTurn =
-      state.currentTurn !== undefined ? state.currentTurn : currentPlayerId
+    normalizedState.currentPlayerId = canonicalCurrentPlayerId
+    normalizedState.currentTurn = canonicalCurrentPlayerId
   }
 
   if ('tiles' in state) {


### PR DESCRIPTION
## 관련 이슈
- (연결할 이슈 번호 입력)

## 작업 배경
실서버 게임 진행 중 아래 문제가 재현되었습니다.

- 무인도(LOCKED/ISLAND 상태)에서도 주사위 버튼이 활성화되는 문제
- 이미 턴 종료 후에도 버튼이 활성화되어 `NOT_YOUR_TURN` ack가 반복되는 문제
- `currentPlayerId`와 `currentTurn` alias 불일치로 턴 판정이 흔들리는 문제
- `react-hooks/exhaustive-deps` 경고로 이벤트 소비 콜백 안정성이 떨어지는 문제
- pre-push 단계에서 `scripts/ai/task-new.test.ts`가 `SyntaxError: Invalid or unexpected token`으로 실패하는 문제
- RollButton 클래스 문자열 비정규 구문(`hover:translate-y-[-2px]` 등)으로 canonical class 제안 경고가 발생하는 문제

---

## 주요 변경 사항

### 1) 턴/무인도 주사위 버튼 가드 로직 수정
`src/pages/GamePage.tsx`

- 턴 판정 기준을 `currentPlayerId ?? currentTurn`으로 통일
- 실서버 모드에서 `normalizedCurrentTurn === null`일 때 `isMyTurn=true`로 열어주던 fallback 제거
- 무인도/잠금 상태(`state === 'locked' | 'island'`) 및 `skipTurns > 0`이면 주사위 버튼 비활성화
- 파산 판정에 `state === 'bankrupt'`도 포함

효과:
- 무인도/잠금 상태에서 주사위를 굴릴 수 없게 됨
- 내 턴이 아닐 때 버튼이 열려 `NOT_YOUR_TURN`이 반복되는 문제 완화

---

### 2) 스토어 턴 alias 동기화 보강
`src/stores/game.store.ts`

- `normalizeState`에서 `currentPlayerId`/`currentTurn` 처리 시 canonical 값을 하나로 강제
- 패치로 `currentPlayerId`만 들어와도 `currentTurn`이 동일하게 동기화되도록 수정

효과:
- 턴 관련 필드 간 불일치 제거
- UI 턴 판정의 일관성 개선

---

### 3) 보드 표시용 플레이어 상태 매핑 보강
`src/pages/game/gameViewModel.ts`

- `mapStorePlayersToBoardPlayers`에서 `state`, `stateDuration`을 보드 모델로 전달
- 기존 `skipTurns`만 반영하던 상태에서 서버 상태 기반 판정 신뢰도 향상

효과:
- 무인도/잠금 상태를 UI 레이어에서 정확히 판단 가능

---

### 4) GameBoard exhaustive-deps 경고 제거 및 이벤트 콜백 안정화
`src/components/board/GameBoard.tsx`

- `handleArrival` 직접 의존 대신 `handleArrivalRef.current(...)` 경유하도록 변경
- 렌더마다 생성되는 함수 참조로 인해 `useCallback`이 재생성되던 경고 제거
- `handleArrivalRef.current = handleArrival`로 최신 로직 동기화

효과:
- `react-hooks/exhaustive-deps` 경고 해소
- 이벤트 큐 소비 콜백의 참조 안정성 개선

---

### 5) RollButton 클래스 정리
`src/components/game/controls/RollButton.tsx`

- 비정규 클래스 문자열 정리
- `hover:translate-y-[-2px]` → `hover:-translate-y-0.5`
- `active:translate-y-[2px]` → `active:translate-y-0.5`
- 클래스 순서 정리로 canonical class 제안 경고 완화

---

### 6) AI 스크립트 테스트 문법 오류 해결
`scripts/ai/task-new.mjs`

- 파일 상단 shebang 제거(`#!/usr/bin/env node`)
- Vitest 환경에서 `scripts/ai/task-new.test.ts` 구문 오류를 유발하던 원인 제거

효과:
- pre-push의 `npm run test`/`npm run test:coverage` 단계에서 해당 테스트 안정 통과

---

## 테스트 및 검증

### 로컬 검증
- `npx vitest run src/stores/game.store.test.ts src/pages/game/gameViewModel.test.ts`
- `npx vitest run src/components/board/useBoardEventQueue.test.tsx src/components/board/gameBoardEventQueueUtils.test.ts`
- `npx vitest run scripts/ai/task-new.test.ts`
- `npm run lint`
- `npm run test`
- `npm run test:coverage`
- `npm run e2e:ci`
- `npm run build`

### 검증 결과
- lint: 통과
- unit/integration: 통과
- coverage: 통과
- e2e: 통과
- build: 통과

---

## 변경 파일
- `src/pages/GamePage.tsx`
- `src/stores/game.store.ts`
- `src/pages/game/gameViewModel.ts`
- `src/stores/game.store.test.ts`
- `src/pages/game/gameViewModel.test.ts`
- `src/components/board/GameBoard.tsx`
- `src/components/game/controls/RollButton.tsx`
- `scripts/ai/task-new.mjs`

---

## 체크리스트
- [x] 턴/무인도 상태에서 주사위 버튼 가드가 올바르게 동작한다.
- [x] `currentPlayerId`/`currentTurn` alias 불일치를 제거했다.
- [x] `react-hooks/exhaustive-deps` 경고를 제거했다.
- [x] `scripts/ai/task-new.test.ts` 문법 오류를 해결했다.
- [x] pre-push 파이프라인(lint/test/coverage/e2e/build) 전체 통과를 확인했다.

---

## 리뷰 시 중점 확인 포인트
- 실서버에서 턴 전환 직후 주사위 버튼 활성/비활성 타이밍
- 무인도 진입 상태(LOCKED/ISLAND)에서 버튼 비활성 일관성
- `game:patch`로 `currentPlayerId`만 오는 케이스에서 UI 턴 표시 정상 여부
- 이벤트 큐 소비 중 콜백 안정성(재구독/중복 소비 이슈 여부)
