### PR TITLE
fix: 대기방 좌석 카드 닉네임 overflow 처리

### DIFF
--- a/src/pages/waiting-room/components/WaitingSeatCard.test.tsx
+++ b/src/pages/waiting-room/components/WaitingSeatCard.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { WaitingSeatCard } from './WaitingSeatCard'
+
+describe('WaitingSeatCard', () => {
+  it('긴 닉네임은 ellipsis 가능한 구조로 렌더링하고 전체 이름은 title로 유지한다', () => {
+    const longNickname = '아주아주아주긴닉네임테스트플레이어'
+
+    render(
+      <WaitingSeatCard
+        seat={{
+          id: 'user-1',
+          nickname: longNickname,
+          isReady: false,
+          isHost: false,
+          isMe: true,
+          avatarColor: '#ef4444',
+        }}
+      />
+    )
+
+    const nicknameLabel = screen.getByText(longNickname)
+
+    expect(nicknameLabel).toHaveAttribute('title', longNickname)
+    expect(nicknameLabel).toHaveClass('truncate')
+    expect(nicknameLabel).toHaveClass('min-w-0')
+    expect(screen.getByText('나')).toHaveClass('shrink-0')
+  })
+})

--- a/src/pages/waiting-room/components/WaitingSeatCard.tsx
+++ b/src/pages/waiting-room/components/WaitingSeatCard.tsx
@@ -42,14 +42,22 @@ export function WaitingSeatCard({ seat }: WaitingSeatCardProps) {
           ) : null}
         </div>
 
-        <p className="truncate text-center text-[2.25rem] font-extrabold tracking-tight text-ui-text-strong">
-          {seat.nickname}
+        <div className="flex w-full items-center justify-center gap-2">
+          <p
+            title={seat.nickname}
+            className={cn(
+              'block min-w-0 truncate text-center text-[2.25rem] font-extrabold tracking-tight text-ui-text-strong',
+              seat.isMe ? 'max-w-[calc(100%-3.5rem)]' : 'max-w-full'
+            )}
+          >
+            {seat.nickname}
+          </p>
           {seat.isMe ? (
-            <span className="ml-2 rounded-lg bg-ui-surface-soft px-2 py-0.5 text-xl font-semibold text-ui-text-subtle">
+            <span className="shrink-0 rounded-lg bg-ui-surface-soft px-2 py-0.5 text-xl font-semibold text-ui-text-subtle">
               나
             </span>
           ) : null}
-        </p>
+        </div>
       </div>
 
       <div className="mt-auto flex justify-end">


### PR DESCRIPTION
## 📌 관련 이슈

> closes #535 

---

## 📝 작업 내용

대기방 플레이어 좌석 카드에서 긴 닉네임이 카드 밖으로 밀려나오던 문제를 수정했습니다.

- 닉네임과 `나` 배지를 같은 텍스트 흐름에서 분리했습니다.
- 닉네임에 실제 ellipsis가 걸릴 수 있도록 `min-w-0`, `truncate`, 폭 제약을 추가했습니다.
- 전체 닉네임은 `title` 속성으로 유지해 hover 시 확인할 수 있도록 했습니다.
- 긴 닉네임 회귀 방지를 위해 좌석 카드 단위 테스트를 추가했습니다.

### 📚 참고한 기준 문서

- `AGENTS.md`
- `docs/ai/manuals/common.md`
- `docs/ai/manuals/waiting-room.md`
- `docs/socket-mock-server.md`
- `docs/rules.md`
- `docs/testing.md`

### 🧪 실행한 검증

- `npx vitest run src/pages/waiting-room/components/WaitingSeatCard.test.tsx`
- `npm run ai:check:waiting-room`

### ⚠️ 남은 리스크

- 지금은 한 줄 ellipsis로 자르기 때문에 매우 긴 닉네임은 끝까지 보이지 않고 hover `title`에 의존합니다.
- 카드 폭이나 배지 크기가 크게 바뀌는 반응형 변경이 들어오면 현재 `max-w-[calc(100%-3.5rem)]` 값은 다시 조정이 필요할 수 있습니다.
