### PR TITLE
fix: 건설 단계 계약(0~3) 정렬 및 BUILD_OR_SKIP 프롬프트 단일화

### DIFF
--- a/src/components/board/BuildingBadge.tsx
+++ b/src/components/board/BuildingBadge.tsx
@@ -35,12 +35,8 @@ const COLOR_TO_THEME: Record<string, { folder: string; prefix: string }> = {
 
 const BUILDING_SUFFIX: Partial<Record<number, string>> = {
   1: '-house.svg',
-  2: '-second-house-upgrade.svg',
-  3: '-third-house-upgrade.svg',
-  4: '-hotel.svg',
-  5: '-second-hotel-upgrade.svg',
-  6: '-third-hotel-upgrade.svg',
-  7: '-landmark.svg',
+  2: '-hotel.svg',
+  3: '-landmark.svg',
 }
 
 const BuildingBadge: React.FC<BuildingBadgeProps> = ({
@@ -49,7 +45,7 @@ const BuildingBadge: React.FC<BuildingBadgeProps> = ({
   isUrgent = false,
   showLandAtLevelZero = true,
 }) => {
-  if (level < 0 || level > 7) return null
+  if (level < 0 || level > 3) return null
   if (level === 0 && !showLandAtLevelZero) return null
 
   const rawPathColor = ownerColor || PLAYER_COLORS[0]

--- a/src/components/board/BuildingIcon.tsx
+++ b/src/components/board/BuildingIcon.tsx
@@ -33,12 +33,8 @@ const COLOR_TO_THEME: Record<string, { folder: string; prefix: string }> = {
 
 const BUILDING_SUFFIX: Record<number, string> = {
   1: '-house.svg',
-  2: '-second-house-upgrade.svg',
-  3: '-third-house-upgrade.svg',
-  4: '-hotel.svg',
-  5: '-second-hotel-upgrade.svg',
-  6: '-third-hotel-upgrade.svg',
-  7: '-landmark.svg',
+  2: '-hotel.svg',
+  3: '-landmark.svg',
 }
 
 const BuildingIcon: React.FC<BuildingIconProps> = ({
@@ -46,7 +42,7 @@ const BuildingIcon: React.FC<BuildingIconProps> = ({
   ownerColor,
   isUrgent = false,
 }) => {
-  if (!level || level < 1 || level > 7) return null
+  if (!level || level < 1 || level > 3) return null
 
   const rawPathColor = ownerColor || PLAYER_COLORS[0]
   const normalizedColor = rawPathColor.trim().toUpperCase()

--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -43,7 +43,6 @@ import {
   BuildingLevel,
   DICE_TIMEOUT,
   type TileData,
-  LEVEL_LABELS,
 } from './board.constants'
 
 import { getBoardSellFallbackRefund } from './gameBoardActionUtils'
@@ -256,10 +255,10 @@ function toBoardBuildingLevel(
 ) {
   if (!hasOwner) return 0 as BuildingLevel
   if (typeof tile.level === 'number') {
-    return Math.min(Math.max(tile.level, 0), 7) as BuildingLevel
+    return Math.min(Math.max(tile.level, 0), 3) as BuildingLevel
   }
   const buildingLevel = typeof tile.building === 'number' ? tile.building : 0
-  return Math.min(Math.max(buildingLevel, 0), 7) as BuildingLevel
+  return Math.min(Math.max(buildingLevel, 0), 3) as BuildingLevel
 }
 
 function buildTileOwnersFromProps(
@@ -770,14 +769,14 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       'current_level',
     ])
     const promptCurrentLevel = Math.min(
-      7,
+      3,
       Math.max(
         0,
         promptCurrentLevelFromPayload ??
           (promptTileId != null ? (tileOwners[promptTileId]?.level ?? 0) : 0)
       )
     ) as BuildingLevel
-    const promptNextLevel = Math.min(promptCurrentLevel + 1, 7) as BuildingLevel
+    const promptNextLevel = Math.min(promptCurrentLevel + 1, 3) as BuildingLevel
 
     const promptBuyChoiceValue = resolvePromptChoiceValue(
       activePrompt,
@@ -1784,17 +1783,13 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
 
       // 서버 프롬프트가 대기 중인 경우 프롬프트 응답으로 처리
       if (
-        activePrompt?.type === 'BUILD' &&
+        activePrompt?.type === 'BUILD_OR_SKIP' &&
         String(tileId) === String(promptTileId)
       ) {
-        onPromptChoice?.('confirm')
+        submitPromptChoice(promptBuildConfirmChoiceValue)
       } else {
-        emitGameAction({
-          type: 'CITY_BUILD',
-          payload: {
-            tileId,
-          },
-        })
+        // 서버 계약 변경: 착지 prompt 기반(BUILD_OR_SKIP)만 허용
+        return
       }
 
       // 건설 후 즉시 매각 모달로 연결 (사용자 요청: 건설하기나 취소 누르면 매각 팝업)
@@ -2155,9 +2150,9 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
             }
 
             // 🏗️ 건설 목표 레벨에 따른 소리 재생
-            if (buildTargetLevel <= 3) {
+            if (buildTargetLevel <= 1) {
               new Audio('/audio/house-buy.mp3').play().catch(() => {})
-            } else if (buildTargetLevel <= 6) {
+            } else if (buildTargetLevel === 2) {
               new Audio('/audio/hotel-build.mp3').play().catch(() => {})
             } else {
               new Audio('/audio/landmark-build.mp3').play().catch(() => {})
@@ -2271,7 +2266,6 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
           open={canShowModal && islandModal.open}
           onConfirm={handleIslandConfirm}
         />
-        {/* 수동 건설 모달 (상시 클릭용) */}
         {cityBuildModal.open && cityBuildModal.tileId != null && (
           <BuildModal
             open={true}
@@ -2279,13 +2273,10 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
               TILES[cityBuildModal.tileId]?.name.replace('\n', ' ') || ''
             }
             nextLevel={
-              ((tileOwners[cityBuildModal.tileId]?.level || 0) +
-                1) as BuildingLevel
-            }
-            nextLevelLabel={
-              LEVEL_LABELS[
-                (tileOwners[cityBuildModal.tileId]?.level || 0) + 1
-              ] || ''
+              Math.min(
+                (tileOwners[cityBuildModal.tileId]?.level || 0) + 1,
+                3
+              ) as BuildingLevel
             }
             buildCostText={formatWon(
               getBuildCost(
@@ -2296,14 +2287,17 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
             nextTollText={formatWon(
               getTollCost(
                 TILES[cityBuildModal.tileId]?.price || 0,
-                ((tileOwners[cityBuildModal.tileId]?.level || 0) +
-                  1) as BuildingLevel
+                Math.min(
+                  (tileOwners[cityBuildModal.tileId]?.level || 0) + 1,
+                  3
+                ) as BuildingLevel
               )
             )}
             onConfirm={() => handleCityBuildConfirm(cityBuildModal.tileId!)}
             onCancel={handleCityBuildCancel}
           />
         )}
+        {/* 수동 건설 모달 (상시 클릭용) */}
       </div>
     )
   }

--- a/src/components/board/board.constants.ts
+++ b/src/components/board/board.constants.ts
@@ -11,37 +11,25 @@ export type TileDir = 'top' | 'bottom' | 'left' | 'right' | 'corner'
 
 /**
  * BuildingLevel 규격:
- * 0: '토지',
- * 1: '집 x1',
- * 2: '집 x2',
- * 3: '집 x3',
- * 4: '호텔 x1',
- * 5: '호텔 x2',
- * 6: '호텔 x3',
- * 7: '랜드마크'
+ * 0: 토지만 보유
+ * 1: 주택
+ * 2: 호텔
+ * 3: 랜드마크
  */
-export type BuildingLevel = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7
+export type BuildingLevel = 0 | 1 | 2 | 3
 
 export const LEVEL_LABELS: Record<number, string> = {
   0: '토지',
-  1: '주택 x1',
-  2: '주택 x2',
-  3: '주택 x3',
-  4: '호텔 x1',
-  5: '호텔 x2',
-  6: '호텔 x3',
-  7: '랜드마크',
+  1: '주택',
+  2: '호텔',
+  3: '랜드마크',
 }
 
 export const LEVEL_MODAL_ICONS: Record<number, string> = {
   0: '/BuyModal-land.svg',
   1: '/BuyModal-house.svg',
-  2: '/BuyModal-house.svg',
-  3: '/BuyModal-house.svg',
-  4: '/BuyModal-hotel.svg',
-  5: '/BuyModal-hotel.svg',
-  6: '/BuyModal-hotel.svg',
-  7: '/BuyModal-landmark.svg',
+  2: '/BuyModal-hotel.svg',
+  3: '/BuyModal-landmark.svg',
 }
 
 export interface TileOwner {
@@ -265,13 +253,9 @@ export function getBuildCost(
   basePrice: number,
   currentLevel: BuildingLevel
 ): number {
-  if (currentLevel === 0) return basePrice * 0.5 // 집 1채
-  if (currentLevel === 1) return basePrice * 0.5 // 집 2채
-  if (currentLevel === 2) return basePrice * 0.5 // 집 3채
-  if (currentLevel === 3) return basePrice * 1.0 // 호텔 1
-  if (currentLevel === 4) return basePrice * 1.0 // 호텔 2
-  if (currentLevel === 5) return basePrice * 1.0 // 호텔 3
-  if (currentLevel === 6) return basePrice * 2.0 // 랜드마크
+  if (currentLevel === 0) return basePrice * 0.5 // 토지 -> 주택
+  if (currentLevel === 1) return basePrice * 1.0 // 주택 -> 호텔
+  if (currentLevel === 2) return basePrice * 2.0 // 호텔 -> 랜드마크
   return 0
 }
 
@@ -279,14 +263,10 @@ export function getTollCost(
   basePrice: number,
   currentLevel: BuildingLevel
 ): number {
-  // 기본 통행료 = basePrice
+  // 기본 통행료 = basePrice (토지)
   if (currentLevel === 0) return basePrice
-  if (currentLevel === 1) return basePrice * 2
-  if (currentLevel === 2) return basePrice * 3
-  if (currentLevel === 3) return basePrice * 5
-  if (currentLevel === 4) return basePrice * 7
-  if (currentLevel === 5) return basePrice * 9
-  if (currentLevel === 6) return basePrice * 12
-  if (currentLevel === 7) return basePrice * 15
+  if (currentLevel === 1) return basePrice * 2 // 주택
+  if (currentLevel === 2) return basePrice * 7 // 호텔
+  if (currentLevel === 3) return basePrice * 15 // 랜드마크
   return basePrice
 }

--- a/src/components/board/gameBoardActionHandlers.ts
+++ b/src/components/board/gameBoardActionHandlers.ts
@@ -248,9 +248,9 @@ export function createGameBoardActionHandlers(
 
       // 🏗️ 건설 목표 레벨에 따른 소리 재생
       const targetLevel = owner ? owner.level + 1 : 1
-      if (targetLevel <= 3) {
+      if (targetLevel <= 1) {
         new Audio('/audio/house-buy.mp3').play().catch(() => {})
-      } else if (targetLevel === 4) {
+      } else if (targetLevel === 2) {
         new Audio('/audio/hotel-build.mp3').play().catch(() => {})
       } else {
         new Audio('/audio/landmark-build.mp3').play().catch(() => {})

--- a/src/components/board/gameBoardStoreBridge.test.ts
+++ b/src/components/board/gameBoardStoreBridge.test.ts
@@ -97,7 +97,7 @@ describe('gameBoardStoreBridge', () => {
   it('tile owner 정보를 store tiles로 반영한다', () => {
     const nextTileOwners: Record<number, TileOwner> = {
       1: { ownerId: 0, ownerColor: '#f00', level: 2 },
-      2: { ownerId: 1, ownerColor: '#00f', level: 5 },
+      2: { ownerId: 1, ownerColor: '#00f', level: 3 },
     }
 
     syncMockStoreTileOwners(nextTileOwners)
@@ -112,7 +112,7 @@ describe('gameBoardStoreBridge', () => {
       expect.objectContaining({
         index: 2,
         owner_id: 'p2',
-        building: 5,
+        building: 3,
       }),
     ])
   })

--- a/src/components/board/gameBoardStoreBridge.ts
+++ b/src/components/board/gameBoardStoreBridge.ts
@@ -3,7 +3,7 @@ import type { BuildingLevel as StoreBuildingLevel } from '../../types/domain'
 import type { PlayerState, TileOwner } from './board.constants'
 
 const toStoreBuildingLevel = (level: number): StoreBuildingLevel =>
-  Math.min(Math.max(level, 0), 7) as StoreBuildingLevel
+  Math.min(Math.max(level, 0), 3) as StoreBuildingLevel
 
 export function syncMockStorePlayers(nextPlayers: PlayerState[]) {
   const { players: storePlayers, setGameState } = useGameStore.getState()

--- a/src/components/board/gameBoardTransactionUtils.ts
+++ b/src/components/board/gameBoardTransactionUtils.ts
@@ -45,7 +45,7 @@ export function upgradeBoardTileOwner(
     ...tileOwners,
     [tileId]: {
       ...existing,
-      level: Math.min(existing.level + 1, 7) as BuildingLevel,
+      level: Math.min(existing.level + 1, 3) as BuildingLevel,
     },
   }
 }

--- a/src/services/socket/gameContractAdapters.test.ts
+++ b/src/services/socket/gameContractAdapters.test.ts
@@ -487,7 +487,7 @@ describe('gameContractAdapters', () => {
       {
         op: 'set',
         path: 'tiles.1.building',
-        value: 7,
+        value: 3,
       },
       {
         op: 'set',

--- a/src/services/socket/gameContractAdapters.ts
+++ b/src/services/socket/gameContractAdapters.ts
@@ -501,7 +501,7 @@ const normalizePlayerFromSnapshot = (
 
 const clampBuildingLevel = (value: unknown): Tile['building'] => {
   const level = toFiniteInt(value, 0)
-  const clamped = Math.min(Math.max(level, 0), 7)
+  const clamped = Math.min(Math.max(level, 0), 3)
   return clamped as Tile['building']
 }
 

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -3,7 +3,7 @@ export type GameId = string
 export type PlayerId = number | string
 export type Money = number
 
-export type BuildingLevel = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7
+export type BuildingLevel = 0 | 1 | 2 | 3
 
 export type TileType =
   | 'start'


### PR DESCRIPTION
## 🔗 관련 이슈
- (이슈 번호 입력)

## ✨ 작업 개요
백엔드 계약 변경 사항에 맞춰 게임 건설 단계를 `0~3`(토지/주택/호텔/랜드마크)로 정렬하고,  
로컬 `CITY_BUILD` 액션 경로를 제거하여 `BUILD_OR_SKIP` 프롬프트 응답 기반으로만 동작하도록 정리했습니다.

## 🛠️ 주요 변경 사항

### 1) BuildingLevel 계약 0~3으로 통일
- `src/types/domain.ts`
  - `BuildingLevel` 타입을 `0 | 1 | 2 | 3`으로 변경
- `src/services/socket/gameContractAdapters.ts`
- `src/components/board/gameBoardStoreBridge.ts`
- `src/components/board/gameBoardTransactionUtils.ts`
  - building level clamp / upgrade 상한을 `3`으로 통일

### 2) 보드 표시/비용 규칙 정렬
- `src/components/board/board.constants.ts`
  - 레벨 라벨/모달 아이콘 맵을 0~3 체계로 정리
  - `getBuildCost`, `getTollCost` 계산 규칙을 3단계 체계 기준으로 정렬
- `src/components/board/BuildingIcon.tsx`
- `src/components/board/BuildingBadge.tsx`
  - 아이콘 suffix 및 렌더 범위를 1~3(또는 0~3) 기준으로 정리

### 3) GameBoard 프롬프트 단일 경로 정리
- `src/components/board/GameBoard.tsx`
  - `toBoardBuildingLevel`, prompt level 계산 상한을 `3`으로 수정
  - `activePrompt.type === 'BUILD_OR_SKIP'`일 때만 건설 응답 처리
  - 로컬 `CITY_BUILD` emit 경로 제거(프롬프트 응답 기반으로 통일)
  - 건설 사운드 분기(주택/호텔/랜드마크)도 3단계 체계로 정렬

### 4) 테스트 기대값 갱신
- `src/components/board/gameBoardStoreBridge.test.ts`
- `src/services/socket/gameContractAdapters.test.ts`
  - 기존 7단계 가정 기대값을 3단계 체계로 수정

## ✅ 검증 결과
- `npm run lint` 통과
- `npx vitest run src/components/board/gameBoardStoreBridge.test.ts src/services/socket/gameContractAdapters.test.ts src/components/board/gameBoardActionHandlers.test.ts src/components/board/gameBoardEventQueueUtils.test.ts` 통과
- `npm run build` 통과

## 🔍 재검토(수기)
- 파일별 diff 수기 재검토 완료
- 전체 diff/stat 재검토 완료
- 커밋 후 `git show --stat` 기준 최종 재검토 완료

## ⚠️ 리스크 / 후속
- `GameBoard` 내부에 `cityBuildModal` 관련 상태/렌더 블록 일부가 구조적으로 남아 있어, 추후 dead-path 정리 리팩터링 PR에서 제거하는 것이 안전합니다.
- 푸시 과정에서 테스트 로그 경고(`act(...)`, Playwright reporter `EPIPE`)가 있었으나 본 변경과 직접 관련 없는 기존 환경성 이슈로 보이며, 원격 푸시는 정상 완료되었습니다.
