### PR TITLE
fix: 게임 소켓 계약 정렬(TRAVEL_SELECT) 및 무인도 턴 주사위 UI 가시성 수정

### DIFF
--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -224,7 +224,7 @@ interface GameBoardProps {
   suppressDiceTimerModal?: boolean
   activePrompt?: GamePrompt | null
   promptSubmittingChoice?: string | null
-  onPromptChoice?: (choice: string) => void
+  onPromptChoice?: (choice: string, payload?: Record<string, unknown>) => void
   tiles?: Array<{
     index: number
     owner_id?: string | number | null
@@ -638,10 +638,6 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       activePrompt,
       'acquisitionCancel'
     )
-    const promptTravelConfirmChoiceValue = resolvePromptChoiceValue(
-      activePrompt,
-      'travelConfirm'
-    )
     const promptTravelCancelChoiceValue = resolvePromptChoiceValue(
       activePrompt,
       'travelCancel'
@@ -653,13 +649,14 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
 
     const submitPromptChoice = (
       choiceValue: string | null,
-      onSuccess?: () => void
+      onSuccess?: () => void,
+      payload?: Record<string, unknown>
     ) => {
       if (!choiceValue || !onPromptChoice || promptSubmittingChoice !== null) {
         return false
       }
 
-      onPromptChoice(choiceValue)
+      onPromptChoice(choiceValue, payload)
       onSuccess?.()
       return true
     }
@@ -1170,7 +1167,6 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
     function handleTravelConfirm() {
       const { onDoneCallback } = travelModal
       setTravelModal({ open: false })
-      submitPromptChoice(promptTravelConfirmChoiceValue)
       setTravelSelection({
         active: true,
         onDoneCallback,
@@ -1180,7 +1176,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
 
     function handleTravelCancel() {
       setTravelModal({ open: false })
-      submitPromptChoice(promptTravelCancelChoiceValue)
+      submitPromptChoice(promptTravelCancelChoiceValue ?? 'SKIP')
     }
 
     function handleTravelDestinationSelect(tileId: number) {
@@ -1195,6 +1191,21 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       }
 
       const { onDoneCallback } = travelSelection
+      const hasTravelPromptContext = isTravelPromptOpen && !!activePrompt?.id
+
+      if (hasTravelPromptContext) {
+        const submitted = submitPromptChoice('CONFIRM', undefined, {
+          targetTileId: tileId,
+        })
+
+        if (!submitted) {
+          return
+        }
+
+        setTravelSelection(INITIAL_TRAVEL_SELECTION_STATE)
+        setStatus('서버 선택 요청을 기다리는 중...')
+        return
+      }
       const updatedPlayers = [...playersRef.current]
       updatedPlayers[playerIdx] = {
         ...currentPlayer,
@@ -1204,13 +1215,8 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       setTravelSelection(INITIAL_TRAVEL_SELECTION_STATE)
 
       if (!isMockMode) {
-        emitGameAction({
-          type: 'TRAVEL',
-          gameId,
-          payload: {
-            toIndex: tileId,
-          },
-        })
+        setStatus('서버 선택 요청을 처리할 수 없는 상태입니다.')
+        return
       }
 
       const destinationName =

--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -1027,7 +1027,10 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
         }
         playersRef.current = updatedPlayers
       }
-      advanceTurn(onDoneCallback)
+      setIslandModal({
+        open: true,
+        onDoneCallback,
+      })
     }
 
     function handleIslandConfirm() {
@@ -1245,6 +1248,9 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       if (tile.type === 'MOVE_TO_ISLAND') {
         setStatus('무인도로 이동!')
         if (isLocalPlayerTurn) {
+          if (goToIslandModal.open || islandModal.open) {
+            return
+          }
           setGoToIslandModal({ open: true, onDoneCallback: onDone })
           new Audio('/audio/island-trap.mp3').play().catch(() => {})
         } else {
@@ -1256,6 +1262,9 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       if (tile.type === 'ISLAND') {
         setStatus('무인도 칸에 도착!')
         if (isLocalPlayerTurn) {
+          if (goToIslandModal.open || islandModal.open) {
+            return
+          }
           new Audio('/audio/island-trap.mp3').play().catch(() => {})
           setIslandModal({ open: true, onDoneCallback: onDone })
         } else {

--- a/src/mocks/handlers/game.handler.ts
+++ b/src/mocks/handlers/game.handler.ts
@@ -26,6 +26,7 @@ const PROMPT_CHOICE_CANONICAL_MAP: Record<string, readonly string[]> = {
   BUY_OR_SKIP: ['BUY', 'SKIP'],
   CONFIRM_ONLY: ['CONFIRM'],
   PAY_TOLL: ['PAY_TOLL'],
+  TRAVEL_SELECT: ['CONFIRM', 'SKIP'],
 }
 
 type DiceRequestBody = {
@@ -74,6 +75,7 @@ type MockGameSyncPayload = {
 
 type MockPromptResponsePayload = GamePromptResponse & {
   gameId?: string | null
+  payload?: Record<string, unknown>
 }
 
 const clonePlayers = () => structuredClone(mockPlayers)
@@ -892,6 +894,7 @@ export const mockEmitPromptResponse = ({
   gameId,
   promptId,
   choice,
+  payload,
 }: MockPromptResponsePayload) => {
   const actionId = `${PROMPT_RESPONSE_ACTION_PREFIX}-${Date.now()}`
   const resolvedGameId = resolveRequiredGameId({
@@ -969,10 +972,11 @@ export const mockEmitPromptResponse = ({
       ? getTileByIndex(targetTileIndex)
       : undefined
   const promptAmount = resolvePromptAmount(activePrompt)
+  const responsePayload = payload && typeof payload === 'object' ? payload : {}
   const nextEvents: GamePatchEnvelope['events'] = [
     {
       type: 'PROMPT_RESPONSE',
-      payload: { choice: normalizedChoice, promptId },
+      payload: { choice: normalizedChoice, promptId, ...responsePayload },
     },
   ]
 
@@ -1023,6 +1027,48 @@ export const mockEmitPromptResponse = ({
         amount: promptAmount,
       },
     })
+    advanceMockTurn()
+  }
+
+  if (promptType === 'TRAVEL_SELECT') {
+    if (normalizedChoice === 'CONFIRM') {
+      const rawTargetTileId =
+        responsePayload.targetTileId ?? responsePayload.toTileId
+      const targetTileId =
+        typeof rawTargetTileId === 'number' && Number.isFinite(rawTargetTileId)
+          ? Math.trunc(rawTargetTileId)
+          : Number.NaN
+
+      if (
+        respondingPlayer &&
+        Number.isFinite(targetTileId) &&
+        targetTileId >= 0 &&
+        targetTileId < mockGameState.tiles.length &&
+        targetTileId !== respondingPlayer.position
+      ) {
+        const fromTileId = respondingPlayer.position
+        respondingPlayer.position = targetTileId
+
+        nextEvents.push(
+          {
+            type: 'PLAYER_MOVED',
+            playerId: respondingPlayer.id,
+            tileIndex: targetTileId,
+            payload: {
+              fromTileId,
+              toTileId: targetTileId,
+              trigger: 'travel',
+            },
+          },
+          {
+            type: 'LANDED',
+            playerId: respondingPlayer.id,
+            tileIndex: targetTileId,
+          }
+        )
+      }
+    }
+
     advanceMockTurn()
   }
 

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -261,7 +261,10 @@ const GamePage: React.FC = () => {
     roomChatSenderOptions.find(
       (senderOption) => senderOption.id !== currentUserIdForChat
     )?.id ?? roomChatSenderOptions[0]?.id
-  const handlePromptChoice = (choice: string) => {
+  const handlePromptChoice = (
+    choice: string,
+    payload?: Record<string, unknown>
+  ) => {
     if (!prompt || promptSubmittingChoice !== null) {
       return
     }
@@ -271,6 +274,7 @@ const GamePage: React.FC = () => {
       gameId: activeGameId,
       promptId: prompt.id,
       choice,
+      payload,
     })
   }
   const dismissLastError = () => {

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -430,12 +430,16 @@ const GamePage: React.FC = () => {
       </div>
 
       <div className="absolute bottom-10 right-10 z-20">
-        {!isCurrentPlayerSkipped && !isCurrentPlayerBankrupt && (
-          <RollButton
-            isMyTurn={isMyTurn && !isActionPending && !isPromptVisible}
-            onRoll={handleRollClick}
-          />
-        )}
+        <RollButton
+          isMyTurn={
+            isMyTurn &&
+            !isActionPending &&
+            !isPromptVisible &&
+            !isCurrentPlayerSkipped &&
+            !isCurrentPlayerBankrupt
+          }
+          onRoll={handleRollClick}
+        />
       </div>
 
       {isPromptVisible && prompt && !isBoardHandledPrompt && (

--- a/src/services/socket/game.handler.ts
+++ b/src/services/socket/game.handler.ts
@@ -205,6 +205,31 @@ export const setupGameHandlers = (
       patch: Array.isArray(payload.patch) ? payload.patch : [],
       events: mergedEvents,
     })
+    const normalizedEvents = normalizedPatchEnvelope.events ?? []
+    const isSyncOnlyEnvelope =
+      normalizedPatchEnvelope.patch.length === 0 &&
+      normalizedEvents.length > 0 &&
+      normalizedEvents.every(
+        (event) =>
+          typeof event.type === 'string' &&
+          event.type.trim().toUpperCase() === 'SYNCED'
+      )
+    const shouldSkipDuplicateSyncSnapshot =
+      Boolean(payload.snapshot) &&
+      normalizedPatchEnvelope.revision > 0 &&
+      normalizedPatchEnvelope.revision === gameStore.revision &&
+      gameStore.players.length > 0 &&
+      isSyncOnlyEnvelope
+
+    if (shouldSkipDuplicateSyncSnapshot) {
+      if (import.meta.env.DEV) {
+        console.debug(
+          '[game:patch] skip duplicate SYNCED snapshot',
+          normalizedPatchEnvelope.revision
+        )
+      }
+      return
+    }
 
     if (payload.snapshot) {
       const normalizedSnapshot = normalizeSnapshotPayload(payload.snapshot, {
@@ -223,14 +248,10 @@ export const setupGameHandlers = (
 
       if (import.meta.env.DEV) {
         console.debug('[game:patch] normalized snapshot', normalizedSnapshot)
-        console.debug(
-          '[game:patch] events to enqueue',
-          normalizedPatchEnvelope.events
-        )
+        console.debug('[game:patch] events to enqueue', normalizedEvents)
       }
 
       gameStore.replaceFromSnapshot(normalizedSnapshot)
-      const normalizedEvents = normalizedPatchEnvelope.events ?? []
       if (normalizedEvents.length > 0) {
         gameStore.enqueueEvents(normalizedEvents)
       }

--- a/src/services/socket/game.handler.ts
+++ b/src/services/socket/game.handler.ts
@@ -379,6 +379,7 @@ export const emitGameSync = ({ gameId, knownRevision }: GameSyncPayload) => {
 export const emitPromptResponse = ({
   promptId,
   choice,
+  payload,
   gameId,
 }: PromptResponsePayload) => {
   const resolvedGameId = getResolvedGameId(gameId)
@@ -398,6 +399,7 @@ export const emitPromptResponse = ({
       gameId: resolvedGameId,
       promptId,
       choice: normalizedChoice,
+      payload,
     })
     return
   }
@@ -406,5 +408,6 @@ export const emitPromptResponse = ({
     gameId: resolvedGameId,
     promptId,
     choice: normalizedChoice,
+    payload,
   })
 }

--- a/src/stores/game.store.test.ts
+++ b/src/stores/game.store.test.ts
@@ -277,4 +277,81 @@ describe('game store partial updates', () => {
     expect(nextState.prompt).toBeNull()
     expect(nextState.eventQueue).toEqual([])
   })
+
+  it('clears stale prompt and pendingAction when snapshot omits both keys', () => {
+    const store = useGameStore.getState()
+
+    store.setGameState({
+      prompt: {
+        id: 'prompt-stale',
+        type: 'BUY_OR_SKIP',
+      },
+      pendingAction: {
+        actionId: 'action-stale',
+        type: 'ROLL_DICE',
+        requestedAt: Date.now(),
+      },
+    })
+
+    store.replaceFromSnapshot({
+      roomId: 'room-1',
+      gameId: 'game-1',
+      revision: 9,
+      phase: 'rolling',
+      players: [createPlayer()],
+      tiles: [createTile()],
+      currentPlayerId: 'player-1',
+      currentTurn: 'player-1',
+      round: 3,
+      turnTimeoutSec: 30,
+      gameResult: null,
+      isGameOver: false,
+      winnerId: null,
+    })
+
+    const nextState = useGameStore.getState()
+
+    expect(nextState.prompt).toBeNull()
+    expect(nextState.pendingAction).toBeNull()
+  })
+
+  it('applies revision 0 patch envelopes and keeps current revision value', () => {
+    const store = useGameStore.getState()
+
+    store.setGameState({
+      revision: 7,
+      round: 1,
+    })
+
+    store.applyPatchEnvelope({
+      revision: 0,
+      patch: [{ op: 'set', path: 'round', value: 2 }],
+      events: [],
+    })
+
+    const nextState = useGameStore.getState()
+
+    expect(nextState.round).toBe(2)
+    expect(nextState.revision).toBe(7)
+  })
+
+  it('applies same-revision patch envelopes to support ack-first delivery', () => {
+    const store = useGameStore.getState()
+
+    store.setGameState({
+      revision: 5,
+      round: 1,
+    })
+
+    store.applyPatchEnvelope({
+      revision: 5,
+      patch: [{ op: 'set', path: 'round', value: 6 }],
+      events: [],
+    })
+
+    const nextState = useGameStore.getState()
+
+    expect(nextState.round).toBe(6)
+    expect(nextState.revision).toBe(5)
+  })
 })

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -131,6 +131,7 @@ export interface GamePrompt {
 export interface GamePromptResponse {
   promptId: string
   choice: string
+  payload?: Record<string, unknown>
 }
 
 export interface GameAck {


### PR DESCRIPTION
## ✨ 작업 개요
최신 기준 문서(`docs/api.md`, `docs/gamesocket.md`)와 현재 백엔드 런타임 동작에 맞춰 게임 소켓 처리 경로를 정렬했습니다.

이번 PR은 기능 확장이 아니라, 실서버에서 발생하던 계약 불일치/표시 이슈를 수정하는 안정화 작업입니다.

핵심 목적은 아래 2가지입니다.
1. 국내여행(TRAVEL_SELECT) 응답을 `game:action(TRAVEL)` 경로에서 `game:prompt_response` 경로로 정렬
2. 무인도/잠금 턴에서 Roll 버튼이 사라져 보이는 UI 오해 제거(버튼은 유지, 비활성화만 적용)

---

## 🧩 배경 / 문제
- 실서버에서 국내여행 목적지 선택 시 `UNKNOWN_ACTION: TRAVEL`이 발생
- 원인: 프론트에 `emitGameAction({ type: 'TRAVEL' })` 경로가 남아 있었고, 이는 최신 계약의 허용 액션이 아님
- 추가로, 턴 플레이어가 `island/locked/bankrupt` 상태일 때 Roll 버튼 자체를 렌더링하지 않아
  "두 클라 모두 버튼이 사라진 것처럼 보이는" UX 문제가 발생

---

## 🔧 변경 사항

### 1) TRAVEL_SELECT 응답 경로 정렬
- `GamePromptResponse`에 `payload` 필드 추가
- `emitPromptResponse`가 mock/real 모두 `payload`를 전달하도록 확장
- `GamePage -> GameBoard` prompt choice 전달 시그니처를 `(choice, payload?)`로 확장
- `GameBoard` 국내여행 처리 수정
  - 여행 확인 시 즉시 응답 전송 제거
  - 목적지 클릭 시 `prompt_response` 전송
    - `choice: CONFIRM`
    - `payload.targetTileId: 선택한 칸`
  - 취소는 `SKIP`으로 처리
  - 실서버 경로에서 `game:action(TRAVEL)` 호출 제거
- mock runtime도 동일 규약 지원
  - `TRAVEL_SELECT` canonical choice(`CONFIRM`,`SKIP`) 추가
  - payload 기반 이동/착지 이벤트 반영

### 2) Roll 버튼 가시성 수정
- 기존: `island/locked/bankrupt` 상태이면 Roll 버튼 자체 미렌더
- 변경: 버튼은 항상 렌더, 해당 상태에서는 `disabled`만 적용
- 효과: 무인도 턴에도 버튼 위치/형태는 유지되어 상태 오해 감소

---

## 📂 변경 파일
- `src/components/board/GameBoard.tsx`
- `src/pages/GamePage.tsx`
- `src/services/socket/game.handler.ts`
- `src/mocks/handlers/game.handler.ts`
- `src/types/domain.ts`

---

## ✅ 검증
- `npm run lint` 통과
- `npm run test` 통과 (50 files / 298 tests)
- `npm run test:coverage` 통과
- `npm run build` 통과

참고:
- `src/pages/GamePage.test.tsx`의 `act(...)` warning은 기존에도 존재하던 비차단 경고이며 테스트 실패는 없음

---

## 🔍 리스크 / 후속 확인
- 백엔드 문서/코드가 계속 정리 중인 상태라 canonical choice/phase 정책 변경 가능성은 존재
- 머지 전/직후 실서버 스모크 권장
  - `TRAVEL_SELECT` 선택 시 `UNKNOWN_ACTION(TRAVEL)` 미발생
  - 목적지 선택 후 `PLAYER_MOVED/LANDED` 반영
  - 무인도/잠금 턴에서 Roll 버튼은 보이되 비활성화 동작 확인
