### PR TITLE
fix: 게임 시작 후 room chat 수신 끊김 문제 수정

### DIFF
--- a/docs/ai/tasks/game-chat-send-reflection-fix/checklist.md
+++ b/docs/ai/tasks/game-chat-send-reflection-fix/checklist.md
@@ -1,0 +1,26 @@
+# Checklist
+
+## Implementation
+
+- [x] 관련 manual과 기존 문서를 읽었다
+- [x] 영향 범위를 정리했다
+- [x] 최소 범위로 구현했다
+- [x] mock/real 경로를 함께 확인했다
+- [ ] 타입/contract 변경이 있으면 관련 코드도 같이 수정했다
+
+## Testing
+
+- [x] `npx vitest run src/pages/game/gameChat.test.ts src/pages/GamePage.test.tsx src/pages/waiting-room/hooks/hooks.test.ts`
+- [x] `npm run lint`
+- [x] `npm run ai:check:game`
+- [x] `npm run ai:check:build`
+
+## Review
+
+- [x] Planner 기준 정리 완료
+- [x] Implementer 범위 구현 완료
+- [x] Reviewer self-review 확인
+- [x] Tester 검증 실행
+- [x] `docs/rules.md` 기준으로 셀프 리뷰했다
+- [x] 리다이렉트, cleanup, 중복 구독, 에러 처리 경계를 확인했다
+- [x] 변경 파일 / 실행한 검증 / 남은 리스크를 정리했다

--- a/docs/ai/tasks/game-chat-send-reflection-fix/context.md
+++ b/docs/ai/tasks/game-chat-send-reflection-fix/context.md
@@ -1,0 +1,51 @@
+# Context
+
+## Current Behavior
+
+- 게임 페이지는 `sendWaitingRoomChat()`로 `send_chat`만 송신하고, 로컬 store에는 메시지를 바로 추가하지 않는다.
+- 채팅 UI는 `useGameStore().messages`만 렌더링하므로, 수신 `chat` 이벤트가 오지 않으면 보낸 메시지도 화면에 나타나지 않는다.
+- 실서버에서는 송신 `send_chat`은 확인되지만, 게임 페이지 기준으로는 `chat` echo가 늦거나 누락될 수 있어 사용자가 새로 보낸 메시지가 비어 보이는 문제가 있다.
+- 추가로 대기방에서 게임으로 이동할 때 waiting-room cleanup이 `leave_room`를 보내고 있어, 게임 중에는 room membership이 끊겨 다른 유저 `chat` broadcast도 못 받는 흐름이 있었다.
+
+## Related Files
+
+- `docs/ai/manuals/common.md`
+- `docs/rules.md`
+- `docs/testing.md`
+- `docs/ai/manuals/game-runtime.md`
+- `src/pages/GamePage.tsx`
+- `src/pages/GamePage.test.tsx`
+- `src/pages/game/gameChat.ts`
+- `src/pages/game/gameChat.test.ts`
+- `src/pages/waiting-room/hooks/hooks.ts`
+- `src/pages/waiting-room/hooks/hooks.test.ts`
+- `src/pages/waiting-room/socket/socket.ts`
+
+## Relevant Manuals
+
+- `docs/ai/manuals/common.md`
+- `docs/rules.md`
+- `docs/testing.md`
+- `docs/ai/manuals/game-runtime.md`
+
+## Constraints
+
+- 게임 런타임의 canonical identifier는 `gameId`지만, 채팅 경계는 현재 `roomId`를 계속 사용한다.
+- 대기방 채팅 송신 계약인 `send_chat({ room_id, message })`는 유지한다.
+- 서버 권위 상태는 `game:*` 런타임 계약이 담당하므로, 채팅 보정은 게임 상태 계산을 침범하지 않는 범위에서만 넣는다.
+- mock/real 소켓 모두 같은 채팅 렌더링 경계를 유지해야 한다.
+- 게임 시작 이동은 대기방을 떠나는 것이 아니라 같은 room에서 game runtime으로 넘어가는 브리지이므로, 이 경로에서는 cleanup leave를 보내면 안 된다.
+
+## Decision Notes
+
+- 송신 직후 로컬에 낙관적 메시지를 추가하고, 이후 서버 `chat` echo가 오면 해당 메시지를 교체하는 방식으로 간다.
+- 이 로직은 게임 페이지 내부에 직접 흩뿌리지 않고 `src/pages/game/gameChat.ts` helper로 분리해 테스트한다.
+- waiting-room controller는 game_start 경로에서 다음 cleanup leave를 명시적으로 skip 하도록 해 room membership을 유지한다.
+- 백엔드 echo 정책만 기다리는 방식은 실서버 차이로 다시 비는 화면이 생길 수 있어 버렸다.
+- store 전역 action을 새로 추가하는 대신, 페이지에서 필요한 최소 reconcile만 수행해 영향 범위를 좁혔다.
+
+## Open Risks
+
+- 같은 사용자가 아주 짧은 시간 안에 동일한 내용을 여러 번 보내면, 서버 echo 매칭이 가장 오래된 pending 메시지부터 정리된다.
+- 서버가 아예 `chat` echo를 보내지 않으면 낙관적 메시지는 그대로 남지만, 현재 사용자 UX 기준으로는 의도된 동작이다.
+- 다른 사용자의 채팅 수신은 cleanup leave 경계 수정으로 맞췄지만, 실서버가 게임 중 `chat`를 실제로 계속 브로드캐스트하는지는 한 번 더 확인이 필요하다.

--- a/docs/ai/tasks/game-chat-send-reflection-fix/plan.md
+++ b/docs/ai/tasks/game-chat-send-reflection-fix/plan.md
@@ -1,0 +1,58 @@
+# Plan
+
+## Task
+
+- 작업 이름: Game Chat Send Reflection Fix
+- 요청 날짜: 2026-03-18
+- 담당 범위: 입력 파일 기준 초안 생성
+
+## Goal
+
+- 게임 페이지에서 `send_chat` 송신은 되지만 채팅창에 바로 반영되지 않는 문제를 수정한다.
+- 서버 `chat` echo가 지연되거나 누락돼도 사용자가 보낸 메시지는 즉시 보이게 한다.
+- 이후 서버 echo가 도착하면 중복 메시지 없이 정리되는 경로를 만든다.
+- 대기방에서 게임으로 이동할 때 cleanup `leave_room`가 실행돼 게임 중 room chat 수신이 끊기는 문제를 막는다.
+
+## In Scope
+
+- `src/pages/GamePage.tsx`
+- `src/features/room-chat/RoomChat.tsx`
+- `src/pages/waiting-room/socket/socket.ts`
+- `src/stores/game.store.ts`
+
+## Out Of Scope
+
+- 대기방 채팅 흐름 전반 리팩터링
+- 백엔드 `send_chat` / `chat` broadcast 정책 변경
+- 게임 채팅 히스토리 영속화 또는 snapshot 계약 확장
+
+## Target Files
+
+- `src/pages/GamePage.tsx`
+- `src/pages/GamePage.test.tsx`
+- `src/pages/game/gameChat.ts`
+- `src/pages/game/gameChat.test.ts`
+- `src/pages/waiting-room/hooks/hooks.ts`
+- `src/pages/waiting-room/hooks/hooks.test.ts`
+
+## Completion Criteria
+
+- 게임 페이지에서 메시지를 보내면 서버 `chat` echo를 기다리지 않고 채팅창에 즉시 표시된다.
+- 같은 메시지에 대한 서버 `chat` echo가 나중에 도착해도 중복 렌더링되지 않는다.
+- 게임 시작 이동으로 대기방이 언마운트될 때 `leave_room` cleanup이 실행되지 않아 room chat 수신이 유지된다.
+- 관련 helper 테스트와 게임 페이지 회귀 테스트가 추가된다.
+- 게임 런타임 변경 기준에 맞는 최소 Vitest, lint, build 검증이 통과한다.
+
+## Role Plan
+
+- Planner: 범위 / 완료 기준 / 참고 문서 정리
+- Implementer: 최소 범위 구현
+- Reviewer: diff / self-review / 위험 신호 확인
+- Tester: 검증 명령 실행과 결과 정리
+
+## Test Plan
+
+- `npx vitest run src/pages/game/gameChat.test.ts src/pages/GamePage.test.tsx src/pages/waiting-room/hooks/hooks.test.ts`
+- `npm run lint`
+- `npm run ai:check:game`
+- `npm run ai:check:build`

--- a/src/pages/GamePage.test.tsx
+++ b/src/pages/GamePage.test.tsx
@@ -1,0 +1,206 @@
+import { forwardRef } from 'react'
+import { Route, Routes } from 'react-router-dom'
+import { act, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import GamePage from './GamePage'
+import { useGameStore } from '../stores/game.store'
+import { useAuthStore } from '../features/auth/session/store'
+import { createAuthSessionFixture } from '../test/fixtures'
+import { renderWithProviders } from '../test/renderWithProviders'
+import type { Player } from '../types/domain'
+
+vi.mock('../config/env', () => ({
+  IS_DEMO_MOCK_ENABLED: false,
+  IS_SOCKET_MOCK_ENABLED: false,
+  SHOULD_ENABLE_MSW: true,
+}))
+
+const { sendWaitingRoomChatMock, emitChatEvent, socketOnMock, socketOffMock } =
+  vi.hoisted(() => {
+    const handlers = new Map<string, Set<(payload: unknown) => void>>()
+
+    return {
+      sendWaitingRoomChatMock: vi.fn(),
+      socketOnMock: vi.fn(
+        (event: string, handler: (payload: unknown) => void) => {
+          const nextHandlers = handlers.get(event) ?? new Set()
+          nextHandlers.add(handler)
+          handlers.set(event, nextHandlers)
+        }
+      ),
+      socketOffMock: vi.fn(
+        (event: string, handler: (payload: unknown) => void) => {
+          handlers.get(event)?.delete(handler)
+        }
+      ),
+      emitChatEvent: (payload: unknown) => {
+        handlers.get('chat')?.forEach((handler) => handler(payload))
+      },
+    }
+  })
+
+vi.mock('../lib/socket', () => ({
+  socket: {
+    on: socketOnMock,
+    off: socketOffMock,
+    connected: true,
+    disconnect: vi.fn(),
+  },
+}))
+
+vi.mock('../pages/waiting-room/socket/socket', () => ({
+  sendWaitingRoomChat: sendWaitingRoomChatMock,
+}))
+
+vi.mock('../hooks/game/useGameState', () => ({
+  useGameState: vi.fn(),
+}))
+
+vi.mock('../hooks/game/useDiceRoll', () => ({
+  useDiceRoll: () => vi.fn(),
+}))
+
+vi.mock('../hooks/game/useTurn', () => ({
+  useTurn: () => false,
+}))
+
+vi.mock('../lib/bgm', () => ({
+  playBgm: vi.fn(),
+  stopBgm: vi.fn(),
+}))
+
+vi.mock('../services/socket/game.handler', () => ({
+  emitPromptResponse: vi.fn(),
+}))
+
+vi.mock('../components/board/GameBoard', () => ({
+  default: forwardRef<HTMLDivElement>(function MockBoardGame(_, ref) {
+    return (
+      <div ref={ref} data-testid="mock-board-game">
+        게임 보드
+      </div>
+    )
+  }),
+}))
+
+vi.mock('../components/game/controls/RollButton', () => ({
+  default: () => <button type="button">주사위</button>,
+}))
+
+vi.mock('../components/game/modals/ExitGameModal', () => ({
+  default: () => null,
+}))
+
+vi.mock('../components/game/modals/promptModalMapping', () => ({
+  isPromptHandledByBoardModal: () => false,
+}))
+
+vi.mock('../components/game/panels/PlayerPanel', () => ({
+  default: () => <div>플레이어 패널</div>,
+}))
+
+vi.mock('../features/room-chat/DevRoomChatControlPanel', () => ({
+  DevRoomChatControlPanel: () => null,
+}))
+
+const createPlayer = (overrides: Partial<Player> = {}): Player => ({
+  id: 'user-1',
+  nickname: '유저1',
+  color: '#ff0000',
+  position: 0,
+  balance: 1000,
+  owned_tiles: [],
+  is_in_jail: false,
+  jail_turn_count: 0,
+  is_bankrupt: false,
+  ...overrides,
+})
+
+function renderGamePage() {
+  return renderWithProviders(
+    <Routes>
+      <Route path="/game/:gameId" element={<GamePage />} />
+    </Routes>,
+    {
+      initialEntries: [
+        {
+          pathname: '/game/game-1',
+          state: {
+            gameId: 'game-1',
+            roomId: 'room-1',
+          },
+        },
+      ],
+    }
+  )
+}
+
+describe('GamePage chat flow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    useAuthStore.setState({
+      session: createAuthSessionFixture({
+        userId: 'user-1',
+        nickname: '유저1',
+      }),
+    })
+
+    useGameStore.getState().resetGame()
+    useGameStore.getState().setGameState({
+      roomId: 'room-1',
+      gameId: 'game-1',
+      currentTurn: 'user-2',
+      players: [
+        createPlayer(),
+        createPlayer({
+          id: 'user-2',
+          nickname: '유저2',
+          color: '#0000ff',
+        }),
+      ],
+      tiles: [],
+      messages: [],
+    })
+  })
+
+  afterEach(() => {
+    useGameStore.getState().resetGame()
+    useAuthStore.setState({ session: null })
+  })
+
+  it('renders a local chat message immediately and avoids duplicates when the server echo arrives', async () => {
+    const user = userEvent.setup()
+
+    renderGamePage()
+
+    await act(async () => {
+      await user.type(
+        screen.getByPlaceholderText('메시지...'),
+        'ㅎㅇㅎㅇ{enter}'
+      )
+    })
+
+    expect(sendWaitingRoomChatMock).toHaveBeenCalledWith({
+      roomId: 'room-1',
+      senderId: 'user-1',
+      senderNickname: '유저1',
+      message: 'ㅎㅇㅎㅇ',
+    })
+
+    expect(await screen.findByText('ㅎㅇㅎㅇ')).toBeInTheDocument()
+
+    act(() => {
+      emitChatEvent({
+        room_id: 'room-1',
+        sender_id: 'user-1',
+        sender_nickname: '유저1',
+        message: 'ㅎㅇㅎㅇ',
+        sent_at: '2026-03-19T01:45:00.314Z',
+      })
+    })
+
+    expect(screen.getAllByText('ㅎㅇㅎㅇ')).toHaveLength(1)
+  })
+})

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -17,13 +17,20 @@ import { playBgm, stopBgm } from '../lib/bgm'
 import { socket } from '../lib/socket'
 import { emitPromptResponse } from '../services/socket/game.handler'
 import { useGameStore } from '../stores/game.store'
-import type { ChatMessage, GamePromptChoice } from '../types/domain'
+import type { GamePromptChoice } from '../types/domain'
 import {
   findBoardCurrentPlayerIndex,
   mapStorePlayersToBoardPlayers,
   mapStoreTilesToBoardTiles,
   calcPlayerTotalAssets,
 } from './game/gameViewModel'
+import {
+  consumePendingGameChatEcho,
+  createOptimisticGameChatMessage,
+  mapGameChatEventToMessage,
+  reconcileGameChatMessages,
+  type PendingGameChatEcho,
+} from './game/gameChat'
 import { sendWaitingRoomChat } from './waiting-room/socket/socket'
 import type { ChatEventPayload } from './waiting-room/api/types'
 
@@ -44,17 +51,6 @@ const FALLBACK_PROMPT_CHOICES: GamePromptChoice[] = [
     value: 'confirm',
   },
 ]
-
-function mapGameChatEventToMessage(payload: ChatEventPayload): ChatMessage {
-  return {
-    id: `${payload.room_id}-${payload.sender_id}-${payload.sent_at}`,
-    sender_id: payload.sender_id,
-    sender_nickname: payload.sender_nickname,
-    content: payload.message,
-    timestamp: payload.sent_at,
-    type: 'talk',
-  }
-}
 
 interface GamePageLocationState {
   roomId?: string
@@ -94,6 +90,7 @@ const GamePage: React.FC = () => {
   >(null)
   const [isExitModalOpen, setIsExitModalOpen] = useState(false)
   const boardRef = useRef<BoardGameHandle>(null)
+  const pendingGameChatEchoesRef = useRef<PendingGameChatEcho[]>([])
 
   // 🎵 배경음악 (BGM) — 게임 진입 시 즉시 재생, 퇴장 시 정지
   useEffect(() => {
@@ -183,16 +180,21 @@ const GamePage: React.FC = () => {
       }
 
       const nextMessage = mapGameChatEventToMessage(payload)
-      const gameStore = useGameStore.getState()
-      const hasSameMessage = gameStore.messages.some(
-        (message) => message.id === nextMessage.id
-      )
+      const consumedPendingEcho = consumePendingGameChatEcho({
+        pendingEchoes: pendingGameChatEchoesRef.current,
+        incomingMessage: nextMessage,
+        currentUserId,
+      })
 
-      if (hasSameMessage) {
-        return
-      }
+      pendingGameChatEchoesRef.current = consumedPendingEcho.pendingEchoes
 
-      gameStore.addMessage(nextMessage)
+      useGameStore.setState((state) => ({
+        messages: reconcileGameChatMessages({
+          previousMessages: state.messages,
+          incomingMessage: nextMessage,
+          matchedPendingId: consumedPendingEcho.matchedPendingId,
+        }),
+      }))
     }
 
     socket.on('chat', handleChat)
@@ -200,16 +202,36 @@ const GamePage: React.FC = () => {
     return () => {
       socket.off('chat', handleChat)
     }
-  }, [activeRoomId])
+  }, [activeRoomId, currentUserId])
 
   const handleSendMessage = (content: string) => {
     if (!activeRoomId) {
       return
     }
 
+    const senderId = currentUserId ?? DEFAULT_GUEST_ID
+    const optimisticMessage = createOptimisticGameChatMessage({
+      roomId: activeRoomId,
+      senderId,
+      senderNickname: currentNickname,
+      message: content,
+    })
+
+    pendingGameChatEchoesRef.current = [
+      ...pendingGameChatEchoesRef.current,
+      {
+        id: optimisticMessage.id,
+        senderId,
+        content,
+        createdAtMs: Date.parse(optimisticMessage.timestamp),
+      },
+    ]
+
+    useGameStore.getState().addMessage(optimisticMessage)
+
     sendWaitingRoomChat({
       roomId: activeRoomId,
-      senderId: currentUserId ?? DEFAULT_GUEST_ID,
+      senderId,
       senderNickname: currentNickname,
       message: content,
     })

--- a/src/pages/game/gameChat.test.ts
+++ b/src/pages/game/gameChat.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+import type { ChatMessage } from '../../types/domain'
+import {
+  consumePendingGameChatEcho,
+  createOptimisticGameChatMessage,
+  mapGameChatEventToMessage,
+  prunePendingGameChatEchoes,
+  reconcileGameChatMessages,
+} from './gameChat'
+
+const createIncomingChatMessage = (): ChatMessage =>
+  mapGameChatEventToMessage({
+    room_id: 'room-1',
+    sender_id: 'user-1',
+    sender_nickname: '유저1',
+    message: 'ㅎㅇㅎㅇ',
+    sent_at: '2026-03-19T01:45:00.314Z',
+  })
+
+describe('gameChat helpers', () => {
+  it('creates an optimistic local chat message for immediate rendering', () => {
+    const message = createOptimisticGameChatMessage({
+      roomId: 'room-1',
+      senderId: 'user-1',
+      senderNickname: '유저1',
+      message: 'ㅎㅇㅎㅇ',
+      now: new Date('2026-03-19T01:45:00.000Z'),
+    })
+
+    expect(message).toMatchObject({
+      sender_id: 'user-1',
+      sender_nickname: '유저1',
+      content: 'ㅎㅇㅎㅇ',
+      timestamp: '2026-03-19T01:45:00.000Z',
+      type: 'talk',
+    })
+    expect(message.id).toContain('local-game-chat:room-1:user-1:')
+  })
+
+  it('matches a server echo to the pending optimistic message and replaces it', () => {
+    const optimisticMessage = createOptimisticGameChatMessage({
+      roomId: 'room-1',
+      senderId: 'user-1',
+      senderNickname: '유저1',
+      message: 'ㅎㅇㅎㅇ',
+      now: new Date('2026-03-19T01:45:00.000Z'),
+    })
+    const incomingMessage = createIncomingChatMessage()
+
+    const consumedPendingEcho = consumePendingGameChatEcho({
+      pendingEchoes: [
+        {
+          id: optimisticMessage.id,
+          senderId: optimisticMessage.sender_id,
+          content: optimisticMessage.content,
+          createdAtMs: Date.parse(optimisticMessage.timestamp),
+        },
+      ],
+      incomingMessage,
+      currentUserId: 'user-1',
+      nowMs: Date.parse('2026-03-19T01:45:01.000Z'),
+    })
+    const reconciledMessages = reconcileGameChatMessages({
+      previousMessages: [optimisticMessage],
+      incomingMessage,
+      matchedPendingId: consumedPendingEcho.matchedPendingId,
+    })
+
+    expect(consumedPendingEcho.matchedPendingId).toBe(optimisticMessage.id)
+    expect(consumedPendingEcho.pendingEchoes).toEqual([])
+    expect(reconciledMessages).toEqual([incomingMessage])
+  })
+
+  it('prunes stale pending echoes and treats unmatched incoming messages as new chats', () => {
+    const incomingMessage = createIncomingChatMessage()
+
+    const consumedPendingEcho = consumePendingGameChatEcho({
+      pendingEchoes: [
+        {
+          id: 'local-game-chat:room-1:user-1:old',
+          senderId: 'user-1',
+          content: 'ㅎㅇㅎㅇ',
+          createdAtMs: Date.parse('2026-03-19T01:44:00.000Z'),
+        },
+      ],
+      incomingMessage,
+      currentUserId: 'user-1',
+      nowMs: Date.parse('2026-03-19T01:45:31.000Z'),
+    })
+    const reconciledMessages = reconcileGameChatMessages({
+      previousMessages: [],
+      incomingMessage,
+      matchedPendingId: consumedPendingEcho.matchedPendingId,
+    })
+
+    expect(
+      prunePendingGameChatEchoes(consumedPendingEcho.pendingEchoes)
+    ).toEqual([])
+    expect(consumedPendingEcho.matchedPendingId).toBeNull()
+    expect(reconciledMessages).toEqual([incomingMessage])
+  })
+})

--- a/src/pages/game/gameChat.ts
+++ b/src/pages/game/gameChat.ts
@@ -1,0 +1,125 @@
+import type { ChatMessage } from '../../types/domain'
+import type { ChatEventPayload } from '../waiting-room/api/types'
+
+const LOCAL_GAME_CHAT_ID_PREFIX = 'local-game-chat'
+const PENDING_GAME_CHAT_TTL_MS = 30_000
+
+export interface PendingGameChatEcho {
+  id: string
+  senderId: string
+  content: string
+  createdAtMs: number
+}
+
+export function mapGameChatEventToMessage(
+  payload: ChatEventPayload
+): ChatMessage {
+  return {
+    id: `${payload.room_id}-${payload.sender_id}-${payload.sent_at}`,
+    sender_id: payload.sender_id,
+    sender_nickname: payload.sender_nickname,
+    content: payload.message,
+    timestamp: payload.sent_at,
+    type: 'talk',
+  }
+}
+
+export function createOptimisticGameChatMessage(params: {
+  roomId: string
+  senderId: string
+  senderNickname: string
+  message: string
+  now?: Date
+}): ChatMessage {
+  const now = params.now ?? new Date()
+
+  return {
+    id: `${LOCAL_GAME_CHAT_ID_PREFIX}:${params.roomId}:${params.senderId}:${now.getTime()}`,
+    sender_id: params.senderId,
+    sender_nickname: params.senderNickname,
+    content: params.message,
+    timestamp: now.toISOString(),
+    type: 'talk',
+  }
+}
+
+const isLocalGameChatId = (messageId: string) =>
+  messageId.startsWith(`${LOCAL_GAME_CHAT_ID_PREFIX}:`)
+
+export function prunePendingGameChatEchoes(
+  pendingEchoes: PendingGameChatEcho[],
+  nowMs: number = Date.now()
+) {
+  return pendingEchoes.filter(
+    (pendingEcho) => nowMs - pendingEcho.createdAtMs <= PENDING_GAME_CHAT_TTL_MS
+  )
+}
+
+export function consumePendingGameChatEcho(params: {
+  pendingEchoes: PendingGameChatEcho[]
+  incomingMessage: ChatMessage
+  currentUserId: string | null
+  nowMs?: number
+}) {
+  const nowMs = params.nowMs ?? Date.now()
+  const prunedPendingEchoes = prunePendingGameChatEchoes(
+    params.pendingEchoes,
+    nowMs
+  )
+
+  if (
+    params.currentUserId == null ||
+    String(params.incomingMessage.sender_id) !== String(params.currentUserId)
+  ) {
+    return {
+      matchedPendingId: null,
+      pendingEchoes: prunedPendingEchoes,
+    }
+  }
+
+  const matchedPendingEcho = prunedPendingEchoes.find(
+    (pendingEcho) =>
+      String(pendingEcho.senderId) === String(params.currentUserId) &&
+      pendingEcho.content === params.incomingMessage.content
+  )
+
+  if (!matchedPendingEcho) {
+    return {
+      matchedPendingId: null,
+      pendingEchoes: prunedPendingEchoes,
+    }
+  }
+
+  return {
+    matchedPendingId: matchedPendingEcho.id,
+    pendingEchoes: prunedPendingEchoes.filter(
+      (pendingEcho) => pendingEcho.id !== matchedPendingEcho.id
+    ),
+  }
+}
+
+export function reconcileGameChatMessages(params: {
+  previousMessages: ChatMessage[]
+  incomingMessage: ChatMessage
+  matchedPendingId?: string | null
+}) {
+  const hasSameServerMessage = params.previousMessages.some(
+    (message) => message.id === params.incomingMessage.id
+  )
+
+  if (hasSameServerMessage) {
+    return params.previousMessages
+  }
+
+  if (!params.matchedPendingId) {
+    return [...params.previousMessages, params.incomingMessage]
+  }
+
+  return params.previousMessages.map((message) =>
+    message.id === params.matchedPendingId &&
+    isLocalGameChatId(message.id) &&
+    message.content === params.incomingMessage.content
+      ? params.incomingMessage
+      : message
+  )
+}

--- a/src/pages/waiting-room/hooks/hooks.test.ts
+++ b/src/pages/waiting-room/hooks/hooks.test.ts
@@ -1,0 +1,114 @@
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createAuthSessionFixture } from '../../../test/fixtures'
+import type { GameStartEventPayload, WaitingRoomSnapshot } from '../api/types'
+import { useWaitingRoomController } from './hooks'
+
+const {
+  useWaitingRoomLifecycleMock,
+  useWaitingRoomSocketSyncMock,
+  useWaitingRoomActionsMock,
+  getStartConditionMetMock,
+  buildWaitingRoomSeatsMock,
+} = vi.hoisted(() => ({
+  useWaitingRoomLifecycleMock: vi.fn(),
+  useWaitingRoomSocketSyncMock: vi.fn(),
+  useWaitingRoomActionsMock: vi.fn(),
+  getStartConditionMetMock: vi.fn(),
+  buildWaitingRoomSeatsMock: vi.fn(),
+}))
+
+vi.mock('../controller/lifecycle', () => ({
+  useWaitingRoomLifecycle: useWaitingRoomLifecycleMock,
+}))
+
+vi.mock('../controller/socketSync', () => ({
+  useWaitingRoomSocketSync: useWaitingRoomSocketSyncMock,
+}))
+
+vi.mock('../controller/actions', () => ({
+  useWaitingRoomActions: useWaitingRoomActionsMock,
+}))
+
+vi.mock('../controller/state', () => ({
+  buildWaitingRoomSeats: buildWaitingRoomSeatsMock,
+  getStartConditionMet: getStartConditionMetMock,
+}))
+
+function createRoomSnapshot(): WaitingRoomSnapshot {
+  return {
+    roomId: 'room-5',
+    title: '즐거운 게임 한판!',
+    status: 'waiting',
+    maxPlayers: 4,
+    isPrivate: false,
+    players: [
+      { id: 'user-1', nickname: '테스터', isReady: false, isHost: true },
+    ],
+    chatMessages: [],
+  }
+}
+
+describe('useWaitingRoomController', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    getStartConditionMetMock.mockReturnValue(false)
+    buildWaitingRoomSeatsMock.mockReturnValue([])
+    useWaitingRoomActionsMock.mockReturnValue({
+      sendChatMessage: vi.fn(),
+      handleToggleReady: vi.fn(),
+      handleStartGame: vi.fn(),
+      leaveRoom: vi.fn(),
+    })
+  })
+
+  it('game_start 이동 경로에서는 cleanup leave를 건너뛰도록 skip ref를 세팅한다', () => {
+    const session = createAuthSessionFixture({
+      userId: 'user-1',
+      nickname: '테스터',
+    })
+    const room = createRoomSnapshot()
+    const parentOnGameStart = vi.fn()
+
+    renderHook(() =>
+      useWaitingRoomController({
+        roomId: room.roomId,
+        session,
+        preJoinedSnapshot: room,
+        onGameStart: parentOnGameStart,
+        onRoomRemoved: vi.fn(),
+      })
+    )
+
+    const actionParams = useWaitingRoomActionsMock.mock.calls[0]?.[0] as
+      | {
+          shouldSkipNextCleanupLeaveRef: { current: boolean }
+        }
+      | undefined
+    const socketSyncParams = useWaitingRoomSocketSyncMock.mock.calls[0]?.[0] as
+      | {
+          onGameStart: (payload: GameStartEventPayload) => void
+        }
+      | undefined
+
+    expect(actionParams).toBeDefined()
+    expect(socketSyncParams).toBeDefined()
+    if (actionParams) {
+      actionParams.shouldSkipNextCleanupLeaveRef.current = false
+    }
+
+    act(() => {
+      socketSyncParams?.onGameStart({
+        game_id: 'game-123',
+        room_id: 'room-5',
+      })
+    })
+
+    expect(actionParams?.shouldSkipNextCleanupLeaveRef.current).toBe(true)
+    expect(parentOnGameStart).toHaveBeenCalledWith({
+      game_id: 'game-123',
+      room_id: 'room-5',
+    })
+  })
+})

--- a/src/pages/waiting-room/hooks/hooks.ts
+++ b/src/pages/waiting-room/hooks/hooks.ts
@@ -75,6 +75,14 @@ export function useWaitingRoomController({
     onRoomRemoved()
   }, [onRoomRemoved])
 
+  const handleGameStartPreservingRoomMembership = useCallback(
+    (payload: GameStartEventPayload) => {
+      shouldSkipNextCleanupLeaveRef.current = true
+      onGameStart(payload)
+    },
+    [onGameStart]
+  )
+
   useWaitingRoomLifecycle({
     roomId,
     session,
@@ -97,7 +105,7 @@ export function useWaitingRoomController({
     session,
     activeRoomId,
     hasReceivedRoomUpdatedRef,
-    onGameStart,
+    onGameStart: handleGameStartPreservingRoomMembership,
     onRoomRemoved: handleRoomRemoved,
     setRoom,
     setChatMessages,


### PR DESCRIPTION
## 📌 관련 이슈

> closes #489

---

## 📝 작업 내용

> 게임 페이지에서는 `send_chat` 송신은 되지만, 게임 시작 후 room membership이 끊기면서 `chat` broadcast를 받지 못해 채팅이 반영되지 않는 문제가 있었습니다.
> 이번 수정에서는 게임 시작 이동 시 room membership을 유지하고, 내가 보낸 메시지는 서버 echo 없이도 즉시 보이도록 보정했습니다.

### 1. 게임 채팅 즉시 반영

- 게임 페이지 채팅 송신 직후 로컬에 낙관적 메시지를 추가하도록 변경했습니다.
- 서버 `chat` echo가 나중에 도착하면 기존 낙관적 메시지를 교체해 중복 렌더링을 막도록 정리했습니다.
- 관련 로직은 `src/pages/game/gameChat.ts` helper로 분리해 테스트 가능하게 정리했습니다.

### 2. 게임 시작 후 room membership 유지

- 대기방에서 게임으로 이동할 때 waiting-room cleanup이 `leave_room`를 보내고 있어 room membership이 끊기던 문제를 수정했습니다.
- game_start 이동 경로에서는 다음 cleanup leave를 skip 하도록 해, 게임 진입 후에도 room chat broadcast를 계속 받을 수 있게 했습니다.

### 3. 회귀 테스트 추가

- 낙관적 게임 채팅 메시지 생성 / echo dedupe helper 테스트를 추가했습니다.
- GamePage에서 송신 직후 메시지가 보이고, 이후 서버 echo가 와도 중복되지 않는 테스트를 추가했습니다.
- waiting-room controller에서 game_start 이동 시 cleanup leave skip ref가 세팅되는 테스트를 추가했습니다.

### 🧠 Task 문서

- `docs/ai/tasks/game-chat-send-reflection-fix/plan.md`
- `docs/ai/tasks/game-chat-send-reflection-fix/context.md`
- `docs/ai/tasks/game-chat-send-reflection-fix/checklist.md`

### 📚 참고한 기준 문서

- `AGENTS.md`
- `docs/rules.md`
- `docs/testing.md`
- `docs/ai/manuals/game-runtime.md`
- `docs/ai/manuals/waiting-room.md`

### 👥 역할 수행

- [x] Planner
- [x] Implementer
- [x] Reviewer
- [x] Tester

### 🧪 실행한 검증

- `npx vitest run src/pages/game/gameChat.test.ts src/pages/GamePage.test.tsx src/pages/waiting-room/hooks/hooks.test.ts`
- `npm run lint`
- `npm run build`
- `npm run ai:check:game`
- `npm run ai:self-review -- --files src/pages/GamePage.tsx src/pages/GamePage.test.tsx src/pages/game/gameChat.ts src/pages/game/gameChat.test.ts docs/ai/tasks/game-chat-send-reflection-fix/plan.md docs/ai/tasks/game-chat-send-reflection-fix/context.md docs/ai/tasks/game-chat-send-reflection-fix/checklist.md`
- `npx prettier --check src/pages/GamePage.tsx src/pages/GamePage.test.tsx src/pages/game/gameChat.ts src/pages/game/gameChat.test.ts src/pages/waiting-room/hooks/hooks.ts src/pages/waiting-room/hooks/hooks.test.ts docs/ai/tasks/game-chat-send-reflection-fix/plan.md docs/ai/tasks/game-chat-send-reflection-fix/context.md docs/ai/tasks/game-chat-send-reflection-fix/checklist.md`

### ⚠️ 남은 리스크

- 프론트는 이제 game_start 이동에서 room membership을 유지합니다. 그래도 실서버가 게임 중 `chat`를 실제로 계속 브로드캐스트하지 않는다면 그건 별도 백엔드 계약 문제로 남습니다.
- `GamePage.test.tsx`는 Zustand 업데이트 특성상 `act(...)` warning 로그가 남지만, 테스트 자체는 통과합니다.

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료
- [x] 큰 작업이면 task 문서 링크를 남겼다
- [x] 참고한 기준 문서를 PR 본문에 남겼다
- [x] 큰 작업이면 Planner / Reviewer / Tester 역할 흔적을 남겼다
- [x] 실행한 검증과 남은 리스크를 PR 본문에 적었다

---

## 📌 추가 메모

- 이번 수정은 게임 채팅 수신 자체를 새 이벤트로 바꾼 것이 아니라, 기존 room chat 경계가 게임 진입 후에도 유지되도록 정리한 범위입니다.
- 게임 채팅은 여전히 `chat` 이벤트 + `roomId` 경계를 사용합니다.