### PR TITLE
fix: 재접속 시 auth bootstrap 완료 누락 수정

### DIFF
--- a/docs/ai/tasks/auth-store-hydration-bootstrap/checklist.md
+++ b/docs/ai/tasks/auth-store-hydration-bootstrap/checklist.md
@@ -1,0 +1,6 @@
+# Checklist
+
+- [ ] auth store가 hydration 완료 상태를 노출한다.
+- [ ] hydration 전에는 bootstrap이 auth 복구를 시작하지 않는다.
+- [ ] hydration 후에는 기존 restore/refresh 흐름이 그대로 동작한다.
+- [ ] 관련 Vitest가 통과한다.

--- a/docs/ai/tasks/auth-store-hydration-bootstrap/context.md
+++ b/docs/ai/tasks/auth-store-hydration-bootstrap/context.md
@@ -1,0 +1,5 @@
+# Context
+
+- `useAuthStore`는 `persist`로 `localStorage` 세션을 복원한다.
+- 앱 첫 진입 시 `useAuthBootstrap`이 너무 빨리 실행되면, persist hydration 전에 refresh fallback 또는 null 분기를 탈 수 있다.
+- 이 경우 재접속 시 세션은 `localStorage`에 남아 있어도 복귀 라우팅이 이어지지 않을 수 있다.

--- a/docs/ai/tasks/auth-store-hydration-bootstrap/plan.md
+++ b/docs/ai/tasks/auth-store-hydration-bootstrap/plan.md
@@ -1,0 +1,12 @@
+# Auth Store Hydration Bootstrap
+
+## 목표
+
+- persisted auth session hydration이 끝나기 전에 bootstrap이 먼저 돌지 않도록 막는다.
+- 재접속 시 홈에 머물고 `me/context` 복귀가 시작되지 않는 race를 줄인다.
+
+## 작업 단계
+
+1. auth store에 hydration 완료 상태를 추가한다.
+2. `useAuthBootstrap`이 hydration 이후에만 restore/refresh를 시작하도록 수정한다.
+3. hydration 지연 상황 회귀 테스트를 추가한다.

--- a/src/features/auth/session/hooks/useAuthBootstrap.test.tsx
+++ b/src/features/auth/session/hooks/useAuthBootstrap.test.tsx
@@ -42,8 +42,47 @@ describe('useAuthBootstrap', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     localStorage.removeItem('marble-pop-auth-session')
-    useAuthStore.setState({ session: null })
+    useAuthStore.setState({ hasHydrated: true, session: null })
     shouldClearAuthSessionMock.mockReturnValue(true)
+  })
+
+  it('persist hydration 전에는 bootstrap을 시작하지 않다가 hydration 이후 복구를 시작한다', async () => {
+    refreshAccessTokenMock.mockResolvedValue({
+      access_token: 'refreshed-token',
+      token_type: 'Bearer',
+      expires_in: 3600,
+    })
+    restoreAuthSessionMock.mockResolvedValue(
+      createAuthSessionFixture({
+        accessToken: 'refreshed-token',
+        userId: 'guest-user',
+        nickname: '게스트',
+        isGuest: true,
+        provider: 'guest',
+      })
+    )
+
+    useAuthStore.setState({ hasHydrated: false, session: null })
+
+    const { result } = renderHook(() => useAuthBootstrap())
+
+    expect(result.current).toBe(true)
+    expect(refreshAccessTokenMock).not.toHaveBeenCalled()
+    expect(restoreAuthSessionMock).not.toHaveBeenCalled()
+
+    act(() => {
+      useAuthStore.setState({ hasHydrated: true })
+    })
+
+    await waitFor(() => {
+      expect(result.current).toBe(false)
+    })
+
+    expect(refreshAccessTokenMock).toHaveBeenCalledTimes(1)
+    expect(restoreAuthSessionMock).toHaveBeenCalledWith({
+      accessToken: 'refreshed-token',
+      fallbackSession: null,
+    })
   })
 
   it('세션이 없으면 refresh fallback으로 세션 복구를 시도한다', async () => {
@@ -78,6 +117,43 @@ describe('useAuthBootstrap', () => {
       userId: 'guest-user',
       nickname: '게스트',
       isGuest: true,
+    })
+  })
+
+  it('persisted access token 복구 후 bootstrap을 종료한다', async () => {
+    useAuthStore.setState({
+      hasHydrated: true,
+      session: createAuthSessionFixture({
+        accessToken: 'persisted-token',
+        userId: 'guest-user',
+        nickname: '게스트',
+        isGuest: true,
+        provider: 'guest',
+      }),
+    })
+    restoreAuthSessionMock.mockResolvedValue(
+      createAuthSessionFixture({
+        accessToken: 'persisted-token',
+        userId: 'guest-user',
+        nickname: '게스트',
+        isGuest: true,
+        provider: 'guest',
+      })
+    )
+
+    const { result } = renderHook(() => useAuthBootstrap())
+
+    await waitFor(() => {
+      expect(result.current).toBe(false)
+    })
+
+    expect(refreshAccessTokenMock).not.toHaveBeenCalled()
+    expect(restoreAuthSessionMock).toHaveBeenCalledWith({
+      accessToken: 'persisted-token',
+      fallbackSession: expect.objectContaining({
+        accessToken: 'persisted-token',
+        provider: 'guest',
+      }),
     })
   })
 

--- a/src/features/auth/session/hooks/useAuthBootstrap.ts
+++ b/src/features/auth/session/hooks/useAuthBootstrap.ts
@@ -17,6 +17,7 @@ type BootstrapRequestMarker = string | 'refresh-fallback' | null
 export function useAuthBootstrap({
   skip = false,
 }: UseAuthBootstrapParams = {}) {
+  const hasHydrated = useAuthStore((state) => state.hasHydrated)
   const session = useAuthStore((state) => state.session)
   const setSession = useAuthStore((state) => state.setSession)
   const clearSession = useAuthStore((state) => state.clearSession)
@@ -65,6 +66,11 @@ export function useAuthBootstrap({
       return
     }
 
+    if (!hasHydrated && !session) {
+      setIsBootstrapping(true)
+      return
+    }
+
     if (hasBootstrappedRef.current) {
       return
     }
@@ -72,8 +78,8 @@ export function useAuthBootstrap({
     hasBootstrappedRef.current = true
 
     const persistedAccessToken = session?.accessToken.trim() ?? ''
+    activeAccessTokenRef.current = persistedAccessToken
 
-    let isDisposed = false
     setIsBootstrapping(true)
     ;(async () => {
       if (!persistedAccessToken) {
@@ -101,7 +107,6 @@ export function useAuthBootstrap({
       .then((restoredSession) => {
         if (
           !restoredSession ||
-          isDisposed ||
           activeAccessTokenRef.current !== persistedAccessToken
         ) {
           return
@@ -110,10 +115,7 @@ export function useAuthBootstrap({
         setSession(restoredSession)
       })
       .catch((error) => {
-        if (
-          isDisposed ||
-          activeAccessTokenRef.current !== persistedAccessToken
-        ) {
+        if (activeAccessTokenRef.current !== persistedAccessToken) {
           return
         }
 
@@ -123,21 +125,10 @@ export function useAuthBootstrap({
         }
       })
       .finally(() => {
-        if (
-          isDisposed ||
-          activeAccessTokenRef.current !== persistedAccessToken
-        ) {
-          return
-        }
-
         bootstrapAccessTokenRef.current = null
         setIsBootstrapping(false)
       })
-
-    return () => {
-      isDisposed = true
-    }
-  }, [clearSession, session, setSession, skip])
+  }, [clearSession, hasHydrated, session, setSession, skip])
 
   return isBootstrapping
 }

--- a/src/features/auth/session/store.ts
+++ b/src/features/auth/session/store.ts
@@ -4,6 +4,7 @@ import type { AuthSession } from './types'
 
 // 인증 세션 스토어 상태/액션 타입 정의
 interface AuthStoreState {
+  hasHydrated: boolean
   session: AuthSession | null
   setSession: (session: AuthSession) => void
   clearSession: () => void
@@ -14,6 +15,7 @@ interface AuthStoreState {
 export const useAuthStore = create<AuthStoreState>()(
   persist(
     (set) => ({
+      hasHydrated: false,
       session: null,
       setSession: (session) => set({ session }),
       clearSession: () => set({ session: null }),
@@ -40,3 +42,15 @@ export const useAuthStore = create<AuthStoreState>()(
     }
   )
 )
+
+useAuthStore.setState({
+  hasHydrated: useAuthStore.persist.hasHydrated(),
+})
+
+useAuthStore.persist.onHydrate(() => {
+  useAuthStore.setState({ hasHydrated: false })
+})
+
+useAuthStore.persist.onFinishHydration(() => {
+  useAuthStore.setState({ hasHydrated: true })
+})


### PR DESCRIPTION
## 📌 관련 이슈

> closes #549 

---

## 📝 작업 내용

브라우저 재접속 시 persisted session과 refresh cookie가 남아 있어도
프론트 auth bootstrap이 끝나기 전에 resume navigation이 막혀
`/users/me/context` 조회와 자동 복귀가 시작되지 않는 문제가 있었습니다.

이번 수정에서는 auth store hydration과 bootstrap 완료 타이밍을 정리해,
persisted access token 복구 후에도 bootstrap이 정상 종료되고
이후 `useAuthResumeNavigation`이 이어지도록 했습니다.

- auth store에 hydration 완료 상태를 노출하도록 정리했습니다.
- `useAuthBootstrap`이 persist hydration 이후 복구를 시작하도록 조정했습니다.
- persisted access token 복구 성공 후 rerender가 발생해도 bootstrap 완료 상태가 누락되지 않도록 수정했습니다.
- bootstrap이 정상 종료된 뒤 `useAuthResumeNavigation`이 `/users/me/context` 조회를 시작할 수 있도록 흐름을 안정화했습니다.
- 관련 bootstrap / resume / App / auth API 테스트를 함께 검증했습니다.
- 작업 문서도 추가했습니다.

### 🧠 Task 문서

- `docs/ai/tasks/auth-store-hydration-bootstrap/plan.md`
- `docs/ai/tasks/auth-store-hydration-bootstrap/context.md`
- `docs/ai/tasks/auth-store-hydration-bootstrap/checklist.md`

### 📚 참고한 기준 문서

- `AGENTS.md`
- `docs/ai/manuals/common.md`
- `docs/rules.md`
- `docs/testing.md`

### 🧪 실행한 검증

- `npx vitest run src/features/auth/session/hooks/useAuthBootstrap.test.tsx src/features/auth/session/hooks/useAuthResumeNavigation.test.tsx src/App.test.tsx src/features/auth/api/api.test.ts`
- `npm run lint`

### ⚠️ 남은 리스크

- 이번 수정은 프론트 bootstrap/resume 타이밍 문제를 다룹니다.
- 이후에도 복귀가 틀어지면 다음으로는 `/users/me/context` 응답값이나 서버 측 room/game context 정합성을 확인해야 합니다.
