### PR TITLE
fix: 게임 나가기 room leave API 연동

### DIFF
--- a/docs/ai/tasks/game-leave-api-flow/checklist.md
+++ b/docs/ai/tasks/game-leave-api-flow/checklist.md
@@ -3,8 +3,8 @@
 ## Implementation
 
 - [x] 관련 manual과 기존 문서를 읽었다
-- [x] leave API 계약과 현재 GamePage 흐름을 정리했다
-- [x] game leave API helper를 추가했다
+- [x] room leave API 계약과 현재 GamePage 흐름을 정리했다
+- [x] game 페이지용 room leave API helper를 추가했다
 - [x] GamePage exit confirm을 async leave 흐름으로 변경했다
 - [x] ExitGameModal pending 상태를 추가했다
 - [x] 관련 테스트를 추가/갱신했다

--- a/docs/ai/tasks/game-leave-api-flow/context.md
+++ b/docs/ai/tasks/game-leave-api-flow/context.md
@@ -3,7 +3,7 @@
 ## Current Behavior
 
 - `GamePage.tsx`의 나가기 버튼은 확인 모달을 띄운 뒤, 확인 시 `window.location.href = '/lobby'`로 바로 이동한다.
-- 현재 프론트에는 게임 명시적 leave API 호출이나 socket emit이 없다.
+- 현재 프론트에는 room leave API 호출이나 socket emit이 없다.
 - 페이지 이동으로 socket disconnect는 발생할 수 있지만, 버튼 기반 leave와 disconnect를 프론트에서 구분하지 못한다.
 
 ## Problem
@@ -11,6 +11,7 @@
 - 서버에는 사용자가 명시적으로 게임을 나갔다는 상태 변경이 반영되지 않는다.
 - leave 실패를 사용자에게 보여줄 수 없고, 서버 정리 전에 화면이 사라진다.
 - reconnect timeout 복구와 명시적 leave가 같은 disconnect 의미로 섞일 수 있다.
+- 백엔드 계약이 `POST /api/rooms/{room_id}/leave`로 정리되었는데, 프론트는 여전히 game leave 기준으로 구현돼 있다.
 
 ## Related Files
 
@@ -27,15 +28,17 @@
 ## Constraints
 
 - 게임 canonical identifier는 `gameId`를 유지한다.
+- 명시적 leave 호출은 `roomId` 기준으로 통일한다.
 - leave 성공 전에는 화면을 유지하고, 실패 시 사용자가 재시도할 수 있어야 한다.
-- mock 모드에서도 최소한 presence 상태는 `lobby`로 정리한다.
+- mock 모드에서도 room membership / presence 상태를 실제 room leave 의미에 가깝게 정리한다.
 - 기존 채팅/보드/game state 렌더링 흐름은 건드리지 않는다.
 
 ## Decision Notes
 
-- leave는 `src/pages/game/api.ts`에 별도 helper로 분리한다.
+- leave는 `src/pages/game/api.ts`에 room leave helper로 분리한다.
 - `GamePage`는 leave helper 결과만 보고 store reset + navigate를 수행한다.
 - exit modal은 `isSubmitting`을 받아 요청 중 중복 클릭과 취소를 막는다.
+- mock 경로는 `mockLeaveWaitingRoom`을 재사용해 room membership 정리까지 맞춘다.
 
 ## Open Risks
 

--- a/docs/ai/tasks/game-leave-api-flow/plan.md
+++ b/docs/ai/tasks/game-leave-api-flow/plan.md
@@ -2,18 +2,18 @@
 
 ## Task
 
-- 작업 이름: game leave api flow
+- 작업 이름: game room leave flow
 - 요청 날짜: 2026-03-20
-- 담당 범위: game leave API 계층, GamePage 종료 흐름, exit modal pending 상태, 관련 테스트, task 문서
+- 담당 범위: room leave API 계층, GamePage 종료 흐름, exit modal pending 상태, 관련 테스트, task 문서
 
 ## Goal
 
-- 게임 페이지의 `나가기` 버튼이 단순 페이지 이동이 아니라 `POST /api/games/{game_id}/leave` 성공 이후에만 로비로 이동하도록 만든다.
+- 게임 페이지의 `나가기` 버튼이 단순 페이지 이동이 아니라 `POST /api/rooms/{room_id}/leave` 성공 이후에만 로비로 이동하도록 만든다.
 
 ## In Scope
 
-- `src/pages/game/api.ts` leave API helper 추가
-- mock 모드 leave fallback 추가
+- `src/pages/game/api.ts` room leave helper 추가
+- mock 모드 room leave fallback 추가
 - `GamePage.tsx` exit confirm async 흐름 적용
 - `ExitGameModal.tsx` pending 상태 지원
 - `GamePage` / game api 테스트 추가
@@ -36,7 +36,7 @@
 
 ## Completion Criteria
 
-- 게임 나가기 버튼 클릭 시 leave API가 호출된다.
+- 게임 나가기 버튼 클릭 시 room leave API가 호출된다.
 - leave 성공 시 game store를 초기화하고 `/lobby`로 이동한다.
 - leave 실패 시 토스트를 띄우고 현재 게임 화면을 유지한다.
 - mock/real 경로 모두 leave helper가 동작한다.

--- a/src/pages/GamePage.test.tsx
+++ b/src/pages/GamePage.test.tsx
@@ -23,7 +23,7 @@ const {
   socketOffMock,
   navigateMock,
   toastErrorMock,
-  leaveGameMock,
+  leaveRoomFromGameMock,
   getGameLeaveErrorMessageMock,
 } = vi.hoisted(() => {
   const handlers = new Map<string, Set<(payload: unknown) => void>>()
@@ -47,7 +47,7 @@ const {
     },
     navigateMock: vi.fn(),
     toastErrorMock: vi.fn(),
-    leaveGameMock: vi.fn(),
+    leaveRoomFromGameMock: vi.fn(),
     getGameLeaveErrorMessageMock: vi.fn(),
   }
 })
@@ -99,7 +99,7 @@ vi.mock('../lib/bgm', () => ({
 }))
 
 vi.mock('../pages/game/api', () => ({
-  leaveGame: leaveGameMock,
+  leaveRoomFromGame: leaveRoomFromGameMock,
   getGameLeaveErrorMessage: getGameLeaveErrorMessageMock,
 }))
 
@@ -261,10 +261,9 @@ describe('GamePage chat flow', () => {
   it('게임 나가기 성공 시 leave API 호출 후 로비로 이동하고 game store를 초기화한다', async () => {
     const user = userEvent.setup()
 
-    leaveGameMock.mockResolvedValue({
+    leaveRoomFromGameMock.mockResolvedValue({
       success: true,
-      roomId: 'room-1',
-      resumeTarget: 'lobby',
+      newHostId: null,
     })
 
     renderGamePage()
@@ -273,10 +272,9 @@ describe('GamePage chat flow', () => {
     await user.click(screen.getByRole('button', { name: '종료' }))
 
     await waitFor(() => {
-      expect(leaveGameMock).toHaveBeenCalledWith({
-        gameId: 'game-1',
+      expect(leaveRoomFromGameMock).toHaveBeenCalledWith({
+        roomId: 'room-1',
         userId: 'user-1',
-        nickname: '유저1',
       })
     })
 
@@ -293,7 +291,7 @@ describe('GamePage chat flow', () => {
   it('게임 나가기 실패 시 토스트를 띄우고 현재 화면을 유지한다', async () => {
     const user = userEvent.setup()
 
-    leaveGameMock.mockRejectedValue(new Error('leave failed'))
+    leaveRoomFromGameMock.mockRejectedValue(new Error('leave failed'))
     getGameLeaveErrorMessageMock.mockReturnValue('게임 나가기에 실패했습니다.')
 
     renderGamePage()

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -35,7 +35,7 @@ import {
   reconcileGameChatMessages,
   type PendingGameChatEcho,
 } from './game/gameChat'
-import { getGameLeaveErrorMessage, leaveGame } from './game/api'
+import { getGameLeaveErrorMessage, leaveRoomFromGame } from './game/api'
 import { sendWaitingRoomChat } from './waiting-room/socket/socket'
 import type { ChatEventPayload } from './waiting-room/api/types'
 
@@ -307,7 +307,7 @@ const GamePage: React.FC = () => {
       return
     }
 
-    if (!activeGameId) {
+    if (!activeRoomId) {
       resetGame()
       setIsExitModalOpen(false)
       navigate('/lobby', { replace: true })
@@ -317,10 +317,9 @@ const GamePage: React.FC = () => {
     setIsLeavePending(true)
 
     try {
-      await leaveGame({
-        gameId: activeGameId,
+      await leaveRoomFromGame({
+        roomId: activeRoomId,
         userId: currentUserId ?? undefined,
-        nickname: currentNickname,
       })
 
       resetGame()

--- a/src/pages/game/api.test.ts
+++ b/src/pages/game/api.test.ts
@@ -3,7 +3,7 @@ import axios from 'axios'
 
 async function loadGameApiModule(options?: { mockEnabled?: boolean }) {
   const postMock = vi.fn()
-  const setMockOnlineUserStatusMock = vi.fn()
+  const mockLeaveWaitingRoomMock = vi.fn()
 
   vi.resetModules()
 
@@ -15,8 +15,8 @@ async function loadGameApiModule(options?: { mockEnabled?: boolean }) {
       post: postMock,
     },
   }))
-  vi.doMock('../../features/presence/mock/mockData', () => ({
-    setMockOnlineUserStatus: setMockOnlineUserStatusMock,
+  vi.doMock('../waiting-room/socket/mockGateway', () => ({
+    mockLeaveWaitingRoom: mockLeaveWaitingRoomMock,
   }))
 
   const module = await import('./api')
@@ -24,7 +24,7 @@ async function loadGameApiModule(options?: { mockEnabled?: boolean }) {
   return {
     module,
     postMock,
-    setMockOnlineUserStatusMock,
+    mockLeaveWaitingRoomMock,
   }
 }
 
@@ -34,47 +34,47 @@ describe('game api', () => {
     vi.resetModules()
   })
 
-  it('leaveGame은 실서버 모드에서 games leave endpoint를 호출한다', async () => {
+  it('leaveRoomFromGame은 실서버 모드에서 rooms leave endpoint를 호출한다', async () => {
     const { module, postMock } = await loadGameApiModule()
 
     postMock.mockResolvedValue({
       data: {
         success: true,
-        room_id: 'room-1',
-        resume_target: 'lobby',
+        new_host_id: 'host-2',
       },
     })
 
-    const result = await module.leaveGame({ gameId: 'game-1' })
+    const result = await module.leaveRoomFromGame({ roomId: 'room-1' })
 
-    expect(postMock).toHaveBeenCalledWith('/games/game-1/leave')
+    expect(postMock).toHaveBeenCalledWith('/rooms/room-1/leave')
     expect(result).toEqual({
       success: true,
-      roomId: 'room-1',
-      resumeTarget: 'lobby',
+      newHostId: 'host-2',
     })
   })
 
-  it('leaveGame은 mock 모드에서 접속 상태를 lobby로 바꾸고 성공 결과를 반환한다', async () => {
-    const { module, postMock, setMockOnlineUserStatusMock } =
+  it('leaveRoomFromGame은 mock 모드에서 waiting-room leave gateway를 재사용한다', async () => {
+    const { module, postMock, mockLeaveWaitingRoomMock } =
       await loadGameApiModule({ mockEnabled: true })
 
-    const result = await module.leaveGame({
-      gameId: 'game-1',
+    mockLeaveWaitingRoomMock.mockResolvedValue({
+      success: true,
+      newHostId: 'host-2',
+    })
+
+    const result = await module.leaveRoomFromGame({
+      roomId: 'room-1',
       userId: 'user-1',
-      nickname: '유저1',
     })
 
     expect(postMock).not.toHaveBeenCalled()
-    expect(setMockOnlineUserStatusMock).toHaveBeenCalledWith(
-      'user-1',
-      'lobby',
-      '유저1'
-    )
+    expect(mockLeaveWaitingRoomMock).toHaveBeenCalledWith({
+      roomId: 'room-1',
+      userId: 'user-1',
+    })
     expect(result).toEqual({
       success: true,
-      roomId: null,
-      resumeTarget: 'lobby',
+      newHostId: 'host-2',
     })
   })
 

--- a/src/pages/game/api.ts
+++ b/src/pages/game/api.ts
@@ -1,55 +1,52 @@
 import { IS_SOCKET_MOCK_ENABLED } from '../../config/env'
 import { getParsedApiErrorMessage, parseApiError } from '../../lib/apiError'
 import { apiClient } from '../../lib/axios'
-import { setMockOnlineUserStatus } from '../../features/presence/mock/mockData'
+import { mockLeaveWaitingRoom } from '../waiting-room/socket/mockGateway'
 
-type LeaveGameResumeTarget = 'lobby' | 'room' | 'game'
-
-interface LeaveGameResponsePayload {
+interface LeaveRoomResponsePayload {
   success: boolean
-  room_id?: string | null
-  resume_target?: LeaveGameResumeTarget | null
+  new_host_id?: string | null
 }
 
-interface LeaveGameParams {
-  gameId: string
+interface LeaveRoomFromGameParams {
+  roomId: string
   userId?: string
-  nickname?: string
 }
 
-export interface LeaveGameResult {
+export interface LeaveRoomFromGameResult {
   success: boolean
-  roomId: string | null
-  resumeTarget: LeaveGameResumeTarget
+  newHostId: string | null
 }
 
 const USE_GAME_API_MOCK = IS_SOCKET_MOCK_ENABLED
 
-export async function leaveGame({
-  gameId,
+export async function leaveRoomFromGame({
+  roomId,
   userId,
-  nickname,
-}: LeaveGameParams): Promise<LeaveGameResult> {
+}: LeaveRoomFromGameParams): Promise<LeaveRoomFromGameResult> {
   if (USE_GAME_API_MOCK) {
-    if (userId) {
-      setMockOnlineUserStatus(String(userId), 'lobby', nickname)
+    if (!userId) {
+      throw new Error('게임 room leave mock 경로에는 userId가 필요합니다.')
     }
 
+    const result = await mockLeaveWaitingRoom({
+      roomId,
+      userId,
+    })
+
     return {
-      success: true,
-      roomId: null,
-      resumeTarget: 'lobby',
+      success: result.success,
+      newHostId: result.newHostId ?? null,
     }
   }
 
-  const { data } = await apiClient.post<LeaveGameResponsePayload>(
-    `/games/${gameId}/leave`
+  const { data } = await apiClient.post<LeaveRoomResponsePayload>(
+    `/rooms/${roomId}/leave`
   )
 
   return {
     success: data.success,
-    roomId: data.room_id ?? null,
-    resumeTarget: data.resume_target ?? 'lobby',
+    newHostId: data.new_host_id ?? null,
   }
 }
 


### PR DESCRIPTION
## 📌 관련 이슈

> closes #547 

---

## 📝 작업 내용

게임 페이지의 `나가기` 버튼이 기존에는 로비로만 바로 이동하고 있었고,
서버에는 명시적 leave 상태가 반영되지 않았습니다.

백엔드와 협의한 최종 계약에 맞춰,
게임 중이든 대기방이든 `POST /api/rooms/{room_id}/leave` 하나로 처리하도록
프론트 나가기 흐름을 정리했습니다.

- `src/pages/game/api.ts`의 leave helper를 `games/{game_id}/leave`가 아니라 `rooms/{room_id}/leave` 기준으로 수정했습니다.
- real 모드에서는 `/rooms/{roomId}/leave`를 호출하도록 변경했습니다.
- mock 모드에서는 waiting-room mock gateway의 room leave 흐름을 재사용하도록 맞췄습니다.
- `GamePage`의 exit confirm은 `roomId` 기준 async leave 흐름으로 변경했습니다.
- leave 성공 시 game store를 정리하고 `/lobby`로 이동하도록 수정했습니다.
- leave 실패 시 토스트를 띄우고 현재 게임 화면을 유지하도록 처리했습니다.
- 관련 API 테스트와 GamePage 흐름 테스트도 room leave 계약 기준으로 갱신했습니다.
- 작업 문서도 새 계약 기준으로 함께 정리했습니다.

### 🧠 Task 문서

- `docs/ai/tasks/game-leave-api-flow/plan.md`
- `docs/ai/tasks/game-leave-api-flow/context.md`
- `docs/ai/tasks/game-leave-api-flow/checklist.md`

### 📚 참고한 기준 문서

- `AGENTS.md`
- `docs/ai/manuals/common.md`
- `docs/ai/manuals/game-runtime.md`
- `docs/rules.md`
- `docs/testing.md`

### 🧪 실행한 검증

- `npx vitest run src/pages/game/api.test.ts src/pages/GamePage.test.tsx`
- `npm run build`
- `npm run lint`

### ⚠️ 남은 리스크

- mock 모드 room leave는 현재 waiting-room mock gateway를 재사용하는 최소 fallback이라, 실제 game 정리/브로드캐스트 의미는 실서버 계약에 의존합니다.
- `GamePage.test.tsx`에는 기존과 동일한 `act(...)` warning이 남아 있지만 테스트는 통과합니다.
- 게임 화면에서 `roomId`를 얻지 못하는 비정상 진입 경로가 있으면 leave 호출 대신 실패 토스트 분기로 떨어질 수 있습니다.
