### PR TITLE
fix: my page stats total_games 계약 반영

### DIFF
--- a/docs/ai/tasks/mypage-total-games-contract-align/checklist.md
+++ b/docs/ai/tasks/mypage-total-games-contract-align/checklist.md
@@ -1,0 +1,22 @@
+# Checklist
+
+## Implementation
+
+- [x] 관련 manual과 기존 문서를 읽었다
+- [x] 영향 범위를 정리했다
+- [x] 최소 범위로 구현했다
+- [x] mock/real 경로를 함께 확인했다
+- [x] 타입/contract 변경이 있으면 관련 코드도 같이 수정했다
+
+## Testing
+
+- [x] 대상 Vitest를 실행했다
+- [ ] 필요 시 `npm run lint`를 실행했다
+- [ ] 필요 시 `npm run build`를 실행했다
+- [ ] 필요 시 Playwright 시나리오를 실행했다
+
+## Review
+
+- [x] `docs/rules.md` 기준으로 셀프 리뷰했다
+- [x] 리다이렉트, cleanup, 중복 구독, 에러 처리 경계를 확인했다
+- [x] 변경 파일 / 실행한 검증 / 남은 리스크를 정리했다

--- a/docs/ai/tasks/mypage-total-games-contract-align/context.md
+++ b/docs/ai/tasks/mypage-total-games-contract-align/context.md
@@ -1,0 +1,32 @@
+# Context
+
+## Current Behavior
+
+- 프론트 내부 `MyPageProfile` 모델은 `stats.total`을 사용한다.
+- `/users/me` 백엔드 계약은 `stats.total_games`로 최종 확정되었다.
+- 현재 API 매핑이 그대로면 총 게임 수가 비어 보이거나 0으로 떨어질 수 있다.
+
+## Related Files
+
+- `src/features/auth/api/api.ts`
+- `src/features/auth/api/api.test.ts`
+- `src/features/auth/session/types.ts`
+- `src/pages/MyPage.tsx`
+- `docs/rules.md`
+- `docs/testing.md`
+
+## Constraints
+
+- UI와 세션 도메인 모델은 최소 범위로 유지한다.
+- 계약 변경은 API 매핑 계층에서 흡수한다.
+- mock 경로를 깨지 않도록 내부 `stats.total` 모델은 유지한다.
+
+## Decision Notes
+
+- 화면/도메인 모델 전반을 `total_games`로 바꾸기보다, API payload를 `total_games -> total`로 변환한다.
+- 필요 시 과도기 호환을 위해 기존 `stats.total`도 fallback으로 허용한다.
+
+## Open Risks
+
+- 백엔드가 최종적으로 `total_games`만 내려준다는 가정에 맞춘 수정이다.
+- 이후 다른 프로필 필드명도 바뀌면 별도 계약 정리가 추가로 필요할 수 있다.

--- a/docs/ai/tasks/mypage-total-games-contract-align/plan.md
+++ b/docs/ai/tasks/mypage-total-games-contract-align/plan.md
@@ -1,0 +1,39 @@
+# Plan
+
+## Task
+
+- 작업 이름: mypage total_games contract align
+- 요청 날짜: 2026-03-19
+- 담당 범위: auth profile API 매핑, 관련 테스트, task 문서
+
+## Goal
+
+- `/users/me` 응답 전적 필드가 `stats.total_games`로 확정된 계약을 프론트에서 안전하게 흡수한다.
+
+## In Scope
+
+- `MyPageProfilePayload` 타입을 새 계약 기준으로 정리
+- 내부 프로필 모델의 `stats.total`로 매핑 보정
+- 관련 Vitest 갱신
+
+## Out Of Scope
+
+- 마이페이지 UI 구조 변경
+- 백엔드 문서/서버 코드 수정
+- 다른 auth/presence/game 계약 정리
+
+## Target Files
+
+- `src/features/auth/api/api.ts`
+- `src/features/auth/api/api.test.ts`
+- `docs/ai/tasks/mypage-total-games-contract-align/*`
+
+## Completion Criteria
+
+- `/users/me`가 `stats.total_games`를 반환해도 마이페이지 총 게임 수가 정상 표시된다.
+- 관련 테스트가 새 계약 기준으로 통과한다.
+
+## Test Plan
+
+- `npx vitest run src/features/auth/api/api.test.ts`
+- 필요 시 `npm run lint`

--- a/src/features/auth/api/api.test.ts
+++ b/src/features/auth/api/api.test.ts
@@ -103,13 +103,13 @@ describe('buildAuthSession', () => {
 })
 
 describe('mapMyPageProfile', () => {
-  it('마이페이지 프로필 id를 문자열로 정규화하고 profile_image를 읽는다', () => {
+  it('마이페이지 프로필 id를 문자열로 정규화하고 total_games를 내부 total로 매핑한다', () => {
     const profile = mapMyPageProfile({
       id: 3,
       nickname: '마블러',
       profile_image: 'https://example.com/avatar.png',
       stats: {
-        total: 10,
+        total_games: 10,
         wins: 6,
         losses: 4,
       },
@@ -436,7 +436,7 @@ describe('auth api integration helpers', () => {
         nickname: '마이페이지유저',
         profile_image_url: 'https://example.com/me.png',
         stats: {
-          total: 20,
+          total_games: 20,
           wins: 11,
           losses: 9,
         },

--- a/src/features/auth/api/api.ts
+++ b/src/features/auth/api/api.ts
@@ -56,7 +56,7 @@ interface MyPageProfilePayload {
   profile_image_url?: string | null
   profile_image?: string | null
   stats: {
-    total: number
+    total_games: number
     wins: number
     losses: number
   }
@@ -128,7 +128,11 @@ export function mapMyPageProfile(payload: MyPageProfilePayload): MyPageProfile {
     id: normalizeId(payload.id),
     nickname: payload.nickname,
     profileImage: readProfileImageUrl(payload),
-    stats: payload.stats,
+    stats: {
+      total: payload.stats.total_games,
+      wins: payload.stats.wins,
+      losses: payload.stats.losses,
+    },
   }
 }
 


### PR DESCRIPTION
## 📌 관련 이슈

> closes #499 

---

## 📝 작업 내용

백엔드 `/users/me` 응답 전적 필드가 `stats.total_games`로 확정되어,
프론트 마이페이지 전적 매핑도 해당 계약에 맞게 정리했습니다.

- `MyPageProfilePayload`를 `stats.total_games` 기준으로 수정했습니다.
- 내부 프론트 도메인 모델은 기존 `stats.total`을 유지하고, API 매핑 계층에서 `total_games -> total`로 변환하도록 정리했습니다.
- 관련 API 테스트도 새 계약 기준으로 갱신했습니다.
- 작업 맥락 추적을 위해 task 문서를 함께 추가했습니다.

### 🧠 Task 문서

- `docs/ai/tasks/mypage-total-games-contract-align/plan.md`
- `docs/ai/tasks/mypage-total-games-contract-align/context.md`
- `docs/ai/tasks/mypage-total-games-contract-align/checklist.md`

### 📚 참고한 기준 문서

- `AGENTS.md`
- `docs/ai/manuals/common.md`
- `docs/rules.md`
- `docs/testing.md`

### 🧪 실행한 검증

- `npx vitest run src/features/auth/api/api.test.ts`
- `npm run ai:self-review -- --files src/features/auth/api/api.ts src/features/auth/api/api.test.ts docs/ai/tasks/mypage-total-games-contract-align/plan.md docs/ai/tasks/mypage-total-games-contract-align/context.md docs/ai/tasks/mypage-total-games-contract-align/checklist.md`

### ⚠️ 남은 리스크

- `npm run lint`, `npm run build`는 이번 변경 범위에서는 실행하지 않았습니다.
- self-review에서 auth refresh/logout 경로 관련 공통 경고가 재출력됐지만, 이번 `total_games` 계약 반영과 직접 충돌하는 내용은 아닙니다.
