### PR TITLE
Fix : 게임 런타임 계약 보정 및 동기화 안정화 (game-over alias / 이벤트 타일 해석 / sync 레이스 완화)

### DIFF
--- a/src/components/board/gameBoardEventQueueUtils.test.ts
+++ b/src/components/board/gameBoardEventQueueUtils.test.ts
@@ -94,6 +94,45 @@ describe('gameBoardEventQueueUtils', () => {
     )
   })
 
+  it('resolves landed tile from nested event.tile payload', () => {
+    const event = {
+      type: 'LANDED',
+      playerId: 2,
+      tile: {
+        tileId: 1,
+        name: '서울',
+      },
+    } as ServerEvent & {
+      tile: { tileId: number; name: string }
+    }
+
+    expect(createBoardStatusFromEvent(event, players, tiles)).toBe(
+      '플레이어2님이 서울 칸에 도착했습니다.'
+    )
+  })
+
+  it('uses chance.description for CHANCE_RESOLVED status message', () => {
+    const event = {
+      type: 'CHANCE_RESOLVED',
+      playerId: 1,
+      chance: {
+        type: 'GAIN_MONEY',
+        power: 300,
+        description: '보너스 300만원을 획득합니다.',
+      },
+    } as ServerEvent & {
+      chance: {
+        type: string
+        power: number
+        description: string
+      }
+    }
+
+    expect(createBoardStatusFromEvent(event, players, tiles)).toBe(
+      '보너스 300만원을 획득합니다.'
+    )
+  })
+
   it('returns toll status with formatted amount', () => {
     const event: ServerEvent = {
       type: 'PAID_TOLL',

--- a/src/components/board/gameBoardEventQueueUtils.ts
+++ b/src/components/board/gameBoardEventQueueUtils.ts
@@ -97,6 +97,40 @@ const getPayloadNumber = (
 const getEventRecord = (event: ServerEvent): Record<string, unknown> =>
   event as unknown as Record<string, unknown>
 
+const getRecordString = (
+  record: Record<string, unknown> | null | undefined,
+  keys: string[]
+) => {
+  if (!record) {
+    return null
+  }
+
+  for (const key of keys) {
+    const raw = record[key]
+    if (typeof raw === 'string' && raw.trim().length > 0) {
+      return raw
+    }
+  }
+
+  return null
+}
+
+const getEventTileRecord = (
+  event: ServerEvent
+): Record<string, unknown> | null => {
+  const eventRecord = getEventRecord(event)
+  if (typeof eventRecord.tile === 'object' && eventRecord.tile !== null) {
+    return eventRecord.tile as Record<string, unknown>
+  }
+
+  const payload = event.payload
+  if (payload && typeof payload.tile === 'object' && payload.tile !== null) {
+    return payload.tile as Record<string, unknown>
+  }
+
+  return null
+}
+
 const getEventNumber = (event: ServerEvent, keys: string[]) => {
   const eventRecord = getEventRecord(event)
 
@@ -148,12 +182,58 @@ export const resolveBoardEventTileIndex = (event: ServerEvent) => {
     return eventLevelIndex
   }
 
+  const eventTile = getEventTileRecord(event)
+  if (eventTile) {
+    const nestedTileIndex = getPayloadNumber(eventTile, [
+      'tileId',
+      'tile_id',
+      'index',
+      'tileIndex',
+    ])
+
+    if (nestedTileIndex != null) {
+      return nestedTileIndex
+    }
+  }
+
   const payload = event.payload
   if (!payload) {
     return null
   }
 
   return getPayloadNumber(payload, ['toIndex', 'tileIndex', 'toTileId'])
+}
+
+const resolveEventTileName = (event: ServerEvent, tiles: TileData[]) => {
+  const eventRecord = getEventRecord(event)
+  const eventTile = getEventTileRecord(event)
+  const explicitTileName =
+    getRecordString(eventRecord, ['tileName', 'tile_name']) ??
+    getRecordString(eventTile, ['name', 'tileName', 'tile_name'])
+
+  if (explicitTileName) {
+    return explicitTileName.replace('\n', ' ')
+  }
+
+  return resolveTileName(tiles, resolveBoardEventTileIndex(event))
+}
+
+const resolveChanceDescription = (event: ServerEvent) => {
+  const eventRecord = getEventRecord(event)
+  const chanceRecord =
+    (typeof eventRecord.chance === 'object' && eventRecord.chance !== null
+      ? (eventRecord.chance as Record<string, unknown>)
+      : null) ??
+    (event.payload?.chance &&
+    typeof event.payload.chance === 'object' &&
+    event.payload.chance !== null
+      ? (event.payload.chance as Record<string, unknown>)
+      : null)
+
+  return (
+    getRecordString(chanceRecord, ['description']) ??
+    getRecordString(event.payload ?? null, ['description'])
+  )
 }
 
 export const extractEventDice = (
@@ -217,13 +297,22 @@ export const createBoardStatusFromEvent = (
   }
 
   if (normalizedType === 'PLAYER_MOVED') {
-    const tileName = resolveTileName(tiles, resolveBoardEventTileIndex(event))
+    const tileName = resolveEventTileName(event, tiles)
     return `${playerName}님이 ${tileName} 칸으로 이동했습니다.`
   }
 
   if (normalizedType === 'LANDED') {
-    const tileName = resolveTileName(tiles, resolveBoardEventTileIndex(event))
+    const tileName = resolveEventTileName(event, tiles)
     return `${playerName}님이 ${tileName} 칸에 도착했습니다.`
+  }
+
+  if (normalizedType === 'CHANCE_RESOLVED') {
+    const chanceDescription = resolveChanceDescription(event)
+    if (chanceDescription) {
+      return chanceDescription
+    }
+
+    return `${playerName}님이 찬스 효과를 적용했습니다.`
   }
 
   if (normalizedType === 'PAID_TOLL') {

--- a/src/hooks/game/useGameState.test.tsx
+++ b/src/hooks/game/useGameState.test.tsx
@@ -1,0 +1,197 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+type SetupOptions = {
+  accessToken: string | null
+  mockEnabled?: boolean
+  socketConnected?: boolean
+  currentTurn?: string | number | null
+  revision?: number
+  playersLength?: number
+}
+
+const createPlayers = (length: number) =>
+  Array.from({ length }, (_, index) => ({ id: `player-${index + 1}` }))
+
+async function setupUseGameState(options: SetupOptions) {
+  vi.resetModules()
+
+  const runtime = {
+    accessToken: options.accessToken,
+    currentTurn: options.currentTurn ?? null,
+    revision: options.revision ?? 0,
+    playersLength: options.playersLength ?? 0,
+  }
+
+  const socketHandlers = new Map<string, (...args: unknown[]) => void>()
+  const connectSocketWithAuthIfNeeded = vi.fn()
+  const emitGameSync = vi.fn()
+  const emitGameSyncTimer = vi.fn()
+  const teardownHandlers = vi.fn()
+  const setupGameHandlers = vi.fn(() => teardownHandlers)
+
+  vi.doMock('../../config/env', () => ({
+    IS_SOCKET_MOCK_ENABLED: options.mockEnabled ?? false,
+  }))
+  vi.doMock('../../features/auth/session/store', () => ({
+    useAuthStore: (
+      selector: (state: { session: { accessToken: string } | null }) => unknown
+    ) =>
+      selector({
+        session: runtime.accessToken
+          ? ({ accessToken: runtime.accessToken } as { accessToken: string })
+          : null,
+      }),
+  }))
+  vi.doMock('../../lib/socket', () => ({
+    socket: {
+      connected: options.socketConnected ?? false,
+      on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+        socketHandlers.set(event, handler)
+      }),
+      off: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+        const registered = socketHandlers.get(event)
+        if (registered === handler) {
+          socketHandlers.delete(event)
+        }
+      }),
+      disconnect: vi.fn(),
+    },
+    connectSocketWithAuthIfNeeded,
+  }))
+  vi.doMock('../../services/socket/game.handler', () => ({
+    setupGameHandlers,
+    emitGameSync,
+    emitGameSyncTimer,
+  }))
+  vi.doMock('../../stores/game.store', () => {
+    const useGameStore = (
+      selector: (state: {
+        currentPlayerId: string | number | null
+        currentTurn: string | number | null
+      }) => unknown
+    ) =>
+      selector({
+        currentPlayerId: runtime.currentTurn,
+        currentTurn: runtime.currentTurn,
+      })
+
+    ;(
+      useGameStore as typeof useGameStore & {
+        getState: () => { players: unknown[]; revision: number }
+      }
+    ).getState = () => ({
+      players: createPlayers(runtime.playersLength),
+      revision: runtime.revision,
+    })
+
+    return { useGameStore }
+  })
+
+  const { useGameState } = await import('./useGameState')
+
+  return {
+    useGameState,
+    runtime,
+    socketHandlers,
+    connectSocketWithAuthIfNeeded,
+    emitGameSync,
+    emitGameSyncTimer,
+    setupGameHandlers,
+    teardownHandlers,
+  }
+}
+
+describe('useGameState', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+  })
+
+  it('real socket 모드에서 accessToken이 없으면 동기화를 시작하지 않는다', async () => {
+    const {
+      useGameState,
+      connectSocketWithAuthIfNeeded,
+      emitGameSync,
+      emitGameSyncTimer,
+      setupGameHandlers,
+    } = await setupUseGameState({
+      accessToken: null,
+      mockEnabled: false,
+    })
+
+    renderHook(() => useGameState('game-1'))
+
+    expect(setupGameHandlers).not.toHaveBeenCalled()
+    expect(connectSocketWithAuthIfNeeded).not.toHaveBeenCalled()
+    expect(emitGameSync).not.toHaveBeenCalled()
+    expect(emitGameSyncTimer).not.toHaveBeenCalled()
+  })
+
+  it('소켓 connect 이벤트에서 game sync와 timer sync를 모두 재요청한다', async () => {
+    const {
+      useGameState,
+      socketHandlers,
+      connectSocketWithAuthIfNeeded,
+      emitGameSync,
+      emitGameSyncTimer,
+    } = await setupUseGameState({
+      accessToken: 'token-1',
+      mockEnabled: false,
+      socketConnected: false,
+      revision: 3,
+      playersLength: 0,
+    })
+
+    renderHook(() => useGameState('game-2'))
+
+    expect(connectSocketWithAuthIfNeeded).toHaveBeenCalledTimes(1)
+    expect(emitGameSync).toHaveBeenCalledWith({
+      gameId: 'game-2',
+      knownRevision: 0,
+    })
+    expect(emitGameSyncTimer).toHaveBeenCalledTimes(1)
+
+    const connectHandler = socketHandlers.get('connect')
+    expect(connectHandler).toBeDefined()
+
+    act(() => {
+      connectHandler?.()
+    })
+
+    expect(emitGameSync).toHaveBeenCalledTimes(2)
+    expect(emitGameSyncTimer).toHaveBeenCalledTimes(2)
+  })
+
+  it('토큰 복구 후 rerender 시 지연된 초기 동기화를 시작한다', async () => {
+    const {
+      useGameState,
+      runtime,
+      connectSocketWithAuthIfNeeded,
+      emitGameSync,
+      emitGameSyncTimer,
+    } = await setupUseGameState({
+      accessToken: null,
+      mockEnabled: false,
+      socketConnected: false,
+    })
+
+    const { rerender } = renderHook(() => useGameState('game-3'))
+
+    expect(connectSocketWithAuthIfNeeded).not.toHaveBeenCalled()
+    expect(emitGameSync).not.toHaveBeenCalled()
+
+    runtime.accessToken = 'restored-token'
+    rerender()
+
+    expect(connectSocketWithAuthIfNeeded).toHaveBeenCalledTimes(1)
+    expect(emitGameSync).toHaveBeenCalledWith({
+      gameId: 'game-3',
+      knownRevision: 0,
+    })
+    expect(emitGameSyncTimer).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/hooks/game/useGameState.ts
+++ b/src/hooks/game/useGameState.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react'
 import { IS_SOCKET_MOCK_ENABLED } from '../../config/env'
+import { useAuthStore } from '../../features/auth/session/store'
 import { connectSocketWithAuthIfNeeded, socket } from '../../lib/socket'
 import {
   emitGameSync,
@@ -12,12 +13,18 @@ const USE_GAME_SOCKET_MOCK = IS_SOCKET_MOCK_ENABLED
 
 export const useGameState = (gameId: string | null) => {
   const syncedGameIdRef = useRef<string | null>(null)
+  const accessToken = useAuthStore(
+    (state) => state.session?.accessToken?.trim() ?? null
+  )
   const currentTurn = useGameStore((state) => {
     return state.currentPlayerId ?? state.currentTurn
   })
 
   useEffect(() => {
     if (!gameId) {
+      return
+    }
+    if (!USE_GAME_SOCKET_MOCK && !accessToken) {
       return
     }
 
@@ -59,6 +66,7 @@ export const useGameState = (gameId: string | null) => {
     }
 
     const handleSocketConnect = () => {
+      syncGameState()
       syncGameTimer()
     }
 
@@ -74,7 +82,7 @@ export const useGameState = (gameId: string | null) => {
       socket.off('connect', handleSocketConnect)
       teardownHandlers()
     }
-  }, [gameId])
+  }, [accessToken, gameId])
 
   useEffect(() => {
     if (!gameId || currentTurn == null) {

--- a/src/services/socket/gameContractAdapters.test.ts
+++ b/src/services/socket/gameContractAdapters.test.ts
@@ -228,6 +228,45 @@ describe('gameContractAdapters', () => {
     })
   })
 
+  it('normalizes game over snapshot aliases and infers isGameOver from finished phase', () => {
+    const normalized = normalizeSnapshotPayload(
+      {
+        gameId: 'game-finished',
+        revision: 15,
+        phase: 'FINISHED',
+        players: [],
+        tiles: [],
+        winner_id: 'player-winner',
+        is_game_over: true,
+        game_result: {
+          reason: 'bankrupt',
+          rankings: [
+            {
+              rank: 1,
+              player_id: 'player-winner',
+              nickname: 'winner',
+              final_assets: 8200000000,
+              is_winner: true,
+            },
+          ],
+        },
+      },
+      {
+        envelopeRevision: 15,
+      }
+    )
+
+    expect(normalized).not.toBeNull()
+    expect(normalized).toMatchObject({
+      phase: 'finished',
+      isGameOver: true,
+      winnerId: 'player-winner',
+      gameResult: {
+        reason: 'bankrupt',
+      },
+    })
+  })
+
   it('normalizes object-shaped snapshot collections', () => {
     const normalized = normalizeSnapshotPayload(
       {
@@ -545,6 +584,33 @@ describe('gameContractAdapters', () => {
         tileIndex: null,
         amount: 3500000000,
         payload: undefined,
+      },
+    ])
+  })
+
+  it('normalizes patch aliases for winner/isGameOver/gameResult fields', () => {
+    const normalized = normalizePatchEnvelopePayload({
+      gameId: 'game-over-patch',
+      revision: 91,
+      patch: [
+        { op: 'set', path: 'winner_id', value: 'player-1' },
+        { op: 'set', path: 'is_game_over', value: 1 },
+        {
+          op: 'set',
+          path: 'game_result',
+          value: { reason: 'round_limit', rankings: [] },
+        },
+      ],
+      events: [],
+    })
+
+    expect(normalized.patch).toEqual([
+      { op: 'set', path: 'winnerId', value: 'player-1' },
+      { op: 'set', path: 'isGameOver', value: true },
+      {
+        op: 'set',
+        path: 'gameResult',
+        value: { reason: 'round_limit', rankings: [] },
       },
     ])
   })

--- a/src/services/socket/gameContractAdapters.ts
+++ b/src/services/socket/gameContractAdapters.ts
@@ -63,6 +63,7 @@ const PHASE_TO_INTERNAL_MAP: Record<string, GameSnapshot['phase']> = {
   WAIT_PROMPT: 'prompt',
   TURN_END: 'resolving',
   GAME_OVER: 'finished',
+  FINISHED: 'finished',
 }
 
 const TILE_TYPE_TO_INTERNAL_MAP: Record<string, Tile['type']> = {
@@ -581,7 +582,21 @@ export const normalizeSnapshotPayload = (
       snapshotPayload.currentTurn ??
       null
   )
+  const normalizedPhase = normalizePhase(snapshotPayload.phase)
   const roundFromTurn = toFiniteInt(snapshotPayload.turn, 1)
+  const normalizedGameResult = (
+    snapshotPayload.gameResult && isRecord(snapshotPayload.gameResult)
+      ? snapshotPayload.gameResult
+      : snapshotPayload.game_result && isRecord(snapshotPayload.game_result)
+        ? snapshotPayload.game_result
+        : null
+  ) as GameSnapshot['gameResult'] | null
+  const normalizedWinnerId =
+    toPlayerIdOrNull(snapshotPayload.winnerId ?? snapshotPayload.winner_id) ??
+    null
+  const normalizedIsGameOver =
+    Boolean(snapshotPayload.isGameOver ?? snapshotPayload.is_game_over) ||
+    normalizedPhase === 'finished'
 
   return {
     roomId: toStringOrNull(snapshotPayload.roomId),
@@ -590,7 +605,7 @@ export const normalizeSnapshotPayload = (
       toStringOrNull(options.envelopeGameId) ??
       null,
     revision: toFiniteInt(snapshotPayload.revision, options.envelopeRevision),
-    phase: normalizePhase(snapshotPayload.phase),
+    phase: normalizedPhase,
     players: playersRaw.map(normalizePlayerFromSnapshot),
     tiles: tilesRaw.map(normalizeTileFromSnapshot),
     currentPlayerId,
@@ -605,12 +620,9 @@ export const normalizeSnapshotPayload = (
         snapshotPayload.pending_prompt ??
         snapshotPayload.pendingPrompt
     ),
-    gameResult:
-      snapshotPayload.gameResult && isRecord(snapshotPayload.gameResult)
-        ? (snapshotPayload.gameResult as GameSnapshot['gameResult'])
-        : null,
-    isGameOver: Boolean(snapshotPayload.isGameOver),
-    winnerId: (snapshotPayload.winnerId ?? null) as GameSnapshot['winnerId'],
+    gameResult: normalizedGameResult,
+    isGameOver: normalizedIsGameOver,
+    winnerId: normalizedWinnerId,
   }
 }
 
@@ -654,6 +666,9 @@ const normalizePathSegment = (segment: string | number): string | number => {
   if (segment === 'ownedTiles') return 'owned_tiles'
   if (segment === 'pending_prompt') return 'prompt'
   if (segment === 'pendingPrompt') return 'prompt'
+  if (segment === 'winner_id') return 'winnerId'
+  if (segment === 'is_game_over') return 'isGameOver'
+  if (segment === 'game_result') return 'gameResult'
   if (segment === 'building_level') return 'building'
   if (segment === 'buildingLevel') return 'building'
   if (segment === 'tile_type') return 'type'
@@ -682,6 +697,18 @@ const normalizePatchSetValue = (
 
   if (pathSegments.length === 1 && firstSegment === 'phase') {
     return normalizePhase(value)
+  }
+
+  if (pathSegments.length === 1 && firstSegment === 'isGameOver') {
+    return Boolean(value)
+  }
+
+  if (pathSegments.length === 1 && firstSegment === 'winnerId') {
+    return toPlayerIdOrNull(value)
+  }
+
+  if (pathSegments.length === 1 && firstSegment === 'gameResult') {
+    return isRecord(value) ? (value as GameSnapshot['gameResult']) : null
   }
 
   if (pathSegments.length === 1 && firstSegment === 'players') {

--- a/src/stores/game.store.test.ts
+++ b/src/stores/game.store.test.ts
@@ -355,6 +355,27 @@ describe('game store partial updates', () => {
     expect(nextState.revision).toBe(5)
   })
 
+  it('marks game over when phase is patched to finished', () => {
+    const store = useGameStore.getState()
+
+    store.setGameState({
+      revision: 10,
+      phase: 'rolling',
+      isGameOver: false,
+    })
+
+    store.applyPatchEnvelope({
+      revision: 11,
+      patch: [{ op: 'set', path: 'phase', value: 'finished' }],
+      events: [],
+    })
+
+    const nextState = useGameStore.getState()
+
+    expect(nextState.phase).toBe('finished')
+    expect(nextState.isGameOver).toBe(true)
+  })
+
   it('applies timer sync to turn timer and prompt timeout when prompt id matches', () => {
     const store = useGameStore.getState()
 

--- a/src/stores/game.store.ts
+++ b/src/stores/game.store.ts
@@ -104,6 +104,10 @@ const normalizeState = (state: Partial<GameState>): Partial<GameState> => {
     normalizedState.eventQueue = state.eventQueue ?? []
   }
 
+  if (normalizedState.phase === 'finished') {
+    normalizedState.isGameOver = true
+  }
+
   return normalizedState
 }
 


### PR DESCRIPTION
## 관련 이슈
- 백엔드 디버그 포인트 반영 (게임 종료 플로우, 이벤트 문구, 새로고침 동기화)

## 작업 내용
### 1) game-over 스냅샷/패치 별칭 보정
- snapshot alias 반영:
  - `winner_id -> winnerId`
  - `is_game_over -> isGameOver`
  - `game_result -> gameResult`
- `phase === FINISHED`일 때 내부 phase를 `finished`로 정규화
- store 정규화 단계에서 `phase === 'finished'`면 `isGameOver = true` 강제 보정
- patch path alias 반영:
  - `winner_id`, `is_game_over`, `game_result`를 canonical 경로로 치환 후 적용

### 2) 이벤트 타일 해석 보강 + CHANCE 문구 우선화
- `LANDED`/`PLAYER_MOVED`에서 top-level 필드뿐 아니라 nested 필드도 해석:
  - `event.tile.tileId`, `event.tile.name`
  - `payload.tile.tileId`, `payload.tile.name`
- 칸 이름 해석 실패로 `알 수 없는 칸`이 뜨던 케이스 보강
- `CHANCE_RESOLVED` 상태 문구 생성 시 기본 문구 대신 `chance.description` 우선 사용

### 3) 새로고침/탭 복귀 동기화 레이스 완화
- `useGameState`에서 실서버 모드일 때 accessToken 없으면 초기 sync/연결 시작을 지연
- socket `connect` 이벤트에서 `game:sync` + `game:sync_timer`를 함께 재요청하도록 보강
- 토큰 복구 후 rerender 시 동기화가 재개되는지 훅 테스트 추가

## 테스트
- 대상 테스트 추가/보강
  - `gameContractAdapters.test.ts`
  - `game.store.test.ts`
  - `gameBoardEventQueueUtils.test.ts`
  - `useGameState.test.tsx` (신규)
- 검증 실행
  - `npm run lint`
  - `npm run build`
  - `vitest` 대상 파일 실행
  - push hook에서 `test`, `test:coverage` 통과

## 리스크 / 후속
- App bootstrap 화면 정책은 유지하고 훅 레벨에서 레이스를 완화한 상태.
  - 인증/라우팅 정책 변경 시 App 레벨 가드 재검토 필요
- 기존 `GamePage.test.tsx`의 act warning은 이번 PR 범위 외
