### PR TITLE
feat: 초기 진입 시 refresh fallback 세션 복구 추가

### DIFF
--- a/docs/ai/tasks/auth-bootstrap-refresh-fallback/checklist.md
+++ b/docs/ai/tasks/auth-bootstrap-refresh-fallback/checklist.md
@@ -1,0 +1,21 @@
+# Checklist
+
+## Implementation
+
+- [x] 관련 manual과 기존 문서를 읽었다
+- [x] bootstrap/refresh/context 현재 흐름을 정리했다
+- [x] `useAuthBootstrap`에 초기 refresh fallback을 추가했다
+- [x] stale bootstrap 무시 규칙을 유지했다
+- [x] 관련 테스트를 보강했다
+
+## Testing
+
+- [x] 대상 Vitest를 실행했다
+- [x] `npm run lint`를 실행했다
+- [x] `npm run ai:self-review`를 실행했다
+
+## Review
+
+- [x] persisted session이 없는 경우만 refresh fallback을 타도록 분리했다
+- [x] refresh 실패 시 비로그인 진입 흐름을 유지했다
+- [x] 변경 파일 / 실행한 검증 / 남은 리스크를 정리했다

--- a/docs/ai/tasks/auth-bootstrap-refresh-fallback/context.md
+++ b/docs/ai/tasks/auth-bootstrap-refresh-fallback/context.md
@@ -1,0 +1,42 @@
+# Context
+
+## Current Behavior
+
+- `useAuthBootstrap`은 persisted `session.accessToken`이 있을 때만 `restoreAuthSession()`을 시작한다.
+- persisted session이 없으면 bootstrap을 바로 종료하고 홈/비로그인 흐름으로 남는다.
+- `useAuthResumeNavigation`은 세션이 복구된 뒤에만 `GET /users/me/context`를 호출한다.
+
+## Problem
+
+- refresh cookie는 살아 있어도 localStorage session이 비어 있으면 자동 세션 복구가 시작되지 않는다.
+- 게스트/카카오 모두 “refresh token 유효 기간 내 자동 재진입” 기대와 어긋날 수 있다.
+- 브라우저 종료 후 localStorage가 비워지거나 초기 session이 없는 경우, resume navigation까지 이어지지 못한다.
+
+## Related Files
+
+- `src/features/auth/session/hooks/useAuthBootstrap.ts`
+- `src/features/auth/session/hooks/useAuthBootstrap.test.tsx`
+- `src/features/auth/api/api.ts`
+- `src/features/auth/session/store.ts`
+- `src/features/auth/session/hooks/useAuthResumeNavigation.ts`
+- `docs/ai/manuals/common.md`
+- `docs/rules.md`
+- `docs/testing.md`
+
+## Constraints
+
+- 기존 persisted access token 기반 복구 흐름은 유지해야 한다.
+- refresh fallback은 session이 없을 때만 작동해야 한다.
+- 중간에 새 세션이 들어오면 이전 bootstrap 결과는 무시해야 한다.
+- refresh 실패 시 기존 비로그인 진입 흐름을 깨면 안 된다.
+
+## Decision Notes
+
+- `useAuthBootstrap`에서 persisted access token이 없을 때 `refreshAccessToken()`을 먼저 시도한다.
+- refresh 성공 시 새 access token으로 `restoreAuthSession()`을 이어서 호출한다.
+- bootstrap 진행 추적 ref는 `refresh-fallback` 같은 명시적 marker를 허용해 session 변경 시 spinner를 올바르게 정리한다.
+
+## Open Risks
+
+- auth mock 모드에서 refresh 결과가 빈 토큰이면 fallback은 자연스럽게 no-op이 된다.
+- refresh cookie 정책이 브라우저/도메인별로 다르면 실제 재현 결과는 환경 설정에 의존한다.

--- a/docs/ai/tasks/auth-bootstrap-refresh-fallback/plan.md
+++ b/docs/ai/tasks/auth-bootstrap-refresh-fallback/plan.md
@@ -1,0 +1,44 @@
+# Plan
+
+## Task
+
+- 작업 이름: auth bootstrap refresh fallback
+- 요청 날짜: 2026-03-20
+- 담당 범위: auth bootstrap 초기 refresh fallback, 관련 테스트, task 문서
+
+## Goal
+
+- 앱 첫 진입 시 persisted session이 없어도 refresh cookie가 유효하면 `/auth/refresh`를 먼저 시도해 세션 복구와 resume navigation 흐름을 이어간다.
+
+## In Scope
+
+- `useAuthBootstrap`의 초기 진입 분기 확장
+- persisted session 부재 시 refresh fallback 추가
+- stale bootstrap 결과 무시 규칙 유지
+- `useAuthBootstrap` 테스트 보강
+- task 문서 추가
+
+## Out Of Scope
+
+- auth API 계약 변경
+- `useAuthResumeNavigation` 분기 변경
+- Kakao callback / nickname setup 흐름 변경
+
+## Target Files
+
+- `src/features/auth/session/hooks/useAuthBootstrap.ts`
+- `src/features/auth/session/hooks/useAuthBootstrap.test.tsx`
+- `docs/ai/tasks/auth-bootstrap-refresh-fallback/*`
+
+## Completion Criteria
+
+- persisted session이 없어도 refresh cookie가 유효하면 세션 복구를 시도한다.
+- refresh 성공 시 `/auth/session` 기반 복구가 이어진다.
+- refresh 실패 시 기존 비로그인 진입 흐름을 유지한다.
+- stale bootstrap 결과는 기존처럼 무시된다.
+
+## Test Plan
+
+- `npx vitest run src/features/auth/session/hooks/useAuthBootstrap.test.tsx`
+- `npm run lint`
+- `npm run ai:self-review -- --files src/features/auth/session/hooks/useAuthBootstrap.ts src/features/auth/session/hooks/useAuthBootstrap.test.tsx docs/ai/tasks/auth-bootstrap-refresh-fallback/plan.md docs/ai/tasks/auth-bootstrap-refresh-fallback/context.md docs/ai/tasks/auth-bootstrap-refresh-fallback/checklist.md`

--- a/src/features/auth/session/hooks/useAuthBootstrap.test.tsx
+++ b/src/features/auth/session/hooks/useAuthBootstrap.test.tsx
@@ -4,16 +4,26 @@ import { createAuthSessionFixture } from '../../../../test/fixtures'
 import { useAuthStore } from '../store'
 import { useAuthBootstrap } from './useAuthBootstrap'
 
-const { restoreAuthSessionMock, shouldClearAuthSessionMock } = vi.hoisted(
-  () => ({
-    restoreAuthSessionMock: vi.fn(),
-    shouldClearAuthSessionMock: vi.fn(),
-  })
-)
+const {
+  refreshAccessTokenMock,
+  restoreAuthSessionMock,
+  shouldClearAuthSessionMock,
+  disconnectSocketAndClearAuthMock,
+} = vi.hoisted(() => ({
+  refreshAccessTokenMock: vi.fn(),
+  restoreAuthSessionMock: vi.fn(),
+  shouldClearAuthSessionMock: vi.fn(),
+  disconnectSocketAndClearAuthMock: vi.fn(),
+}))
 
 vi.mock('../../api/api', () => ({
+  refreshAccessToken: refreshAccessTokenMock,
   restoreAuthSession: restoreAuthSessionMock,
   shouldClearAuthSession: shouldClearAuthSessionMock,
+}))
+
+vi.mock('../../../../lib/socket', () => ({
+  disconnectSocketAndClearAuth: disconnectSocketAndClearAuthMock,
 }))
 
 function createDeferredPromise<T>() {
@@ -36,14 +46,53 @@ describe('useAuthBootstrap', () => {
     shouldClearAuthSessionMock.mockReturnValue(true)
   })
 
-  it('세션이 없으면 bootstrap을 바로 종료한다', async () => {
+  it('세션이 없으면 refresh fallback으로 세션 복구를 시도한다', async () => {
+    refreshAccessTokenMock.mockResolvedValue({
+      access_token: 'refreshed-token',
+      token_type: 'Bearer',
+      expires_in: 3600,
+    })
+    restoreAuthSessionMock.mockResolvedValue(
+      createAuthSessionFixture({
+        accessToken: 'refreshed-token',
+        userId: 'guest-user',
+        nickname: '게스트',
+        isGuest: true,
+        provider: 'guest',
+      })
+    )
+
     const { result } = renderHook(() => useAuthBootstrap())
 
     await waitFor(() => {
       expect(result.current).toBe(false)
     })
 
+    expect(refreshAccessTokenMock).toHaveBeenCalledTimes(1)
+    expect(restoreAuthSessionMock).toHaveBeenCalledWith({
+      accessToken: 'refreshed-token',
+      fallbackSession: null,
+    })
+    expect(useAuthStore.getState().session).toMatchObject({
+      accessToken: 'refreshed-token',
+      userId: 'guest-user',
+      nickname: '게스트',
+      isGuest: true,
+    })
+  })
+
+  it('refresh fallback이 실패하면 비로그인 상태로 bootstrap을 종료한다', async () => {
+    refreshAccessTokenMock.mockRejectedValue(new Error('refresh failed'))
+
+    const { result } = renderHook(() => useAuthBootstrap())
+
+    await waitFor(() => {
+      expect(result.current).toBe(false)
+    })
+
+    expect(refreshAccessTokenMock).toHaveBeenCalledTimes(1)
     expect(restoreAuthSessionMock).not.toHaveBeenCalled()
+    expect(useAuthStore.getState().session).toBeNull()
   })
 
   it('복구 중 새 세션이 들어오면 이전 복구 결과를 무시하고 bootstrap을 종료한다', async () => {
@@ -84,6 +133,66 @@ describe('useAuthBootstrap', () => {
       deferredRestore.resolve(
         createAuthSessionFixture({
           accessToken: 'restored-token',
+          userId: 'restored-user',
+          nickname: '복구세션',
+        })
+      )
+      await deferredRestore.promise
+    })
+
+    expect(useAuthStore.getState().session).toMatchObject({
+      accessToken: 'guest-token',
+      userId: 'guest-user',
+      nickname: '게스트',
+      isGuest: true,
+    })
+  })
+
+  it('refresh fallback 중 새 세션이 들어오면 이전 복구 결과를 무시한다', async () => {
+    const deferredRefresh = createDeferredPromise<{
+      access_token: string
+      token_type: string
+      expires_in: number
+    }>()
+    const deferredRestore =
+      createDeferredPromise<ReturnType<typeof createAuthSessionFixture>>()
+
+    refreshAccessTokenMock.mockReturnValue(deferredRefresh.promise)
+    restoreAuthSessionMock.mockReturnValue(deferredRestore.promise)
+
+    const { result } = renderHook(() => useAuthBootstrap())
+
+    expect(result.current).toBe(true)
+
+    act(() => {
+      useAuthStore.getState().setSession(
+        createAuthSessionFixture({
+          accessToken: 'guest-token',
+          userId: 'guest-user',
+          nickname: '게스트',
+          isGuest: true,
+          provider: 'guest',
+        })
+      )
+    })
+
+    await waitFor(() => {
+      expect(result.current).toBe(false)
+    })
+
+    await act(async () => {
+      deferredRefresh.resolve({
+        access_token: 'refreshed-token',
+        token_type: 'Bearer',
+        expires_in: 3600,
+      })
+      await deferredRefresh.promise
+    })
+
+    await act(async () => {
+      deferredRestore.resolve(
+        createAuthSessionFixture({
+          accessToken: 'refreshed-token',
           userId: 'restored-user',
           nickname: '복구세션',
         })

--- a/src/features/auth/session/hooks/useAuthBootstrap.ts
+++ b/src/features/auth/session/hooks/useAuthBootstrap.ts
@@ -1,11 +1,17 @@
 import { useEffect, useRef, useState } from 'react'
-import { restoreAuthSession, shouldClearAuthSession } from '../../api/api'
+import {
+  refreshAccessToken,
+  restoreAuthSession,
+  shouldClearAuthSession,
+} from '../../api/api'
 import { useAuthStore } from '../store'
 import { disconnectSocketAndClearAuth } from '../../../../lib/socket'
 
 interface UseAuthBootstrapParams {
   skip?: boolean
 }
+
+type BootstrapRequestMarker = string | 'refresh-fallback' | null
 
 // 앱 초기 진입 시 persisted accessToken으로 세션을 1회 복구
 export function useAuthBootstrap({
@@ -18,7 +24,7 @@ export function useAuthBootstrap({
   const [isBootstrapping, setIsBootstrapping] = useState(!skip)
   const hasBootstrappedRef = useRef(false)
   const activeAccessTokenRef = useRef(session?.accessToken.trim() ?? '')
-  const bootstrapAccessTokenRef = useRef<string | null>(null)
+  const bootstrapAccessTokenRef = useRef<BootstrapRequestMarker>(null)
 
   useEffect(() => {
     const currentAccessToken = session?.accessToken.trim() ?? ''
@@ -29,7 +35,21 @@ export function useAuthBootstrap({
     }
 
     const bootstrapAccessToken = bootstrapAccessTokenRef.current
-    if (!bootstrapAccessToken || bootstrapAccessToken === currentAccessToken) {
+    if (bootstrapAccessToken === null) {
+      return
+    }
+
+    if (bootstrapAccessToken === 'refresh-fallback') {
+      if (!currentAccessToken) {
+        return
+      }
+
+      bootstrapAccessTokenRef.current = null
+      setIsBootstrapping(false)
+      return
+    }
+
+    if (bootstrapAccessToken === currentAccessToken) {
       return
     }
 
@@ -51,30 +71,49 @@ export function useAuthBootstrap({
 
     hasBootstrappedRef.current = true
 
-    const accessToken = session?.accessToken.trim()
-    if (!accessToken) {
-      bootstrapAccessTokenRef.current = null
-      setIsBootstrapping(false)
-      return
-    }
+    const persistedAccessToken = session?.accessToken.trim() ?? ''
 
     let isDisposed = false
-    bootstrapAccessTokenRef.current = accessToken
     setIsBootstrapping(true)
+    ;(async () => {
+      if (!persistedAccessToken) {
+        bootstrapAccessTokenRef.current = 'refresh-fallback'
+        const refreshResult = await refreshAccessToken()
+        const refreshedAccessToken = refreshResult.access_token.trim()
 
-    restoreAuthSession({
-      accessToken,
-      fallbackSession: session,
-    })
+        if (!refreshedAccessToken) {
+          return null
+        }
+
+        return restoreAuthSession({
+          accessToken: refreshedAccessToken,
+          fallbackSession: null,
+        })
+      }
+
+      bootstrapAccessTokenRef.current = persistedAccessToken
+
+      return restoreAuthSession({
+        accessToken: persistedAccessToken,
+        fallbackSession: session,
+      })
+    })()
       .then((restoredSession) => {
-        if (isDisposed || activeAccessTokenRef.current !== accessToken) {
+        if (
+          !restoredSession ||
+          isDisposed ||
+          activeAccessTokenRef.current !== persistedAccessToken
+        ) {
           return
         }
 
         setSession(restoredSession)
       })
       .catch((error) => {
-        if (isDisposed || activeAccessTokenRef.current !== accessToken) {
+        if (
+          isDisposed ||
+          activeAccessTokenRef.current !== persistedAccessToken
+        ) {
           return
         }
 
@@ -84,7 +123,10 @@ export function useAuthBootstrap({
         }
       })
       .finally(() => {
-        if (isDisposed || activeAccessTokenRef.current !== accessToken) {
+        if (
+          isDisposed ||
+          activeAccessTokenRef.current !== persistedAccessToken
+        ) {
           return
         }
 


### PR DESCRIPTION
## 📌 관련 이슈

> closes #543

---

## 📝 작업 내용

앱 초기 진입 시 persisted session이 없어도 refresh cookie가 유효하면
세션 복구를 시도할 수 있도록 auth bootstrap 흐름을 확장했습니다.

기존에는 저장된 `accessToken`이 있을 때만 `restoreAuthSession()`이 시작되어,
localStorage session이 비어 있으면 refresh token이 살아 있어도
자동 로그인 유지와 재접속 복귀 흐름이 시작되지 않을 수 있었습니다.

이번 수정에서는:
- persisted session이 없을 때 `refreshAccessToken()`을 먼저 시도하고
- refresh 성공 시 새 access token으로 `restoreAuthSession()`을 이어서 호출하며
- stale bootstrap 결과는 기존처럼 무시하도록 정리했습니다.

### 변경 사항

- `useAuthBootstrap`에 초기 refresh fallback 분기를 추가했습니다.
- refresh fallback 성공 시 세션 복구 후 기존 resume navigation 흐름으로 이어질 수 있도록 했습니다.
- refresh 실패 시에는 기존 비로그인 진입 흐름을 유지합니다.
- persisted access token 기반 복구와 refresh fallback 경로 모두 stale 결과 무시 규칙을 유지하도록 정리했습니다.
- 관련 hook 테스트를 보강했습니다.
- 작업 문서를 함께 추가했습니다.

### 🧠 Task 문서

- `docs/ai/tasks/auth-bootstrap-refresh-fallback/plan.md`
- `docs/ai/tasks/auth-bootstrap-refresh-fallback/context.md`
- `docs/ai/tasks/auth-bootstrap-refresh-fallback/checklist.md`

### 📚 참고한 기준 문서

- `AGENTS.md`
- `docs/ai/manuals/common.md`
- `docs/rules.md`
- `docs/testing.md`

### 🧪 실행한 검증

- `npx vitest run src/features/auth/session/hooks/useAuthBootstrap.test.tsx`
- `npm run lint`
- `npm run ai:self-review -- --files src/features/auth/session/hooks/useAuthBootstrap.ts src/features/auth/session/hooks/useAuthBootstrap.test.tsx docs/ai/tasks/auth-bootstrap-refresh-fallback/plan.md docs/ai/tasks/auth-bootstrap-refresh-fallback/context.md docs/ai/tasks/auth-bootstrap-refresh-fallback/checklist.md`

### ⚠️ 남은 리스크

- auth mock 모드에서는 refresh 결과가 빈 토큰이면 fallback이 no-op으로 끝납니다.
- self-review에서 auth refresh/logout 경로 관련 공통 경고가 다시 출력됐지만, 이번 bootstrap fallback 변경과 직접 충돌하는 새 이슈는 확인되지 않았습니다.
