### PR TITLE
fix: 게임 종료 후 GamePage 로딩 고정 수정

### DIFF
--- a/src/pages/GamePage.test.tsx
+++ b/src/pages/GamePage.test.tsx
@@ -309,4 +309,62 @@ describe('GamePage chat flow', () => {
       screen.getByRole('dialog', { name: '게임 종료' })
     ).toBeInTheDocument()
   })
+
+  it('플레이어 목록이 비어 있어도 종료 상태면 로딩 화면 대신 게임 화면을 유지한다', () => {
+    useGameStore.getState().setGameState({
+      players: [],
+      phase: 'finished',
+      isGameOver: true,
+      gameResult: {
+        reason: 'max_rounds',
+        winner: {
+          playerId: 'user-1',
+          nickname: '유저1',
+          balance: 1000,
+          assets: 1200,
+        },
+      },
+    })
+
+    renderGamePage()
+
+    expect(screen.queryByText('게임 로딩 중...')).not.toBeInTheDocument()
+    expect(screen.getByTestId('mock-board-game')).toBeInTheDocument()
+  })
+
+  it('플레이어 목록이 비어 있고 gameResult만 있어도 로딩 화면으로 가지 않는다', () => {
+    useGameStore.getState().setGameState({
+      players: [],
+      phase: 'resolving',
+      isGameOver: false,
+      gameResult: {
+        reason: 'disconnect_timeout',
+        winner: {
+          playerId: 'user-2',
+          nickname: '유저2',
+          balance: 2000,
+          assets: 2400,
+        },
+      },
+    })
+
+    renderGamePage()
+
+    expect(screen.queryByText('게임 로딩 중...')).not.toBeInTheDocument()
+    expect(screen.getByTestId('mock-board-game')).toBeInTheDocument()
+  })
+
+  it('플레이어 목록이 비어 있고 종료 상태가 아니면 기존처럼 로딩 화면을 표시한다', () => {
+    useGameStore.getState().setGameState({
+      players: [],
+      phase: 'rolling',
+      isGameOver: false,
+      gameResult: null,
+    })
+
+    renderGamePage()
+
+    expect(screen.getByText('게임 로딩 중...')).toBeInTheDocument()
+    expect(screen.queryByTestId('mock-board-game')).not.toBeInTheDocument()
+  })
 })

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -383,8 +383,10 @@ const GamePage: React.FC = () => {
     })
   }
 
+  const isTerminalGameState =
+    isGameOver || phase === 'finished' || gameResult !== null
   const isWaitingForServerState =
-    !USE_GAME_SOCKET_MOCK && storePlayers.length === 0
+    !USE_GAME_SOCKET_MOCK && storePlayers.length === 0 && !isTerminalGameState
 
   if (isWaitingForServerState) {
     return (


### PR DESCRIPTION
## 📌 관련 이슈

> closes #552 

---

## 📝 작업 내용

게임 종료 후에도 `GamePage`가 `게임 로딩 중...` 화면에 머무르며
결과 화면으로 넘어가지 않던 문제를 수정했습니다.

원인은 `GamePage`가 `storePlayers.length === 0`만 보고 로딩 상태를 판단하던 점이었고,
종료 snapshot/patch에서 플레이어 목록이 비어 오는 경우에도
종료 상태 대신 로딩 화면으로 빠질 수 있었습니다.

이번 수정에서는:
- `GamePage`의 로딩 조건을 종료 상태와 분리했습니다.
- 아래 중 하나면 종료 상태로 간주하도록 정리했습니다.
  - `isGameOver === true`
  - `phase === 'finished'`
  - `gameResult != null`
- 종료 상태에서는 `players.length === 0`이어도 로딩 화면을 띄우지 않도록 수정했습니다.
- 관련 회귀 테스트를 추가해 종료 상태와 비종료 상태의 로딩 분기를 각각 검증했습니다.

### 📚 참고한 기준 문서

- `AGENTS.md`
- `docs/ai/manuals/common.md`
- `docs/ai/manuals/game-runtime.md`
- `docs/rules.md`
- `docs/testing.md`

### 🧪 실행한 검증

- `npx vitest run src/pages/GamePage.test.tsx`
- `npm run ai:self-review -- --files src/pages/GamePage.tsx src/pages/GamePage.test.tsx`
- `npm run ai:check:game`
- `npm run build`

### ⚠️ 남은 리스크

- `GamePage.test.tsx`의 기존 `act(...)` warning은 그대로 남아 있지만 테스트는 통과합니다.
- 이번 수정은 종료 상태에서 로딩 화면에 갇히는 문제를 막는 범위입니다. 종료 직후 추가 `sync`/`sync_timer`로 인한 서버 오류는 별도 후속 이슈로 분리해 보는 것이 맞습니다.
