### PR TITLE
feat: 게임 나가기 leave API 연동

### DIFF
--- a/docs/ai/tasks/game-leave-api-flow/checklist.md
+++ b/docs/ai/tasks/game-leave-api-flow/checklist.md
@@ -1,0 +1,22 @@
+# Checklist
+
+## Implementation
+
+- [x] 관련 manual과 기존 문서를 읽었다
+- [x] leave API 계약과 현재 GamePage 흐름을 정리했다
+- [x] game leave API helper를 추가했다
+- [x] GamePage exit confirm을 async leave 흐름으로 변경했다
+- [x] ExitGameModal pending 상태를 추가했다
+- [x] 관련 테스트를 추가/갱신했다
+
+## Testing
+
+- [x] 대상 Vitest를 실행했다
+- [x] `npm run build`를 실행했다
+
+## Review
+
+- [x] leave 성공 이후에만 로비 이동하도록 정리했다
+- [x] leave 실패 시 현재 화면 유지와 오류 안내를 추가했다
+- [x] mock/real 경로가 함께 동작하도록 맞췄다
+- [x] 변경 파일 / 실행한 검증 / 남은 리스크를 정리했다

--- a/docs/ai/tasks/game-leave-api-flow/context.md
+++ b/docs/ai/tasks/game-leave-api-flow/context.md
@@ -1,0 +1,43 @@
+# Context
+
+## Current Behavior
+
+- `GamePage.tsx`의 나가기 버튼은 확인 모달을 띄운 뒤, 확인 시 `window.location.href = '/lobby'`로 바로 이동한다.
+- 현재 프론트에는 게임 명시적 leave API 호출이나 socket emit이 없다.
+- 페이지 이동으로 socket disconnect는 발생할 수 있지만, 버튼 기반 leave와 disconnect를 프론트에서 구분하지 못한다.
+
+## Problem
+
+- 서버에는 사용자가 명시적으로 게임을 나갔다는 상태 변경이 반영되지 않는다.
+- leave 실패를 사용자에게 보여줄 수 없고, 서버 정리 전에 화면이 사라진다.
+- reconnect timeout 복구와 명시적 leave가 같은 disconnect 의미로 섞일 수 있다.
+
+## Related Files
+
+- `src/pages/GamePage.tsx`
+- `src/components/game/modals/ExitGameModal.tsx`
+- `src/pages/game/*`
+- `src/stores/game.store.ts`
+- `src/features/presence/mock/mockData.ts`
+- `docs/ai/manuals/common.md`
+- `docs/ai/manuals/game-runtime.md`
+- `docs/rules.md`
+- `docs/testing.md`
+
+## Constraints
+
+- 게임 canonical identifier는 `gameId`를 유지한다.
+- leave 성공 전에는 화면을 유지하고, 실패 시 사용자가 재시도할 수 있어야 한다.
+- mock 모드에서도 최소한 presence 상태는 `lobby`로 정리한다.
+- 기존 채팅/보드/game state 렌더링 흐름은 건드리지 않는다.
+
+## Decision Notes
+
+- leave는 `src/pages/game/api.ts`에 별도 helper로 분리한다.
+- `GamePage`는 leave helper 결과만 보고 store reset + navigate를 수행한다.
+- exit modal은 `isSubmitting`을 받아 요청 중 중복 클릭과 취소를 막는다.
+
+## Open Risks
+
+- leave 이후 room membership 정리와 다른 참가자에 대한 broadcast는 서버 정책에 의존한다.
+- mock 모드 leave는 presence를 `lobby`로 바꾸는 최소 fallback만 제공하므로, 실서버와 완전히 동일한 상태 정리는 아니다.

--- a/docs/ai/tasks/game-leave-api-flow/plan.md
+++ b/docs/ai/tasks/game-leave-api-flow/plan.md
@@ -1,0 +1,47 @@
+# Plan
+
+## Task
+
+- 작업 이름: game leave api flow
+- 요청 날짜: 2026-03-20
+- 담당 범위: game leave API 계층, GamePage 종료 흐름, exit modal pending 상태, 관련 테스트, task 문서
+
+## Goal
+
+- 게임 페이지의 `나가기` 버튼이 단순 페이지 이동이 아니라 `POST /api/games/{game_id}/leave` 성공 이후에만 로비로 이동하도록 만든다.
+
+## In Scope
+
+- `src/pages/game/api.ts` leave API helper 추가
+- mock 모드 leave fallback 추가
+- `GamePage.tsx` exit confirm async 흐름 적용
+- `ExitGameModal.tsx` pending 상태 지원
+- `GamePage` / game api 테스트 추가
+- task 문서 추가
+
+## Out Of Scope
+
+- leave 이후 서버 socket broadcast 정책 변경
+- disconnect timeout / reconnect 의미 분리 구현
+- game socket payload 스키마 변경
+
+## Target Files
+
+- `src/pages/game/api.ts`
+- `src/pages/game/api.test.ts`
+- `src/pages/GamePage.tsx`
+- `src/pages/GamePage.test.tsx`
+- `src/components/game/modals/ExitGameModal.tsx`
+- `docs/ai/tasks/game-leave-api-flow/*`
+
+## Completion Criteria
+
+- 게임 나가기 버튼 클릭 시 leave API가 호출된다.
+- leave 성공 시 game store를 초기화하고 `/lobby`로 이동한다.
+- leave 실패 시 토스트를 띄우고 현재 게임 화면을 유지한다.
+- mock/real 경로 모두 leave helper가 동작한다.
+
+## Test Plan
+
+- `npx vitest run src/pages/game/api.test.ts src/pages/GamePage.test.tsx`
+- `npm run build`

--- a/src/components/game/modals/ExitGameModal.tsx
+++ b/src/components/game/modals/ExitGameModal.tsx
@@ -2,18 +2,24 @@ import { useEffect, Fragment } from 'react'
 
 interface ExitGameModalProps {
   open: boolean
+  isSubmitting?: boolean
   onCancel?: () => void
   onConfirm?: () => void
 }
 
-const ExitGameModal = ({ open, onCancel, onConfirm }: ExitGameModalProps) => {
+const ExitGameModal = ({
+  open,
+  isSubmitting = false,
+  onCancel,
+  onConfirm,
+}: ExitGameModalProps) => {
   useEffect(() => {
     if (!open) {
       return
     }
 
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
+      if (event.key === 'Escape' && !isSubmitting) {
         onCancel?.()
       }
     }
@@ -22,7 +28,7 @@ const ExitGameModal = ({ open, onCancel, onConfirm }: ExitGameModalProps) => {
     return () => {
       window.removeEventListener('keydown', handleKeyDown)
     }
-  }, [open, onCancel])
+  }, [isSubmitting, open, onCancel])
 
   if (!open) {
     return null
@@ -57,17 +63,19 @@ const ExitGameModal = ({ open, onCancel, onConfirm }: ExitGameModalProps) => {
           <div className="mt-10 flex items-center justify-center gap-4">
             <button
               type="button"
+              disabled={isSubmitting}
               onClick={onCancel}
-              className="h-14 min-w-40 rounded-[20px] bg-[#E9EEF5] px-8 text-[24px] font-black tracking-tight text-[#64748B] transition-colors hover:bg-[#DCE3ED]"
+              className="h-14 min-w-40 rounded-[20px] bg-[#E9EEF5] px-8 text-[24px] font-black tracking-tight text-[#64748B] transition-colors hover:bg-[#DCE3ED] disabled:cursor-not-allowed disabled:opacity-60"
             >
               취소
             </button>
             <button
               type="button"
+              disabled={isSubmitting}
               onClick={onConfirm}
-              className="h-14 min-w-40 rounded-[20px] bg-[#E10606] px-8 text-[24px] font-black tracking-tight text-white shadow-[0_10px_24px_rgba(225,6,6,0.35)] transition-colors hover:bg-[#C80505]"
+              className="h-14 min-w-40 rounded-[20px] bg-[#E10606] px-8 text-[24px] font-black tracking-tight text-white shadow-[0_10px_24px_rgba(225,6,6,0.35)] transition-colors hover:bg-[#C80505] disabled:cursor-not-allowed disabled:opacity-60"
             >
-              종료
+              {isSubmitting ? '종료 중...' : '종료'}
             </button>
           </div>
         </div>

--- a/src/pages/GamePage.test.tsx
+++ b/src/pages/GamePage.test.tsx
@@ -1,6 +1,6 @@
 import { forwardRef } from 'react'
 import { Route, Routes } from 'react-router-dom'
-import { act, screen } from '@testing-library/react'
+import { act, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import GamePage from './GamePage'
@@ -16,29 +16,57 @@ vi.mock('../config/env', () => ({
   SHOULD_ENABLE_MSW: true,
 }))
 
-const { sendWaitingRoomChatMock, emitChatEvent, socketOnMock, socketOffMock } =
-  vi.hoisted(() => {
-    const handlers = new Map<string, Set<(payload: unknown) => void>>()
+const {
+  sendWaitingRoomChatMock,
+  emitChatEvent,
+  socketOnMock,
+  socketOffMock,
+  navigateMock,
+  toastErrorMock,
+  leaveGameMock,
+  getGameLeaveErrorMessageMock,
+} = vi.hoisted(() => {
+  const handlers = new Map<string, Set<(payload: unknown) => void>>()
 
-    return {
-      sendWaitingRoomChatMock: vi.fn(),
-      socketOnMock: vi.fn(
-        (event: string, handler: (payload: unknown) => void) => {
-          const nextHandlers = handlers.get(event) ?? new Set()
-          nextHandlers.add(handler)
-          handlers.set(event, nextHandlers)
-        }
-      ),
-      socketOffMock: vi.fn(
-        (event: string, handler: (payload: unknown) => void) => {
-          handlers.get(event)?.delete(handler)
-        }
-      ),
-      emitChatEvent: (payload: unknown) => {
-        handlers.get('chat')?.forEach((handler) => handler(payload))
-      },
-    }
-  })
+  return {
+    sendWaitingRoomChatMock: vi.fn(),
+    socketOnMock: vi.fn(
+      (event: string, handler: (payload: unknown) => void) => {
+        const nextHandlers = handlers.get(event) ?? new Set()
+        nextHandlers.add(handler)
+        handlers.set(event, nextHandlers)
+      }
+    ),
+    socketOffMock: vi.fn(
+      (event: string, handler: (payload: unknown) => void) => {
+        handlers.get(event)?.delete(handler)
+      }
+    ),
+    emitChatEvent: (payload: unknown) => {
+      handlers.get('chat')?.forEach((handler) => handler(payload))
+    },
+    navigateMock: vi.fn(),
+    toastErrorMock: vi.fn(),
+    leaveGameMock: vi.fn(),
+    getGameLeaveErrorMessageMock: vi.fn(),
+  }
+})
+
+vi.mock('react-hot-toast', () => ({
+  default: {
+    error: toastErrorMock,
+  },
+}))
+
+vi.mock('react-router-dom', async () => {
+  const actual =
+    await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  }
+})
 
 vi.mock('../lib/socket', () => ({
   socket: {
@@ -70,8 +98,14 @@ vi.mock('../lib/bgm', () => ({
   stopBgm: vi.fn(),
 }))
 
+vi.mock('../pages/game/api', () => ({
+  leaveGame: leaveGameMock,
+  getGameLeaveErrorMessage: getGameLeaveErrorMessageMock,
+}))
+
 vi.mock('../services/socket/game.handler', () => ({
   emitPromptResponse: vi.fn(),
+  emitGameAction: vi.fn(),
 }))
 
 vi.mock('../components/board/GameBoard', () => ({
@@ -89,7 +123,27 @@ vi.mock('../components/game/controls/RollButton', () => ({
 }))
 
 vi.mock('../components/game/modals/ExitGameModal', () => ({
-  default: () => null,
+  default: ({
+    open,
+    isSubmitting,
+    onCancel,
+    onConfirm,
+  }: {
+    open: boolean
+    isSubmitting?: boolean
+    onCancel?: () => void
+    onConfirm?: () => void
+  }) =>
+    open ? (
+      <div role="dialog" aria-label="게임 종료">
+        <button type="button" onClick={onCancel} disabled={isSubmitting}>
+          취소
+        </button>
+        <button type="button" onClick={onConfirm} disabled={isSubmitting}>
+          {isSubmitting ? '종료 중...' : '종료'}
+        </button>
+      </div>
+    ) : null,
 }))
 
 vi.mock('../components/game/modals/promptModalMapping', () => ({
@@ -202,5 +256,59 @@ describe('GamePage chat flow', () => {
     })
 
     expect(screen.getAllByText('ㅎㅇㅎㅇ')).toHaveLength(1)
+  })
+
+  it('게임 나가기 성공 시 leave API 호출 후 로비로 이동하고 game store를 초기화한다', async () => {
+    const user = userEvent.setup()
+
+    leaveGameMock.mockResolvedValue({
+      success: true,
+      roomId: 'room-1',
+      resumeTarget: 'lobby',
+    })
+
+    renderGamePage()
+
+    await user.click(screen.getByRole('button', { name: '나가기' }))
+    await user.click(screen.getByRole('button', { name: '종료' }))
+
+    await waitFor(() => {
+      expect(leaveGameMock).toHaveBeenCalledWith({
+        gameId: 'game-1',
+        userId: 'user-1',
+        nickname: '유저1',
+      })
+    })
+
+    await waitFor(() => {
+      expect(navigateMock).toHaveBeenCalledWith('/lobby', { replace: true })
+    })
+
+    expect(useGameStore.getState().players).toHaveLength(0)
+    expect(
+      screen.queryByRole('dialog', { name: '게임 종료' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('게임 나가기 실패 시 토스트를 띄우고 현재 화면을 유지한다', async () => {
+    const user = userEvent.setup()
+
+    leaveGameMock.mockRejectedValue(new Error('leave failed'))
+    getGameLeaveErrorMessageMock.mockReturnValue('게임 나가기에 실패했습니다.')
+
+    renderGamePage()
+
+    await user.click(screen.getByRole('button', { name: '나가기' }))
+    await user.click(screen.getByRole('button', { name: '종료' }))
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith('게임 나가기에 실패했습니다.')
+    })
+
+    expect(navigateMock).not.toHaveBeenCalled()
+    expect(useGameStore.getState().players).toHaveLength(2)
+    expect(
+      screen.getByRole('dialog', { name: '게임 종료' })
+    ).toBeInTheDocument()
   })
 })

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { ArrowLeft } from 'lucide-react'
-import { useLocation, useParams } from 'react-router-dom'
+import toast from 'react-hot-toast'
+import { useLocation, useNavigate, useParams } from 'react-router-dom'
 import BoardGame, { BoardGameHandle } from '../components/board/GameBoard'
 import RollButton from '../components/game/controls/RollButton'
 import ExitGameModal from '../components/game/modals/ExitGameModal'
@@ -34,6 +35,7 @@ import {
   reconcileGameChatMessages,
   type PendingGameChatEcho,
 } from './game/gameChat'
+import { getGameLeaveErrorMessage, leaveGame } from './game/api'
 import { sendWaitingRoomChat } from './waiting-room/socket/socket'
 import type { ChatEventPayload } from './waiting-room/api/types'
 
@@ -64,6 +66,7 @@ const GamePage: React.FC = () => {
   const { gameId: routeGameId } = useParams<{ gameId: string }>()
   const location = useLocation()
   const locationState = location.state as GamePageLocationState | null
+  const navigate = useNavigate()
   const authSession = useAuthStore((state) => state.session)
   const currentPlayerId = useGameStore((s) => s.currentPlayerId)
   const currentTurn = useGameStore((s) => s.currentTurn)
@@ -82,6 +85,7 @@ const GamePage: React.FC = () => {
   const storeGameId = useGameStore((s) => s.gameId)
   const clearPrompt = useGameStore((s) => s.clearPrompt)
   const setLastError = useGameStore((s) => s.setLastError)
+  const resetGame = useGameStore((s) => s.resetGame)
   const activeGameId =
     locationState?.gameId ??
     routeGameId ??
@@ -93,6 +97,7 @@ const GamePage: React.FC = () => {
     string | null
   >(null)
   const [isExitModalOpen, setIsExitModalOpen] = useState(false)
+  const [isLeavePending, setIsLeavePending] = useState(false)
   const boardRef = useRef<BoardGameHandle>(null)
   const pendingGameChatEchoesRef = useRef<PendingGameChatEcho[]>([])
 
@@ -297,6 +302,39 @@ const GamePage: React.FC = () => {
   const dismissLastError = () => {
     setLastError(null)
   }
+  const handleExitConfirm = async () => {
+    if (isLeavePending) {
+      return
+    }
+
+    if (!activeGameId) {
+      resetGame()
+      setIsExitModalOpen(false)
+      navigate('/lobby', { replace: true })
+      return
+    }
+
+    setIsLeavePending(true)
+
+    try {
+      await leaveGame({
+        gameId: activeGameId,
+        userId: currentUserId ?? undefined,
+        nickname: currentNickname,
+      })
+
+      resetGame()
+      setIsExitModalOpen(false)
+      navigate('/lobby', { replace: true })
+    } catch (error) {
+      toast.error(
+        getGameLeaveErrorMessage(error, '게임 나가기에 실패했습니다.')
+      )
+    } finally {
+      setIsLeavePending(false)
+    }
+  }
+
   const handleRollClick = () => {
     if (
       !isMyTurn ||
@@ -545,11 +583,9 @@ const GamePage: React.FC = () => {
 
       <ExitGameModal
         open={isExitModalOpen}
+        isSubmitting={isLeavePending}
         onCancel={() => setIsExitModalOpen(false)}
-        onConfirm={() => {
-          setIsExitModalOpen(false)
-          window.location.href = '/lobby'
-        }}
+        onConfirm={handleExitConfirm}
       />
 
       <DevRoomChatControlPanel

--- a/src/pages/game/api.test.ts
+++ b/src/pages/game/api.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import axios from 'axios'
+
+async function loadGameApiModule(options?: { mockEnabled?: boolean }) {
+  const postMock = vi.fn()
+  const setMockOnlineUserStatusMock = vi.fn()
+
+  vi.resetModules()
+
+  vi.doMock('../../config/env', () => ({
+    IS_SOCKET_MOCK_ENABLED: options?.mockEnabled ?? false,
+  }))
+  vi.doMock('../../lib/axios', () => ({
+    apiClient: {
+      post: postMock,
+    },
+  }))
+  vi.doMock('../../features/presence/mock/mockData', () => ({
+    setMockOnlineUserStatus: setMockOnlineUserStatusMock,
+  }))
+
+  const module = await import('./api')
+
+  return {
+    module,
+    postMock,
+    setMockOnlineUserStatusMock,
+  }
+}
+
+describe('game api', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.resetModules()
+  })
+
+  it('leaveGame은 실서버 모드에서 games leave endpoint를 호출한다', async () => {
+    const { module, postMock } = await loadGameApiModule()
+
+    postMock.mockResolvedValue({
+      data: {
+        success: true,
+        room_id: 'room-1',
+        resume_target: 'lobby',
+      },
+    })
+
+    const result = await module.leaveGame({ gameId: 'game-1' })
+
+    expect(postMock).toHaveBeenCalledWith('/games/game-1/leave')
+    expect(result).toEqual({
+      success: true,
+      roomId: 'room-1',
+      resumeTarget: 'lobby',
+    })
+  })
+
+  it('leaveGame은 mock 모드에서 접속 상태를 lobby로 바꾸고 성공 결과를 반환한다', async () => {
+    const { module, postMock, setMockOnlineUserStatusMock } =
+      await loadGameApiModule({ mockEnabled: true })
+
+    const result = await module.leaveGame({
+      gameId: 'game-1',
+      userId: 'user-1',
+      nickname: '유저1',
+    })
+
+    expect(postMock).not.toHaveBeenCalled()
+    expect(setMockOnlineUserStatusMock).toHaveBeenCalledWith(
+      'user-1',
+      'lobby',
+      '유저1'
+    )
+    expect(result).toEqual({
+      success: true,
+      roomId: null,
+      resumeTarget: 'lobby',
+    })
+  })
+
+  it('getGameLeaveErrorMessage는 공통 API 오류 메시지를 사용한다', async () => {
+    const { module } = await loadGameApiModule()
+
+    const error = new axios.AxiosError(
+      'Request failed with status code 403',
+      undefined,
+      undefined,
+      undefined,
+      {
+        status: 403,
+        statusText: 'error',
+        headers: {},
+        config: { headers: {} as never },
+        data: {
+          message: '게임을 나갈 수 없습니다.',
+        },
+      }
+    )
+
+    expect(
+      module.getGameLeaveErrorMessage(error, '게임 나가기에 실패했습니다.')
+    ).toBe('게임을 나갈 수 없습니다.')
+  })
+})

--- a/src/pages/game/api.ts
+++ b/src/pages/game/api.ts
@@ -1,0 +1,61 @@
+import { IS_SOCKET_MOCK_ENABLED } from '../../config/env'
+import { getParsedApiErrorMessage, parseApiError } from '../../lib/apiError'
+import { apiClient } from '../../lib/axios'
+import { setMockOnlineUserStatus } from '../../features/presence/mock/mockData'
+
+type LeaveGameResumeTarget = 'lobby' | 'room' | 'game'
+
+interface LeaveGameResponsePayload {
+  success: boolean
+  room_id?: string | null
+  resume_target?: LeaveGameResumeTarget | null
+}
+
+interface LeaveGameParams {
+  gameId: string
+  userId?: string
+  nickname?: string
+}
+
+export interface LeaveGameResult {
+  success: boolean
+  roomId: string | null
+  resumeTarget: LeaveGameResumeTarget
+}
+
+const USE_GAME_API_MOCK = IS_SOCKET_MOCK_ENABLED
+
+export async function leaveGame({
+  gameId,
+  userId,
+  nickname,
+}: LeaveGameParams): Promise<LeaveGameResult> {
+  if (USE_GAME_API_MOCK) {
+    if (userId) {
+      setMockOnlineUserStatus(String(userId), 'lobby', nickname)
+    }
+
+    return {
+      success: true,
+      roomId: null,
+      resumeTarget: 'lobby',
+    }
+  }
+
+  const { data } = await apiClient.post<LeaveGameResponsePayload>(
+    `/games/${gameId}/leave`
+  )
+
+  return {
+    success: data.success,
+    roomId: data.room_id ?? null,
+    resumeTarget: data.resume_target ?? 'lobby',
+  }
+}
+
+export function getGameLeaveErrorMessage(
+  error: unknown,
+  fallbackMessage: string
+) {
+  return getParsedApiErrorMessage(parseApiError(error), fallbackMessage)
+}


### PR DESCRIPTION
## 📌 관련 이슈

> closes #539 

---

## 📝 작업 내용

게임 페이지의 `나가기` 버튼이 기존에는 로비로만 바로 이동하고 서버에는 명시적 이탈 상태가 반영되지 않았습니다.
이번 PR에서는 `POST /api/games/{game_id}/leave` 계약을 프론트에 반영해,
leave 성공 이후에만 로비로 이동하도록 흐름을 정리했습니다.

- `src/pages/game/api.ts`에 game leave API helper를 추가했습니다.
- real 모드에서는 `/games/{gameId}/leave`를 호출하고, mock 모드에서는 presence를 `lobby`로 되돌리는 최소 fallback을 추가했습니다.
- `GamePage`의 exit confirm을 async leave 흐름으로 변경했습니다.
- leave 성공 시 game store를 초기화하고 `/lobby`로 이동하도록 수정했습니다.
- leave 실패 시 토스트를 띄우고 현재 게임 화면을 유지하도록 처리했습니다.
- `ExitGameModal`에 `isSubmitting` 상태를 추가해 요청 중 중복 클릭과 취소를 막았습니다.
- 관련 API 테스트와 GamePage 사용자 흐름 테스트를 추가했습니다.
- 작업 맥락 추적을 위해 task 문서를 함께 추가했습니다.

### 🧠 Task 문서

- `docs/ai/tasks/game-leave-api-flow/plan.md`
- `docs/ai/tasks/game-leave-api-flow/context.md`
- `docs/ai/tasks/game-leave-api-flow/checklist.md`

### 📚 참고한 기준 문서

- `AGENTS.md`
- `docs/ai/manuals/common.md`
- `docs/ai/manuals/game-runtime.md`
- `docs/rules.md`
- `docs/testing.md`

### 🧪 실행한 검증

- `npx vitest run src/pages/game/api.test.ts src/pages/GamePage.test.tsx`
- `npm run lint`
- `npm run build`

### ⚠️ 남은 리스크

- mock 모드 leave는 현재 presence를 `lobby`로 되돌리는 최소 fallback만 제공합니다. room membership 정리와 다른 참가자 broadcast는 실서버 계약에 의존합니다.
- `GamePage.test.tsx`에는 기존과 동일한 `act(...)` warning이 남아 있지만, 테스트는 통과합니다.
