### PR TITLE
fix: 게임 재연결 시 sync 재요청 누락 수정

### DIFF
--- a/docs/ai/tasks/game-reconnect-sync/checklist.md
+++ b/docs/ai/tasks/game-reconnect-sync/checklist.md
@@ -1,0 +1,19 @@
+# Checklist
+
+## Implementation
+
+- [x] 관련 manual과 기존 문서를 읽었다
+- [x] reconnect 문제 범위를 정리했다
+- [x] `useGameState`의 reconnect sync 분기를 수정했다
+- [x] 관련 테스트를 보강했다
+
+## Testing
+
+- [x] 대상 Vitest를 실행했다
+- [x] `npm run build`를 실행했다
+
+## Review
+
+- [x] initial mount와 reconnect 경로를 분리했다
+- [x] reconnect 시 `knownRevision` 기반 재동기화를 유지했다
+- [x] 변경 파일 / 실행한 검증 / 남은 리스크를 정리했다

--- a/docs/ai/tasks/game-reconnect-sync/context.md
+++ b/docs/ai/tasks/game-reconnect-sync/context.md
@@ -1,0 +1,41 @@
+# Context
+
+## Current Behavior
+
+- `useGameState`는 mount 시 `game:sync`와 `game:sync_timer`를 요청한다.
+- 같은 `gameId`에서 이미 `players.length > 0`이면 초기 동기화를 생략한다.
+- socket `connect` 이벤트에서도 같은 `syncGameState` 분기를 그대로 사용한다.
+
+## Problem
+
+- 같은 게임 화면을 유지한 상태에서 소켓이 끊겼다가 다시 연결되면, 로컬 store에 기존 player state가 남아 있다는 이유로 `game:sync`가 재요청되지 않을 수 있다.
+- 이 경우 끊긴 동안 놓친 patch를 다시 못 받아 화면이 stale 상태로 남을 수 있다.
+- 새로고침은 보통 store가 비어 `knownRevision: 0` snapshot 경로를 타지만, reconnect는 다른 조건으로 다뤄야 한다.
+
+## Related Files
+
+- `src/hooks/game/useGameState.ts`
+- `src/hooks/game/useGameState.test.tsx`
+- `src/services/socket/game.handler.ts`
+- `src/stores/game.store.ts`
+- `docs/ai/manuals/common.md`
+- `docs/ai/manuals/game-runtime.md`
+- `docs/rules.md`
+- `docs/testing.md`
+
+## Constraints
+
+- initial mount에서 같은 게임 상태를 이미 들고 있을 때 불필요한 sync 반복은 피한다.
+- reconnect에서는 local state 유무보다 서버 재동기화를 우선한다.
+- `knownRevision`은 reconnect 시 현재 store revision을 사용한다.
+- mock/real runtime 경로의 visible behavior를 깨지 않는다.
+
+## Decision Notes
+
+- `syncGameState`에 force 옵션을 추가해 reconnect 분기만 별도로 강제 sync 처리한다.
+- gameId가 바뀐 경우는 기존처럼 `knownRevision: 0` full sync로 유지한다.
+
+## Open Risks
+
+- reconnect 직후 revision이 오래된 상태면 서버가 diff 대신 snapshot을 줄 수 있다.
+- leave/기권과 disconnect 의미 분리는 이번 범위에 포함하지 않는다.

--- a/docs/ai/tasks/game-reconnect-sync/plan.md
+++ b/docs/ai/tasks/game-reconnect-sync/plan.md
@@ -1,0 +1,41 @@
+# Plan
+
+## Task
+
+- 작업 이름: game reconnect sync
+- 요청 날짜: 2026-03-20
+- 담당 범위: game runtime reconnect sync 분기, 관련 테스트, task 문서
+
+## Goal
+
+- 게임 화면 유지 상태에서 소켓이 끊겼다가 다시 연결될 때, 기존 로컬 상태 유무와 관계없이 `game:sync`를 다시 보내 누락 patch를 복구한다.
+
+## In Scope
+
+- `useGameState`의 initial sync / reconnect sync 분기 정리
+- reconnect 시 `knownRevision` 기반 재동기화 강제
+- `useGameState` 테스트 보강
+- task 문서 추가
+
+## Out Of Scope
+
+- 게임 leave/기권 계약 추가
+- game socket payload 스키마 변경
+- waiting-room / lobby / presence 흐름 수정
+
+## Target Files
+
+- `src/hooks/game/useGameState.ts`
+- `src/hooks/game/useGameState.test.tsx`
+- `docs/ai/tasks/game-reconnect-sync/*`
+
+## Completion Criteria
+
+- reconnect 시에는 local players 상태가 남아 있어도 `game:sync`를 다시 보낸다.
+- initial mount의 중복 sync 생략 규칙은 유지된다.
+- 관련 Vitest와 build가 통과한다.
+
+## Test Plan
+
+- `npx vitest run src/hooks/game/useGameState.test.tsx`
+- `npm run build`

--- a/src/hooks/game/useGameState.test.tsx
+++ b/src/hooks/game/useGameState.test.tsx
@@ -131,7 +131,7 @@ describe('useGameState', () => {
     expect(emitGameSyncTimer).not.toHaveBeenCalled()
   })
 
-  it('소켓 connect 이벤트에서 game sync와 timer sync를 모두 재요청한다', async () => {
+  it('소켓 reconnect 시 기존 local state가 있어도 current revision 기준으로 game sync를 재요청한다', async () => {
     const {
       useGameState,
       socketHandlers,
@@ -143,13 +143,13 @@ describe('useGameState', () => {
       mockEnabled: false,
       socketConnected: false,
       revision: 3,
-      playersLength: 0,
+      playersLength: 2,
     })
 
     renderHook(() => useGameState('game-2'))
 
     expect(connectSocketWithAuthIfNeeded).toHaveBeenCalledTimes(1)
-    expect(emitGameSync).toHaveBeenCalledWith({
+    expect(emitGameSync).toHaveBeenNthCalledWith(1, {
       gameId: 'game-2',
       knownRevision: 0,
     })
@@ -163,6 +163,10 @@ describe('useGameState', () => {
     })
 
     expect(emitGameSync).toHaveBeenCalledTimes(2)
+    expect(emitGameSync).toHaveBeenNthCalledWith(2, {
+      gameId: 'game-2',
+      knownRevision: 3,
+    })
     expect(emitGameSyncTimer).toHaveBeenCalledTimes(2)
   })
 

--- a/src/hooks/game/useGameState.ts
+++ b/src/hooks/game/useGameState.ts
@@ -37,12 +37,12 @@ export const useGameState = (gameId: string | null) => {
       connectSocketWithAuthIfNeeded()
     }
 
-    const syncGameState = () => {
+    const syncGameState = ({ force = false }: { force?: boolean } = {}) => {
       const gameChanged = syncedGameIdRef.current !== gameId
       const { players, revision } = useGameStore.getState()
 
-      // 같은 게임에서 이미 상태를 들고 있으면 초기 동기화를 반복하지 않는다.
-      if (!gameChanged && players.length > 0) return
+      // 초기 진입에서는 같은 게임 상태를 이미 들고 있으면 중복 sync를 생략한다.
+      if (!force && !gameChanged && players.length > 0) return
 
       emitGameSync({
         gameId,
@@ -66,7 +66,8 @@ export const useGameState = (gameId: string | null) => {
     }
 
     const handleSocketConnect = () => {
-      syncGameState()
+      // reconnect에서는 local state 유무와 관계없이 누락 patch 복구를 다시 요청한다.
+      syncGameState({ force: true })
       syncGameTimer()
     }
 


### PR DESCRIPTION
## 📌 관련 이슈

> closes #537 

---

## 📝 작업 내용

게임 화면을 유지한 상태에서 소켓이 끊겼다가 다시 연결되면,
끊긴 동안 놓친 patch를 복구하기 위해 `game:sync`를 다시 보내야 하는데
기존 프론트는 local player state가 남아 있으면 이를 생략할 수 있었습니다.

이번 수정에서는 initial mount와 reconnect 경로를 분리해,
reconnect 시에는 기존 local state 유무와 관계없이 `knownRevision` 기준으로 `game:sync`를 다시 요청하도록 정리했습니다.

- `useGameState`의 `syncGameState`에 force 분기를 추가했습니다.
- initial mount에서는 기존처럼 같은 게임 상태를 이미 들고 있으면 중복 sync를 생략합니다.
- socket `connect` 이벤트에서는 reconnect 경로로 간주하고 `force: true`로 `game:sync`를 다시 요청하도록 변경했습니다.
- reconnect 시에는 current store revision을 `knownRevision`으로 보내도록 테스트를 보강했습니다.
- 작업 문서도 함께 추가했습니다.

### 🧠 Task 문서

- `docs/ai/tasks/game-reconnect-sync/plan.md`
- `docs/ai/tasks/game-reconnect-sync/context.md`
- `docs/ai/tasks/game-reconnect-sync/checklist.md`

### 📚 참고한 기준 문서

- `AGENTS.md`
- `docs/ai/manuals/common.md`
- `docs/ai/manuals/game-runtime.md`
- `docs/rules.md`
- `docs/testing.md`

### 🧪 실행한 검증

- `npx vitest run src/hooks/game/useGameState.test.tsx`
- `npm run build`

### ⚠️ 남은 리스크

- reconnect 시 `knownRevision`을 보내도록 바꿨기 때문에, 서버가 오래된 revision에 대해 diff 대신 snapshot을 돌려주는 경우는 계속 서버 정책에 의존합니다.
- 이번 수정은 reconnect sync만 다루며, 게임 나가기 버튼의 명시적 leave 계약이나 disconnect/기권 의미 분리는 포함하지 않았습니다.
