### PR TITLE
feat: 사용자 참가 컨텍스트 기반 재진입 복귀 흐름 추가

### DIFF
--- a/docs/ai/tasks/auth-resume-context-routing/checklist.md
+++ b/docs/ai/tasks/auth-resume-context-routing/checklist.md
@@ -1,0 +1,23 @@
+# Checklist
+
+## Implementation
+
+- [x] 관련 manual과 기존 문서를 읽었다
+- [x] 영향 범위를 정리했다
+- [x] `users/me/context` 타입과 API를 추가했다
+- [x] App 공통 resume routing hook을 추가했다
+- [x] 기존 홈 리다이렉트 흐름을 정리했다
+- [x] mock/real 경로를 함께 확인했다
+
+## Testing
+
+- [x] 대상 Vitest를 실행했다
+- [x] `npm run ai:self-review`를 실행했다
+- [x] `npm run lint`를 실행했다
+- [x] `npm run build`를 실행했다
+
+## Review
+
+- [x] `resume_target`을 최우선 분기로 사용하도록 고정했다
+- [x] callback / nickname setup / session clear 경계를 확인했다
+- [x] 변경 파일 / 실행한 검증 / 남은 리스크를 정리했다

--- a/docs/ai/tasks/auth-resume-context-routing/context.md
+++ b/docs/ai/tasks/auth-resume-context-routing/context.md
@@ -1,0 +1,39 @@
+# Context
+
+## Current Behavior
+
+- 앱은 persisted access token이 있으면 `restoreAuthSession`으로 세션만 복구한다.
+- 복구가 끝난 뒤 홈 화면에서는 `useRedirectAuthenticatedToLobby`가 무조건 `/lobby`로 보낸다.
+- 새로고침/재접속 시 사용자가 실제로 참가 중인 방/게임 문맥을 서버 기준으로 복원하는 API 분기가 없다.
+
+## Related Files
+
+- `src/App.tsx`
+- `src/pages/HomePage.tsx`
+- `src/features/auth/api/api.ts`
+- `src/features/auth/session/hooks/useAuthBootstrap.ts`
+- `src/pages/waiting-room/page/WaitingRoomPage.tsx`
+- `src/pages/GamePage.tsx`
+- `docs/ai/manuals/common.md`
+- `docs/ai/manuals/lobby.md`
+- `docs/ai/manuals/waiting-room.md`
+- `docs/rules.md`
+- `docs/testing.md`
+
+## Constraints
+
+- `resume_target`을 최우선 분기 기준으로 사용한다.
+- `room_status`, `presence_status`는 보조 정보로만 사용한다.
+- callback 페이지와 nickname setup 페이지의 기존 흐름은 유지한다.
+- waiting-room/game 페이지는 location state가 없어도 동작해야 하며, 가능한 최소 state만 주입한다.
+
+## Decision Notes
+
+- 복귀 분기는 HomePage가 아니라 App 공통 훅에서 한 번 처리한다.
+- `resume_target = room`이면 `room_status = playing`이어도 room 경로를 유지한다.
+- mock auth 모드에서는 기본값으로 lobby context를 반환해 기존 mock 개발 흐름을 깨지 않는다.
+
+## Open Risks
+
+- `users/me/context` 호출 실패 시 앱은 fallback 경로를 선택해야 하므로, 홈 경로에서만 `/lobby` fallback을 사용한다.
+- 게임 경로가 이미 맞는 경우에도 location state에 `roomId`가 없으면 채팅 문맥이 늦게 붙을 수 있다.

--- a/docs/ai/tasks/auth-resume-context-routing/plan.md
+++ b/docs/ai/tasks/auth-resume-context-routing/plan.md
@@ -1,0 +1,51 @@
+# Plan
+
+## Task
+
+- 작업 이름: auth resume context routing
+- 요청 날짜: 2026-03-19
+- 담당 범위: auth context API, App resume routing hook, 관련 테스트, task 문서
+
+## Goal
+
+- 세션 복구 이후 `GET /api/users/me/context` 응답의 `resume_target`을 기준으로 로비/대기방/게임 복귀 경로를 일관되게 결정한다.
+
+## In Scope
+
+- `users/me/context` 응답 타입과 API 헬퍼 추가
+- mock auth 경로용 기본 context 응답 추가
+- App 레벨 공통 resume routing hook 추가
+- 홈 전용 로비 리다이렉트 흐름 정리
+- 관련 Vitest 추가/수정
+
+## Out Of Scope
+
+- waiting-room/game 상세 UI 변경
+- 백엔드 문서/서버 코드 수정
+- me/context 응답 자체의 비즈니스 규칙 변경
+
+## Target Files
+
+- `src/features/auth/session/types.ts`
+- `src/features/auth/api/api.ts`
+- `src/features/auth/api/api.test.ts`
+- `src/features/auth/api/mockApi.ts`
+- `src/features/auth/mock/session.ts`
+- `src/features/auth/session/hooks/useAuthResumeNavigation.ts`
+- `src/features/auth/session/hooks/useAuthResumeNavigation.test.tsx`
+- `src/App.tsx`
+- `src/App.test.tsx`
+- `src/pages/HomePage.tsx`
+- `docs/ai/tasks/auth-resume-context-routing/*`
+
+## Completion Criteria
+
+- 세션이 복구된 사용자는 `resume_target` 기준으로 `/lobby`, `/rooms/:roomId`, `/game/:gameId` 중 올바른 경로로 복귀한다.
+- `resume_target = room`인데 `room_status = playing`이어도 room 분기를 유지한다.
+- 기존 callback / nickname setup 흐름은 유지된다.
+- 관련 Vitest가 통과한다.
+
+## Test Plan
+
+- `npx vitest run src/features/auth/api/api.test.ts src/features/auth/session/hooks/useAuthResumeNavigation.test.tsx src/App.test.tsx`
+- `npm run ai:self-review -- --files src/features/auth/session/types.ts src/features/auth/api/api.ts src/features/auth/api/api.test.ts src/features/auth/api/mockApi.ts src/features/auth/mock/session.ts src/features/auth/session/hooks/useAuthResumeNavigation.ts src/features/auth/session/hooks/useAuthResumeNavigation.test.tsx src/App.tsx src/App.test.tsx src/pages/HomePage.tsx docs/ai/tasks/auth-resume-context-routing/plan.md docs/ai/tasks/auth-resume-context-routing/context.md docs/ai/tasks/auth-resume-context-routing/checklist.md`

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -5,10 +5,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import App from './App'
 import { createAuthSessionFixture } from './test/fixtures'
 
-const { useAuthBootstrapMock, useAuthStoreMock } = vi.hoisted(() => ({
-  useAuthBootstrapMock: vi.fn(),
-  useAuthStoreMock: vi.fn(),
-}))
+const { useAuthBootstrapMock, useAuthResumeNavigationMock, useAuthStoreMock } =
+  vi.hoisted(() => ({
+    useAuthBootstrapMock: vi.fn(),
+    useAuthResumeNavigationMock: vi.fn(),
+    useAuthStoreMock: vi.fn(),
+  }))
 
 vi.mock('./components/DesktopViewportGuard', () => ({
   DesktopViewportGuard: ({ children }: { children: ReactNode }) => (
@@ -18,6 +20,10 @@ vi.mock('./components/DesktopViewportGuard', () => ({
 
 vi.mock('./features/auth/session/hooks/useAuthBootstrap', () => ({
   useAuthBootstrap: useAuthBootstrapMock,
+}))
+
+vi.mock('./features/auth/session/hooks/useAuthResumeNavigation', () => ({
+  useAuthResumeNavigation: useAuthResumeNavigationMock,
 }))
 
 vi.mock('./features/auth/session/store', () => ({
@@ -63,6 +69,7 @@ function renderApp(initialEntry: string) {
 describe('App auth bootstrap gating', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    useAuthResumeNavigationMock.mockReturnValue(false)
     useAuthStoreMock.mockImplementation((selector) =>
       selector({
         session: null,
@@ -112,5 +119,26 @@ describe('App auth bootstrap gating', () => {
       screen.queryByText('세션 정보를 확인하고 있습니다.')
     ).not.toBeInTheDocument()
     expect(await screen.findByText('로비 페이지')).toBeInTheDocument()
+  })
+
+  it('세션이 있는 상태에서 참가 컨텍스트를 확인 중이면 복귀 확인 화면을 보여준다', () => {
+    useAuthBootstrapMock.mockReturnValue(false)
+    useAuthResumeNavigationMock.mockReturnValue(true)
+    useAuthStoreMock.mockImplementation((selector) =>
+      selector({
+        session: createAuthSessionFixture({
+          accessToken: 'persisted-token',
+          userId: 'user-1',
+          nickname: '테스터',
+        }),
+      })
+    )
+
+    renderApp('/')
+
+    expect(
+      screen.getByText('참가 정보를 확인하고 있습니다.')
+    ).toBeInTheDocument()
+    expect(screen.queryByText('홈 페이지')).not.toBeInTheDocument()
   })
 })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { Routes, Route, useLocation } from 'react-router-dom'
 import { DesktopViewportGuard } from './components/DesktopViewportGuard'
 import { KAKAO_LOGIN_CALLBACK_PATH } from './features/auth/api/api'
 import { useAuthBootstrap } from './features/auth/session/hooks/useAuthBootstrap'
+import { useAuthResumeNavigation } from './features/auth/session/hooks/useAuthResumeNavigation'
 import { useAuthStore } from './features/auth/session/store'
 
 const HomePage = lazy(() => import('./pages/HomePage'))
@@ -51,31 +52,36 @@ function App() {
   const session = useAuthStore((state) => state.session)
   const isHomeRoute = location.pathname === '/'
   const isKakaoCallbackRoute = location.pathname === KAKAO_LOGIN_CALLBACK_PATH
+  const isNicknameSetupRoute = location.pathname === '/nickname-setup'
   const hasPersistedSession = Boolean(session)
   const isAuthBootstrapping = useAuthBootstrap({
     skip: isKakaoCallbackRoute,
   })
+  const isAuthResumeRouting = useAuthResumeNavigation({
+    session,
+    skip: isAuthBootstrapping || isKakaoCallbackRoute || isNicknameSetupRoute,
+  })
   const shouldShowBootstrapScreen =
-    isAuthBootstrapping &&
-    !hasPersistedSession &&
-    !isHomeRoute &&
-    !isKakaoCallbackRoute
+    ((isAuthBootstrapping && !hasPersistedSession && !isHomeRoute) ||
+      (isAuthResumeRouting && hasPersistedSession)) &&
+    !isKakaoCallbackRoute &&
+    !isNicknameSetupRoute
+  const bootstrapMessage = isAuthResumeRouting
+    ? '참가 정보를 확인하고 있습니다.'
+    : '세션 정보를 확인하고 있습니다.'
 
   return (
     <DesktopViewportGuard>
       {shouldShowBootstrapScreen ? (
         <div className="flex min-h-screen items-center justify-center bg-ui-app-bg px-4">
           <p className="text-sm font-medium text-ui-text-muted">
-            세션 정보를 확인하고 있습니다.
+            {bootstrapMessage}
           </p>
         </div>
       ) : (
         <Suspense fallback={<RouteLoadingScreen />}>
           <Routes>
-            <Route
-              path="/"
-              element={<HomePage isAuthBootstrapping={isAuthBootstrapping} />}
-            />
+            <Route path="/" element={<HomePage />} />
             <Route
               path={KAKAO_LOGIN_CALLBACK_PATH}
               element={<KakaoLoginCallbackPage />}

--- a/src/features/auth/api/api.test.ts
+++ b/src/features/auth/api/api.test.ts
@@ -5,9 +5,11 @@ import {
   buildAuthSession,
   completeKakaoLogin,
   getAuthErrorMessage,
+  getMyContext,
   getMyPageProfile,
   loginAsGuest,
   logoutAuthSession,
+  mapAuthResumeContext,
   mapMyPageProfile,
   refreshAccessToken,
   restoreAuthSession,
@@ -128,6 +130,28 @@ describe('mapMyPageProfile', () => {
   })
 })
 
+describe('mapAuthResumeContext', () => {
+  it('users/me/context 응답을 내부 resume context 모델로 변환한다', () => {
+    const context = mapAuthResumeContext({
+      room_id: 'room-7',
+      room_title: '친구방',
+      room_status: 'playing',
+      game_id: '17',
+      presence_status: 'playing',
+      resume_target: 'game',
+    })
+
+    expect(context).toEqual({
+      roomId: 'room-7',
+      roomTitle: '친구방',
+      roomStatus: 'playing',
+      gameId: '17',
+      presenceStatus: 'playing',
+      resumeTarget: 'game',
+    })
+  })
+})
+
 describe('auth api integration helpers', () => {
   const originalBaseUrl = apiClient.defaults.baseURL
   const originalLocation = window.location
@@ -235,6 +259,35 @@ describe('auth api integration helpers', () => {
     expect(restored.userId).toBe('14')
     expect(restored.needsNicknameSetup).toBe(true)
     expect(restored.provider).toBe('kakao')
+  })
+
+  it('getMyContext는 Authorization 헤더로 참가 컨텍스트를 조회한다', async () => {
+    const getSpy = vi.spyOn(apiClient, 'get').mockResolvedValue({
+      data: {
+        room_id: 'room-7',
+        room_title: '친구방',
+        room_status: 'playing',
+        game_id: '17',
+        presence_status: 'playing',
+        resume_target: 'game',
+      },
+    })
+
+    const context = await getMyContext('persisted-token')
+
+    expect(getSpy).toHaveBeenCalledWith('/users/me/context', {
+      headers: {
+        Authorization: 'Bearer persisted-token',
+      },
+    })
+    expect(context).toEqual({
+      roomId: 'room-7',
+      roomTitle: '친구방',
+      roomStatus: 'playing',
+      gameId: '17',
+      presenceStatus: 'playing',
+      resumeTarget: 'game',
+    })
   })
 
   it('loginAsGuest는 실제 계약 응답을 프론트 세션으로 매핑한다', async () => {

--- a/src/features/auth/api/api.ts
+++ b/src/features/auth/api/api.ts
@@ -8,13 +8,18 @@ import {
   type RefreshAccessTokenResponsePayload,
 } from '../../../lib/axios'
 import {
+  mockGetMyContext,
   mockGuestLogin,
   mockGetMyPageProfile,
   mockKakaoLogin,
   mockSetNickname,
 } from './mockApi'
 import type {
+  AuthContextRoomStatus,
+  AuthPresenceStatus,
   AuthProvider,
+  AuthResumeContext,
+  AuthResumeTarget,
   AuthSession,
   MyPageProfile,
   MyPageProfileResult,
@@ -44,6 +49,15 @@ interface AuthSessionResponse {
 }
 
 type AuthSessionPayload = AuthUserPayload
+
+interface AuthResumeContextPayload {
+  room_id: string | null
+  room_title: string | null
+  room_status: AuthContextRoomStatus | null
+  game_id: string | null
+  presence_status: AuthPresenceStatus
+  resume_target: AuthResumeTarget
+}
 
 interface UpdateNicknameResponsePayload {
   id: number | string
@@ -136,6 +150,19 @@ export function mapMyPageProfile(payload: MyPageProfilePayload): MyPageProfile {
   }
 }
 
+export function mapAuthResumeContext(
+  payload: AuthResumeContextPayload
+): AuthResumeContext {
+  return {
+    roomId: payload.room_id,
+    roomTitle: payload.room_title,
+    roomStatus: payload.room_status,
+    gameId: payload.game_id,
+    presenceStatus: payload.presence_status,
+    resumeTarget: payload.resume_target,
+  }
+}
+
 function buildApiPath(path: string) {
   const baseUrl = String(apiClient.defaults.baseURL ?? '/api').replace(
     /\/+$/,
@@ -208,6 +235,23 @@ export async function completeKakaoLogin({
     provider: 'kakao',
     needsNicknameSetup: isNewUser || restored.user.nickname.trim().length === 0,
   })
+}
+
+export async function getMyContext(accessToken: string) {
+  if (IS_AUTH_MOCK_ENABLED) {
+    return mockGetMyContext()
+  }
+
+  const { data } = await apiClient.get<AuthResumeContextPayload>(
+    '/users/me/context',
+    {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    }
+  )
+
+  return mapAuthResumeContext(data)
 }
 
 export async function refreshAccessToken() {

--- a/src/features/auth/api/mockApi.ts
+++ b/src/features/auth/api/mockApi.ts
@@ -1,4 +1,8 @@
-export { mockKakaoLogin, mockGuestLogin } from '../mock/session'
+export {
+  mockGetMyContext,
+  mockKakaoLogin,
+  mockGuestLogin,
+} from '../mock/session'
 export { validateNickname } from '../nickname/validation'
 export {
   mockCheckNicknameAvailability,

--- a/src/features/auth/mock/session.ts
+++ b/src/features/auth/mock/session.ts
@@ -1,4 +1,4 @@
-import type { AuthSession } from '../session/types'
+import type { AuthResumeContext, AuthSession } from '../session/types'
 import { resetMockOnlineUsers } from '../../presence/mock/mockData'
 import { resetMockWaitingRooms } from '../../../pages/waiting-room/socket/mockGateway'
 import { MOCK_AUTH_DELAY_MS } from './constants'
@@ -70,4 +70,18 @@ export async function mockGuestLogin() {
   }
 
   return session
+}
+
+// mock 모드의 재진입 복귀는 기본 로비 상태로 단순화
+export async function mockGetMyContext(): Promise<AuthResumeContext> {
+  await delay(MOCK_AUTH_DELAY_MS)
+
+  return {
+    roomId: null,
+    roomTitle: null,
+    roomStatus: null,
+    gameId: null,
+    presenceStatus: 'lobby',
+    resumeTarget: 'lobby',
+  }
 }

--- a/src/features/auth/session/hooks/useAuthResumeNavigation.test.tsx
+++ b/src/features/auth/session/hooks/useAuthResumeNavigation.test.tsx
@@ -1,0 +1,142 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createAuthSessionFixture } from '../../../../test/fixtures'
+import { useAuthResumeNavigation } from './useAuthResumeNavigation'
+
+const {
+  clearSessionMock,
+  disconnectSocketAndClearAuthMock,
+  getMyContextMock,
+  locationRef,
+  navigateMock,
+  shouldClearAuthSessionMock,
+} = vi.hoisted(() => ({
+  clearSessionMock: vi.fn(),
+  disconnectSocketAndClearAuthMock: vi.fn(),
+  getMyContextMock: vi.fn(),
+  locationRef: {
+    current: {
+      pathname: '/',
+      state: null,
+    },
+  },
+  navigateMock: vi.fn(),
+  shouldClearAuthSessionMock: vi.fn(),
+}))
+
+vi.mock('react-router-dom', () => ({
+  useLocation: () => locationRef.current,
+  useNavigate: () => navigateMock,
+}))
+
+vi.mock('../../api/api', () => ({
+  getMyContext: getMyContextMock,
+  shouldClearAuthSession: shouldClearAuthSessionMock,
+}))
+
+vi.mock('../store', () => ({
+  useAuthStore: (selector: (state: { clearSession: () => void }) => unknown) =>
+    selector({
+      clearSession: clearSessionMock,
+    }),
+}))
+
+vi.mock('../../../../lib/socket', () => ({
+  disconnectSocketAndClearAuth: disconnectSocketAndClearAuthMock,
+}))
+
+describe('useAuthResumeNavigation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    locationRef.current = {
+      pathname: '/',
+      state: null,
+    }
+    shouldClearAuthSessionMock.mockReturnValue(false)
+  })
+
+  it('resume_target이 room이면 room_status와 무관하게 대기방 경로로 복귀한다', async () => {
+    getMyContextMock.mockResolvedValue({
+      roomId: 'room-42',
+      roomTitle: '친구방',
+      roomStatus: 'playing',
+      gameId: null,
+      presenceStatus: 'playing',
+      resumeTarget: 'room',
+    })
+
+    const { result } = renderHook(() =>
+      useAuthResumeNavigation({
+        session: createAuthSessionFixture({
+          accessToken: 'resume-token',
+          userId: 'user-1',
+        }),
+      })
+    )
+
+    expect(result.current).toBe(true)
+
+    await waitFor(() => {
+      expect(navigateMock).toHaveBeenCalledWith('/rooms/room-42', {
+        replace: true,
+        state: {
+          roomId: 'room-42',
+          roomTitle: '친구방',
+        },
+      })
+    })
+  })
+
+  it('home 경로에서 context 조회가 실패하면 lobby로 fallback 이동한다', async () => {
+    getMyContextMock.mockRejectedValue(new Error('temporary error'))
+
+    renderHook(() =>
+      useAuthResumeNavigation({
+        session: createAuthSessionFixture({
+          accessToken: 'resume-token',
+          userId: 'user-1',
+        }),
+      })
+    )
+
+    await waitFor(() => {
+      expect(navigateMock).toHaveBeenCalledWith('/lobby', { replace: true })
+    })
+  })
+
+  it('401 오류면 세션과 소켓을 정리하고 홈으로 복귀한다', async () => {
+    const authError = new Error('unauthorized')
+    getMyContextMock.mockRejectedValue(authError)
+    shouldClearAuthSessionMock.mockReturnValue(true)
+
+    renderHook(() =>
+      useAuthResumeNavigation({
+        session: createAuthSessionFixture({
+          accessToken: 'expired-token',
+          userId: 'user-1',
+        }),
+      })
+    )
+
+    await waitFor(() => {
+      expect(clearSessionMock).toHaveBeenCalledTimes(1)
+      expect(disconnectSocketAndClearAuthMock).toHaveBeenCalledTimes(1)
+      expect(navigateMock).toHaveBeenCalledWith('/', { replace: true })
+    })
+  })
+
+  it('skip이면 context 조회를 생략한다', () => {
+    renderHook(() =>
+      useAuthResumeNavigation({
+        session: createAuthSessionFixture({
+          accessToken: 'resume-token',
+          userId: 'user-1',
+        }),
+        skip: true,
+      })
+    )
+
+    expect(getMyContextMock).not.toHaveBeenCalled()
+    expect(navigateMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/features/auth/session/hooks/useAuthResumeNavigation.ts
+++ b/src/features/auth/session/hooks/useAuthResumeNavigation.ts
@@ -1,0 +1,145 @@
+import { useEffect, useRef, useState } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
+import { getMyContext, shouldClearAuthSession } from '../../api/api'
+import { disconnectSocketAndClearAuth } from '../../../../lib/socket'
+import { useAuthStore } from '../store'
+import type { AuthResumeContext, AuthSession } from '../types'
+
+interface UseAuthResumeNavigationParams {
+  session: AuthSession | null
+  skip?: boolean
+}
+
+interface ResumeNavigationState {
+  roomId?: string
+  roomTitle?: string
+  gameId?: string
+}
+
+interface ResumeDestination {
+  pathname: string
+  state?: ResumeNavigationState
+}
+
+function buildResumeIdentity(session: AuthSession | null) {
+  if (!session || session.needsNicknameSetup) {
+    return ''
+  }
+
+  return `${session.provider}:${session.userId}`
+}
+
+export function resolveResumeDestination(
+  context: AuthResumeContext
+): ResumeDestination {
+  if (context.resumeTarget === 'game' && context.gameId) {
+    return {
+      pathname: `/game/${context.gameId}`,
+      state: {
+        gameId: context.gameId,
+        roomId: context.roomId ?? undefined,
+      },
+    }
+  }
+
+  if (context.resumeTarget === 'room' && context.roomId) {
+    return {
+      pathname: `/rooms/${context.roomId}`,
+      state: {
+        roomId: context.roomId,
+        roomTitle: context.roomTitle ?? undefined,
+      },
+    }
+  }
+
+  return {
+    pathname: '/lobby',
+  }
+}
+
+export function useAuthResumeNavigation({
+  session,
+  skip = false,
+}: UseAuthResumeNavigationParams) {
+  const navigate = useNavigate()
+  const location = useLocation()
+  const clearSession = useAuthStore((state) => state.clearSession)
+  const [isResolving, setIsResolving] = useState(false)
+  const resolvedIdentityRef = useRef('')
+  const activeAccessTokenRef = useRef(session?.accessToken.trim() ?? '')
+
+  useEffect(() => {
+    activeAccessTokenRef.current = session?.accessToken.trim() ?? ''
+  }, [session])
+
+  useEffect(() => {
+    const resumeIdentity = buildResumeIdentity(session)
+    const accessToken = session?.accessToken.trim() ?? ''
+
+    if (skip || !resumeIdentity || !accessToken) {
+      if (!resumeIdentity) {
+        resolvedIdentityRef.current = ''
+      }
+      setIsResolving(false)
+      return
+    }
+
+    if (resolvedIdentityRef.current === resumeIdentity) {
+      setIsResolving(false)
+      return
+    }
+
+    let isDisposed = false
+    setIsResolving(true)
+
+    getMyContext(accessToken)
+      .then((context) => {
+        if (isDisposed || activeAccessTokenRef.current !== accessToken) {
+          return
+        }
+
+        resolvedIdentityRef.current = resumeIdentity
+
+        const destination = resolveResumeDestination(context)
+        if (location.pathname === destination.pathname) {
+          return
+        }
+
+        navigate(destination.pathname, {
+          replace: true,
+          state: destination.state,
+        })
+      })
+      .catch((error) => {
+        if (isDisposed || activeAccessTokenRef.current !== accessToken) {
+          return
+        }
+
+        resolvedIdentityRef.current = resumeIdentity
+
+        if (shouldClearAuthSession(error)) {
+          clearSession()
+          disconnectSocketAndClearAuth()
+          navigate('/', { replace: true })
+          return
+        }
+
+        if (location.pathname === '/') {
+          navigate('/lobby', { replace: true })
+        }
+      })
+      .finally(() => {
+        if (isDisposed || activeAccessTokenRef.current !== accessToken) {
+          return
+        }
+
+        setIsResolving(false)
+      })
+
+    return () => {
+      isDisposed = true
+    }
+  }, [clearSession, location.pathname, navigate, session, skip])
+
+  return isResolving
+}

--- a/src/features/auth/session/types.ts
+++ b/src/features/auth/session/types.ts
@@ -1,5 +1,8 @@
 // 로그인 공급자 종류 정의
 export type AuthProvider = 'kakao' | 'guest'
+export type AuthContextRoomStatus = 'waiting' | 'playing'
+export type AuthPresenceStatus = 'lobby' | 'in_room' | 'playing'
+export type AuthResumeTarget = 'lobby' | 'room' | 'game'
 
 // 클라이언트에서 유지하는 인증 세션 형태
 export interface AuthSession {
@@ -10,6 +13,16 @@ export interface AuthSession {
   isGuest: boolean
   needsNicknameSetup: boolean
   provider: AuthProvider
+}
+
+// 세션 복구 뒤 앱 재진입 분기에 사용하는 사용자 참가 컨텍스트
+export interface AuthResumeContext {
+  roomId: string | null
+  roomTitle: string | null
+  roomStatus: AuthContextRoomStatus | null
+  gameId: string | null
+  presenceStatus: AuthPresenceStatus
+  resumeTarget: AuthResumeTarget
 }
 
 // 마이페이지 전적 집계 타입

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -14,7 +14,6 @@ import {
   loginAsGuest,
   startKakaoLogin,
 } from '../features/auth/api/api'
-import { useRedirectAuthenticatedToLobby } from '../features/auth/session/hooks/useRedirectAuthenticatedToLobby'
 import { useAuthStore } from '../features/auth/session/store'
 
 // 홈 하단 기능 소개 카드 메타데이터
@@ -40,21 +39,12 @@ const featureCards = [
 ]
 
 // 로그인 진입 홈 화면 렌더링과 인증 흐름 제어
-interface HomePageProps {
-  isAuthBootstrapping?: boolean
-}
-
-function HomePage({ isAuthBootstrapping = false }: HomePageProps) {
+function HomePage() {
   const navigate = useNavigate()
-  const session = useAuthStore((state) => state.session)
   const setSession = useAuthStore((state) => state.setSession)
 
   const [isKakaoLoading, setIsKakaoLoading] = useState(false)
   const [isGuestLoading, setIsGuestLoading] = useState(false)
-
-  useRedirectAuthenticatedToLobby(session, {
-    skip: isAuthBootstrapping,
-  })
 
   const isAnyLoading = isKakaoLoading || isGuestLoading
 


### PR DESCRIPTION
## 📌 관련 이슈

> closes #509

---

## 📝 작업 내용

세션 복구 이후 사용자가 현재 어느 방/게임에 참가 중인지 확인할 수 있도록
`GET /api/users/me/context` 계약을 프론트에 반영하고,
`resume_target`을 최우선 분기 기준으로 사용하는 재진입 복귀 흐름을 추가했습니다.

- `users/me/context` 응답 타입과 API 매핑을 추가했습니다.
- mock auth 모드에서도 기본 `lobby` context를 반환하도록 정리했습니다.
- App 레벨에 `useAuthResumeNavigation` 훅을 추가해 세션 복구 뒤 `/lobby`, `/rooms/:roomId`, `/game/:gameId` 중 적절한 경로로 복귀하도록 했습니다.
- `resume_target = room`인데 `room_status = playing`인 경우도 room 분기를 유지하도록 구현했습니다.
- 기존 HomePage의 “활성 세션이면 무조건 `/lobby`” 리다이렉트는 제거하고, App 공통 분기로 통합했습니다.
- 관련 API / 훅 / App 테스트를 추가·갱신했습니다.

### 🧠 Task 문서

- `docs/ai/tasks/auth-resume-context-routing/plan.md`
- `docs/ai/tasks/auth-resume-context-routing/context.md`
- `docs/ai/tasks/auth-resume-context-routing/checklist.md`

### 📚 참고한 기준 문서

- `AGENTS.md`
- `docs/ai/manuals/common.md`
- `docs/ai/manuals/lobby.md`
- `docs/ai/manuals/waiting-room.md`
- `docs/rules.md`
- `docs/testing.md`

### 🧪 실행한 검증

- `npx vitest run src/features/auth/api/api.test.ts src/features/auth/session/hooks/useAuthResumeNavigation.test.tsx src/App.test.tsx`
- `npm run lint`
- `npm run ai:self-review -- --files src/features/auth/session/types.ts src/features/auth/api/api.ts src/features/auth/api/api.test.ts src/features/auth/api/mockApi.ts src/features/auth/mock/session.ts src/features/auth/session/hooks/useAuthResumeNavigation.ts src/features/auth/session/hooks/useAuthResumeNavigation.test.tsx src/App.tsx src/App.test.tsx src/pages/HomePage.tsx docs/ai/tasks/auth-resume-context-routing/plan.md docs/ai/tasks/auth-resume-context-routing/context.md docs/ai/tasks/auth-resume-context-routing/checklist.md`
- `npm run build`

### ⚠️ 남은 리스크

- 이번 PR은 앱 재진입 시점의 복귀 라우팅만 다룹니다. 같은 세션 안에서 이후 참가 컨텍스트가 바뀌는 실시간 재분기까지는 포함하지 않습니다.
- 현재 경로가 이미 `/game/:gameId`와 일치하는 새로고침 상황에서는 location state에 `roomId`를 다시 주입하지 않아, 게임 채팅 문맥은 game snapshot sync 이후에 맞춰질 수 있습니다.
