### PR TITLE
chore: 로컬 env 백엔드 origin을 duckdns https로 변경

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,6 +1,6 @@
 # 실백엔드 연결용 예시
-VITE_API_URL=http://13.209.49.56:8000/api
-VITE_SOCKET_URL=http://13.209.49.56:8000
+VITE_API_URL=https://modoo-marble.duckdns.org/api
+VITE_SOCKET_URL=https://modoo-marble.duckdns.org
 VITE_USE_SOCKET_MOCK=false
 VITE_ENABLE_DEMO_MOCK=false
 VITE_ALLOW_ALL_MOCK_TURNS=false

--- a/.env.development.real
+++ b/.env.development.real
@@ -1,6 +1,6 @@
 # 실백엔드 연결용 예시
-VITE_API_URL=http://13.209.49.56:8000/api
-VITE_SOCKET_URL=http://13.209.49.56:8000
+VITE_API_URL=https://modoo-marble.duckdns.org/api
+VITE_SOCKET_URL=https://modoo-marble.duckdns.org
 VITE_USE_SOCKET_MOCK=false
 VITE_ENABLE_DEMO_MOCK=false
 VITE_ALLOW_ALL_MOCK_TURNS=false


### PR DESCRIPTION
## 📌 관련 이슈

> closes #497 

---

## 📝 작업 내용

기존 로컬 개발 env가 IP 기반 백엔드 주소를 바라보고 있어,
로컬 프론트가 새 HTTPS 도메인 기준으로 REST / socket을 호출하도록 정리했습니다.

- `.env.development`의 `VITE_API_URL`을 `https://modoo-marble.duckdns.org/api`로 변경했습니다.
- `.env.development`의 `VITE_SOCKET_URL`을 `https://modoo-marble.duckdns.org`로 변경했습니다.
- `.env.development.real`의 `VITE_API_URL`을 `https://modoo-marble.duckdns.org/api`로 변경했습니다.
- `.env.development.real`의 `VITE_SOCKET_URL`을 `https://modoo-marble.duckdns.org`로 변경했습니다.

### 📚 참고한 기준 문서

- `AGENTS.md`

### 🧪 실행한 검증

- `.env.development` 값 반영 확인
- `.env.development.real` 값 반영 확인

### ⚠️ 남은 리스크

- 백엔드 CORS, cookie `Secure` / `SameSite`, 카카오 redirect URI가 새 도메인 기준으로 맞지 않으면 로그인/refresh는 여전히 실패할 수 있습니다.
- Vercel 환경변수는 이번 PR 범위에 포함되지 않아, 배포 환경은 별도 변경이 필요합니다.
