### PR TITLE
feat: 카카오 로그인 시작 시 프론트 콜백 주소 전달

### DIFF
--- a/src/features/auth/api/api.test.ts
+++ b/src/features/auth/api/api.test.ts
@@ -324,6 +324,7 @@ describe('auth api integration helpers', () => {
       configurable: true,
       value: {
         ...window.location,
+        origin: 'http://localhost:5173',
         assign: assignSpy,
       },
     })
@@ -332,7 +333,7 @@ describe('auth api integration helpers', () => {
 
     expect(result).toBeNull()
     expect(assignSpy).toHaveBeenCalledWith(
-      'http://localhost:3000/api/auth/kakao/login'
+      'http://localhost:3000/api/auth/kakao/login?frontend_redirect=http%3A%2F%2Flocalhost%3A5173%2Fauth%2Fkakao%2Fcallback'
     )
   })
 

--- a/src/features/auth/api/api.ts
+++ b/src/features/auth/api/api.ts
@@ -171,6 +171,10 @@ function buildApiPath(path: string) {
   return `${baseUrl}${path}`
 }
 
+function buildFrontendCallbackRedirect() {
+  return new URL(KAKAO_LOGIN_CALLBACK_PATH, window.location.origin).toString()
+}
+
 async function getAuthSessionWithToken(accessToken: string) {
   const response = await apiClient.get<AuthSessionPayload>('/auth/session', {
     headers: {
@@ -285,7 +289,13 @@ export async function startKakaoLogin() {
     return mockKakaoLogin()
   }
 
-  window.location.assign(buildApiPath('/auth/kakao/login'))
+  const loginStartUrl = new URL(buildApiPath('/auth/kakao/login'))
+  loginStartUrl.searchParams.set(
+    'frontend_redirect',
+    buildFrontendCallbackRedirect()
+  )
+
+  window.location.assign(loginStartUrl.toString())
   return null
 }
 


### PR DESCRIPTION
## 📌 관련 이슈

> closes #514 

---

## 📝 작업 내용

카카오 로그인 시작 시 현재 프론트 origin 기준 callback 주소를 계산해
`frontend_redirect` 쿼리로 함께 전달하도록 변경했습니다.

- `startKakaoLogin()`에서 현재 origin 기반 callback URL을 생성하도록 수정했습니다.
- `/auth/kakao/login` 호출 시 `frontend_redirect` 쿼리를 함께 붙이도록 변경했습니다.
- 로컬 환경에서는 `http://localhost:5173/auth/kakao/callback`,
  배포 환경에서는 `https://blue-marble-frontend.vercel.app/auth/kakao/callback`
  이 자동으로 전달되는 구조입니다.
- 관련 auth API 테스트도 함께 갱신했습니다.

### 📚 참고한 기준 문서

- `AGENTS.md`
- `docs/ai/manuals/common.md`
- `docs/rules.md`
- `docs/testing.md`

### 🧪 실행한 검증

- `npx vitest run src/features/auth/api/api.test.ts`
- `npm run lint`

### ⚠️ 남은 리스크

- 이번 PR은 프론트가 `frontend_redirect`를 전달하는 것까지만 포함합니다.
- 실제 로컬/배포 callback 분기는 백엔드가 해당 쿼리를 읽고 allowlist 검증 후 redirect에 반영해야 정상 동작합니다.
- 카카오 개발자 콘솔에도 로컬/배포 callback URL이 함께 등록돼 있어야 합니다.
