### PR TITLE
refactor: PR Guard를 문서 근거 경고 중심으로 단순화

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -26,44 +26,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: npm
-
-      - run: npm ci
-
       - name: Collect changed files
         id: changed-files
         run: |
           git diff --name-only --diff-filter=ACMR \
             "${{ github.event.pull_request.base.sha }}" \
             "${{ github.event.pull_request.head.sha }}" > /tmp/changed-files.txt
-
-          count="$(wc -l < /tmp/changed-files.txt | tr -d ' ')"
-          echo "count=$count" >> "$GITHUB_OUTPUT"
-
-      - name: Run AI self review
-        if: steps.changed-files.outputs.count != '0'
-        run: |
-          mapfile -t changed_files < /tmp/changed-files.txt
-          node scripts/ai/self-review.mjs --files "${changed_files[@]}" > /tmp/ai-self-review.txt
-
-      - name: Write empty self review fallback
-        if: steps.changed-files.outputs.count == '0'
-        run: |
-          echo "No changed files detected for this pull request." > /tmp/ai-self-review.txt
-
-      - name: Run AI validation orchestration plan
-        if: steps.changed-files.outputs.count != '0'
-        run: |
-          mapfile -t changed_files < /tmp/changed-files.txt
-          node scripts/ai/validation-plan.mjs --files "${changed_files[@]}" > /tmp/ai-validation-plan.txt
-
-      - name: Write empty validation plan fallback
-        if: steps.changed-files.outputs.count == '0'
-        run: |
-          echo "No validation orchestration selected because there are no changed files." > /tmp/ai-validation-plan.txt
 
       - name: Upsert PR comment
         uses: actions/github-script@v7
@@ -72,7 +40,6 @@ jobs:
             const fs = require('node:fs')
 
             const marker = '<!-- ai-review -->'
-            const maxSectionLength = 24000
             const issueNumber = context.issue.number
             const { owner, repo } = context.repo
             const highRiskPrefixes = [
@@ -94,81 +61,12 @@ jobs:
               return fs.existsSync(path) ? fs.readFileSync(path, 'utf8').trim() : ''
             }
 
-            function truncate(value) {
-              if (value.length <= maxSectionLength) {
-                return value
-              }
-
-              return `${value.slice(0, maxSectionLength)}\n\n...truncated`
+            function startsWithAnyPrefix(file, prefixes) {
+              return prefixes.some((prefix) => file.startsWith(prefix))
             }
 
             function escapeRegExp(value) {
               return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-            }
-
-            function extractScriptSection(text, heading, nextHeadings = []) {
-              if (!text) {
-                return ''
-              }
-
-              const escapedHeading = escapeRegExp(heading)
-              const escapedNextHeadings = nextHeadings.map(escapeRegExp).join('|')
-              const boundary = escapedNextHeadings
-                ? `(?:\\n(?:${escapedNextHeadings})\\n|$)`
-                : '$'
-              const pattern = new RegExp(
-                `${escapedHeading}\\n([\\s\\S]*?)${boundary}`
-              )
-              const match = text.match(pattern)
-
-              return match?.[1]?.trim() ?? ''
-            }
-
-            function extractBulletLines(section) {
-              if (!section) {
-                return []
-              }
-
-              return section
-                .split('\n')
-                .map((line) => line.trim())
-                .filter((line) => line.startsWith('- '))
-            }
-
-            function formatBulletSection(lines, emptyFallback = '- none') {
-              if (!lines.length) {
-                return emptyFallback
-              }
-
-              return lines.join('\n')
-            }
-
-            function formatChangedFiles(files, maxItems = 8) {
-              if (!files.length) {
-                return '- none'
-              }
-
-              const visibleFiles = files
-                .slice(0, maxItems)
-                .map((file) => `- \`${file}\``)
-              const remainingCount = files.length - maxItems
-
-              if (remainingCount > 0) {
-                visibleFiles.push(`- ...and ${remainingCount} more`)
-              }
-
-              return visibleFiles.join('\n')
-            }
-
-            const selfReview = truncate(readFile('/tmp/ai-self-review.txt'))
-            const validationPlan = truncate(readFile('/tmp/ai-validation-plan.txt'))
-            const changedFiles = readFile('/tmp/changed-files.txt')
-            const changedFileArray = changedFiles
-              ? changedFiles.split('\n').filter(Boolean)
-              : []
-
-            function startsWithAnyPrefix(file, prefixes) {
-              return prefixes.some((prefix) => file.startsWith(prefix))
             }
 
             function extractSection(body, heading) {
@@ -341,52 +239,12 @@ jobs:
               )
             }
 
-            function hasCheckedRole(section, roleName) {
-              if (!section) {
-                return false
-              }
-
-              const rolePattern = new RegExp(`- \\[x\\] ${escapeRegExp(roleName)}\\b`)
-              return rolePattern.test(section)
-            }
-
-            function extractCommandMentions(section) {
-              if (!section) {
-                return new Set()
-              }
-
-              const commands = section
-                .split('\n')
-                .map((line) => line.trim())
-                .filter(Boolean)
-                .flatMap((line) => {
-                  const checkedQuotedMatch = line.match(
-                    /^- \[x\]\s+`([^`]+)`$/i
-                  )
-                  if (checkedQuotedMatch) {
-                    return [checkedQuotedMatch[1]]
-                  }
-
-                  if (/^- \[ \]\s+`[^`]+`$/.test(line)) {
-                    return []
-                  }
-
-                  const quotedMatches = [...line.matchAll(/`([^`]+)`/g)].map(
-                    (match) => match[1]
-                  )
-
-                  if (quotedMatches.length > 0) {
-                    return quotedMatches
-                  }
-
-                  const commandMatch = line.match(/^- (npm run .+)$/)
-                  return commandMatch ? [commandMatch[1]] : []
-                })
-
-              return new Set(commands)
-            }
-
             const pullRequestBody = context.payload.pull_request?.body ?? ''
+            const changedFiles = readFile('/tmp/changed-files.txt')
+            const changedFileArray = changedFiles
+              ? changedFiles.split('\n').filter(Boolean)
+              : []
+
             const taskSection = extractSection(
               pullRequestBody,
               '## 🧠 Task 문서 (큰 작업이면 필수)'
@@ -394,10 +252,6 @@ jobs:
             const manualSection = extractSection(
               pullRequestBody,
               '## 📚 참고한 기준 문서'
-            )
-            const roleSection = extractSection(
-              pullRequestBody,
-              '## 👥 역할 수행'
             )
             const validationSection = extractSection(
               pullRequestBody,
@@ -407,6 +261,7 @@ jobs:
               pullRequestBody,
               '## ⚠️ 남은 리스크'
             )
+
             const isLargeChange =
               changedFileArray.length >= largeChangeFileCountThreshold ||
               changedFileArray.some((file) =>
@@ -415,136 +270,47 @@ jobs:
             const hasTaskDocumentEvidence =
               hasTaskDocumentLinks(taskSection) ||
               hasTaskDocumentTripletInChangedFiles(changedFileArray)
-            const workflowWarnings = []
+            const warnings = []
 
             if (isLargeChange && !hasTaskDocumentEvidence) {
-              workflowWarnings.push(
-                `큰 변경으로 보이지만 task 문서 근거(plan/context/checklist)가 없습니다. PR 본문 Task 섹션 또는 changed files 안의 task 문서 3종 세트가 필요합니다. 기준: 파일 ${largeChangeFileCountThreshold}개 이상 또는 고위험 경로 변경.`
+              warnings.push(
+                `큰 변경으로 보이지만 task 문서 근거(plan/context/checklist)가 없습니다. 기준: 파일 ${largeChangeFileCountThreshold}개 이상 또는 고위험 경로 변경.`
               )
             }
-
-            if (!hasMeaningfulValidationContent(validationSection)) {
-              workflowWarnings.push(
-                '`실행한 검증` 섹션이 비어 있거나 기본 placeholder 상태입니다.'
-              )
-            }
-
-            if (!hasMeaningfulRiskContent(riskSection)) {
-              workflowWarnings.push(
-                '`남은 리스크` 섹션이 비어 있거나 기본 placeholder 상태입니다.'
-              )
-            }
-
-            const requiredValidationCommands = extractBulletLines(
-              extractScriptSection(validationPlan, 'Required checks:', [
-                'Suggested checks:',
-              ])
-            ).map((line) => line.replace(/^- /, ''))
-            const mentionedValidationCommands =
-              extractCommandMentions(validationSection)
 
             if (
               isLargeChange &&
               !hasRequiredManualEvidence(manualSection, changedFileArray)
             ) {
-              workflowWarnings.push(
+              warnings.push(
                 '고위험 변경으로 보이지만 참고한 기준 문서 섹션에 필요한 manual 근거가 없습니다.'
               )
             }
 
-            if (
-              isLargeChange &&
-              !['Planner', 'Reviewer', 'Tester'].every((role) =>
-                hasCheckedRole(roleSection, role)
-              )
-            ) {
-              workflowWarnings.push(
-                '큰 변경으로 보이지만 Planner / Reviewer / Tester 역할 수행 흔적이 충분하지 않습니다.'
+            if (!hasMeaningfulValidationContent(validationSection)) {
+              warnings.push(
+                '`실행한 검증` 섹션이 비어 있거나 기본 placeholder 상태입니다.'
               )
             }
 
-            if (hasMeaningfulValidationContent(validationSection)) {
-              const missingRequiredChecks = requiredValidationCommands.filter(
-                (command) => !mentionedValidationCommands.has(command)
+            if (!hasMeaningfulRiskContent(riskSection)) {
+              warnings.push(
+                '`남은 리스크` 섹션이 비어 있거나 기본 placeholder 상태입니다.'
               )
-
-              if (missingRequiredChecks.length > 0) {
-                workflowWarnings.push(
-                  `Required check 중 PR 본문 실행한 검증에 보이지 않는 항목이 있습니다: ${missingRequiredChecks.join(', ')}`
-                )
-              }
             }
 
-            const warningSection = workflowWarnings.length
-              ? workflowWarnings.map((warning) => `- ${warning}`).join('\n')
+            const warningSection = warnings.length
+              ? warnings.map((warning) => `- ${warning}`).join('\n')
               : '- none'
-            const validationRequired = formatBulletSection(
-              requiredValidationCommands.map((command) => `- ${command}`)
-            )
-            const validationSuggested = formatBulletSection(
-              extractBulletLines(
-                extractScriptSection(validationPlan, 'Suggested checks:')
-              )
-            )
-            const relevantManuals = formatBulletSection(
-              extractBulletLines(
-                extractScriptSection(selfReview, 'Relevant Manuals', [
-                  'Findings',
-                ])
-              )
-            )
-            const selfReviewFindings = formatBulletSection(
-              extractBulletLines(
-                extractScriptSection(selfReview, 'Findings', ['Test Gaps'])
-              )
-            )
-            const selfReviewTestGaps = formatBulletSection(
-              extractBulletLines(
-                extractScriptSection(selfReview, 'Test Gaps', ['Warnings'])
-              )
-            )
-            const selfReviewWarnings = formatBulletSection(
-              extractBulletLines(
-                extractScriptSection(selfReview, 'Warnings', [
-                  'Suggested Validation Commands',
-                ])
-              )
-            )
-            const changedFilesSection = `- Total: ${changedFileArray.length}\n${formatChangedFiles(
-              changedFileArray
-            )}`
 
             const body = `${marker}
-            ## 🤖 AI Review
+            ## 🛡️ PR Guard
 
-            이 코멘트는 PR 변경 파일 기준으로 자동 갱신됩니다.
-            기존 CI를 대체하지 않고, deterministic warning / validation 결과를 짧게 요약합니다.
-            생성형 PR summary와 code review는 Gemini Code Assist가 담당합니다.
+            이 코멘트는 PR 본문에서 빠진 근거를 확인하기 위한 경량 검수입니다.
+            코드 품질 검사는 CI가, 생성형 리뷰는 Gemini Code Assist가 담당합니다.
 
-            ### Changed Files
-            ${changedFilesSection}
-
-            ### Workflow Warnings
+            ### PR 경고
             ${warningSection}
-
-            ### Findings
-            ${selfReviewFindings}
-
-            ### Test Gaps
-            ${selfReviewTestGaps}
-
-            ### Required Checks
-            ${validationRequired}
-
-            ### Suggested Checks
-            ${validationSuggested}
-
-            ### Self Review Notes
-            Relevant manuals:
-            ${relevantManuals}
-
-            Review warnings:
-            ${selfReviewWarnings}
             `
 
             const comments = await github.paginate(github.rest.issues.listComments, {

--- a/docs/ai/tasks/ai-review-pr-guard-slimming/checklist.md
+++ b/docs/ai/tasks/ai-review-pr-guard-slimming/checklist.md
@@ -1,0 +1,19 @@
+# Checklist
+
+## Implementation
+
+- [x] 관련 manual과 기존 문서를 읽었다
+- [x] 영향 범위를 정리했다
+- [x] `AI Review` 코멘트를 warning 전용 PR Guard로 축소했다
+- [x] self-review / validation-plan / changed files / required checks / suggested checks 출력을 제거했다
+
+## Testing
+
+- [x] `npx prettier --check ...`
+- [x] workflow `github-script` 블록 문법 확인
+
+## Review
+
+- [x] CI / Gemini와 역할이 겹치지 않게 정리됐는지 확인했다
+- [x] warning이 task 문서 / 기준 문서 / 검증 / 리스크 누락에만 집중하는지 확인했다
+- [x] 변경 파일 / 실행한 검증 / 남은 리스크를 정리했다

--- a/docs/ai/tasks/ai-review-pr-guard-slimming/context.md
+++ b/docs/ai/tasks/ai-review-pr-guard-slimming/context.md
@@ -1,0 +1,30 @@
+# Context
+
+## Current Behavior
+
+- 현재 `AI Review`는 warning, findings, test gaps, required checks, suggested checks까지 같이 출력한다.
+- 하지만 실제 품질 게이트는 CI가 담당하고, 생성형 리뷰는 Gemini가 담당해 역할이 겹친다.
+- GitHub PR 화면에도 changed files는 이미 보이므로 코멘트 반복 가치가 낮다.
+
+## Relevant Manuals
+
+- `docs/ai/manuals/common.md`
+- `docs/rules.md`
+- `docs/testing.md`
+
+## Constraints
+
+- task 문서, 기준 문서, 검증, 리스크 누락 warning은 유지한다.
+- 큰 변경 판단 기준은 기존과 동일하게 유지한다.
+- 코멘트는 짧고 바로 읽히는 형태여야 한다.
+
+## Decision Notes
+
+- `AI Review`를 진짜 리뷰어처럼 보이게 하기보다, PR Guard로 역할을 축소하는 편이 더 정확하다.
+- CI가 이미 하는 검사를 코멘트에서 반복하지 않는다.
+- findings/test gaps는 지금 규칙 밀도가 낮아 노이즈 대비 가치가 적으므로 과감히 제거한다.
+
+## Open Risks
+
+- role 수행 흔적 warning도 함께 제거하므로, 역할 분리 강제력은 약해진다.
+- 나중에 deterministic finding 규칙이 충분히 쌓이면 다시 확장할 여지는 남는다.

--- a/docs/ai/tasks/ai-review-pr-guard-slimming/plan.md
+++ b/docs/ai/tasks/ai-review-pr-guard-slimming/plan.md
@@ -1,0 +1,34 @@
+# Plan
+
+## Task
+
+- 작업 이름: AI Review PR Guard Slimming
+- 요청 날짜: 2026-03-19
+- 담당 범위: `AI Review` 코멘트를 경량 PR Guard로 단순화
+
+## Goal
+
+- `AI Review`를 CI/Gemini와 겹치지 않는 경량 PR Guard 역할로 줄인다.
+- PR 본문에서 빠진 근거를 드러내는 warning만 남기고, 중복 섹션은 제거한다.
+
+## In Scope
+
+- `.github/workflows/ai-review.yml`
+- `docs/ai/tasks/ai-review-pr-guard-slimming/*`
+
+## Out Of Scope
+
+- Gemini 리뷰 동작 변경
+- CI 워크플로우 변경
+- branch protection 정책 변경
+
+## Completion Criteria
+
+- `AI Review` 코멘트는 `PR 경고`만 남긴다.
+- task 문서, 기준 문서, 실행한 검증, 남은 리스크 warning만 유지한다.
+- self-review / validation-plan / changed files / required checks / suggested checks 출력은 제거한다.
+
+## Test Plan
+
+- `npx prettier --check .github/workflows/ai-review.yml docs/ai/tasks/ai-review-pr-guard-slimming/plan.md docs/ai/tasks/ai-review-pr-guard-slimming/context.md docs/ai/tasks/ai-review-pr-guard-slimming/checklist.md`
+- workflow `github-script` 블록 문법 확인


### PR DESCRIPTION
## 📌 관련 이슈

> closes #486 

---

## 📝 작업 내용

> 기존 `AI Review` 코멘트는 changed files, 검증 추천, self-review 성격의 안내까지 함께 보여주면서
> CI와 역할이 겹치고, 실제 PR 화면에서는 신호보다 노이즈가 더 크게 느껴지는 문제가 있었습니다.
>
> 이번 작업에서는 이를 경량 `PR Guard`로 정리해, 코드 품질 검사는 CI와 Gemini에 맡기고
> PR 본문에서 빠진 문서·검증 근거만 드러내는 역할에 집중하도록 단순화했습니다.

### 1. PR Guard 코멘트 단순화

- PR 코멘트의 중심을 `PR 경고` 한 섹션으로 줄였습니다.
- `changed files`, `required/suggested checks`, `findings`, `test gaps`, `self-review` 성격의 출력은 제거했습니다.
- 코멘트는 `문서 근거 / 검증 근거 / 리스크 누락`만 짧게 드러내도록 정리했습니다.

### 2. 남긴 warning 기준

- 큰 변경인데 task 문서 근거(`plan.md / context.md / checklist.md`)가 없는 경우
- 큰 변경인데 `참고한 기준 문서` 섹션에 필요한 manual 근거가 없는 경우
- `실행한 검증` 섹션이 비어 있거나 기본 placeholder 상태인 경우
- `남은 리스크` 섹션이 비어 있거나 기본 placeholder 상태인 경우

### 3. 역할 재정리

- 코드 품질과 실제 통과 여부는 계속 CI가 담당합니다.
- 생성형 summary / code review는 Gemini가 담당합니다.
- 이번 workflow는 `AI Review`라기보다, PR에서 빠진 근거를 드러내는 경량 `PR Guard` 역할에 더 가깝도록 정리했습니다.

### 🧠 Task 문서

- `docs/ai/tasks/ai-review-pr-guard-slimming/plan.md`
- `docs/ai/tasks/ai-review-pr-guard-slimming/context.md`
- `docs/ai/tasks/ai-review-pr-guard-slimming/checklist.md`

### 🧪 실행한 검증

- `npx prettier --check .github/workflows/ai-review.yml docs/ai/tasks/ai-review-pr-guard-slimming/plan.md docs/ai/tasks/ai-review-pr-guard-slimming/context.md docs/ai/tasks/ai-review-pr-guard-slimming/checklist.md`
- workflow `github-script` 블록 문법 확인

### ⚠️ 남은 리스크

- 역할 수행 흔적 warning까지 같이 제거했기 때문에, 역할 분리 강제력은 이전보다 약해졌습니다.
- 향후 deterministic finding 규칙이 충분히 쌓이면 `주요 확인 사항` 같은 섹션을 다시 키울 여지는 있습니다.
- 실제 PR에서 코멘트 톤이 의도대로 더 읽히는지는 merge 전 몇 개 PR에서 추가 확인이 필요합니다.

---

## ✅ 체크리스트

- [x] CI와 중복되는 changed files / 검증 추천 출력 제거
- [x] task 문서 / 기준 문서 / 검증 / 리스크 누락 warning만 유지
- [x] PR 코멘트를 경량 PR Guard 형태로 단순화
- [x] 관련 task 문서 정리

---

## 📌 추가 메모

- 이번 작업은 생성형 리뷰를 강화하는 것이 아니라, PR 자동 코멘트의 역할을 더 정확하게 좁히는 리팩토링입니다.
- 코드 품질 자체는 계속 CI와 Gemini 리뷰가 중심이 되고, 이 workflow는 PR 근거 누락 확인에 집중합니다.
