### PR TITLE
refactor: PR 템플릿을 PR Guard 기준에 맞게 정리

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,6 +14,7 @@
 
 > `docs/ai/tasks/<task-slug>/plan.md`, `context.md`, `checklist.md` 링크를 남겨주세요.
 > 작은 단일 파일 수정이면 생략 가능합니다.
+> 이번 PR에서 task 문서 3종이 함께 변경됐으면 본문 링크를 생략해도 됩니다.
 
 - plan:
 - context:
@@ -24,41 +25,34 @@
 ## 📚 참고한 기준 문서
 
 > 이번 작업에서 실제로 읽고 기준으로 삼은 문서를 적어주세요.
+> 고위험 변경이면 변경 경로에 맞는 manual을 실제 경로로 추가해야 PR Guard 경고가 뜨지 않습니다.
+> 예: `docs/ai/manuals/lobby.md`, `docs/ai/manuals/waiting-room.md`, `docs/ai/manuals/game-runtime.md`, `docs/socket-mock-server.md`
 
 - `AGENTS.md`
 - `docs/rules.md`
 - `docs/testing.md`
-- 추가 manual / 문서:
-
----
-
-## 👥 역할 수행
-
-> 큰 변경이면 Planner / Reviewer / Tester 흔적이 PR에서 보여야 합니다.
-
-- [ ] Planner
-- [ ] Implementer
-- [ ] Reviewer
-- [ ] Tester
+- 추가 manual / 문서 경로:
 
 ---
 
 ## 🧪 실행한 검증
 
 > 실제로 실행한 명령만 적어주세요.
-
-- [ ] `npm run lint`
-- [ ] `npm run test`
-- [ ] `npm run build`
-- [ ] 기타:
+> 아래 예시는 참고용이므로, 실행하지 않은 명령은 그대로 두지 말고 지워주세요.
+> 예:
+>
+> - `npm run lint`
+> - `npx vitest run src/...`
+> - `npm run build`
 
 ---
 
 ## ⚠️ 남은 리스크
 
 > 이번 PR에서 의도적으로 제외한 범위, 추후 확인이 필요한 리스크를 적어주세요.
-
-- 없음 / 또는 리스크 작성
+> 리스크가 없다면 아래처럼 실제 문장으로 적어주세요.
+>
+> - 현재 확인된 추가 리스크는 없습니다.
 
 ---
 
@@ -69,7 +63,6 @@
 - [ ] 관련 이슈 연결 완료
 - [ ] 큰 작업이면 task 문서 링크를 남겼다
 - [ ] 참고한 기준 문서를 PR 본문에 남겼다
-- [ ] 큰 작업이면 Planner / Reviewer / Tester 역할 흔적을 남겼다
 - [ ] 실행한 검증과 남은 리스크를 PR 본문에 적었다
 
 ---

--- a/docs/ai/tasks/pr-template-pr-guard-alignment/checklist.md
+++ b/docs/ai/tasks/pr-template-pr-guard-alignment/checklist.md
@@ -1,0 +1,24 @@
+# Checklist
+
+## Implementation
+
+- [x] 관련 manual과 기존 문서를 읽었다
+- [x] 영향 범위를 정리했다
+- [x] 최소 범위로 구현했다
+- [ ] mock/real 경로를 함께 확인했다
+- [ ] 타입/contract 변경이 있으면 관련 코드도 같이 수정했다
+
+## Testing
+
+- [ ] `npx prettier --check .github/PULL_REQUEST_TEMPLATE.md`
+- [ ] `npm run ai:self-review -- --files .github/PULL_REQUEST_TEMPLATE.md docs/ai/tasks/pr-template-pr-guard-alignment/plan.md docs/ai/tasks/pr-template-pr-guard-alignment/context.md docs/ai/tasks/pr-template-pr-guard-alignment/checklist.md`
+
+## Review
+
+- [x] Planner 기준 정리 완료
+- [x] Implementer 범위 구현 완료
+- [ ] Reviewer self-review 확인
+- [ ] Tester 검증 실행
+- [ ] `docs/rules.md` 기준으로 셀프 리뷰했다
+- [x] 리다이렉트, cleanup, 중복 구독, 에러 처리 경계를 확인했다
+- [ ] 변경 파일 / 실행한 검증 / 남은 리스크를 정리했다

--- a/docs/ai/tasks/pr-template-pr-guard-alignment/context.md
+++ b/docs/ai/tasks/pr-template-pr-guard-alignment/context.md
@@ -1,0 +1,38 @@
+# Context
+
+## Current Behavior
+
+- 현재 PR Guard는 `Task 문서`, `참고한 기준 문서`, `실행한 검증`, `남은 리스크` 섹션을 읽어 경고를 띄운다.
+- 하지만 PR 템플릿에는 `역할 수행`처럼 현재 guard가 검사하지 않는 섹션이 남아 있고, `남은 리스크`와 `실행한 검증` 예시는 placeholder를 그대로 둬도 충분해 보이게 작성돼 있다.
+- 그 결과 팀원 입장에서는 템플릿을 채웠다고 생각해도 PR Guard 경고가 뜨는 혼선이 생긴다.
+
+## Related Files
+
+- `docs/ai/manuals/common.md`
+- `docs/rules.md`
+- `docs/testing.md`
+- `.github/PULL_REQUEST_TEMPLATE.md`
+
+## Relevant Manuals
+
+- `docs/ai/manuals/common.md`
+- `docs/rules.md`
+- `docs/testing.md`
+
+## Constraints
+
+- PR Guard가 찾는 섹션 제목은 유지해야 한다.
+- 템플릿은 팀 전체가 바로 이해할 수 있게 한국어 안내 위주로 유지한다.
+- workflow 로직을 바꾸지 않고 템플릿만으로 혼선을 줄이는 방향을 우선한다.
+
+## Decision Notes
+
+- `역할 수행` 섹션은 현재 guard가 검사하지 않으므로 템플릿에서 제거해 실제 요구사항과 안내를 맞춘다.
+- `실행한 검증`과 `남은 리스크` 예시는 bullet placeholder 대신 blockquote 설명으로 바꿔, 실제 내용을 입력해야 한다는 점을 분명히 한다.
+- `참고한 기준 문서`에는 고위험 변경 시 필요한 manual 경로 예시를 명시해, 팀원이 어떤 경로를 넣어야 하는지 바로 이해할 수 있게 한다.
+- workflow를 템플릿에 맞춰 다시 넓히는 대안도 있었지만, 현재 목적은 경량 PR Guard 유지이므로 템플릿을 현재 guard에 맞추는 쪽을 선택했다.
+
+## Open Risks
+
+- 팀원이 이미 익숙한 기존 템플릿 흐름과 달라졌다고 느낄 수 있어, 실제 PR 몇 건으로 반응을 한 번 확인할 필요가 있다.
+- 이후 PR Guard가 다시 역할 흔적까지 검사하게 되면 템플릿도 함께 다시 맞춰야 한다.

--- a/docs/ai/tasks/pr-template-pr-guard-alignment/plan.md
+++ b/docs/ai/tasks/pr-template-pr-guard-alignment/plan.md
@@ -1,0 +1,44 @@
+# Plan
+
+## Task
+
+- 작업 이름: Pr Template Pr Guard Alignment
+- 요청 날짜: 2026-03-19
+- 담당 범위: 입력 파일 기준 초안 생성
+
+## Goal
+
+- PR 템플릿이 현재 PR Guard 경고 기준과 어긋나 팀원이 placeholder를 그대로 두고도 통과할 것처럼 보이는 문제를 줄인다.
+- 템플릿에서 실제로 필요한 섹션과 예시만 남겨, 팀원이 PR Guard 경고 없이 PR을 작성하기 쉽게 만든다.
+
+## In Scope
+
+- `.github/PULL_REQUEST_TEMPLATE.md`
+
+## Out Of Scope
+
+- PR Guard workflow 로직 변경
+- 새로운 검사 항목 추가
+- PR 본문 자동 생성 도구 추가
+
+## Target Files
+
+- `.github/PULL_REQUEST_TEMPLATE.md`
+
+## Completion Criteria
+
+- 템플릿에서 PR Guard가 실제로 검사하는 `Task 문서`, `참고한 기준 문서`, `실행한 검증`, `남은 리스크` 안내가 더 명확해진다.
+- `역할 수행`처럼 현재 PR Guard가 검사하지 않는 섹션은 제거하거나 optional로 내려 팀 혼선을 줄인다.
+- placeholder를 그대로 둬도 통과할 것처럼 보이던 예시를 blockquote 설명으로 바꿔, 실제 내용을 입력해야 한다는 점이 드러난다.
+
+## Role Plan
+
+- Planner: 범위 / 완료 기준 / 참고 문서 정리
+- Implementer: 최소 범위 구현
+- Reviewer: diff / self-review / 위험 신호 확인
+- Tester: 검증 명령 실행과 결과 정리
+
+## Test Plan
+
+- `npx prettier --check .github/PULL_REQUEST_TEMPLATE.md`
+- `npm run ai:self-review -- --files .github/PULL_REQUEST_TEMPLATE.md docs/ai/tasks/pr-template-pr-guard-alignment/plan.md docs/ai/tasks/pr-template-pr-guard-alignment/context.md docs/ai/tasks/pr-template-pr-guard-alignment/checklist.md`


### PR DESCRIPTION
## 📌 관련 이슈

> closes #493 

---

## 📝 작업 내용

> PR Guard가 실제로 검사하는 항목과 PR 템플릿 안내가 어긋나 있어,
> 팀원이 템플릿만 보면 통과 가능한지 판단하기 어려운 부분이 있었습니다.
> 이번 수정에서는 PR Guard 기준에 맞춰 템플릿을 슬림하게 정리했습니다.

### 변경 내용

- `역할 수행` 섹션을 제거했습니다.
- `참고한 기준 문서`에 실제 manual 경로를 적어야 한다는 안내를 명확히 했습니다.
- `실행한 검증`은 placeholder 대신 실제 실행한 명령 예시 중심으로 바꿨습니다.
- `남은 리스크`는 placeholder 대신 실제 통과 가능한 문장 예시로 바꿨습니다.
- 전체적으로 `Task 문서 / 참고한 기준 문서 / 실행한 검증 / 남은 리스크` 중심으로 정리했습니다.

### 🧠 Task 문서

- `docs/ai/tasks/pr-template-pr-guard-alignment/plan.md`
- `docs/ai/tasks/pr-template-pr-guard-alignment/context.md`
- `docs/ai/tasks/pr-template-pr-guard-alignment/checklist.md`

### 📚 참고한 기준 문서

- `AGENTS.md`
- `docs/ai/manuals/common.md`
- `docs/rules.md`
- `docs/testing.md`

### 🧪 실행한 검증

- `npm run ai:self-review -- --files .github/PULL_REQUEST_TEMPLATE.md docs/ai/tasks/pr-template-pr-guard-alignment/plan.md docs/ai/tasks/pr-template-pr-guard-alignment/context.md docs/ai/tasks/pr-template-pr-guard-alignment/checklist.md`
- `npx prettier --write .github/PULL_REQUEST_TEMPLATE.md`
- `npx prettier --check .github/PULL_REQUEST_TEMPLATE.md docs/ai/tasks/pr-template-pr-guard-alignment/plan.md docs/ai/tasks/pr-template-pr-guard-alignment/context.md docs/ai/tasks/pr-template-pr-guard-alignment/checklist.md`

### ⚠️ 남은 리스크

- 팀이 기존 placeholder 방식에 익숙했다면 몇 번의 PR 동안은 적응이 필요합니다.
- 이후 PR Guard가 다시 `roles`까지 검사하도록 바뀌면 템플릿도 다시 조정해야 합니다.
