### PR TITLE
fix: 로그아웃/offline 접속자 목록 반영 지연 수정

### DIFF
--- a/docs/ai/tasks/presence-logout-reflection-fix/checklist.md
+++ b/docs/ai/tasks/presence-logout-reflection-fix/checklist.md
@@ -1,0 +1,28 @@
+# Checklist
+
+## Implementation
+
+- [x] 관련 manual과 기존 문서를 읽었다
+- [x] 영향 범위를 정리했다
+- [x] 최소 범위로 구현했다
+- [x] mock/real 경로를 함께 확인했다
+- [x] 타입/contract 변경이 있으면 관련 코드도 같이 수정했다
+
+## Testing
+
+- [x] `npm run lint`
+- [x] `npm run ai:check:lobby`
+- [x] `npm run ai:check:waiting-room`
+- [ ] `npm run ai:check:chat-e2e`
+- [ ] `npm run ai:check:waiting-room-e2e`
+- [x] `npm run ai:check:build`
+
+## Review
+
+- [x] Planner 기준 정리 완료
+- [x] Implementer 범위 구현 완료
+- [x] Reviewer self-review 확인
+- [x] Tester 검증 실행
+- [x] `docs/rules.md` 기준으로 셀프 리뷰했다
+- [x] 리다이렉트, cleanup, 중복 구독, 에러 처리 경계를 확인했다
+- [x] 변경 파일 / 실행한 검증 / 남은 리스크를 정리했다

--- a/docs/ai/tasks/presence-logout-reflection-fix/context.md
+++ b/docs/ai/tasks/presence-logout-reflection-fix/context.md
@@ -1,0 +1,56 @@
+# Context
+
+## Current Behavior
+
+- `useOnlineUsersSocket`는 초기/재동기화 시 `/users/online` REST snapshot을 읽고, 이후 `online_users` 소켓 이벤트로 접속자 목록을 갱신한다.
+- 실서버는 전체 `online_users` 스냅샷 외에 `user_status_changed` 증분 이벤트도 보내며, 로그아웃/연결 종료 시 `status: offline`이 들어온다.
+- 현재 구현은 소켓 이벤트가 먼저 최신 목록을 반영해도, 이미 진행 중이던 이전 snapshot 응답이 늦게 돌아오면 그 오래된 결과가 다시 목록을 덮어쓸 수 있다.
+- 기존 프론트는 `user_status_changed`를 전혀 구독하지 않아, 상대 로그아웃은 새로고침 전까지 목록에서 빠지지 않았다.
+- 대기방은 `room.players`를 접속자 목록에 다시 합치고 있어, online snapshot에서 빠진 사용자를 stale room snapshot이 다시 되살릴 수 있다.
+
+## Related Files
+
+- `docs/ai/manuals/common.md`
+- `docs/rules.md`
+- `docs/testing.md`
+- `docs/ai/manuals/lobby.md`
+- `docs/ai/manuals/waiting-room.md`
+- `docs/socket-mock-server.md`
+- `src/features/presence/online-users/useOnlineUsersSocket.ts`
+- `src/features/presence/online-users/onlineUsersModel.ts`
+- `src/features/presence/online-users/api.ts`
+- `src/features/presence/online-users/useOnlineUsersSocket.test.tsx`
+- `src/features/presence/online-users/onlineUsersModel.test.ts`
+- `src/features/presence/online-users/api.test.ts`
+- `src/contracts/socket/events.ts`
+- `src/contracts/socket/schemas.ts`
+- `src/contracts/socket/schemas.test.ts`
+- `src/pages/waiting-room/page/WaitingRoomPage.tsx`
+- `src/pages/waiting-room/page/WaitingRoomPage.test.tsx`
+
+## Relevant Manuals
+
+- `docs/ai/manuals/common.md`
+- `docs/rules.md`
+- `docs/testing.md`
+- `docs/ai/manuals/lobby.md`
+- `docs/ai/manuals/waiting-room.md`
+- `docs/socket-mock-server.md`
+
+## Constraints
+
+- 접속자 목록의 source of truth는 `/users/online` + `online_users` + `user_status_changed` 조합으로 유지한다.
+- mock 모드와 real 모드의 visible behavior를 크게 벌리지 않는다.
+- current user는 접속자 목록에서 계속 보여야 한다.
+
+## Decision Notes
+
+- 실시간 `online_users` 이벤트를 받으면 pending snapshot 결과를 무효화해 오래된 REST 응답이 최신 socket 상태를 덮어쓰지 못하게 한다.
+- `user_status_changed`는 `offline`이면 제거, 그 외 상태면 upsert로 처리해 실서버 증분 이벤트를 바로 반영한다.
+- 대기방 user list는 online snapshot에 존재하는 유저만 room status로 보정하고, 현재 사용자만 별도로 보정한다.
+- stale room/player 문제를 프론트에서 광범위하게 덮기보다, 접속자 목록 merge 범위만 최소 수정한다.
+
+## Open Risks
+
+- backend가 room snapshot에서 로그아웃 유저를 늦게 정리하면 seat 카드와 user list가 일시적으로 다르게 보일 수 있다.
+- snapshot fallback을 더 공격적으로 줄이면 초기 로딩 중 유저 표시 정책이 달라질 수 있어 테스트로 확인이 필요하다.

--- a/docs/ai/tasks/presence-logout-reflection-fix/plan.md
+++ b/docs/ai/tasks/presence-logout-reflection-fix/plan.md
@@ -1,0 +1,69 @@
+# Plan
+
+## Task
+
+- 작업 이름: Presence Logout Reflection Fix
+- 요청 날짜: 2026-03-18
+- 담당 범위: 입력 파일 기준 초안 생성
+
+## Goal
+
+- 상대 사용자가 로그아웃하거나 연결이 끊겼을 때 로비/대기방 접속자 목록이 즉시 반영되도록 수정한다.
+- `online_users` 실시간 이벤트가 늦게 도착한 REST snapshot에 덮어써지지 않게 하고, 대기방은 stale `room.players`를 근거로 오프라인 사용자를 다시 추가하지 않게 한다.
+
+## In Scope
+
+- `src/features/presence/online-users/useOnlineUsersSocket.ts`
+- `src/features/presence/online-users/onlineUsersModel.ts`
+- `src/features/presence/online-users/api.ts`
+- `src/features/presence/online-users/useOnlineUsersSocket.test.tsx`
+- `src/features/presence/online-users/onlineUsersModel.test.ts`
+- `src/features/presence/online-users/api.test.ts`
+- `src/contracts/socket/events.ts`
+- `src/contracts/socket/schemas.ts`
+- `src/contracts/socket/schemas.test.ts`
+- `src/pages/waiting-room/page/WaitingRoomPage.tsx`
+- `src/pages/waiting-room/page/WaitingRoomPage.test.tsx`
+
+## Out Of Scope
+
+- backend의 room cleanup 정책 변경
+- DM 정책이나 unread 계산 방식 변경
+- waiting-room seat 카드 자체의 player snapshot 정합성 수정
+
+## Target Files
+
+- `src/features/presence/online-users/useOnlineUsersSocket.ts`
+- `src/features/presence/online-users/onlineUsersModel.ts`
+- `src/features/presence/online-users/api.ts`
+- `src/features/presence/online-users/useOnlineUsersSocket.test.tsx`
+- `src/features/presence/online-users/onlineUsersModel.test.ts`
+- `src/features/presence/online-users/api.test.ts`
+- `src/contracts/socket/events.ts`
+- `src/contracts/socket/schemas.ts`
+- `src/contracts/socket/schemas.test.ts`
+- `src/pages/waiting-room/page/WaitingRoomPage.tsx`
+- `src/pages/waiting-room/page/WaitingRoomPage.test.tsx`
+
+## Completion Criteria
+
+- 로비에서 `online_users` 이벤트로 빠진 사용자가 늦게 도착한 snapshot 때문에 다시 나타나지 않는다.
+- `user_status_changed`의 `offline` 이벤트가 들어오면 새로고침 없이 해당 사용자가 목록에서 바로 제거된다.
+- 대기방 접속자 목록은 online snapshot에 없는 room player를 다시 추가하지 않는다.
+- 관련 presence/waiting-room 테스트가 회귀 케이스를 포함해 통과한다.
+
+## Role Plan
+
+- Planner: 범위 / 완료 기준 / 참고 문서 정리
+- Implementer: 최소 범위 구현
+- Reviewer: diff / self-review / 위험 신호 확인
+- Tester: 검증 명령 실행과 결과 정리
+
+## Test Plan
+
+- `npm run lint`
+- `npm run ai:check:lobby`
+- `npm run ai:check:waiting-room`
+- `npm run ai:check:chat-e2e`
+- `npm run ai:check:waiting-room-e2e`
+- `npm run ai:check:build`

--- a/src/contracts/socket/events.ts
+++ b/src/contracts/socket/events.ts
@@ -1,6 +1,7 @@
 // 소켓 도메인 이벤트 이름을 단일 상수로 관리
 export const SOCKET_EVENTS = {
   onlineUsers: 'online_users',
+  userStatusChanged: 'user_status_changed',
   enterRoom: 'enter_room',
   leaveRoom: 'leave_room',
   sendChat: 'send_chat',
@@ -25,6 +26,7 @@ export type SocketEventName = (typeof SOCKET_EVENTS)[keyof typeof SOCKET_EVENTS]
 
 // 접속 상태 표현은 정의서 기준 값으로 고정
 export type ContractUserStatus = 'lobby' | 'in_room' | 'playing'
+export type ContractUserRealtimeStatus = ContractUserStatus | 'offline'
 
 // 접속자 목록 기본 모델
 export interface ContractOnlineUser {
@@ -35,6 +37,12 @@ export interface ContractOnlineUser {
 
 export interface OnlineUsersEventPayload {
   users: ContractOnlineUser[]
+}
+
+export interface UserStatusChangedEventPayload {
+  id: string | number
+  nickname: string
+  status: ContractUserRealtimeStatus
 }
 
 // 1:1 DM 이벤트 모델

--- a/src/contracts/socket/schemas.test.ts
+++ b/src/contracts/socket/schemas.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { gameStartEventSchema, validateSocketEventPayload } from './schemas'
+import {
+  gameStartEventSchema,
+  userStatusChangedEventSchema,
+  validateSocketEventPayload,
+} from './schemas'
 
 describe('socket schema validator', () => {
   it('유효한 payload는 success=true와 파싱 데이터를 반환한다', () => {
@@ -30,6 +34,24 @@ describe('socket schema validator', () => {
       expect(result.error.message).toBe('Socket payload validation failed')
       expect(typeof result.error.detail).toBe('string')
       expect(result.error.detail?.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('user_status_changed는 숫자 id와 offline 상태를 허용한다', () => {
+    const result = validateSocketEventPayload(userStatusChangedEventSchema, {
+      id: 196,
+      nickname: 'Guest_010fwimn',
+      status: 'offline',
+    })
+
+    expect(result.success).toBe(true)
+
+    if (result.success) {
+      expect(result.data).toEqual({
+        id: 196,
+        nickname: 'Guest_010fwimn',
+        status: 'offline',
+      })
     }
   })
 })

--- a/src/contracts/socket/schemas.ts
+++ b/src/contracts/socket/schemas.ts
@@ -3,6 +3,12 @@ import { SOCKET_EVENTS } from './events'
 
 // 사용자 상태 enum을 계약 스키마로 고정
 export const contractUserStatusSchema = z.enum(['lobby', 'in_room', 'playing'])
+export const contractUserRealtimeStatusSchema = z.enum([
+  'lobby',
+  'in_room',
+  'playing',
+  'offline',
+])
 
 export const contractOnlineUserSchema = z.object({
   id: z.string().min(1),
@@ -12,6 +18,12 @@ export const contractOnlineUserSchema = z.object({
 
 export const onlineUsersEventSchema = z.object({
   users: z.array(contractOnlineUserSchema),
+})
+
+export const userStatusChangedEventSchema = z.object({
+  id: z.union([z.string().min(1), z.number()]),
+  nickname: z.string().min(1),
+  status: contractUserRealtimeStatusSchema,
 })
 
 export const directMessageSendEventSchema = z.object({
@@ -75,6 +87,7 @@ export const gameStartEventSchema = z.object({
 
 export const eventPayloadSchemas = {
   [SOCKET_EVENTS.onlineUsers]: onlineUsersEventSchema,
+  [SOCKET_EVENTS.userStatusChanged]: userStatusChangedEventSchema,
   [SOCKET_EVENTS.enterRoom]: enterRoomEventSchema,
   [SOCKET_EVENTS.leaveRoom]: leaveRoomEventSchema,
   [SOCKET_EVENTS.sendChat]: sendChatEventSchema,

--- a/src/features/presence/online-users/api.test.ts
+++ b/src/features/presence/online-users/api.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { normalizeOnlineUsersPayload } from './api'
+import {
+  normalizeOnlineUserStatusChangedPayload,
+  normalizeOnlineUsersPayload,
+} from './api'
 
 describe('normalizeOnlineUsersPayload', () => {
   it('숫자 id를 문자열로 정규화하고 nickname 공백을 제거한다', () => {
@@ -47,5 +50,31 @@ describe('normalizeOnlineUsersPayload', () => {
         status: 'playing',
       },
     ])
+  })
+})
+
+describe('normalizeOnlineUserStatusChangedPayload', () => {
+  it('숫자 id와 offline 상태를 정규화한다', () => {
+    expect(
+      normalizeOnlineUserStatusChangedPayload({
+        id: 7,
+        nickname: '  로그아웃유저 ',
+        status: 'offline',
+      })
+    ).toEqual({
+      id: '7',
+      nickname: '로그아웃유저',
+      status: 'offline',
+    })
+  })
+
+  it('지원하지 않는 상태나 잘못된 payload는 null을 반환한다', () => {
+    expect(
+      normalizeOnlineUserStatusChangedPayload({
+        id: 9,
+        nickname: '이상유저',
+        status: 'online',
+      })
+    ).toBeNull()
   })
 })

--- a/src/features/presence/online-users/api.ts
+++ b/src/features/presence/online-users/api.ts
@@ -1,5 +1,10 @@
 import { apiClient } from '../../../lib/axios'
-import type { OnlineUserPayload, OnlineUserStatus } from '../types'
+import type {
+  OnlineUserPayload,
+  OnlineUserRealtimeStatus,
+  OnlineUserStatus,
+  OnlineUserStatusChangedEventPayload,
+} from '../types'
 
 // 접속자 목록 초기 스냅샷 응답 타입
 interface OnlineUsersResponsePayload {
@@ -11,6 +16,10 @@ const ONLINE_USER_STATUS_VALUES: OnlineUserStatus[] = [
   'lobby',
   'in_room',
   'playing',
+]
+const ONLINE_USER_REALTIME_STATUS_VALUES: OnlineUserRealtimeStatus[] = [
+  ...ONLINE_USER_STATUS_VALUES,
+  'offline',
 ]
 
 function toRecord(value: unknown): UnknownRecord | null {
@@ -30,6 +39,21 @@ function normalizeOnlineUserStatus(value: unknown): OnlineUserStatus | null {
   }
 
   return value as OnlineUserStatus
+}
+
+function normalizeOnlineUserRealtimeStatus(
+  value: unknown
+): OnlineUserRealtimeStatus | null {
+  if (
+    typeof value !== 'string' ||
+    !ONLINE_USER_REALTIME_STATUS_VALUES.includes(
+      value as OnlineUserRealtimeStatus
+    )
+  ) {
+    return null
+  }
+
+  return value as OnlineUserRealtimeStatus
 }
 
 function normalizeOnlineUserPayload(value: unknown): OnlineUserPayload | null {
@@ -67,6 +91,34 @@ export function normalizeOnlineUsersPayload(payloadUsers: unknown) {
     const normalizedUser = normalizeOnlineUserPayload(user)
     return normalizedUser ? [normalizedUser] : []
   })
+}
+
+export function normalizeOnlineUserStatusChangedPayload(
+  payload: unknown
+): OnlineUserStatusChangedEventPayload | null {
+  const record = toRecord(payload)
+  if (!record) {
+    return null
+  }
+
+  const id = record.id
+  const nickname = record.nickname
+  const status = normalizeOnlineUserRealtimeStatus(record.status)
+
+  if (
+    (typeof id !== 'string' && typeof id !== 'number') ||
+    typeof nickname !== 'string' ||
+    nickname.trim().length === 0 ||
+    !status
+  ) {
+    return null
+  }
+
+  return {
+    id: String(id),
+    nickname: nickname.trim(),
+    status,
+  }
 }
 
 // 전체 온라인 유저 목록 초기 스냅샷 조회

--- a/src/features/presence/online-users/onlineUsersModel.test.ts
+++ b/src/features/presence/online-users/onlineUsersModel.test.ts
@@ -122,4 +122,48 @@ describe('mergeOnlineUsersWithRoomPlayers', () => {
       })
     )
   })
+
+  it('online snapshot에 없는 room player는 기본값으로 다시 추가하지 않는다', () => {
+    const merged = mergeOnlineUsersWithRoomPlayers(
+      [
+        createOnlineUserFixture({
+          id: 'user-1',
+          nickname: '테스터',
+          status: 'lobby',
+        }),
+      ],
+      [
+        {
+          id: 'user-2',
+          nickname: '상대방',
+        },
+      ],
+      'in_room'
+    )
+
+    expect(merged).toHaveLength(1)
+    expect(merged.find((user) => user.id === 'user-2')).toBeUndefined()
+  })
+
+  it('옵션을 주면 snapshot에 없는 room player도 fallback으로 포함할 수 있다', () => {
+    const merged = mergeOnlineUsersWithRoomPlayers(
+      [],
+      [
+        {
+          id: 'user-2',
+          nickname: '상대방',
+        },
+      ],
+      'in_room',
+      { includeMissingPlayers: true }
+    )
+
+    expect(merged).toContainEqual(
+      expect.objectContaining({
+        id: 'user-2',
+        nickname: '상대방',
+        status: 'in_room',
+      })
+    )
+  })
 })

--- a/src/features/presence/online-users/onlineUsersModel.ts
+++ b/src/features/presence/online-users/onlineUsersModel.ts
@@ -22,6 +22,10 @@ function createOnlineUserViewModel(user: OnlineUserPayload): OnlineUser {
   }
 }
 
+interface MergeOnlineUsersWithRoomPlayersOptions {
+  includeMissingPlayers?: boolean
+}
+
 // 접속자 payload를 UI 전용 접속자 모델로 매핑
 export function mapOnlineUsersToViewModel(
   payloadUsers: OnlineUserPayload[]
@@ -54,20 +58,30 @@ export function mergeOnlineUsersWithCurrentUser(
   return Array.from(usersById.values())
 }
 
-// room.players를 기준으로 현재 방 참가자의 상태를 접속자 목록에 반영한다
+// room.players를 기준으로 현재 방 참가자의 상태를 접속자 목록에 반영한다.
+// source of truth는 여전히 online snapshot이며, 명시적으로 허용한 경우에만
+// snapshot에 없는 room player를 목록에 추가한다.
 export function mergeOnlineUsersWithRoomPlayers(
   users: OnlineUser[],
   players: Array<{
     id: string
     nickname: string
   }>,
-  status: Extract<OnlineUserPayload['status'], 'in_room' | 'playing'>
+  status: Extract<OnlineUserPayload['status'], 'in_room' | 'playing'>,
+  options: MergeOnlineUsersWithRoomPlayersOptions = {}
 ) {
+  const { includeMissingPlayers = false } = options
   const usersById = new Map<string, OnlineUser>(
     users.map((user) => [user.id, user])
   )
 
   players.forEach((player) => {
+    const existingUser = usersById.get(player.id)
+
+    if (!existingUser && !includeMissingPlayers) {
+      return
+    }
+
     usersById.set(
       player.id,
       createOnlineUserViewModel({

--- a/src/features/presence/online-users/onlineUsersSocket.ts
+++ b/src/features/presence/online-users/onlineUsersSocket.ts
@@ -8,6 +8,7 @@ import type { OnlineUserPayload, OnlineUsersEventPayload } from '../types'
 
 // 접속자 목록 소켓 이벤트 이름
 export const ONLINE_USERS_EVENT_NAME = 'online_users'
+export const ONLINE_USER_STATUS_CHANGED_EVENT_NAME = 'user_status_changed'
 export const ONLINE_USERS_REFRESH_REQUEST_EVENT_NAME =
   'online-users-refresh-request'
 const SOCKET_MOCK_INTERVAL_MS = 5_000

--- a/src/features/presence/online-users/useOnlineUsersSocket.test.tsx
+++ b/src/features/presence/online-users/useOnlineUsersSocket.test.tsx
@@ -13,21 +13,25 @@ const {
   socketOffMock,
   getOnlineUsersSnapshotMock,
   normalizeOnlineUsersPayloadMock,
+  normalizeOnlineUserStatusChangedPayloadMock,
   isOnlineUsersSocketMockModeMock,
   startOnlineUsersMockBroadcastMock,
   stopMockBroadcastMock,
   ensureOnlineUsersSocketConnectionMock,
   onlineUsersRefreshRequestEventName,
+  onlineUserStatusChangedEventName,
 } = vi.hoisted(() => ({
   socketOnMock: vi.fn(),
   socketOffMock: vi.fn(),
   getOnlineUsersSnapshotMock: vi.fn(),
   normalizeOnlineUsersPayloadMock: vi.fn((users) => users),
+  normalizeOnlineUserStatusChangedPayloadMock: vi.fn((payload) => payload),
   isOnlineUsersSocketMockModeMock: vi.fn(),
   startOnlineUsersMockBroadcastMock: vi.fn(),
   stopMockBroadcastMock: vi.fn(),
   ensureOnlineUsersSocketConnectionMock: vi.fn(),
   onlineUsersRefreshRequestEventName: 'online-users-refresh-request',
+  onlineUserStatusChangedEventName: 'user_status_changed',
 }))
 
 vi.mock('../../../lib/socket', () => ({
@@ -40,10 +44,13 @@ vi.mock('../../../lib/socket', () => ({
 vi.mock('./api', () => ({
   getOnlineUsersSnapshot: getOnlineUsersSnapshotMock,
   normalizeOnlineUsersPayload: normalizeOnlineUsersPayloadMock,
+  normalizeOnlineUserStatusChangedPayload:
+    normalizeOnlineUserStatusChangedPayloadMock,
 }))
 
 vi.mock('./onlineUsersSocket', () => ({
   ONLINE_USERS_EVENT_NAME: 'online_users',
+  ONLINE_USER_STATUS_CHANGED_EVENT_NAME: onlineUserStatusChangedEventName,
   ONLINE_USERS_REFRESH_REQUEST_EVENT_NAME: onlineUsersRefreshRequestEventName,
   isOnlineUsersSocketMockMode: isOnlineUsersSocketMockModeMock,
   startOnlineUsersMockBroadcast: startOnlineUsersMockBroadcastMock,
@@ -64,6 +71,34 @@ describe('useOnlineUsersSocket', () => {
             nickname: user.nickname.trim(),
           }))
         : []
+    )
+    normalizeOnlineUserStatusChangedPayloadMock.mockImplementation(
+      (payload) => {
+        if (!payload || typeof payload !== 'object') {
+          return null
+        }
+
+        const normalizedPayload = payload as {
+          id?: unknown
+          nickname?: unknown
+          status?: unknown
+        }
+
+        if (
+          (typeof normalizedPayload.id !== 'string' &&
+            typeof normalizedPayload.id !== 'number') ||
+          typeof normalizedPayload.nickname !== 'string' ||
+          typeof normalizedPayload.status !== 'string'
+        ) {
+          return null
+        }
+
+        return {
+          id: String(normalizedPayload.id),
+          nickname: normalizedPayload.nickname.trim(),
+          status: normalizedPayload.status,
+        }
+      }
     )
     startOnlineUsersMockBroadcastMock.mockReturnValue(stopMockBroadcastMock)
   })
@@ -125,6 +160,91 @@ describe('useOnlineUsersSocket', () => {
       nickname: 'alpha',
       status: 'in_room',
       avatarText: 'A',
+    })
+  })
+
+  it('실시간 online_users 이벤트 이후 늦게 도착한 snapshot 응답은 최신 목록을 덮어쓰지 않는다', async () => {
+    let resolveSnapshot: ((users: unknown[]) => void) | null = null
+
+    getOnlineUsersSnapshotMock.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveSnapshot = resolve
+      })
+    )
+
+    const { result } = renderHook(() => useOnlineUsersSocket())
+
+    act(() => {
+      emitSocketEvent(socketOnMock, 'online_users', {
+        users: [
+          {
+            id: 'user-live',
+            nickname: '실시간유저',
+            status: 'lobby',
+          },
+        ],
+      })
+    })
+
+    expect(result.current.data).toHaveLength(1)
+    expect(result.current.data[0]).toMatchObject({
+      id: 'user-live',
+      nickname: '실시간유저',
+      status: 'lobby',
+    })
+
+    await act(async () => {
+      resolveSnapshot?.([
+        createOnlineUserPayloadFixture({
+          id: 'user-stale',
+          nickname: '오래된유저',
+          status: 'in_room',
+        }),
+      ])
+      await Promise.resolve()
+    })
+
+    expect(result.current.data).toHaveLength(1)
+    expect(result.current.data[0]).toMatchObject({
+      id: 'user-live',
+      nickname: '실시간유저',
+      status: 'lobby',
+    })
+  })
+
+  it('user_status_changed offline 이벤트 수신 시 해당 사용자를 목록에서 제거한다', async () => {
+    getOnlineUsersSnapshotMock.mockResolvedValue([
+      createOnlineUserPayloadFixture({
+        id: '1',
+        nickname: '남아있는유저',
+        status: 'lobby',
+      }),
+      createOnlineUserPayloadFixture({
+        id: '2',
+        nickname: '로그아웃유저',
+        status: 'in_room',
+      }),
+    ])
+
+    const { result } = renderHook(() => useOnlineUsersSocket())
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    act(() => {
+      emitSocketEvent(socketOnMock, onlineUserStatusChangedEventName, {
+        id: 2,
+        nickname: '로그아웃유저',
+        status: 'offline',
+      })
+    })
+
+    expect(result.current.data).toHaveLength(1)
+    expect(result.current.data[0]).toMatchObject({
+      id: '1',
+      nickname: '남아있는유저',
+      status: 'lobby',
     })
   })
 
@@ -244,6 +364,10 @@ describe('useOnlineUsersSocket', () => {
     expect(stopMockBroadcastMock).toHaveBeenCalledTimes(1)
     expect(socketOffMock).toHaveBeenCalledWith(
       'online_users',
+      expect.any(Function)
+    )
+    expect(socketOffMock).toHaveBeenCalledWith(
+      onlineUserStatusChangedEventName,
       expect.any(Function)
     )
   })

--- a/src/features/presence/online-users/useOnlineUsersSocket.ts
+++ b/src/features/presence/online-users/useOnlineUsersSocket.ts
@@ -1,15 +1,28 @@
 import { useEffect, useState } from 'react'
 import { socket } from '../../../lib/socket'
-import { getOnlineUsersSnapshot, normalizeOnlineUsersPayload } from './api'
-import { mapOnlineUsersToViewModel } from './onlineUsersModel'
+import {
+  getOnlineUsersSnapshot,
+  normalizeOnlineUserStatusChangedPayload,
+  normalizeOnlineUsersPayload,
+} from './api'
+import {
+  getOnlineUserAvatarBackground,
+  getOnlineUserAvatarText,
+  mapOnlineUsersToViewModel,
+} from './onlineUsersModel'
 import {
   ensureOnlineUsersSocketConnection,
+  ONLINE_USER_STATUS_CHANGED_EVENT_NAME,
   isOnlineUsersSocketMockMode,
   ONLINE_USERS_EVENT_NAME,
   ONLINE_USERS_REFRESH_REQUEST_EVENT_NAME,
   startOnlineUsersMockBroadcast,
 } from './onlineUsersSocket'
-import type { OnlineUser, OnlineUsersEventPayload } from '../types'
+import type {
+  OnlineUser,
+  OnlineUsersEventPayload,
+  OnlineUserStatusChangedEventPayload,
+} from '../types'
 
 interface OnlineUsersSyncState {
   latestSnapshotRequestId: number
@@ -34,6 +47,10 @@ function createOnlineUsersSyncState(): OnlineUsersSyncState {
 function startSnapshotRequest(syncState: OnlineUsersSyncState) {
   syncState.latestSnapshotRequestId += 1
   return syncState.latestSnapshotRequestId
+}
+
+function invalidatePendingSnapshotResults(syncState: OnlineUsersSyncState) {
+  syncState.latestSnapshotRequestId += 1
 }
 
 function isStaleSnapshotResult(
@@ -62,6 +79,35 @@ function mapOnlineUsersEventPayloadToViewModel(
   return mapOnlineUsersToViewModel(
     normalizeOnlineUsersPayload(readOnlineUsersEventPayloadUsers(payload))
   )
+}
+
+function applyOnlineUserStatusChangedEvent(
+  previousUsers: OnlineUser[],
+  payload: OnlineUserStatusChangedEventPayload | unknown
+) {
+  const normalizedPayload = normalizeOnlineUserStatusChangedPayload(payload)
+
+  if (!normalizedPayload) {
+    return previousUsers
+  }
+
+  if (normalizedPayload.status === 'offline') {
+    return previousUsers.filter((user) => user.id !== normalizedPayload.id)
+  }
+
+  const nextUsersById = new Map<string, OnlineUser>(
+    previousUsers.map((user) => [user.id, user])
+  )
+
+  nextUsersById.set(normalizedPayload.id, {
+    id: normalizedPayload.id,
+    nickname: normalizedPayload.nickname,
+    status: normalizedPayload.status,
+    avatarText: getOnlineUserAvatarText(normalizedPayload.nickname),
+    avatarBackground: getOnlineUserAvatarBackground(normalizedPayload.id),
+  })
+
+  return Array.from(nextUsersById.values())
 }
 
 function applyReconnectPendingState(
@@ -104,6 +150,18 @@ export function useOnlineUsersSocket() {
       )
     }
 
+    const updateUsers = (
+      updater: (previousUsers: OnlineUser[]) => OnlineUser[]
+    ) => {
+      setUsers((previousUsers) => {
+        const nextUsers = updater(previousUsers)
+        syncState.latestUsersCount = nextUsers.length
+        return nextUsers
+      })
+      setIsLoading(false)
+      setIsError(false)
+    }
+
     async function syncOnlineUsersSnapshot() {
       const requestId = startSnapshotRequest(syncState)
 
@@ -130,7 +188,23 @@ export function useOnlineUsersSocket() {
         return
       }
 
+      // 실시간 이벤트를 먼저 반영했으면, 이미 진행 중이던 이전 snapshot 응답이
+      // 늦게 도착해도 최신 접속자 목록을 다시 덮어쓰지 못하게 막는다.
+      invalidatePendingSnapshotResults(syncState)
       applyNextUsers(mapOnlineUsersEventPayloadToViewModel(payload))
+    }
+
+    const handleUserStatusChanged = (
+      payload: OnlineUserStatusChangedEventPayload | unknown
+    ) => {
+      if (!isActive) {
+        return
+      }
+
+      invalidatePendingSnapshotResults(syncState)
+      updateUsers((previousUsers) =>
+        applyOnlineUserStatusChangedEvent(previousUsers, payload)
+      )
     }
 
     // 새로고침/재인증 경계의 connect_error는 일시 상태일 수 있어 즉시 hard error로 노출하지 않는다.
@@ -170,6 +244,7 @@ export function useOnlineUsersSocket() {
     }
 
     socket.on(ONLINE_USERS_EVENT_NAME, handleOnlineUsers)
+    socket.on(ONLINE_USER_STATUS_CHANGED_EVENT_NAME, handleUserStatusChanged)
 
     let stopMockBroadcast = () => {
       // no-op
@@ -198,6 +273,7 @@ export function useOnlineUsersSocket() {
     return () => {
       isActive = false
       socket.off(ONLINE_USERS_EVENT_NAME, handleOnlineUsers)
+      socket.off(ONLINE_USER_STATUS_CHANGED_EVENT_NAME, handleUserStatusChanged)
       socket.off('connect', handleConnect)
       socket.off('connect_error', handleConnectError)
       socket.off('disconnect', handleDisconnect)

--- a/src/features/presence/types.ts
+++ b/src/features/presence/types.ts
@@ -1,5 +1,6 @@
 // 접속자 상태 값 타입
 export type OnlineUserStatus = 'lobby' | 'in_room' | 'playing'
+export type OnlineUserRealtimeStatus = OnlineUserStatus | 'offline'
 
 // 서버에서 내려주는 접속자 payload 타입
 export interface OnlineUserPayload {
@@ -11,6 +12,13 @@ export interface OnlineUserPayload {
 // 접속자 목록 소켓 이벤트 payload 타입
 export interface OnlineUsersEventPayload {
   users: OnlineUserPayload[]
+}
+
+// 접속자 상태 변경 소켓 이벤트 payload 타입
+export interface OnlineUserStatusChangedEventPayload {
+  id: string
+  nickname: string
+  status: OnlineUserRealtimeStatus
 }
 
 // UI 렌더링용 아바타 필드를 포함한 접속자 모델

--- a/src/pages/waiting-room/page/WaitingRoomPage.test.tsx
+++ b/src/pages/waiting-room/page/WaitingRoomPage.test.tsx
@@ -1,4 +1,4 @@
-import { act, screen, waitFor } from '@testing-library/react'
+import { act, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { MemoryRouterProps } from 'react-router-dom'
 import { Route, Routes } from 'react-router-dom'
@@ -414,6 +414,32 @@ describe('WaitingRoomPage interaction', () => {
     await waitFor(() => {
       expect(screen.getAllByText('대기방')).toHaveLength(2)
     })
+  })
+
+  it('online snapshot에 없는 room player는 접속자 목록에 다시 추가하지 않는다', async () => {
+    useOnlineUsersSocketMock.mockReturnValue({
+      data: [
+        {
+          id: 'user-1',
+          nickname: '테스터',
+          status: 'lobby',
+          avatarText: '테',
+          avatarBackground: '#ef4444',
+        },
+      ],
+      isLoading: false,
+      isError: false,
+    })
+
+    renderWaitingRoomPage()
+
+    const userListPanel = screen.getByText('접속자 목록').closest('aside')
+
+    expect(userListPanel).not.toBeNull()
+    expect(within(userListPanel as HTMLElement).getByText('1명')).toBeVisible()
+    expect(
+      within(userListPanel as HTMLElement).queryByText('상대방')
+    ).not.toBeInTheDocument()
   })
 
   it('초기 진입(POP)에서는 location.state의 preJoinedSnapshot을 재사용하지 않는다', () => {

--- a/src/pages/waiting-room/page/WaitingRoomPage.tsx
+++ b/src/pages/waiting-room/page/WaitingRoomPage.tsx
@@ -22,7 +22,10 @@ import { DirectMessagePanel } from '../../../features/presence/components/Direct
 import { UserListPanel } from '../../../features/presence/components/UserListPanel'
 import { useDirectMessageController } from '../../../features/presence/direct-message/useDirectMessageController'
 import { removeMockOnlineUser } from '../../../features/presence/mock/mockData'
-import { mergeOnlineUsersWithRoomPlayers } from '../../../features/presence/online-users/onlineUsersModel'
+import {
+  mergeOnlineUsersWithCurrentUser,
+  mergeOnlineUsersWithRoomPlayers,
+} from '../../../features/presence/online-users/onlineUsersModel'
 import { useOnlineUsersSocket } from '../../../features/presence/online-users/useOnlineUsersSocket'
 import { cn } from '../../../lib/utils'
 import { disconnectSocketAndClearAuth } from '../../../lib/socket'
@@ -124,16 +127,23 @@ function WaitingRoomPage() {
   } = useOnlineUsersSocket()
 
   const waitingRoomUsers = useMemo(() => {
-    if (!room) {
+    if (!room || !session) {
       return users
     }
 
-    return mergeOnlineUsersWithRoomPlayers(
+    const roomStatus = room.status === 'playing' ? 'playing' : 'in_room'
+    const mergedUsers = mergeOnlineUsersWithRoomPlayers(
       users,
       room.players,
-      room.status === 'playing' ? 'playing' : 'in_room'
+      roomStatus
     )
-  }, [room, users])
+
+    return mergeOnlineUsersWithCurrentUser(mergedUsers, {
+      id: session.userId,
+      nickname: session.nickname,
+      status: roomStatus,
+    })
+  }, [room, session, users])
 
   const {
     dmTargetUser,


### PR DESCRIPTION
## 📌 관련 이슈

> closes #488

---

## 📝 작업 내용

> 로그아웃 또는 연결 종료 시 소켓에서는 `user_status_changed` 이벤트가 들어오지만,
> 로비/대기방 접속자 목록에는 즉시 반영되지 않고 새로고침 후에야 사라지는 문제가 있었습니다.
> 이번 수정에서는 실서버 계약에 맞춰 `offline` 증분 이벤트를 처리하고, stale snapshot/room merge로 인해 떠난 유저가 다시 보이는 경계도 함께 보정했습니다.

### 1. presence 증분 이벤트 계약 반영

- 실서버에서 내려오는 `user_status_changed` 이벤트를 소켓 계약과 프론트 타입에 반영했습니다.
- `status: "offline"`를 포함한 실시간 상태 변화를 정규화하도록 schema / type / normalizer를 추가했습니다.
- 프론트는 `online_users` 전체 스냅샷뿐 아니라 `user_status_changed` 증분 이벤트도 처리하도록 수정했습니다.

### 2. 로그아웃/offline 즉시 반영

- `useOnlineUsersSocket`에서 `user_status_changed` + `offline` 이벤트 수신 시 사용자를 접속자 목록에서 즉시 제거하도록 수정했습니다.
- 그 외 상태 변경은 기존 사용자 정보를 upsert 하도록 정리했습니다.
- 실시간 이벤트 이후 늦게 도착한 REST snapshot 응답이 최신 상태를 다시 덮어쓰지 못하도록 race를 보정했습니다.

### 3. 대기방 stale user 재주입 방지

- 대기방은 `room.players`를 기준으로 접속자 목록을 다시 합치면서 stale user를 다시 살릴 수 있었는데,
  online snapshot에 없는 사용자를 기본적으로 다시 추가하지 않도록 merge 경계를 수정했습니다.
- 대신 현재 사용자 자신은 별도 merge로 안전하게 유지하도록 보정했습니다.

### 4. 테스트 및 계약 보강

- `user_status_changed` 계약 schema / normalizer 테스트를 추가했습니다.
- snapshot in-flight 중 증분 이벤트가 먼저 오더라도 stale snapshot이 최신 상태를 덮지 않는 테스트를 추가했습니다.
- 대기방 user list에서 offline user가 다시 살아나지 않는 테스트를 추가했습니다.

### 🧠 Task 문서

- `docs/ai/tasks/presence-logout-reflection-fix/plan.md`
- `docs/ai/tasks/presence-logout-reflection-fix/context.md`
- `docs/ai/tasks/presence-logout-reflection-fix/checklist.md`

### 🧪 실행한 검증

- `npx vitest run src/features/presence/online-users/api.test.ts src/features/presence/online-users/useOnlineUsersSocket.test.tsx src/features/presence/online-users/onlineUsersModel.test.ts src/contracts/socket/schemas.test.ts src/pages/waiting-room/page/WaitingRoomPage.test.tsx`
- `npm run lint`
- `npm run build`
- `npm run ai:check:lobby`
- `npm run ai:check:waiting-room`
- `npm run ai:self-review -- --files src/features/presence/types.ts src/features/presence/online-users/api.ts src/features/presence/online-users/api.test.ts src/features/presence/online-users/onlineUsersSocket.ts src/features/presence/online-users/useOnlineUsersSocket.ts src/features/presence/online-users/useOnlineUsersSocket.test.tsx src/features/presence/online-users/onlineUsersModel.ts src/features/presence/online-users/onlineUsersModel.test.ts src/contracts/socket/events.ts src/contracts/socket/schemas.ts src/contracts/socket/schemas.test.ts src/pages/waiting-room/page/WaitingRoomPage.tsx src/pages/waiting-room/page/WaitingRoomPage.test.tsx docs/ai/tasks/presence-logout-reflection-fix/plan.md docs/ai/tasks/presence-logout-reflection-fix/context.md docs/ai/tasks/presence-logout-reflection-fix/checklist.md`
- `npx prettier --check src/features/presence/types.ts src/features/presence/online-users/api.ts src/features/presence/online-users/api.test.ts src/features/presence/online-users/onlineUsersSocket.ts src/features/presence/online-users/useOnlineUsersSocket.ts src/features/presence/online-users/useOnlineUsersSocket.test.tsx src/features/presence/online-users/onlineUsersModel.ts src
