### PR TITLE
Feat + FIX :game:sync_timer 클라이언트 연동 및 BUILD_OR_SKIP 프롬프트 모달 복구

### DIFF
--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -568,7 +568,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
     const tileOwnersRef = useRef<Record<number, TileOwner>>(tileOwners)
     const promptModalKind = resolvePromptModalKind(activePrompt)
     const isBuyPromptOpen = promptModalKind === 'buy'
-    /* isBuildPromptOpen suppressed to prioritize manual click */
+    const isBuildPromptOpen = promptModalKind === 'build'
     const isTollPromptOpen = promptModalKind === 'toll'
     const isSellPromptOpen = promptModalKind === 'sell'
     const isAcquisitionPromptOpen = promptModalKind === 'acquisition'
@@ -1454,6 +1454,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
 
     const buyTile = promptTile
     const buyModalOpen = isBuyPromptOpen
+    const buildModalOpen = isBuildPromptOpen
     const buildTile = promptTile
     const currentLevel = promptCurrentLevel
     const buildTargetLevel = promptNextLevel
@@ -1509,7 +1510,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       !isBuyPromptDismissed &&
       !insufficientFundsModal.open
     const buildModalVisible =
-      canShowModal && cityBuildModal.open && !insufficientFundsModal.open
+      canShowModal && buildModalOpen && !insufficientFundsModal.open
     const acquisitionModalOpen =
       canShowModal &&
       acquisitionModalOpenRaw &&

--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -729,6 +729,24 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
     }
 
     useEffect(() => {
+      if (!activePrompt) {
+        return
+      }
+
+      if (promptSubmittingChoice !== null) {
+        setStatus('선택을 전송했습니다. 서버 응답을 기다리는 중...')
+        return
+      }
+
+      const promptTitle =
+        typeof activePrompt.title === 'string' &&
+        activePrompt.title.trim() !== ''
+          ? activePrompt.title.trim()
+          : '선택'
+      setStatus(`${promptTitle} 진행 중`)
+    }, [activePrompt, promptSubmittingChoice])
+
+    useEffect(() => {
       tileOwnersRef.current = derivedTileOwners
     }, [derivedTileOwners])
 
@@ -1286,7 +1304,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
         }
 
         setTravelSelection(INITIAL_TRAVEL_SELECTION_STATE)
-        setStatus('서버 선택 요청을 기다리는 중...')
+        setStatus('선택을 전송했습니다. 서버 응답을 기다리는 중...')
         return
       }
       const updatedPlayers = [...playersRef.current]
@@ -1375,7 +1393,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       }
 
       if (tile.type === 'PROPERTY') {
-        setStatus('서버 선택 요청을 기다리는 중...')
+        setStatus('다음 선택지를 준비하는 중...')
         onDone?.()
         return
       }

--- a/src/hooks/game/useGameState.ts
+++ b/src/hooks/game/useGameState.ts
@@ -3,6 +3,7 @@ import { IS_SOCKET_MOCK_ENABLED } from '../../config/env'
 import { connectSocketWithAuthIfNeeded, socket } from '../../lib/socket'
 import {
   emitGameSync,
+  emitGameSyncTimer,
   setupGameHandlers,
 } from '../../services/socket/game.handler'
 import { useGameStore } from '../../stores/game.store'
@@ -40,9 +41,34 @@ export const useGameState = (gameId: string | null) => {
       syncedGameIdRef.current = gameId
     }
 
+    const syncGameTimer = () => {
+      emitGameSyncTimer({ gameId })
+    }
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        syncGameTimer()
+      }
+    }
+
+    const handleWindowFocus = () => {
+      syncGameTimer()
+    }
+
+    const handleSocketConnect = () => {
+      syncGameTimer()
+    }
+
     syncGameState()
+    syncGameTimer()
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+    window.addEventListener('focus', handleWindowFocus)
+    socket.on('connect', handleSocketConnect)
 
     return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+      window.removeEventListener('focus', handleWindowFocus)
+      socket.off('connect', handleSocketConnect)
       teardownHandlers()
     }
   }, [gameId])

--- a/src/mocks/handlers/game.handler.ts
+++ b/src/mocks/handlers/game.handler.ts
@@ -73,6 +73,10 @@ type MockGameSyncPayload = {
   knownRevision?: number
 }
 
+type MockGameSyncTimerPayload = {
+  gameId?: string | null
+}
+
 type MockPromptResponsePayload = GamePromptResponse & {
   gameId?: string | null
   payload?: Record<string, unknown>
@@ -916,6 +920,35 @@ export const mockEmitGameSync = ({
       ],
     })
   }, 0)
+}
+
+export const mockEmitGameSyncTimer = ({ gameId }: MockGameSyncTimerPayload) => {
+  const resolvedGameId = resolveRequiredGameId({ gameId })
+  if (!resolvedGameId) {
+    return
+  }
+
+  const promptRemainingSec =
+    mockGameState.prompt &&
+    typeof mockGameState.prompt.timeoutSec === 'number' &&
+    mockGameState.prompt.timeoutSec > 0 &&
+    typeof mockGameState.promptIssuedAtMs === 'number'
+      ? Math.max(
+          0,
+          Math.ceil(
+            mockGameState.prompt.timeoutSec -
+              (Date.now() - mockGameState.promptIssuedAtMs) / 1000
+          )
+        )
+      : null
+
+  emitSocketEvent('game:timer_sync', {
+    gameId: resolvedGameId,
+    turnRemainingSec: MOCK_TURN_TIMEOUT_SEC,
+    promptId: mockGameState.prompt?.id ?? null,
+    promptRemainingSec,
+    syncedAt: new Date().toISOString(),
+  })
 }
 
 export const mockEmitGameAction = ({

--- a/src/services/socket/game.handler.ts
+++ b/src/services/socket/game.handler.ts
@@ -3,6 +3,7 @@ import { socket } from '../../lib/socket'
 import {
   mockEmitGameAction,
   mockEmitGameSync,
+  mockEmitGameSyncTimer,
   mockEmitPromptResponse,
 } from '../../mocks/handlers/game.handler'
 import { useGameStore } from '../../stores/game.store'
@@ -19,6 +20,7 @@ import {
   normalizePromptChoiceValue,
   normalizePromptPayload,
   normalizeSnapshotPayload,
+  normalizeTimerSyncPayload,
 } from './gameContractAdapters'
 
 type Teardown = () => void
@@ -52,6 +54,10 @@ type PromptResponsePayload = GamePromptResponse & {
   gameId?: GameId | null
 }
 
+type GameSyncTimerPayload = {
+  gameId?: GameId | null
+}
+
 let teardownGameHandlersRef: Teardown | null = null
 const USE_GAME_SOCKET_MOCK = IS_SOCKET_MOCK_ENABLED
 let lastDiceRolledEnqueuedAt = 0
@@ -66,6 +72,11 @@ const PROMPT_ID_REQUIRED_ERROR: GameError = {
 const GAME_ID_REQUIRED_ERROR: GameError = {
   code: 'INVALID_GAME_ID',
   message: 'Game events must include a valid gameId.',
+}
+
+const TIMER_SYNC_PAYLOAD_INVALID_ERROR: GameError = {
+  code: 'INVALID_TIMER_SYNC',
+  message: 'Received game:timer_sync payload is invalid.',
 }
 
 const toFiniteNumber = (value: unknown): number | null => {
@@ -284,16 +295,28 @@ export const setupGameHandlers = (
     useGameStore.getState().setLastError(error)
   }
 
+  const handleGameTimerSync = (payload: unknown) => {
+    const normalizedTimerSync = normalizeTimerSyncPayload(payload)
+    if (!normalizedTimerSync) {
+      useGameStore.getState().setLastError(TIMER_SYNC_PAYLOAD_INVALID_ERROR)
+      return
+    }
+
+    useGameStore.getState().applyTimerSync(normalizedTimerSync)
+  }
+
   socket.on('game:ack', handleGameAck)
   socket.on('game:patch', handleGamePatch)
   socket.on('game:prompt', handleGamePrompt)
   socket.on('game:error', handleGameError)
+  socket.on('game:timer_sync', handleGameTimerSync)
 
   const teardown = () => {
     socket.off('game:ack', handleGameAck)
     socket.off('game:patch', handleGamePatch)
     socket.off('game:prompt', handleGamePrompt)
     socket.off('game:error', handleGameError)
+    socket.off('game:timer_sync', handleGameTimerSync)
   }
 
   teardownGameHandlersRef = teardown
@@ -373,6 +396,25 @@ export const emitGameSync = ({ gameId, knownRevision }: GameSyncPayload) => {
   socket.emit('game:sync', {
     gameId: resolvedGameId,
     knownRevision,
+  })
+}
+
+export const emitGameSyncTimer = ({ gameId }: GameSyncTimerPayload) => {
+  const resolvedGameId = getResolvedGameId(gameId)
+  if (!resolvedGameId) {
+    useGameStore.getState().setLastError(GAME_ID_REQUIRED_ERROR)
+    return
+  }
+
+  if (USE_GAME_SOCKET_MOCK) {
+    mockEmitGameSyncTimer({
+      gameId: resolvedGameId,
+    })
+    return
+  }
+
+  socket.emit('game:sync_timer', {
+    gameId: resolvedGameId,
   })
 }
 

--- a/src/services/socket/gameContractAdapters.test.ts
+++ b/src/services/socket/gameContractAdapters.test.ts
@@ -4,6 +4,7 @@ import {
   normalizePatchEnvelopePayload,
   normalizePromptPayload,
   normalizeSnapshotPayload,
+  normalizeTimerSyncPayload,
 } from './gameContractAdapters'
 
 describe('gameContractAdapters', () => {
@@ -585,5 +586,41 @@ describe('gameContractAdapters', () => {
         }),
       },
     ])
+  })
+
+  it('normalizes game:timer_sync payload with canonical fields', () => {
+    const normalized = normalizeTimerSyncPayload({
+      gameId: 'game-10',
+      turnRemainingSec: 18,
+      promptId: 'prompt-1',
+      promptRemainingSec: 7,
+      syncedAt: '2026-03-19T10:00:00.000Z',
+    })
+
+    expect(normalized).toEqual({
+      gameId: 'game-10',
+      turnRemainingSec: 18,
+      promptId: 'prompt-1',
+      promptRemainingSec: 7,
+      syncedAt: '2026-03-19T10:00:00.000Z',
+    })
+  })
+
+  it('normalizes game:timer_sync payload with legacy aliases', () => {
+    const normalized = normalizeTimerSyncPayload({
+      game_id: 'game-11',
+      turn_remaining_sec: '9',
+      prompt_id: 'prompt-legacy',
+      prompt_left_sec: '4',
+      server_time: '2026-03-19T10:01:00.000Z',
+    })
+
+    expect(normalized).toEqual({
+      gameId: 'game-11',
+      turnRemainingSec: 9,
+      promptId: 'prompt-legacy',
+      promptRemainingSec: 4,
+      syncedAt: '2026-03-19T10:01:00.000Z',
+    })
   })
 })

--- a/src/services/socket/gameContractAdapters.ts
+++ b/src/services/socket/gameContractAdapters.ts
@@ -4,6 +4,7 @@ import type {
   GamePrompt,
   GamePromptChoice,
   GameSnapshot,
+  GameTimerSync,
   Player,
   PlayerId,
   ServerEvent,
@@ -778,3 +779,47 @@ export const normalizePatchEnvelopePayload = (
         .filter((event): event is ServerEvent => event !== null)
     : [],
 })
+
+export const normalizeTimerSyncPayload = (
+  payload: unknown
+): GameTimerSync | null => {
+  if (!isRecord(payload)) {
+    return null
+  }
+
+  const gameId =
+    toStringOrNull(payload.gameId) ?? toStringOrNull(payload.game_id)
+  const turnRemainingSec =
+    toFiniteNumber(
+      payload.turnRemainingSec ??
+        payload.turn_remaining_sec ??
+        payload.turnLeftSec ??
+        payload.turn_left_sec ??
+        payload.remainingTurnSec ??
+        payload.remaining_turn_sec
+    ) ?? null
+  const promptId =
+    toStringOrNull(payload.promptId) ?? toStringOrNull(payload.prompt_id)
+  const promptRemainingSec =
+    toFiniteNumber(
+      payload.promptRemainingSec ??
+        payload.prompt_remaining_sec ??
+        payload.promptLeftSec ??
+        payload.prompt_left_sec ??
+        payload.remainingPromptSec ??
+        payload.remaining_prompt_sec
+    ) ?? null
+  const syncedAt =
+    toStringOrNull(payload.syncedAt) ??
+    toStringOrNull(payload.synced_at) ??
+    toStringOrNull(payload.serverTime) ??
+    toStringOrNull(payload.server_time)
+
+  return {
+    gameId,
+    turnRemainingSec,
+    promptId,
+    promptRemainingSec,
+    syncedAt,
+  }
+}

--- a/src/stores/game.store.test.ts
+++ b/src/stores/game.store.test.ts
@@ -354,4 +354,59 @@ describe('game store partial updates', () => {
     expect(nextState.round).toBe(6)
     expect(nextState.revision).toBe(5)
   })
+
+  it('applies timer sync to turn timer and prompt timeout when prompt id matches', () => {
+    const store = useGameStore.getState()
+
+    store.setGameState({
+      gameId: 'game-before-sync',
+      turnTimeoutSec: 30,
+      turnTimerKey: 1,
+      prompt: {
+        id: 'prompt-sync-target',
+        type: 'CONFIRM_ONLY',
+        timeoutSec: 20,
+      },
+    })
+
+    store.applyTimerSync({
+      gameId: 'game-after-sync',
+      turnRemainingSec: 13,
+      promptId: 'prompt-sync-target',
+      promptRemainingSec: 5,
+      syncedAt: '2026-03-19T12:00:00.000Z',
+    })
+
+    const nextState = useGameStore.getState()
+
+    expect(nextState.gameId).toBe('game-after-sync')
+    expect(nextState.session.gameId).toBe('game-after-sync')
+    expect(nextState.turnTimeoutSec).toBe(13)
+    expect(nextState.turnTimerKey).toBeGreaterThan(1)
+    expect(nextState.prompt?.timeoutSec).toBe(5)
+    expect(nextState.session.syncedAt).toBe('2026-03-19T12:00:00.000Z')
+  })
+
+  it('does not overwrite prompt timeout when timer sync prompt id is different', () => {
+    const store = useGameStore.getState()
+
+    store.setGameState({
+      prompt: {
+        id: 'prompt-current',
+        type: 'BUY_OR_SKIP',
+        timeoutSec: 14,
+      },
+    })
+
+    store.applyTimerSync({
+      turnRemainingSec: 9,
+      promptId: 'prompt-other',
+      promptRemainingSec: 3,
+    })
+
+    const nextState = useGameStore.getState()
+
+    expect(nextState.turnTimeoutSec).toBe(9)
+    expect(nextState.prompt?.timeoutSec).toBe(14)
+  })
 })

--- a/src/stores/game.store.ts
+++ b/src/stores/game.store.ts
@@ -9,6 +9,7 @@ import type {
   GameResult,
   GameSnapshot,
   GameState,
+  GameTimerSync,
   PendingGameAction,
   Player,
   PlayerId,
@@ -26,6 +27,7 @@ interface GameActions {
   addMessage: (message: ChatMessage) => void
   replaceFromSnapshot: (snapshot: GameSnapshot) => void
   applyPatchEnvelope: (envelope: GamePatchEnvelope) => void
+  applyTimerSync: (timerSync: GameTimerSync) => void
   setPendingAction: (action: PendingGameAction | null) => void
   resolveAck: (ack: GameAck) => void
   setPrompt: (prompt: GameState['prompt']) => void
@@ -436,6 +438,40 @@ export const useGameStore = create<GameStoreState>()(
         }
         draft.eventQueue.push(...(envelope.events ?? []))
         Object.assign(draft, normalizeState(draft))
+      }),
+
+    applyTimerSync: (timerSync) =>
+      set((draft) => {
+        const nowIso = new Date().toISOString()
+
+        if (timerSync.gameId != null) {
+          draft.gameId = timerSync.gameId
+          draft.session.gameId = timerSync.gameId
+        }
+
+        if (typeof timerSync.turnRemainingSec === 'number') {
+          const normalizedTurnRemainingSec = Math.max(
+            0,
+            Math.trunc(timerSync.turnRemainingSec)
+          )
+          draft.turnTimeoutSec = normalizedTurnRemainingSec
+          draft.turnTimerKey = Date.now()
+        }
+
+        if (
+          draft.prompt &&
+          typeof timerSync.promptId === 'string' &&
+          draft.prompt.id === timerSync.promptId &&
+          typeof timerSync.promptRemainingSec === 'number'
+        ) {
+          draft.prompt.timeoutSec = Math.max(
+            0,
+            Math.trunc(timerSync.promptRemainingSec)
+          )
+        }
+
+        draft.session.transport = 'event-socket'
+        draft.session.syncedAt = timerSync.syncedAt ?? nowIso
       }),
 
     setPendingAction: (action) =>

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -224,6 +224,14 @@ export interface GamePatchEnvelope {
   events?: ServerEvent[]
 }
 
+export interface GameTimerSync {
+  gameId?: GameId | null
+  turnRemainingSec?: number | null
+  promptId?: string | null
+  promptRemainingSec?: number | null
+  syncedAt?: string | null
+}
+
 export interface GameState extends GameSnapshot {
   messages: ChatMessage[]
   // 기존 화면과의 호환을 위해 currentTurn alias를 유지한다.


### PR DESCRIPTION
## 📌 관련 이슈

> closes #<이슈번호>

---

## 📝 작업 내용

1. `game:sync_timer` 요청/`game:timer_sync` 응답 흐름을 프론트 런타임에 추가했습니다.
2. 게임 소켓 어댑터에 `timer_sync` 정규화 로직을 추가해 snake_case/camelCase 혼용 payload를 모두 수용하도록 했습니다.
3. store에 `applyTimerSync` 액션을 추가해 서버 기준 남은 턴 시간/프롬프트 시간을 반영하도록 했습니다.
4. `useGameState`에서 초기 진입, 탭 복귀(visibilitychange), window focus, socket reconnect 시 타이머 동기화를 재요청하도록 구성했습니다.
5. mock 경로에도 `mockEmitGameSyncTimer`를 추가해 mock/real 양쪽에서 동일한 API 경로를 유지했습니다.
6. BUILD 계열 프롬프트(`BUILD_OR_SKIP`)가 상태 텍스트만 남고 모달이 안 뜨던 문제를 수정했습니다.
7. prompt 전송/대기 상태 문구를 개선해서 “안 끝난 것처럼 보이는” UX 혼동을 줄였습니다.

변경 파일:
- `src/types/domain.ts`
- `src/stores/game.store.ts`
- `src/stores/game.store.test.ts`
- `src/services/socket/gameContractAdapters.ts`
- `src/services/socket/gameContractAdapters.test.ts`
- `src/services/socket/game.handler.ts`
- `src/hooks/game/useGameState.ts`
- `src/mocks/handlers/game.handler.ts`
- `src/components/board/GameBoard.tsx`

---

## 🧠 Task 문서 (큰 작업이면 필수)

- plan: 해당 없음 (브랜치 내 구현 + 테스트 중심 진행)
- context: 해당 없음
- checklist: 해당 없음

---

## 📚 참고한 기준 문서

- `AGENTS.md`
- `docs/ai/manuals/common.md`
- `docs/rules.md`
- `docs/testing.md`
- `docs/ai/manuals/game-runtime.md`
- `docs/gamesocket.md` (팀 공지 최신 계약 기준 확인)

---

## 🧪 실행한 검증

- `npm run test -- src/services/socket/gameContractAdapters.test.ts src/stores/game.store.test.ts`
- `npm run test -- src/mocks/handlers/game.handler.test.ts`
- `npx eslint src/components/board/GameBoard.tsx`
- `npm run test -- src/components/board/useBoardEventQueue.test.tsx src/components/board/gameBoardEventQueueUtils.test.ts`
- `npm run lint`
- `npm run build`
- pre-push 자동 게이트 통과:
- `npm run lint`
- `npm run test`
- `npm run test:coverage`
- `npm run build`

참고:
- pre-push 중 `GamePage.test.tsx`의 `act(...)` warning은 기존에도 존재하던 non-blocking warning이며, 이번 변경으로 새로 실패를 유발하지는 않았습니다.

---

## ⚠️ 남은 리스크

- 백엔드 `game:timer_sync` payload 키가 현재 어댑터 alias 범위(`turnRemainingSec`, `turn_remaining_sec`, `promptRemainingSec`, `prompt_remaining_sec` 등)를 벗어나면 타이머 반영이 누락될 수 있습니다.
- `applyTimerSync`는 `promptId`가 현재 active prompt와 일치할 때만 prompt 타이머를 갱신하므로, 서버 prompt 교체 타이밍이 빠를 경우 짧은 순간 타이머 표시가 이전 값으로 보일 수 있습니다.
- 탭 복귀/focus/reconnect 시점마다 sync 요청을 보내므로, 네트워크 품질이 불안정한 환경에서 타이머가 짧게 점프하는 체감이 있을 수 있습니다.
- mock의 `turnRemainingSec`는 현재 고정값으로 발행되어, mock 환경에서는 실서버 수준의 초 단위 정확 동기화 시뮬레이션이 제한적입니다.
- 이번 PR은 BUILD 프롬프트 모달 노출 복구에 집중했기 때문에, 금액 표시 정책(`buildCost`/`nextToll` 단위 일관성)은 별도 정리 이슈에서 추가 보완이 필요합니다.
- 상태 배지 문구는 개선했지만, “현재 prompt 단계(구매/건설/통행료)”를 별도 UI 컴포넌트로 분리한 것은 아니라서 텍스트 기반 안내의 한계는 남아 있습니다.
- `GameBoard.tsx`는 여전히 대형 파일이므로, 동일 영역 병렬 작업(PR 동시 수정) 시 충돌 가능성이 높습니다.
- `revision=0` 구간에서 서버가 snapshot/patch를 혼합해 보낼 때의 장시간 soak 테스트(장기 세션)는 아직 별도 수행하지 않았습니다.
- E2E 게임 시나리오 전체(`e2e:game`)는 이번 PR 범위에서 별도 실행하지 않았습니다.

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [ ] 관련 이슈 연결 완료
- [ ] 큰 작업이면 task 문서 링크를 남겼다
- [x] 참고한 기준 문서를 PR 본문에 남겼다
- [x] 실행한 검증과 남은 리스크를 PR 본문에 적었다

---

## 📸 스크린샷 (선택)

- BUILD_OR_SKIP prompt 수신 후 build 모달 정상 노출 캡처
- prompt 응답 전송 후 상태 문구 전환 캡처
