### PR TITLE
FIX : 서버 phase 기준으로 ROLL/END_TURN 전환 및 자산 액션 가드 정렬

### DIFF
--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -98,6 +98,7 @@ import type {
 import '../../styles/board.css'
 import { formatWon } from '../../lib/utils'
 import type {
+  GamePhase,
   GamePrompt,
   GameResult,
   PlayerId,
@@ -230,6 +231,8 @@ interface GameBoardProps {
   gameId?: string | null
   players: PlayerState[]
   curPlayer: number
+  gamePhase?: GamePhase | null
+  allowAssetActions?: boolean
   suppressDiceTimerModal?: boolean
   activePrompt?: GamePrompt | null
   promptSubmittingChoice?: string | null
@@ -299,6 +302,8 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       gameId,
       players,
       curPlayer,
+      gamePhase = null,
+      allowAssetActions = false,
       suppressDiceTimerModal = false,
       activePrompt = null,
       promptSubmittingChoice = null,
@@ -1601,10 +1606,17 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
         bankruptModal.open ||
         gameResultModal.open)
     const activePlayerId = players[curPlayer]?.id ?? null
+    const isAssetActionPhase =
+      gamePhase === 'rolling' || gamePhase === 'resolving'
     const isTravelSelectableTile = (tileId: number) =>
       travelSelection.active && tileId !== players[curPlayer]?.pos
     const isOwnedTileSellClickable = (tileId: number) => {
-      if (travelSelection.active || hasBlockingModal) {
+      if (
+        travelSelection.active ||
+        hasBlockingModal ||
+        !allowAssetActions ||
+        !isAssetActionPhase
+      ) {
         return false
       }
       if (activePlayerId == null) {
@@ -1640,6 +1652,9 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       const effectiveLocalPlayerId = localPlayerId ?? players[curPlayer]?.id
       const isMyTurn =
         String(players[curPlayer]?.id) === String(effectiveLocalPlayerId)
+      if (!allowAssetActions || !isAssetActionPhase || !isMyTurn) {
+        return
+      }
 
       // 본인 땅인 경우
       const owner = tileOwners[tileId]

--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -50,6 +50,7 @@ import { getBoardSellFallbackRefund } from './gameBoardActionUtils'
 import { useBoardEventQueue } from './useBoardEventQueue'
 import {
   getBoardEventAnimationHoldMs,
+  resolveBoardCardModalContentFromEvent,
   resolveBoardEventTileIndex,
   type BoardEventAnimationKind,
 } from './gameBoardEventQueueUtils'
@@ -442,6 +443,10 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       (event: ServerEvent) => {
         const normalizedType =
           typeof event.type === 'string' ? event.type.trim().toUpperCase() : ''
+        const isLocalPlayerEvent =
+          localPlayerId == null ||
+          event.playerId == null ||
+          String(event.playerId) === String(localPlayerId)
 
         if (normalizedType === 'DICE_ROLLED') {
           if (rollAnimationIntervalRef.current !== null) {
@@ -491,11 +496,42 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
           )
           return
         }
+
+        if (normalizedType === 'CHANCE_RESOLVED') {
+          if (!isLocalPlayerEvent) {
+            return
+          }
+
+          const cardModalContent = resolveBoardCardModalContentFromEvent(
+            event,
+            TILES
+          )
+
+          if (!cardModalContent) {
+            return
+          }
+
+          setCardModal({
+            open: true,
+            variant: cardModalContent.variant,
+            title: cardModalContent.title,
+            descriptionLine1: cardModalContent.descriptionLine1,
+            descriptionLine2: cardModalContent.descriptionLine2,
+            onDoneCallback: undefined,
+          })
+
+          if (cardModalContent.variant === 'CHANCE') {
+            new Audio('/audio/chance.mp3').play().catch(() => {})
+          } else {
+            new Audio('/audio/event.mp3').play().catch(() => {})
+          }
+        }
       },
       [
         emitMockEndTurn,
         freezeDiceRollValues,
         flashDiceRollAnimation,
+        localPlayerId,
         movePlayerSequentially,
       ]
     )
@@ -1410,6 +1446,11 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
         return
       }
       if (tile.type === 'CHANCE' || tile.type === 'EVENT') {
+        if (!isMockMode) {
+          onDone?.()
+          return
+        }
+
         if (isLocalPlayerTurn) {
           setCardModal({
             open: true,
@@ -2075,6 +2116,10 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
         <CardModal
           open={canShowModal && cardModal.open}
           variant={cardModal.variant}
+          title={cardModal.title}
+          descriptionLine1={cardModal.descriptionLine1}
+          descriptionLine2={cardModal.descriptionLine2}
+          highlightText={cardModal.highlightText}
           onConfirm={handleCardConfirm}
         />
         <TravelModal

--- a/src/components/board/gameBoard.types.ts
+++ b/src/components/board/gameBoard.types.ts
@@ -20,6 +20,10 @@ export interface BuildModalState {
 export interface CardModalState {
   open: boolean
   variant: 'EVENT' | 'CHANCE'
+  title?: string
+  descriptionLine1?: string
+  descriptionLine2?: string
+  highlightText?: string
   onDoneCallback?: () => void
 }
 

--- a/src/components/board/gameBoardEventQueueUtils.test.ts
+++ b/src/components/board/gameBoardEventQueueUtils.test.ts
@@ -6,13 +6,14 @@ import {
   extractEventDice,
   getBoardEventAnimationHoldMs,
   getBoardEventConsumeDelayMs,
+  resolveBoardCardModalContentFromEvent,
   resolveBoardEventAnimationKind,
 } from './gameBoardEventQueueUtils'
 
 const players: PlayerState[] = [
   {
     id: 1,
-    name: '플레이어1',
+    name: 'Player 1',
     color: '#f00',
     pos: 0,
     money: 1000,
@@ -20,7 +21,7 @@ const players: PlayerState[] = [
   },
   {
     id: 2,
-    name: '플레이어2',
+    name: 'Player 2',
     color: '#0f0',
     pos: 0,
     money: 1000,
@@ -30,8 +31,10 @@ const players: PlayerState[] = [
 
 const tiles: TileData[] = [
   { id: 0, name: 'START', type: 'START' },
-  { id: 1, name: '서울', type: 'PROPERTY', price: 1000, color: '#f00' },
-  { id: 2, name: '부산', type: 'PROPERTY', price: 1000, color: '#0f0' },
+  { id: 1, name: 'Seoul', type: 'PROPERTY', price: 1000, color: '#f00' },
+  { id: 2, name: 'Busan', type: 'PROPERTY', price: 1000, color: '#0f0' },
+  { id: 3, name: 'Chance', type: 'CHANCE' },
+  { id: 4, name: 'Event', type: 'EVENT' },
 ]
 
 describe('gameBoardEventQueueUtils', () => {
@@ -67,6 +70,7 @@ describe('gameBoardEventQueueUtils', () => {
       playerId: 1,
       dice: [4, 1],
     }
+
     expect(extractEventDice(event as unknown as ServerEvent)).toEqual([4, 1])
   })
 
@@ -78,7 +82,7 @@ describe('gameBoardEventQueueUtils', () => {
     }
 
     expect(createBoardStatusFromEvent(event, players, tiles)).toBe(
-      '플레이어1님이 부산 칸으로 이동했습니다.'
+      'Player 1님이 Busan 칸으로 이동했습니다.'
     )
   })
 
@@ -90,7 +94,7 @@ describe('gameBoardEventQueueUtils', () => {
     } as ServerEvent & { toTileId: number }
 
     expect(createBoardStatusFromEvent(event, players, tiles)).toBe(
-      '플레이어1님이 서울 칸으로 이동했습니다.'
+      'Player 1님이 Seoul 칸으로 이동했습니다.'
     )
   })
 
@@ -100,14 +104,14 @@ describe('gameBoardEventQueueUtils', () => {
       playerId: 2,
       tile: {
         tileId: 1,
-        name: '서울',
+        name: 'Seoul',
       },
     } as ServerEvent & {
       tile: { tileId: number; name: string }
     }
 
     expect(createBoardStatusFromEvent(event, players, tiles)).toBe(
-      '플레이어2님이 서울 칸에 도착했습니다.'
+      'Player 2님이 Seoul 칸에 도착했습니다.'
     )
   })
 
@@ -118,7 +122,7 @@ describe('gameBoardEventQueueUtils', () => {
       chance: {
         type: 'GAIN_MONEY',
         power: 300,
-        description: '보너스 300만원을 획득합니다.',
+        description: 'Gain 300',
       },
     } as ServerEvent & {
       chance: {
@@ -128,9 +132,59 @@ describe('gameBoardEventQueueUtils', () => {
       }
     }
 
-    expect(createBoardStatusFromEvent(event, players, tiles)).toBe(
-      '보너스 300만원을 획득합니다.'
-    )
+    expect(createBoardStatusFromEvent(event, players, tiles)).toBe('Gain 300')
+  })
+
+  it('resolves card modal content from CHANCE_RESOLVED with chance tile', () => {
+    const event = {
+      type: 'CHANCE_RESOLVED',
+      playerId: 1,
+      tileId: 3,
+      chance: {
+        description: 'Chance card line',
+      },
+    } as ServerEvent & {
+      tileId: number
+      chance: { description: string }
+    }
+
+    expect(resolveBoardCardModalContentFromEvent(event, tiles)).toEqual({
+      variant: 'CHANCE',
+      descriptionLine1: 'Chance card line',
+      descriptionLine2: '',
+    })
+  })
+
+  it('resolves card modal content from nested tile with event variant', () => {
+    const event = {
+      type: 'CHANCE_RESOLVED',
+      playerId: 1,
+      tile: {
+        tileId: 4,
+        type: 'EVENT',
+      },
+      chance: {
+        description: 'Event card line1\nline2',
+      },
+    } as ServerEvent & {
+      tile: { tileId: number; type: string }
+      chance: { description: string }
+    }
+
+    expect(resolveBoardCardModalContentFromEvent(event, tiles)).toEqual({
+      variant: 'EVENT',
+      descriptionLine1: 'Event card line1',
+      descriptionLine2: 'line2',
+    })
+  })
+
+  it('returns null card modal content for unsupported event types', () => {
+    const event: ServerEvent = {
+      type: 'PLAYER_MOVED',
+      playerId: 1,
+    }
+
+    expect(resolveBoardCardModalContentFromEvent(event, tiles)).toBeNull()
   })
 
   it('returns toll status with formatted amount', () => {
@@ -141,7 +195,7 @@ describe('gameBoardEventQueueUtils', () => {
     }
 
     expect(createBoardStatusFromEvent(event, players, tiles)).toBe(
-      '플레이어2님이 통행료 2.5억을 지불했습니다.'
+      'Player 2님이 통행료 2.5억을 지불했습니다.'
     )
   })
 

--- a/src/components/board/gameBoardEventQueueUtils.ts
+++ b/src/components/board/gameBoardEventQueueUtils.ts
@@ -11,6 +11,13 @@ export type BoardEventAnimationKind =
   | 'turn_end'
   | 'sync'
 
+export type BoardCardModalContent = {
+  variant: 'EVENT' | 'CHANCE'
+  title?: string
+  descriptionLine1?: string
+  descriptionLine2?: string
+}
+
 const normalizeEventType = (type: unknown) =>
   typeof type === 'string' ? type.trim().toUpperCase() : ''
 
@@ -234,6 +241,79 @@ const resolveChanceDescription = (event: ServerEvent) => {
     getRecordString(chanceRecord, ['description']) ??
     getRecordString(event.payload ?? null, ['description'])
   )
+}
+
+const resolveCardModalVariant = (
+  event: ServerEvent,
+  tiles: TileData[]
+): 'EVENT' | 'CHANCE' => {
+  const eventRecord = getEventRecord(event)
+  const eventTile = getEventTileRecord(event)
+  const explicitTileType =
+    getRecordString(eventRecord, ['tileType', 'tile_type']) ??
+    getRecordString(eventTile, ['type', 'tileType', 'tile_type']) ??
+    getRecordString(event.payload ?? null, ['tileType', 'tile_type'])
+
+  const normalizedTileType = explicitTileType?.trim().toUpperCase()
+  if (normalizedTileType === 'CHANCE') {
+    return 'CHANCE'
+  }
+  if (normalizedTileType === 'EVENT') {
+    return 'EVENT'
+  }
+
+  const tileIndex = resolveBoardEventTileIndex(event)
+  if (tileIndex != null && tiles[tileIndex]?.type === 'CHANCE') {
+    return 'CHANCE'
+  }
+
+  return 'EVENT'
+}
+
+const splitCardDescriptionLines = (description: string) => {
+  const lines = description
+    .split(/\r?\n/g)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+
+  if (lines.length === 0) {
+    return { descriptionLine1: undefined, descriptionLine2: '' }
+  }
+
+  if (lines.length === 1) {
+    return { descriptionLine1: lines[0], descriptionLine2: '' }
+  }
+
+  return {
+    descriptionLine1: lines[0],
+    descriptionLine2: lines.slice(1).join(' '),
+  }
+}
+
+export const resolveBoardCardModalContentFromEvent = (
+  event: ServerEvent,
+  tiles: TileData[]
+): BoardCardModalContent | null => {
+  const normalizedType = toCanonicalEventType(event.type)
+  if (normalizedType !== 'CHANCE_RESOLVED') {
+    return null
+  }
+
+  const variant = resolveCardModalVariant(event, tiles)
+  const chanceDescription = resolveChanceDescription(event)
+
+  if (!chanceDescription) {
+    return { variant }
+  }
+
+  const { descriptionLine1, descriptionLine2 } =
+    splitCardDescriptionLines(chanceDescription)
+
+  return {
+    variant,
+    descriptionLine1,
+    descriptionLine2,
+  }
 }
 
 export const extractEventDice = (

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -67,6 +67,7 @@ const GamePage: React.FC = () => {
   const authSession = useAuthStore((state) => state.session)
   const currentPlayerId = useGameStore((s) => s.currentPlayerId)
   const currentTurn = useGameStore((s) => s.currentTurn)
+  const phase = useGameStore((s) => s.phase)
   const messages = useGameStore((s) => s.messages)
   const storePlayers = useGameStore((s) => s.players)
   const storeTiles = useGameStore((s) => s.tiles)
@@ -91,7 +92,6 @@ const GamePage: React.FC = () => {
   const [promptSubmittingChoice, setPromptSubmittingChoice] = useState<
     string | null
   >(null)
-  const [hasRolledThisTurn, setHasRolledThisTurn] = useState(false)
   const [isExitModalOpen, setIsExitModalOpen] = useState(false)
   const boardRef = useRef<BoardGameHandle>(null)
   const pendingGameChatEchoesRef = useRef<PendingGameChatEcho[]>([])
@@ -174,17 +174,6 @@ const GamePage: React.FC = () => {
   }, [lastError])
 
   useEffect(() => {
-    if (lastAck?.type === 'ROLL_DICE' && !lastAck.ok) {
-      setHasRolledThisTurn(false)
-      return
-    }
-
-    if (lastAck?.type === 'END_TURN' && lastAck.ok) {
-      setHasRolledThisTurn(false)
-    }
-  }, [lastAck])
-
-  useEffect(() => {
     if (!activeRoomId) {
       return
     }
@@ -258,25 +247,23 @@ const GamePage: React.FC = () => {
   const currentPlayerState = boardPlayers[boardCurPlayer]
   const isCurrentPlayerBankrupt =
     currentPlayerState?.money <= 0 || currentPlayerState?.state === 'bankrupt'
-  const isCurrentPlayerSkipped =
-    (currentPlayerState?.skipTurns ?? 0) > 0 ||
-    currentPlayerState?.state === 'locked' ||
-    currentPlayerState?.state === 'island'
+  const isRollPhase = phase === 'rolling'
+  const isEndTurnPhase = phase === 'resolving' && !prompt
   const canControlTurn =
     isMyTurn &&
     !isActionPending &&
     !isPromptVisible &&
-    !isCurrentPlayerSkipped &&
-    !isCurrentPlayerBankrupt
-  const rollButtonMode: 'roll' | 'end_turn' = hasRolledThisTurn
+    !isCurrentPlayerBankrupt &&
+    (isRollPhase || isEndTurnPhase)
+  const rollButtonMode: 'roll' | 'end_turn' = isEndTurnPhase
     ? 'end_turn'
     : 'roll'
-
-  useEffect(() => {
-    if (!isMyTurn) {
-      setHasRolledThisTurn(false)
-    }
-  }, [currentTurn, isMyTurn])
+  const canManageAssetsThisTurn =
+    isMyTurn &&
+    !isActionPending &&
+    !isPromptVisible &&
+    !isCurrentPlayerBankrupt &&
+    (phase === 'rolling' || phase === 'resolving')
   const roomChatSenderOptions = useMemo(
     () =>
       storePlayers.map((player) => ({
@@ -311,7 +298,15 @@ const GamePage: React.FC = () => {
     setLastError(null)
   }
   const handleRollClick = () => {
-    if (hasRolledThisTurn) {
+    if (
+      !isMyTurn ||
+      isActionPending ||
+      isPromptVisible ||
+      isCurrentPlayerBankrupt
+    ) {
+      return
+    }
+    if (!isRollPhase) {
       return
     }
     if (!activeGameId) {
@@ -324,10 +319,20 @@ const GamePage: React.FC = () => {
     boardRef.current?.rollDice()
     new Audio('/audio/dice-roll.mp3').play().catch(() => {})
     diceRoll(activeGameId)
-    setHasRolledThisTurn(true)
   }
 
   const handleEndTurnClick = () => {
+    if (
+      !isMyTurn ||
+      isActionPending ||
+      isPromptVisible ||
+      isCurrentPlayerBankrupt
+    ) {
+      return
+    }
+    if (!isEndTurnPhase) {
+      return
+    }
     if (!activeGameId || pendingAction !== null) {
       return
     }
@@ -436,6 +441,8 @@ const GamePage: React.FC = () => {
               promptSubmittingChoice={promptSubmittingChoice}
               onPromptChoice={handlePromptChoice}
               localPlayerId={currentUserId}
+              gamePhase={phase}
+              allowAssetActions={canManageAssetsThisTurn}
               gameResult={gameResult}
               isGameOver={isGameOver}
               winnerId={winnerId}


### PR DESCRIPTION
## ✨ 작업 개요
게임 턴 제어를 로컬 상태 기반이 아니라 서버 authoritative 상태(`phase`) 기반으로 정렬했습니다.  
추가로, 찬스/이벤트 카드 표시 경로를 서버 이벤트 기준으로 연결한 변경과 함께 턴 종료/자산 액션 가드를 정리했습니다.

## 🎯 변경 사항

### 1) 턴 제어(ROLL/END_TURN) 기준 정렬
- 기존 `hasRolledThisTurn` 로컬 플래그 기반 전환 제거
- 버튼 모드를 서버 `phase`로 결정하도록 변경
- `phase === 'rolling'`일 때 `ROLL`
- `phase === 'resolving' && !prompt`일 때 `END TURN`
- ROLL 클릭 직후 로컬 상태로 END로 바꾸지 않도록 수정
- 서버 patch/snapshot phase 반영 시점에만 버튼 모드가 전환되도록 변경

### 2) END_TURN 가능 조건 정렬
- END_TURN 전송 조건을 서버 계약에 맞게 정리
- 내 턴 + pending/prompt 없음 + `phase === 'resolving'`일 때만 전송
- WAIT_ROLL/기타 phase에서 잘못된 END_TURN 전송 방지

### 3) locked/island 로컬 차단 제거
- 프론트 로컬 상태로 roll을 막는 경로 제거
- 서버 authoritative 흐름에 맞게 허용/거절은 서버 응답 기준으로 처리

### 4) 자산 액션(매각/증설) 가드 정렬
- 로컬 roll 플래그 기준 차단 제거
- 내 턴 + pending/prompt 없음 + 서버 phase(`rolling|resolving`) 기준으로 가드
- 다른 플레이어 턴 동시성 이슈 방지를 위한 자기 턴 가드 유지

### 5) 찬스/이벤트 카드 서버 이벤트 연결(동일 PR 범위 포함)
- CHANCE/EVENT 결과를 서버 이벤트(`CHANCE_RESOLVED`) 기반으로 표시
- 카드 문구는 서버 `chance.description` 우선 사용 경로 정렬

## 📂 변경 파일
- `src/pages/GamePage.tsx`
- `src/components/board/GameBoard.tsx`
- (동일 브랜치 선행 커밋) 찬스/이벤트 카드 연결 관련 파일

## ✅ 기대 효과
- 새로고침/재접속/sync 이후에도 버튼 모드 불일치 감소
- ROLL 거절/ack 누락/desync 상황에서 로컬-서버 상태 틀어짐 완화
- 턴 종료/자산 액션 조건이 서버 계약과 일치
- 찬스/이벤트 카드 문구가 서버 데이터와 일치

## 🧪 검증
- `npm run lint` 통과
- `npx vitest run src/pages/GamePage.test.tsx src/components/game/controls/RollButton.test.tsx` 통과
- 수동 확인:
  - 내 턴 rolling에서 ROLL 노출
  - resolving + prompt 없음에서 END TURN 노출
  - prompt 대기 중 버튼 전환/활성 조건 확인
  - locked/island 상태에서 로컬 강제 차단 제거 확인

## ⚠️ 리스크 / 후속
- 서버 `phase` enum 변경 시 프론트 버튼 모드 조건도 함께 업데이트 필요
- 배포 서버 계약 변경(문서 갱신 포함) 시 phase 문자열/이벤트 스키마 재확인 필요
