### PR TITLE
feat: 게임 턴 종료를 명시 액션(ROLL→END TURN)으로 전환

### DIFF
--- a/src/components/game/controls/RollButton.test.tsx
+++ b/src/components/game/controls/RollButton.test.tsx
@@ -1,0 +1,56 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import RollButton from './RollButton'
+
+vi.mock('../../../stores/game.store', () => ({
+  useGameStore: (
+    selector: (state: {
+      turnTimeoutSec: number
+      turnTimerKey: number
+    }) => unknown
+  ) => selector({ turnTimeoutSec: 30, turnTimerKey: 1 }),
+}))
+
+vi.mock('../../../hooks/game/useGameTimer', () => ({
+  useGameTimer: () => [30],
+}))
+
+describe('RollButton', () => {
+  it('기본 모드에서 ROLL 버튼이 onRoll을 호출한다', () => {
+    const onRoll = vi.fn()
+
+    render(<RollButton isMyTurn={true} onRoll={onRoll} />)
+
+    fireEvent.click(screen.getByRole('button'))
+    expect(onRoll).toHaveBeenCalledTimes(1)
+    expect(screen.getByText('ROLL')).toBeInTheDocument()
+  })
+
+  it('end_turn 모드에서 END 버튼이 onEndTurn을 호출한다', () => {
+    const onRoll = vi.fn()
+    const onEndTurn = vi.fn()
+
+    render(
+      <RollButton
+        isMyTurn={true}
+        mode="end_turn"
+        onRoll={onRoll}
+        onEndTurn={onEndTurn}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button'))
+    expect(onEndTurn).toHaveBeenCalledTimes(1)
+    expect(onRoll).not.toHaveBeenCalled()
+    expect(screen.getByText('END')).toBeInTheDocument()
+  })
+
+  it('end_turn 모드에서 onEndTurn이 없으면 버튼이 비활성화된다', () => {
+    const onRoll = vi.fn()
+
+    render(<RollButton isMyTurn={true} mode="end_turn" onRoll={onRoll} />)
+
+    const button = screen.getByRole('button')
+    expect(button).toBeDisabled()
+  })
+})

--- a/src/components/game/controls/RollButton.tsx
+++ b/src/components/game/controls/RollButton.tsx
@@ -5,15 +5,26 @@ import { useGameTimer } from '../../../hooks/game/useGameTimer'
 interface RollControlProps {
   isMyTurn: boolean
   onRoll: () => void
+  mode?: 'roll' | 'end_turn'
+  onEndTurn?: () => void
 }
 
-const RollControl: React.FC<RollControlProps> = ({ isMyTurn, onRoll }) => {
+const RollControl: React.FC<RollControlProps> = ({
+  isMyTurn,
+  onRoll,
+  mode = 'roll',
+  onEndTurn,
+}) => {
   const turnTimeoutSec = useGameStore((s) => s.turnTimeoutSec)
   const turnTimerKey = useGameStore((s) => s.turnTimerKey)
   const [timeLeft] = useGameTimer({
     initialTime: turnTimeoutSec,
     resetSignal: turnTimerKey,
   })
+  const isEndTurnMode = mode === 'end_turn'
+  const canClick =
+    isMyTurn && (!isEndTurnMode || typeof onEndTurn === 'function')
+  const handleClick = isEndTurnMode ? (onEndTurn ?? onRoll) : onRoll
 
   const dashArray = 251 // Approx circumference for r=40
   const dashOffset = dashArray * (1 - timeLeft / (turnTimeoutSec || 30))
@@ -71,13 +82,19 @@ const RollControl: React.FC<RollControlProps> = ({ isMyTurn, onRoll }) => {
       </div>
 
       <button
-        onClick={onRoll}
-        disabled={!isMyTurn}
-        className="group relative flex h-24 w-24 flex-col items-center justify-center gap-0.5 rounded-3xl border-4 border-[#BEDBFF] bg-linear-to-br from-[#2B7FFF] to-[#4F39F6] text-white shadow-[0_0_0_4px_rgba(255,255,255,0.5),0_20px_25px_-5px_rgba(142,197,255,0.5)] transition-all hover:-translate-y-0.5 hover:shadow-2xl active:translate-y-0.5 active:scale-95 disabled:grayscale disabled:opacity-50"
+        onClick={handleClick}
+        disabled={!canClick}
+        className={`group relative flex h-24 w-24 flex-col items-center justify-center gap-0.5 rounded-3xl border-4 text-white shadow-[0_0_0_4px_rgba(255,255,255,0.5),0_20px_25px_-5px_rgba(142,197,255,0.5)] transition-all hover:-translate-y-0.5 hover:shadow-2xl active:translate-y-0.5 active:scale-95 disabled:grayscale disabled:opacity-50 ${
+          isEndTurnMode
+            ? 'border-[#FCD34D] bg-linear-to-br from-[#F59E0B] to-[#F97316]'
+            : 'border-[#BEDBFF] bg-linear-to-br from-[#2B7FFF] to-[#4F39F6]'
+        }`}
       >
-        <span className="text-3xl leading-none drop-shadow-md">🎲</span>
+        <span className="text-3xl leading-none drop-shadow-md">
+          {isEndTurnMode ? '⏭' : '🎲'}
+        </span>
         <span className="text-[10px] font-black tracking-widest opacity-90 uppercase">
-          ROLL
+          {isEndTurnMode ? 'END' : 'ROLL'}
         </span>
       </button>
     </div>

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -15,7 +15,10 @@ import { useGameState } from '../hooks/game/useGameState'
 import { useTurn } from '../hooks/game/useTurn'
 import { playBgm, stopBgm } from '../lib/bgm'
 import { socket } from '../lib/socket'
-import { emitPromptResponse } from '../services/socket/game.handler'
+import {
+  emitGameAction,
+  emitPromptResponse,
+} from '../services/socket/game.handler'
 import { useGameStore } from '../stores/game.store'
 import type { GamePromptChoice } from '../types/domain'
 import {
@@ -88,6 +91,7 @@ const GamePage: React.FC = () => {
   const [promptSubmittingChoice, setPromptSubmittingChoice] = useState<
     string | null
   >(null)
+  const [hasRolledThisTurn, setHasRolledThisTurn] = useState(false)
   const [isExitModalOpen, setIsExitModalOpen] = useState(false)
   const boardRef = useRef<BoardGameHandle>(null)
   const pendingGameChatEchoesRef = useRef<PendingGameChatEcho[]>([])
@@ -170,6 +174,17 @@ const GamePage: React.FC = () => {
   }, [lastError])
 
   useEffect(() => {
+    if (lastAck?.type === 'ROLL_DICE' && !lastAck.ok) {
+      setHasRolledThisTurn(false)
+      return
+    }
+
+    if (lastAck?.type === 'END_TURN' && lastAck.ok) {
+      setHasRolledThisTurn(false)
+    }
+  }, [lastAck])
+
+  useEffect(() => {
     if (!activeRoomId) {
       return
     }
@@ -247,6 +262,21 @@ const GamePage: React.FC = () => {
     (currentPlayerState?.skipTurns ?? 0) > 0 ||
     currentPlayerState?.state === 'locked' ||
     currentPlayerState?.state === 'island'
+  const canControlTurn =
+    isMyTurn &&
+    !isActionPending &&
+    !isPromptVisible &&
+    !isCurrentPlayerSkipped &&
+    !isCurrentPlayerBankrupt
+  const rollButtonMode: 'roll' | 'end_turn' = hasRolledThisTurn
+    ? 'end_turn'
+    : 'roll'
+
+  useEffect(() => {
+    if (!isMyTurn) {
+      setHasRolledThisTurn(false)
+    }
+  }, [currentTurn, isMyTurn])
   const roomChatSenderOptions = useMemo(
     () =>
       storePlayers.map((player) => ({
@@ -281,9 +311,34 @@ const GamePage: React.FC = () => {
     setLastError(null)
   }
   const handleRollClick = () => {
+    if (hasRolledThisTurn) {
+      return
+    }
+    if (!activeGameId) {
+      return
+    }
+    if (!USE_GAME_SOCKET_MOCK && !socket.connected) {
+      return
+    }
+
     boardRef.current?.rollDice()
     new Audio('/audio/dice-roll.mp3').play().catch(() => {})
     diceRoll(activeGameId)
+    setHasRolledThisTurn(true)
+  }
+
+  const handleEndTurnClick = () => {
+    if (!activeGameId || pendingAction !== null) {
+      return
+    }
+    if (!USE_GAME_SOCKET_MOCK && !socket.connected) {
+      return
+    }
+
+    emitGameAction({
+      type: 'END_TURN',
+      gameId: activeGameId,
+    })
   }
 
   const isWaitingForServerState =
@@ -431,14 +486,10 @@ const GamePage: React.FC = () => {
 
       <div className="absolute bottom-10 right-10 z-20">
         <RollButton
-          isMyTurn={
-            isMyTurn &&
-            !isActionPending &&
-            !isPromptVisible &&
-            !isCurrentPlayerSkipped &&
-            !isCurrentPlayerBankrupt
-          }
+          isMyTurn={canControlTurn}
+          mode={rollButtonMode}
           onRoll={handleRollClick}
+          onEndTurn={handleEndTurnClick}
         />
       </div>
 


### PR DESCRIPTION
## ✨ 작업 개요
주사위 1회 굴림 이후에도 같은 턴에서 추가 행위(매각/증설 등)를 수행할 수 있도록, 턴 종료를 자동 흐름이 아닌 명시 액션으로 전환했습니다.

## 🎯 변경 사항
- `GamePage`에 `hasRolledThisTurn` 상태를 추가해 턴 내 버튼 모드를 `ROLL` → `END`로 전환
- `ROLL` 전송 이후 같은 턴에서 중복 굴림 방지
- `END_TURN` 버튼 클릭 시에만 턴 종료 액션 송신
- 턴 변경(`isMyTurn` false) 또는 `END_TURN` ack 성공 시 롤 상태 초기화
- `RollButton`에 모드(`roll | end_turn`) + `onEndTurn` 핸들러 추가
- 소켓 미연결/`gameId` 부재 시 롤 상태 잠김 방지 가드 추가
- `RollButton` 모드 동작 테스트 추가

## 🧪 검증
- `npx vitest run src/components/game/controls/RollButton.test.tsx src/pages/GamePage.test.tsx src/hooks/game/useDiceRoll.test.ts src/stores/game.store.test.ts`
- `npm run lint`
- `npm run build`
- push 훅에서 `lint/test/test:coverage/e2e:ci/build` 전체 통과

## 📂 변경 파일
- `src/pages/GamePage.tsx`
- `src/components/game/controls/RollButton.tsx`
- `src/components/game/controls/RollButton.test.tsx`

## ⚠️ 리스크/후속
- 서버가 `prompt_response` 직후 자동 `TURN_ENDED`를 발행하는 정책이면, 프론트의 명시 `END_TURN` UX와 체감 불일치가 남을 수 있습니다.
- 서버 최종 턴 종료 정책 문서와 맞춘 후속 동기화가 필요합니다.
