### PR TITLE
fix: 방 비밀번호 입력 브라우저 경고 팝업 완화

### DIFF
--- a/src/pages/lobby/CreateRoomModal.test.tsx
+++ b/src/pages/lobby/CreateRoomModal.test.tsx
@@ -67,7 +67,8 @@ describe('CreateRoomModal', () => {
     const passwordInput = screen.getByPlaceholderText(
       '비밀번호 (4자리)'
     ) as HTMLInputElement
-    expect(passwordInput).toHaveAttribute('autocomplete', 'new-password')
+    expect(passwordInput).toHaveAttribute('type', 'text')
+    expect(passwordInput).toHaveAttribute('autocomplete', 'off')
 
     await user.type(passwordInput, '12')
     expect(

--- a/src/pages/lobby/CreateRoomModal.tsx
+++ b/src/pages/lobby/CreateRoomModal.tsx
@@ -199,11 +199,11 @@ export function CreateRoomModal({
           {isPrivateRoomEnabled ? (
             <input
               name="room-access-code"
-              type="password"
+              type="text"
               inputMode="numeric"
               pattern="[0-9]*"
               maxLength={ROOM_PASSWORD_LENGTH}
-              autoComplete="new-password"
+              autoComplete="off"
               data-1p-ignore="true"
               data-lpignore="true"
               value={roomPassword}

--- a/src/pages/lobby/LobbyPage.test.tsx
+++ b/src/pages/lobby/LobbyPage.test.tsx
@@ -435,7 +435,7 @@ describe('LobbyPage filter and toggle regression', () => {
     await user.type(screen.getByPlaceholderText('비밀번호 입력'), '1234')
     expect(screen.getByPlaceholderText('비밀번호 입력')).toHaveAttribute(
       'autocomplete',
-      'new-password'
+      'off'
     )
     await user.click(screen.getByRole('button', { name: '입장' }))
 

--- a/src/pages/lobby/PrivateRoomJoinModal.test.tsx
+++ b/src/pages/lobby/PrivateRoomJoinModal.test.tsx
@@ -1,0 +1,41 @@
+import { useState } from 'react'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { renderWithProviders } from '../../test/renderWithProviders'
+import { PrivateRoomJoinModal } from './PrivateRoomJoinModal'
+
+describe('PrivateRoomJoinModal', () => {
+  it('비밀번호 입력은 브라우저 비밀번호 필드가 아닌 숫자 코드 입력으로 렌더링한다', async () => {
+    const user = userEvent.setup()
+
+    function TestHarness() {
+      const [password, setPassword] = useState('')
+
+      return (
+        <PrivateRoomJoinModal
+          roomTitle="비밀방"
+          password={password}
+          isSubmitting={false}
+          isPasswordInvalid={false}
+          onPasswordChange={setPassword}
+          onClose={vi.fn()}
+          onSubmit={vi.fn()}
+        />
+      )
+    }
+
+    renderWithProviders(<TestHarness />)
+
+    const passwordInput = screen.getByPlaceholderText(
+      '비밀번호 입력'
+    ) as HTMLInputElement
+
+    expect(passwordInput).toHaveAttribute('type', 'text')
+    expect(passwordInput).toHaveAttribute('autocomplete', 'off')
+
+    await user.type(passwordInput, '12ab34')
+
+    expect(passwordInput.value).toBe('1234')
+  })
+})

--- a/src/pages/lobby/PrivateRoomJoinModal.tsx
+++ b/src/pages/lobby/PrivateRoomJoinModal.tsx
@@ -120,11 +120,11 @@ export function PrivateRoomJoinModal({
         >
           <input
             name="private-room-access-code"
-            type="password"
+            type="text"
             inputMode="numeric"
             pattern="[0-9]*"
             maxLength={ROOM_PASSWORD_LENGTH}
-            autoComplete="new-password"
+            autoComplete="off"
             data-1p-ignore="true"
             data-lpignore="true"
             value={password}


### PR DESCRIPTION
## 📌 관련 이슈

> closes #518 

---

## 📝 작업 내용

방 생성과 비밀방 입장에 사용하는 4자리 방 비밀번호 입력이
브라우저에서 계정 비밀번호 필드로 오인되어
비밀번호 변경/저장 관련 팝업이 뜨는 문제를 완화했습니다.

- 방 생성 모달의 비밀번호 입력을 `type="password"`에서 숫자 코드 입력으로 변경했습니다.
- 비밀방 입장 모달도 동일하게 `type="text" + inputMode="numeric" + autocomplete="off"` 조합으로 정리했습니다.
- 두 입력 모두 숫자만 받고 4자리 제한을 유지하도록 기존 필터링 로직은 그대로 유지했습니다.
- 관련 테스트를 갱신하고 비밀방 입장 모달 테스트를 추가했습니다.

### 📚 참고한 기준 문서

- `AGENTS.md`
- `docs/ai/manuals/common.md`
- `docs/ai/manuals/lobby.md`
- `docs/rules.md`
- `docs/testing.md`

### 🧪 실행한 검증

- `npx vitest run src/pages/lobby/CreateRoomModal.test.tsx src/pages/lobby/PrivateRoomJoinModal.test.tsx`
- `npm run lint`

### ⚠️ 남은 리스크

- 입력이 더 이상 `password` 타입이 아니므로 4자리 방 비밀번호가 화면에 그대로 보입니다.
- 크롬 경고는 크게 줄겠지만, 서드파티 비밀번호 매니저별 휴리스틱은 완전히 동일하지 않을 수 있습니다.
