### PR TITLE
fix: GameBoard eventQueue selector 무한 렌더 수정

### DIFF
--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -49,6 +49,7 @@ import { getBoardSellFallbackRefund } from './gameBoardActionUtils'
 import { syncMockStorePlayers } from './gameBoardStoreBridge'
 import { useBoardEventQueue } from './useBoardEventQueue'
 import {
+  getPendingMovePlayerIdsFromEvents,
   getBoardEventAnimationHoldMs,
   resolveBoardCardModalContentFromEvent,
   resolveBoardEventTileIndex,
@@ -343,17 +344,10 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
     useEffect(() => {
       isAnimatingRef.current = isMoving
     }, [isMoving])
-    const pendingMovePlayerIds = useGameStore((state) =>
-      state.eventQueue
-        .filter(
-          (event) =>
-            typeof event.type === 'string' &&
-            ['PLAYER_MOVED', 'PLAYER_MOVE', 'MOVED'].includes(
-              event.type.trim().toUpperCase()
-            ) &&
-            event.playerId != null
-        )
-        .map((event) => String(event.playerId))
+    const eventQueue = useGameStore((state) => state.eventQueue)
+    const pendingMovePlayerIds = useMemo(
+      () => getPendingMovePlayerIdsFromEvents(eventQueue),
+      [eventQueue]
     )
     const pendingMovePlayerIdSet = useMemo(
       () => new Set(pendingMovePlayerIds),

--- a/src/components/board/gameBoardEventQueueUtils.test.ts
+++ b/src/components/board/gameBoardEventQueueUtils.test.ts
@@ -6,6 +6,7 @@ import {
   extractEventDice,
   getBoardEventAnimationHoldMs,
   getBoardEventConsumeDelayMs,
+  getPendingMovePlayerIdsFromEvents,
   resolveBoardCardModalContentFromEvent,
   resolveBoardEventAnimationKind,
 } from './gameBoardEventQueueUtils'
@@ -49,6 +50,37 @@ describe('gameBoardEventQueueUtils', () => {
     }
 
     expect(extractEventDice(event)).toEqual([3, 4])
+  })
+
+  it('collects only pending move player ids from move event aliases', () => {
+    const events: ServerEvent[] = [
+      {
+        type: 'PLAYER_MOVED',
+        playerId: 1,
+      },
+      {
+        type: 'PLAYER_MOVE',
+        playerId: 'guest-2',
+      },
+      {
+        type: 'MOVED',
+        playerId: 3,
+      },
+      {
+        type: 'TURN_ENDED',
+        playerId: 4,
+      },
+      {
+        type: 'PLAYER_MOVED',
+        playerId: null,
+      },
+    ]
+
+    expect(getPendingMovePlayerIdsFromEvents(events)).toEqual([
+      '1',
+      'guest-2',
+      '3',
+    ])
   })
 
   it('extracts dice values from alias payload keys', () => {

--- a/src/components/board/gameBoardEventQueueUtils.ts
+++ b/src/components/board/gameBoardEventQueueUtils.ts
@@ -54,6 +54,15 @@ export const resolveBoardEventAnimationKind = (
   return 'none'
 }
 
+export const getPendingMovePlayerIdsFromEvents = (events: ServerEvent[]) =>
+  events
+    .filter(
+      (event) =>
+        toCanonicalEventType(event.type) === 'PLAYER_MOVED' &&
+        event.playerId != null
+    )
+    .map((event) => String(event.playerId))
+
 export const getBoardEventConsumeDelayMs = (event: ServerEvent): number => {
   const kind = resolveBoardEventAnimationKind(event)
   if (kind === 'dice') return 420


### PR DESCRIPTION
## 📌 관련 이슈

> closes #545 

---

## 📝 작업 내용

게임 시작 후 `GameBoard` 진입 시
`getSnapshot should be cached` 경고와 함께 무한 렌더가 발생하던 문제를 수정했습니다.

원인은 `useGameStore` selector 안에서 `eventQueue.filter(...).map(...)`로
매 렌더마다 새 배열을 반환하던 점이었고,
Zustand `useSyncExternalStore`가 이를 매번 새로운 snapshot으로 인식하면서
무한 업데이트 루프가 발생하고 있었습니다.

이번 수정에서는:
- `useGameStore`에서는 `eventQueue` 원본만 구독하도록 바꿨습니다.
- pending move player id 계산은 `useMemo` 기반 파생 로직으로 분리했습니다.
- 관련 파생 로직은 `gameBoardEventQueueUtils.ts`로 추출했습니다.
- 회귀 방지를 위해 유틸 단위 테스트를 추가했습니다.

### 📚 참고한 기준 문서

- `AGENTS.md`
- `docs/ai/manuals/common.md`
- `docs/ai/manuals/game-runtime.md`
- `docs/rules.md`
- `docs/testing.md`

### 🧪 실행한 검증

- `npx vitest run src/components/board/gameBoardEventQueueUtils.test.ts`
- `npm run build`

### ⚠️ 남은 리스크

- 이번 수정은 `GameBoard` selector 안정성 문제를 고친 것입니다.
- 이후에도 게임 화면 진입이 실패하면 다음 단계로는 `game_start` payload, snapshot, `GamePage` 진입 state 경로를 확인해야 합니다.
