### PR TITLE
Fix : 게임 종료 후 sync 중단 및 GAME_OVER winner/assets 계약 반영

### DIFF
--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -1216,6 +1216,19 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
 
       return [...rankings].sort((left, right) => left.rank - right.rank)
     }, [gameResult])
+    const winnerResultRow = useMemo(() => {
+      const winner = gameResult?.winner
+      if (!winner) {
+        return null
+      }
+
+      return {
+        id: String(winner.playerId),
+        nickname: winner.nickname,
+        totalAssetText: formatWon(winner.assets),
+        ownedCityCountText: '-',
+      }
+    }, [gameResult])
     const resultModalRows = useMemo(() => {
       if (serverResultRows.length > 0) {
         return serverResultRows.map((result) => ({
@@ -1225,6 +1238,9 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
           ownedCityCountText: '-',
         }))
       }
+      if (winnerResultRow) {
+        return [winnerResultRow]
+      }
 
       return fallbackPlayerResults.map((result) => ({
         id: result.id,
@@ -1232,8 +1248,11 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
         totalAssetText: formatWon(result.totalAsset),
         ownedCityCountText: `${result.ownedCityCount}개`,
       }))
-    }, [fallbackPlayerResults, serverResultRows])
+    }, [fallbackPlayerResults, serverResultRows, winnerResultRow])
     const resultModalWinnerName = useMemo(() => {
+      if (gameResult?.winner?.nickname) {
+        return gameResult.winner.nickname
+      }
       if (serverResultRows.length > 0) {
         const winnerByFlag = serverResultRows.find((result) => result.is_winner)
         const winnerById =
@@ -1254,7 +1273,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
         fallbackPlayerResults.find((result) => !result.isBankrupt)?.nickname ??
         '승리자'
       )
-    }, [fallbackPlayerResults, serverResultRows, winnerId])
+    }, [fallbackPlayerResults, gameResult, serverResultRows, winnerId])
 
     function handleBankruptConfirm() {
       const { onDoneCallback } = bankruptModal

--- a/src/hooks/game/useGameState.test.tsx
+++ b/src/hooks/game/useGameState.test.tsx
@@ -8,6 +8,8 @@ type SetupOptions = {
   currentTurn?: string | number | null
   revision?: number
   playersLength?: number
+  phase?: 'waiting' | 'rolling' | 'moving' | 'resolving' | 'prompt' | 'finished'
+  isGameOver?: boolean
 }
 
 const createPlayers = (length: number) =>
@@ -21,6 +23,8 @@ async function setupUseGameState(options: SetupOptions) {
     currentTurn: options.currentTurn ?? null,
     revision: options.revision ?? 0,
     playersLength: options.playersLength ?? 0,
+    phase: options.phase ?? 'rolling',
+    isGameOver: options.isGameOver ?? false,
   }
 
   const socketHandlers = new Map<string, (...args: unknown[]) => void>()
@@ -69,20 +73,31 @@ async function setupUseGameState(options: SetupOptions) {
       selector: (state: {
         currentPlayerId: string | number | null
         currentTurn: string | number | null
+        phase: string
+        isGameOver: boolean
       }) => unknown
     ) =>
       selector({
         currentPlayerId: runtime.currentTurn,
         currentTurn: runtime.currentTurn,
+        phase: runtime.phase,
+        isGameOver: runtime.isGameOver,
       })
 
     ;(
       useGameStore as typeof useGameStore & {
-        getState: () => { players: unknown[]; revision: number }
+        getState: () => {
+          players: unknown[]
+          revision: number
+          phase: string
+          isGameOver: boolean
+        }
       }
     ).getState = () => ({
       players: createPlayers(runtime.playersLength),
       revision: runtime.revision,
+      phase: runtime.phase,
+      isGameOver: runtime.isGameOver,
     })
 
     return { useGameStore }
@@ -196,6 +211,60 @@ describe('useGameState', () => {
       gameId: 'game-3',
       knownRevision: 0,
     })
+    expect(emitGameSyncTimer).toHaveBeenCalledTimes(1)
+  })
+
+  it('게임 종료 상태면 sync와 timer sync를 시작하지 않는다', async () => {
+    const {
+      useGameState,
+      setupGameHandlers,
+      connectSocketWithAuthIfNeeded,
+      emitGameSync,
+      emitGameSyncTimer,
+    } = await setupUseGameState({
+      accessToken: 'token-over',
+      mockEnabled: false,
+      phase: 'finished',
+      isGameOver: true,
+    })
+
+    renderHook(() => useGameState('game-over'))
+
+    expect(setupGameHandlers).not.toHaveBeenCalled()
+    expect(connectSocketWithAuthIfNeeded).not.toHaveBeenCalled()
+    expect(emitGameSync).not.toHaveBeenCalled()
+    expect(emitGameSyncTimer).not.toHaveBeenCalled()
+  })
+
+  it('게임 진행 중 종료되면 이후 reconnect/focus에서도 sync를 보내지 않는다', async () => {
+    const {
+      useGameState,
+      runtime,
+      socketHandlers,
+      emitGameSync,
+      emitGameSyncTimer,
+    } = await setupUseGameState({
+      accessToken: 'token-finish-during-game',
+      mockEnabled: false,
+      socketConnected: false,
+    })
+
+    const { rerender } = renderHook(() => useGameState('game-finished-later'))
+
+    expect(emitGameSync).toHaveBeenCalledTimes(1)
+    expect(emitGameSyncTimer).toHaveBeenCalledTimes(1)
+
+    runtime.phase = 'finished'
+    runtime.isGameOver = true
+    rerender()
+
+    const connectHandler = socketHandlers.get('connect')
+    act(() => {
+      connectHandler?.()
+      window.dispatchEvent(new Event('focus'))
+    })
+
+    expect(emitGameSync).toHaveBeenCalledTimes(1)
     expect(emitGameSyncTimer).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/hooks/game/useGameState.ts
+++ b/src/hooks/game/useGameState.ts
@@ -16,12 +16,18 @@ export const useGameState = (gameId: string | null) => {
   const accessToken = useAuthStore(
     (state) => state.session?.accessToken?.trim() ?? null
   )
+  const phase = useGameStore((state) => state.phase)
+  const isGameOver = useGameStore((state) => state.isGameOver)
   const currentTurn = useGameStore((state) => {
     return state.currentPlayerId ?? state.currentTurn
   })
+  const isGameFinished = isGameOver || phase === 'finished'
 
   useEffect(() => {
     if (!gameId) {
+      return
+    }
+    if (isGameFinished) {
       return
     }
     if (!USE_GAME_SOCKET_MOCK && !accessToken) {
@@ -39,7 +45,15 @@ export const useGameState = (gameId: string | null) => {
 
     const syncGameState = ({ force = false }: { force?: boolean } = {}) => {
       const gameChanged = syncedGameIdRef.current !== gameId
-      const { players, revision } = useGameStore.getState()
+      const {
+        players,
+        revision,
+        phase: currentPhase,
+        isGameOver: gameEnded,
+      } = useGameStore.getState()
+      if (gameEnded || currentPhase === 'finished') {
+        return
+      }
 
       // 초기 진입에서는 같은 게임 상태를 이미 들고 있으면 중복 sync를 생략한다.
       if (!force && !gameChanged && players.length > 0) return
@@ -52,6 +66,11 @@ export const useGameState = (gameId: string | null) => {
     }
 
     const syncGameTimer = () => {
+      const { phase: currentPhase, isGameOver: gameEnded } =
+        useGameStore.getState()
+      if (gameEnded || currentPhase === 'finished') {
+        return
+      }
       emitGameSyncTimer({ gameId })
     }
 
@@ -83,16 +102,19 @@ export const useGameState = (gameId: string | null) => {
       socket.off('connect', handleSocketConnect)
       teardownHandlers()
     }
-  }, [accessToken, gameId])
+  }, [accessToken, gameId, isGameFinished])
 
   useEffect(() => {
     if (!gameId || currentTurn == null) {
       return
     }
+    if (isGameFinished) {
+      return
+    }
 
     // 턴 변경 시 서버 기준 남은 시간을 다시 받아서 0초 고정 상태를 방지한다.
     emitGameSyncTimer({ gameId })
-  }, [gameId, currentTurn])
+  }, [gameId, currentTurn, isGameFinished])
 
   return {}
 }

--- a/src/services/socket/gameContractAdapters.test.ts
+++ b/src/services/socket/gameContractAdapters.test.ts
@@ -263,6 +263,49 @@ describe('gameContractAdapters', () => {
       winnerId: 'player-winner',
       gameResult: {
         reason: 'bankrupt',
+        winner: {
+          playerId: 'player-winner',
+          nickname: 'winner',
+          assets: 8200000000,
+        },
+      },
+    })
+  })
+
+  it('normalizes GAME_OVER winner payload with balance/assets fields', () => {
+    const normalized = normalizeSnapshotPayload(
+      {
+        gameId: 'game-over-new-contract',
+        revision: 22,
+        phase: 'GAME_OVER',
+        players: [],
+        tiles: [],
+        game_result: {
+          reason: 'max_rounds',
+          winner: {
+            playerId: 2,
+            nickname: 'guest',
+            balance: 530000,
+            assets: 610000,
+          },
+        },
+      },
+      { envelopeRevision: 22 }
+    )
+
+    expect(normalized).not.toBeNull()
+    expect(normalized).toMatchObject({
+      phase: 'finished',
+      isGameOver: true,
+      winnerId: 2,
+      gameResult: {
+        reason: 'max_rounds',
+        winner: {
+          playerId: 2,
+          nickname: 'guest',
+          balance: 530000000000,
+          assets: 610000000000,
+        },
       },
     })
   })
@@ -610,7 +653,7 @@ describe('gameContractAdapters', () => {
       {
         op: 'set',
         path: 'gameResult',
-        value: { reason: 'round_limit', rankings: [] },
+        value: { reason: 'round_limit', rankings: undefined, winner: null },
       },
     ])
   })

--- a/src/services/socket/gameContractAdapters.ts
+++ b/src/services/socket/gameContractAdapters.ts
@@ -3,6 +3,8 @@ import type {
   GamePatchOperation,
   GamePrompt,
   GamePromptChoice,
+  GameRanking,
+  GameResult,
   GameSnapshot,
   GameTimerSync,
   Player,
@@ -558,6 +560,180 @@ const normalizeTileFromSnapshot = (
   }
 }
 
+const normalizeGameResultReason = (value: unknown): GameResult['reason'] => {
+  if (typeof value !== 'string') {
+    return 'max_rounds'
+  }
+
+  const normalizedReason = value.trim().toLowerCase()
+  if (normalizedReason === 'last_player_standing') {
+    return 'last_player_standing'
+  }
+  if (normalizedReason === 'max_rounds') {
+    return 'max_rounds'
+  }
+  if (normalizedReason === 'disconnect_timeout') {
+    return 'disconnect_timeout'
+  }
+  if (normalizedReason === 'round_limit') {
+    return 'round_limit'
+  }
+  if (normalizedReason === 'bankrupt') {
+    return 'bankrupt'
+  }
+
+  return 'max_rounds'
+}
+
+const normalizeGameRanking = (
+  rankingPayload: unknown,
+  fallbackRank: number
+): GameRanking | null => {
+  if (!isRecord(rankingPayload)) {
+    return null
+  }
+
+  const playerId = toPlayerIdOrNull(
+    rankingPayload.player_id ??
+      rankingPayload.playerId ??
+      rankingPayload.id ??
+      rankingPayload.userId
+  )
+  if (playerId == null) {
+    return null
+  }
+
+  const nickname =
+    toStringOrNull(rankingPayload.nickname) ??
+    toStringOrNull(rankingPayload.name) ??
+    `Player ${String(playerId)}`
+
+  const finalAssetsRaw =
+    rankingPayload.final_assets ??
+    rankingPayload.finalAssets ??
+    rankingPayload.assets
+
+  return {
+    rank: Math.max(
+      1,
+      toFiniteInt(rankingPayload.rank ?? rankingPayload.order, fallbackRank)
+    ),
+    player_id: playerId,
+    nickname,
+    final_assets: normalizeMoneyToWon(finalAssetsRaw, 0),
+    is_winner: Boolean(
+      rankingPayload.is_winner ??
+      rankingPayload.isWinner ??
+      rankingPayload.winner
+    ),
+  }
+}
+
+const normalizeGameResultWinner = (
+  winnerPayload: unknown
+): NonNullable<GameResult['winner']> => {
+  if (!isRecord(winnerPayload)) {
+    return null
+  }
+
+  const playerId = toPlayerIdOrNull(
+    winnerPayload.playerId ??
+      winnerPayload.player_id ??
+      winnerPayload.id ??
+      winnerPayload.userId
+  )
+  if (playerId == null) {
+    return null
+  }
+
+  const nickname =
+    toStringOrNull(winnerPayload.nickname) ??
+    toStringOrNull(winnerPayload.name) ??
+    `Player ${String(playerId)}`
+
+  return {
+    playerId,
+    nickname,
+    balance: normalizeMoneyToWon(
+      winnerPayload.balance ?? winnerPayload.money,
+      0
+    ),
+    assets: normalizeMoneyToWon(
+      winnerPayload.assets ??
+        winnerPayload.final_assets ??
+        winnerPayload.finalAssets,
+      0
+    ),
+  }
+}
+
+const normalizeGameResultPayload = (
+  gameResultPayload: unknown
+): GameSnapshot['gameResult'] | null => {
+  if (!isRecord(gameResultPayload)) {
+    return null
+  }
+
+  const rankingsRaw = Array.isArray(gameResultPayload.rankings)
+    ? gameResultPayload.rankings
+    : Array.isArray(gameResultPayload.results)
+      ? gameResultPayload.results
+      : []
+
+  const rankings = rankingsRaw
+    .map((ranking, index) => normalizeGameRanking(ranking, index + 1))
+    .filter((ranking): ranking is GameRanking => ranking !== null)
+
+  const winnerFromPayload = normalizeGameResultWinner(gameResultPayload.winner)
+  const winnerFromRankings =
+    rankings.find((ranking) => ranking.is_winner) ??
+    (rankings.length > 0 ? rankings[0] : null)
+  const normalizedWinner =
+    winnerFromPayload ??
+    (winnerFromRankings
+      ? {
+          playerId: winnerFromRankings.player_id,
+          nickname: winnerFromRankings.nickname,
+          balance: 0,
+          assets: winnerFromRankings.final_assets,
+        }
+      : null)
+
+  return {
+    reason: normalizeGameResultReason(
+      gameResultPayload.reason ?? gameResultPayload.endReason
+    ),
+    rankings: rankings.length > 0 ? rankings : undefined,
+    winner: normalizedWinner,
+  }
+}
+
+const resolveWinnerIdFromGameResult = (
+  gameResult: GameSnapshot['gameResult'] | null
+): PlayerId | null => {
+  if (!gameResult) {
+    return null
+  }
+
+  if (gameResult.winner?.playerId != null) {
+    return toPlayerIdOrNull(gameResult.winner.playerId)
+  }
+
+  const winnerRanking = gameResult.rankings?.find(
+    (ranking) => ranking.is_winner
+  )
+  if (winnerRanking?.player_id != null) {
+    return toPlayerIdOrNull(winnerRanking.player_id)
+  }
+
+  const firstRanking = gameResult.rankings?.[0]
+  if (firstRanking?.player_id != null) {
+    return toPlayerIdOrNull(firstRanking.player_id)
+  }
+
+  return null
+}
+
 export const normalizeSnapshotPayload = (
   snapshotPayload: unknown,
   options: SnapshotNormalizeOptions
@@ -584,15 +760,12 @@ export const normalizeSnapshotPayload = (
   )
   const normalizedPhase = normalizePhase(snapshotPayload.phase)
   const roundFromTurn = toFiniteInt(snapshotPayload.turn, 1)
-  const normalizedGameResult = (
-    snapshotPayload.gameResult && isRecord(snapshotPayload.gameResult)
-      ? snapshotPayload.gameResult
-      : snapshotPayload.game_result && isRecord(snapshotPayload.game_result)
-        ? snapshotPayload.game_result
-        : null
-  ) as GameSnapshot['gameResult'] | null
+  const normalizedGameResult = normalizeGameResultPayload(
+    snapshotPayload.gameResult ?? snapshotPayload.game_result
+  )
   const normalizedWinnerId =
     toPlayerIdOrNull(snapshotPayload.winnerId ?? snapshotPayload.winner_id) ??
+    resolveWinnerIdFromGameResult(normalizedGameResult) ??
     null
   const normalizedIsGameOver =
     Boolean(snapshotPayload.isGameOver ?? snapshotPayload.is_game_over) ||
@@ -708,7 +881,7 @@ const normalizePatchSetValue = (
   }
 
   if (pathSegments.length === 1 && firstSegment === 'gameResult') {
-    return isRecord(value) ? (value as GameSnapshot['gameResult']) : null
+    return normalizeGameResultPayload(value)
   }
 
   if (pathSegments.length === 1 && firstSegment === 'players') {

--- a/src/services/socket/gameContractAdapters.ts
+++ b/src/services/socket/gameContractAdapters.ts
@@ -631,7 +631,7 @@ const normalizeGameRanking = (
 
 const normalizeGameResultWinner = (
   winnerPayload: unknown
-): NonNullable<GameResult['winner']> => {
+): GameResult['winner'] => {
   if (!isRecord(winnerPayload)) {
     return null
   }

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -106,8 +106,19 @@ export type GameRanking = {
 }
 
 export type GameResult = {
-  reason: 'bankrupt' | 'round_limit'
-  rankings: GameRanking[]
+  reason:
+    | 'bankrupt'
+    | 'round_limit'
+    | 'last_player_standing'
+    | 'max_rounds'
+    | 'disconnect_timeout'
+  rankings?: GameRanking[]
+  winner?: {
+    playerId: PlayerId
+    nickname: string
+    balance: Money
+    assets: Money
+  } | null
 }
 
 export interface GamePromptChoice {


### PR DESCRIPTION
## 📌 작업 개요
게임 종료 플로우에서 발생하던 두 가지 문제를 함께 수정했습니다.

1) 게임이 끝난 뒤에도 `game:sync`, `game:sync_timer`를 계속 시도해 불필요한 에러가 나는 문제  
2) 서버의 최신 GAME_OVER 계약(`winner.balance`, `winner.assets`, reason 확장)을 결과 모달/UI가 충분히 반영하지 못하던 문제

---

## ✅ 변경 내용

### 1. 게임 종료 이후 sync/timer-sync 중단
- `useGameState`에서 `isGameOver || phase === 'finished'`를 종료 상태로 판단
- 종료 상태일 때:
  - 초기 sync effect 실행 차단
  - `syncGameState`, `syncGameTimer` 실행 차단
  - reconnect/focus 기반 재동기화도 차단

대상 파일:
- `src/hooks/game/useGameState.ts`
- `src/hooks/game/useGameState.test.tsx`

### 2. GAME_OVER 계약 정규화 강화
- `GameResult.reason` 확장:
  - `last_player_standing`, `max_rounds`, `disconnect_timeout` 추가
- `gameResult.winner` 구조 반영:
  - `playerId`, `nickname`, `balance`, `assets`
- 스냅샷/패치 alias 정규화 및 winnerId 유도 보강:
  - `winner_id`, `is_game_over`, `game_result` 대응
  - `phase === finished`면 gameOver로 해석

대상 파일:
- `src/types/domain.ts`
- `src/services/socket/gameContractAdapters.ts`
- `src/services/socket/gameContractAdapters.test.ts`

### 3. 결과 모달 winner-only payload 대응
- `rankings`가 없어도 `gameResult.winner`만 있으면 결과 모달이 정상 표시되도록 fallback 추가
- 우승자 이름도 `gameResult.winner.nickname` 우선 사용

대상 파일:
- `src/components/board/GameBoard.tsx`

---

## 🧪 검증

### 수동/단위 검증
- `npx vitest run src/hooks/game/useGameState.test.tsx src/services/socket/gameContractAdapters.test.ts src/stores/game.store.test.ts src/components/board/gameBoardEventQueueUtils.test.ts`
- `npm run lint`
- `npm run build`

### pre-push 자동 검증(훅)
- `npm run lint`
- `npm run test`
- `npm run test:coverage`
- 모두 통과 후 push 완료

---

## ⚠️ 리스크 / 확인 필요사항
- 현재 브랜치 범위는 “종료 이후 sync 차단 + 결과 계약 반영”입니다.
- 실서버에서 GAME_OVER 이벤트(reason별)별 실제 payload가 모두 동일 계약으로 내려오는지는 QA에서 추가 확인 필요합니다.
- 테스트 로그의 기존 `act(...)` warning은 이번 변경으로 새로 생긴 실패가 아니라 기존 경고성 로그입니다(테스트는 pass).

---

## 📂 변경 파일
- `src/hooks/game/useGameState.ts`
- `src/hooks/game/useGameState.test.tsx`
- `src/types/domain.ts`
- `src/services/socket/gameContractAdapters.ts`
- `src/services/socket/gameContractAdapters.test.ts`
- `src/components/board/GameBoard.tsx`
