### PR TITLE
fix: 게임 종료 시 결과 모달 자동 노출 연결

### DIFF
--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -70,7 +70,12 @@ import type {
 } from './gameBoard.types'
 import '../../styles/board.css'
 import { formatWon } from '../../lib/utils'
-import type { GamePrompt, PlayerId, ServerEvent } from '../../types/domain'
+import type {
+  GamePrompt,
+  GameResult,
+  PlayerId,
+  ServerEvent,
+} from '../../types/domain'
 import { playLongSfx, stopLongSfx } from '../../lib/bgm'
 import { IS_SOCKET_MOCK_ENABLED } from '../../config/env'
 import { emitGameAction } from '../../services/socket/game.handler'
@@ -229,6 +234,9 @@ interface GameBoardProps {
     price?: number
   }>
   localPlayerId?: string | number | null
+  gameResult?: GameResult | null
+  isGameOver?: boolean
+  winnerId?: PlayerId | null
 }
 
 function toBoardBuildingLevel(
@@ -289,6 +297,9 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       onPromptChoice,
       tiles = [],
       localPlayerId,
+      gameResult = null,
+      isGameOver = false,
+      winnerId = null,
     },
     ref
   ) => {
@@ -880,12 +891,22 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       open: false,
     })
 
-    function getPlayerResults() {
-      const results = playersRef.current.map((player, index) => {
+    useEffect(() => {
+      const shouldOpenGameResultModal = isGameOver || gameResult != null
+      if (shouldOpenGameResultModal) {
+        setGameResultModal((prev) => (prev.open ? prev : { open: true }))
+        return
+      }
+
+      setGameResultModal({ open: false })
+    }, [gameResult, isGameOver])
+
+    const getPlayerResults = useCallback(() => {
+      const results = players.map((player, index) => {
         let propertyValue = 0
         let cityCount = 0
 
-        Object.entries(tileOwnersRef.current).forEach(([tileId, owner]) => {
+        Object.entries(tileOwners).forEach(([tileId, owner]) => {
           if (String(owner.ownerId) !== String(player.id)) {
             return
           }
@@ -917,7 +938,58 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
         }
         return right.totalAsset - left.totalAsset
       })
-    }
+    }, [players, tileOwners])
+    const fallbackPlayerResults = useMemo(
+      () => getPlayerResults(),
+      [getPlayerResults]
+    )
+    const serverResultRows = useMemo(() => {
+      const rankings = gameResult?.rankings
+      if (!rankings || rankings.length === 0) {
+        return []
+      }
+
+      return [...rankings].sort((left, right) => left.rank - right.rank)
+    }, [gameResult])
+    const resultModalRows = useMemo(() => {
+      if (serverResultRows.length > 0) {
+        return serverResultRows.map((result) => ({
+          id: String(result.player_id),
+          nickname: result.nickname,
+          totalAssetText: formatWon(result.final_assets),
+          ownedCityCountText: '-',
+        }))
+      }
+
+      return fallbackPlayerResults.map((result) => ({
+        id: result.id,
+        nickname: result.nickname,
+        totalAssetText: formatWon(result.totalAsset),
+        ownedCityCountText: `${result.ownedCityCount}개`,
+      }))
+    }, [fallbackPlayerResults, serverResultRows])
+    const resultModalWinnerName = useMemo(() => {
+      if (serverResultRows.length > 0) {
+        const winnerByFlag = serverResultRows.find((result) => result.is_winner)
+        const winnerById =
+          winnerId == null
+            ? null
+            : serverResultRows.find(
+                (result) => String(result.player_id) === String(winnerId)
+              )
+        return (
+          winnerByFlag?.nickname ??
+          winnerById?.nickname ??
+          serverResultRows[0]?.nickname ??
+          '승리자'
+        )
+      }
+
+      return (
+        fallbackPlayerResults.find((result) => !result.isBankrupt)?.nickname ??
+        '승리자'
+      )
+    }, [fallbackPlayerResults, serverResultRows, winnerId])
 
     function handleBankruptConfirm() {
       const { onDoneCallback } = bankruptModal
@@ -1833,15 +1905,8 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
         />
         <GameResultModal
           open={gameResultModal.open}
-          winnerName={
-            getPlayerResults().find((r) => !r.isBankrupt)?.nickname ?? '승리자'
-          }
-          results={getPlayerResults().map((r) => ({
-            id: r.id,
-            nickname: r.nickname,
-            totalAssetText: formatWon(r.totalAsset),
-            ownedCityCountText: `${r.ownedCityCount}개`,
-          }))}
+          winnerName={resultModalWinnerName}
+          results={resultModalRows}
           onBackToLobby={() => {
             setGameResultModal({ open: false })
             window.location.href = '/' // Redirect to home/lobby

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -71,6 +71,9 @@ const GamePage: React.FC = () => {
   const messages = useGameStore((s) => s.messages)
   const storePlayers = useGameStore((s) => s.players)
   const storeTiles = useGameStore((s) => s.tiles)
+  const gameResult = useGameStore((s) => s.gameResult)
+  const isGameOver = useGameStore((s) => s.isGameOver)
+  const winnerId = useGameStore((s) => s.winnerId)
   const prompt = useGameStore((s) => s.prompt)
   const pendingAction = useGameStore((s) => s.pendingAction)
   const lastAck = useGameStore((s) => s.lastAck)
@@ -352,6 +355,9 @@ const GamePage: React.FC = () => {
               promptSubmittingChoice={promptSubmittingChoice}
               onPromptChoice={handlePromptChoice}
               localPlayerId={currentUserId}
+              gameResult={gameResult}
+              isGameOver={isGameOver}
+              winnerId={winnerId}
             />
           </div>
         </div>


### PR DESCRIPTION
## ✅ 관련 이슈
- (이슈 번호 입력)

---

## 📌 작업 개요
게임 종료 상태(`isGameOver`, `gameResult`, `winnerId`)가 store에 반영되어도
실제 UI에서 `GameResultModal`이 열리지 않던 문제를 수정했습니다.

기존에는 `GameResultModal` 컴포넌트가 렌더 트리에만 존재하고,
`open: true`로 전환되는 경로가 없어 게임 종료 후에도 결과 모달이 뜨지 않았습니다.

---

## 🎯 작업 목적
- 게임 종료 시점에 결과 모달이 **자동으로 노출**되도록 보장
- 서버가 제공하는 `gameResult.rankings`를 우선 사용해 결과 표시
- 서버 데이터가 없는 경우에도 기존 로컬 계산 결과로 fallback 표시 유지
- 기존 게임 진행 로직(프롬프트/턴/이벤트 큐)을 깨뜨리지 않는 최소 수정

---

## 🛠 변경 내용 상세

### 1) `src/pages/GamePage.tsx`
- `useGameStore`에서 아래 상태를 추가 구독:
  - `gameResult`
  - `isGameOver`
  - `winnerId`
- `BoardGame` 컴포넌트에 종료 상태 props 전달:
  - `gameResult={gameResult}`
  - `isGameOver={isGameOver}`
  - `winnerId={winnerId}`

목적:
- 종료 판단/결과 렌더링 책임을 보드 컴포넌트로 명확히 전달

---

### 2) `src/components/board/GameBoard.tsx`
- `GameBoardProps` 확장:
  - `gameResult?: GameResult | null`
  - `isGameOver?: boolean`
  - `winnerId?: PlayerId | null`
- 종료 감지 effect 추가:
  - `isGameOver || gameResult != null`이면 `GameResultModal` 자동 open
  - 종료 상태가 아니면 close
- 결과 데이터 계산 경로 정리:
  - 서버 `gameResult.rankings`가 있으면 서버 랭킹 우선 사용
  - 없으면 기존 `players + tileOwners` 기반 fallback 계산 사용
- 우승자 표시 로직 보강:
  - 우선순위: `is_winner` 플래그 → `winnerId` 매칭 → rank 1 → 기본값 `"승리자"`
- `GameResultModal` props를 실데이터 기반으로 교체:
  - `winnerName={resultModalWinnerName}`
  - `results={resultModalRows}`

목적:
- “모달이 열리지 않음” 문제를 해결하면서,
  서버 결과/로컬 fallback 모두 안전하게 지원

---

## 🔍 검증 내역
아래 검증을 로컬에서 수행했습니다.

- `npm run lint` ✅
- `npx vitest run src/components/board/gameBoardEventQueueUtils.test.ts src/components/board/gameBoardStoreBridge.test.ts src/components/board/gameBoardLocalEngine.test.ts` ✅ (19/19)
- `npm run build` ✅

추가로 pre-push 훅 기준 전체 검증 경로에서 푸시 완료 확인했습니다.

---

## 🧪 수동 확인 시나리오
1. 게임을 종료 상태로 진입시킨다 (`isGameOver=true` 또는 `gameResult` 수신)
2. 결과 모달이 자동으로 노출되는지 확인
3. 서버 `rankings`가 있는 경우 랭킹/우승자 표시가 서버
