### PR TITLE
fix: 게임 종료 로딩과 대기방 복귀 흐름 수정

### DIFF
--- a/docs/ai/tasks/game-finished-loading-stuck/checklist.md
+++ b/docs/ai/tasks/game-finished-loading-stuck/checklist.md
@@ -1,0 +1,6 @@
+# Checklist
+
+- [ ] 종료 상태(`isGameOver`, `phase === 'finished'`, `gameResult`)에서는 `players=[]`여도 로딩 화면을 띄우지 않는다.
+- [ ] `GAME_NOT_FOUND`, `NOT_GAME_MEMBER`, `INVALID_GAME_ID` 발생 시 room 또는 lobby fallback 이동을 시작한다.
+- [ ] 종료 상태가 아니고 `players=[]`인 경우는 기존처럼 로딩 화면을 유지한다.
+- [ ] 관련 `GamePage` 테스트와 build가 통과한다.

--- a/docs/ai/tasks/game-finished-loading-stuck/context.md
+++ b/docs/ai/tasks/game-finished-loading-stuck/context.md
@@ -1,0 +1,6 @@
+# Context
+
+- 새 `GAME_OVER` 계약은 winner-only payload와 `players=[]` 상태를 포함할 수 있다.
+- `GameBoard`는 `isGameOver || gameResult`만 있으면 결과 모달을 열 수 있다.
+- 현재 `GamePage`는 `storePlayers.length === 0`만 보고 `게임 로딩 중...`으로 빠져 종료 상태도 로딩으로 오해한다.
+- 종료 직후 stale game route로 진입하면 `game:error(GAME_NOT_FOUND 등)`가 와도 로딩 분기가 먼저 실행될 수 있다.

--- a/docs/ai/tasks/game-finished-loading-stuck/plan.md
+++ b/docs/ai/tasks/game-finished-loading-stuck/plan.md
@@ -1,0 +1,15 @@
+# Game Finished Loading Stuck
+
+## 목표
+
+- 게임 종료 상태를 `GamePage` 로딩 분기와 분리한다.
+- `players=[]`인 종료 snapshot/patch에서도 결과 화면 렌더 경로를 막지 않는다.
+- stale `/game/:gameId` 진입 시 fatal game error를 로딩보다 먼저 처리한다.
+
+## 작업 단계
+
+1. `GamePage`에 종료 상태 판정(`isGameOver`, `phase === 'finished'`, `gameResult`)을 추가한다.
+2. `GAME_NOT_FOUND`, `NOT_GAME_MEMBER`, `INVALID_GAME_ID`를 stale game fatal error로 분류한다.
+3. room 문맥이 있으면 `/rooms/:roomId`, 없으면 `/lobby`로 fallback 이동을 추가한다.
+4. 로딩 분기를 "종료 상태도 아니고 fatal error도 아니고 players가 비어 있는 경우"로 좁힌다.
+5. 종료 상태/비종료 상태/fatal error fallback 회귀 테스트를 `GamePage.test.tsx`에 추가한다.

--- a/docs/ai/tasks/game-over-return-flow/checklist.md
+++ b/docs/ai/tasks/game-over-return-flow/checklist.md
@@ -1,0 +1,7 @@
+# Checklist
+
+- [ ] 결과 모달 확인 시 `roomId`가 있으면 같은 대기방(`/rooms/:roomId`)으로 이동한다.
+- [ ] 결과 모달 확인 시 `roomId`가 없으면 `/lobby`로 이동한다.
+- [ ] 종료 상태에서는 fatal game error가 있어도 결과 확인 전 자동 fallback 이동하지 않는다.
+- [ ] 결과 모달 확인 및 fatal game fallback 전에 `resetGame()`이 호출된다.
+- [ ] `GamePage` 테스트와 build/lint 검증이 통과한다.

--- a/docs/ai/tasks/game-over-return-flow/context.md
+++ b/docs/ai/tasks/game-over-return-flow/context.md
@@ -1,0 +1,7 @@
+# Context
+
+- 현재 결과 모달은 `GameBoard` 내부에서 열리며 확인 버튼이 `window.location.href = '/'`를 직접 호출한다.
+- 게임 종료 후 자동 대기방 복귀는 구현되어 있지 않고, 사용자는 게임 페이지에 머무른다.
+- stale `/game/:gameId` 진입 시 `GAME_NOT_FOUND` 같은 fatal error가 올 수 있으므로 이 경로에서도 stale game state를 정리해야 한다.
+- `GamePage`는 이미 `activeRoomId`를 알고 있어 결과 확인 시 대기방 복귀 결정을 맡기기에 적합하다.
+- 종료 상태에서 fatal game error가 늦게 도착할 수 있으므로, 결과 모달이 열린 이후에는 fatal fallback이 버튼 클릭 복귀를 가로채지 않아야 한다.

--- a/docs/ai/tasks/game-over-return-flow/plan.md
+++ b/docs/ai/tasks/game-over-return-flow/plan.md
@@ -1,0 +1,15 @@
+# Game Over Return Flow
+
+## 목표
+
+- 게임 종료 후 결과 모달을 유지한 채, 확인 시 같은 `roomId`의 대기방으로 복귀시킨다.
+- `GameBoard`가 직접 라우팅하지 않고 `GamePage`가 대기방/로비 이동을 결정하도록 정리한다.
+- stale game fatal error fallback에서도 stale game store를 함께 정리한다.
+
+## 작업 단계
+
+1. `GameBoard` 결과 모달 확인 액션을 상위 콜백으로 위임한다.
+2. 결과 모달 버튼 라벨을 `대기방으로 돌아가기`로 맞춘다.
+3. `GamePage`에 종료 결과 확인 핸들러를 추가해 `roomId`가 있으면 `/rooms/:roomId`, 없으면 `/lobby`로 이동시킨다.
+4. fatal game route error fallback에서 `resetGame()`도 함께 호출해 stale store를 남기지 않도록 한다.
+5. 결과 확인 복귀/fatal fallback 회귀 테스트를 `GamePage.test.tsx`에 추가한다.

--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -250,6 +250,7 @@ interface GameBoardProps {
   gameResult?: GameResult | null
   isGameOver?: boolean
   winnerId?: PlayerId | null
+  onGameResultConfirm?: () => void
 }
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -318,6 +319,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       gameResult = null,
       isGameOver = false,
       winnerId = null,
+      onGameResultConfirm,
     },
     ref
   ) => {
@@ -2376,9 +2378,10 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
           open={canShowModal && gameResultModal.open}
           winnerName={resultModalWinnerName}
           results={resultModalRows}
-          onBackToLobby={() => {
+          returnToWaitingRoomLabel="대기방으로 돌아가기"
+          onReturnToWaitingRoom={() => {
             setGameResultModal({ open: false })
-            window.location.href = '/' // Redirect to home/lobby
+            onGameResultConfirm?.()
           }}
         />
         <GoToIslandModal

--- a/src/components/game/modals/GameResultModal.tsx
+++ b/src/components/game/modals/GameResultModal.tsx
@@ -5,8 +5,8 @@ interface GameResultModalProps {
   winnerName?: string
   title?: string
   subtitle?: string
-  backToLobbyLabel?: string
-  onBackToLobby?: () => void
+  returnToWaitingRoomLabel?: string
+  onReturnToWaitingRoom?: () => void
   results?: {
     id: string
     nickname: string
@@ -16,7 +16,7 @@ interface GameResultModalProps {
 }
 
 const DEFAULT_TITLE = 'GAME OVER'
-const DEFAULT_BACK_LABEL = '로비로 돌아가기'
+const DEFAULT_RETURN_TO_WAITING_ROOM_LABEL = '대기방으로 돌아가기'
 
 const DEFAULT_RESULTS: NonNullable<GameResultModalProps['results']> = [
   {
@@ -50,8 +50,8 @@ const GameResultModal: React.FC<GameResultModalProps> = ({
   winnerName = '플레이어 1',
   title = DEFAULT_TITLE,
   subtitle,
-  backToLobbyLabel = DEFAULT_BACK_LABEL,
-  onBackToLobby,
+  returnToWaitingRoomLabel = DEFAULT_RETURN_TO_WAITING_ROOM_LABEL,
+  onReturnToWaitingRoom,
   results = DEFAULT_RESULTS,
 }) => {
   if (!open) {
@@ -129,11 +129,11 @@ const GameResultModal: React.FC<GameResultModalProps> = ({
 
         <button
           type="button"
-          onClick={onBackToLobby}
+          onClick={onReturnToWaitingRoom}
           className="mx-auto mt-6 flex h-15 w-full items-center justify-center rounded-[18px] bg-[#245FE5] text-[30px] font-black tracking-tight text-white shadow-lg transition-colors hover:bg-[#1F56D1]"
           style={{ maxWidth: '760px' }}
         >
-          🏠 {backToLobbyLabel}
+          🏠 {returnToWaitingRoomLabel}
         </button>
       </div>
     </div>

--- a/src/pages/GamePage.test.tsx
+++ b/src/pages/GamePage.test.tsx
@@ -109,10 +109,22 @@ vi.mock('../services/socket/game.handler', () => ({
 }))
 
 vi.mock('../components/board/GameBoard', () => ({
-  default: forwardRef<HTMLDivElement>(function MockBoardGame(_, ref) {
+  default: forwardRef<
+    HTMLDivElement,
+    {
+      gameResult?: object | null
+      isGameOver?: boolean
+      onGameResultConfirm?: () => void
+    }
+  >(function MockBoardGame(props, ref) {
     return (
       <div ref={ref} data-testid="mock-board-game">
         게임 보드
+        {Boolean(props.isGameOver || props.gameResult) && (
+          <button type="button" onClick={props.onGameResultConfirm}>
+            대기방으로 돌아가기
+          </button>
+        )}
       </div>
     )
   }),
@@ -171,13 +183,18 @@ const createPlayer = (overrides: Partial<Player> = {}): Player => ({
   ...overrides,
 })
 
-function renderGamePage() {
+function renderGamePage(options?: {
+  initialEntries?: Array<{
+    pathname: string
+    state?: Record<string, unknown>
+  }>
+}) {
   return renderWithProviders(
     <Routes>
       <Route path="/game/:gameId" element={<GamePage />} />
     </Routes>,
     {
-      initialEntries: [
+      initialEntries: options?.initialEntries ?? [
         {
           pathname: '/game/game-1',
           state: {
@@ -308,5 +325,256 @@ describe('GamePage chat flow', () => {
     expect(
       screen.getByRole('dialog', { name: '게임 종료' })
     ).toBeInTheDocument()
+  })
+
+  it('players가 비어 있어도 finished gameResult가 있으면 로딩 화면 대신 게임 화면을 렌더한다', () => {
+    useGameStore.getState().resetGame()
+    useGameStore.getState().setGameState({
+      roomId: 'room-1',
+      gameId: 'game-1',
+      phase: 'finished',
+      isGameOver: true,
+      players: [],
+      tiles: [],
+      gameResult: {
+        reason: 'max_rounds',
+        winner: {
+          playerId: 'user-1',
+          nickname: '유저1',
+          balance: 300000,
+          assets: 455000,
+        },
+      },
+    })
+
+    renderGamePage()
+
+    expect(screen.queryByText('게임 로딩 중...')).not.toBeInTheDocument()
+    expect(screen.getByTestId('mock-board-game')).toBeInTheDocument()
+  })
+
+  it('players가 비어 있어도 isGameOver면 로딩 화면 대신 게임 화면을 렌더한다', () => {
+    useGameStore.getState().resetGame()
+    useGameStore.getState().setGameState({
+      roomId: 'room-1',
+      gameId: 'game-1',
+      phase: 'rolling',
+      isGameOver: true,
+      players: [],
+      tiles: [],
+      gameResult: null,
+    })
+
+    renderGamePage()
+
+    expect(screen.queryByText('게임 로딩 중...')).not.toBeInTheDocument()
+    expect(screen.getByTestId('mock-board-game')).toBeInTheDocument()
+  })
+
+  it('종료 상태가 아니고 players가 비어 있으면 기존처럼 로딩 화면을 렌더한다', () => {
+    useGameStore.getState().resetGame()
+    useGameStore.getState().setGameState({
+      roomId: 'room-1',
+      gameId: 'game-1',
+      phase: 'rolling',
+      isGameOver: false,
+      players: [],
+      tiles: [],
+      gameResult: null,
+    })
+
+    renderGamePage()
+
+    expect(screen.getByText('게임 로딩 중...')).toBeInTheDocument()
+    expect(screen.queryByTestId('mock-board-game')).not.toBeInTheDocument()
+  })
+
+  it('fatal game error와 roomId가 있으면 해당 대기방으로 fallback 이동한다', async () => {
+    useGameStore.getState().resetGame()
+    useGameStore.getState().setGameState({
+      roomId: 'room-1',
+      gameId: 'game-1',
+      phase: 'rolling',
+      isGameOver: false,
+      players: [],
+      tiles: [],
+      gameResult: null,
+      lastError: {
+        code: 'GAME_NOT_FOUND',
+        message: '게임을 찾을 수 없습니다.',
+      },
+    })
+
+    renderGamePage()
+
+    expect(screen.queryByText('게임 로딩 중...')).not.toBeInTheDocument()
+    expect(
+      screen.getByText('참가 정보를 다시 확인하고 있습니다...')
+    ).toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(navigateMock).toHaveBeenCalledWith('/rooms/room-1', {
+        replace: true,
+        state: {
+          roomId: 'room-1',
+        },
+      })
+    })
+
+    expect(useGameStore.getState().players).toHaveLength(0)
+  })
+
+  it('fatal game error와 roomId가 없으면 로비로 fallback 이동한다', async () => {
+    useGameStore.getState().resetGame()
+    useGameStore.getState().setGameState({
+      roomId: null,
+      gameId: 'game-1',
+      phase: 'rolling',
+      isGameOver: false,
+      players: [],
+      tiles: [],
+      gameResult: null,
+      lastError: {
+        code: 'INVALID_GAME_ID',
+        message: 'gameId가 필요합니다.',
+      },
+    })
+
+    renderGamePage({
+      initialEntries: [
+        {
+          pathname: '/game/game-1',
+          state: {
+            gameId: 'game-1',
+          },
+        },
+      ],
+    })
+
+    await waitFor(() => {
+      expect(navigateMock).toHaveBeenCalledWith('/lobby', { replace: true })
+    })
+
+    expect(useGameStore.getState().players).toHaveLength(0)
+  })
+
+  it('게임 종료 결과 확인 시 같은 대기방으로 이동하고 game store를 초기화한다', async () => {
+    const user = userEvent.setup()
+
+    useGameStore.getState().setGameState({
+      roomId: 'room-1',
+      gameId: 'game-1',
+      phase: 'finished',
+      isGameOver: true,
+      gameResult: {
+        reason: 'max_rounds',
+        winner: {
+          playerId: 'user-1',
+          nickname: '유저1',
+          balance: 300000,
+          assets: 455000,
+        },
+      },
+    })
+
+    renderGamePage()
+
+    await user.click(
+      screen.getByRole('button', { name: '대기방으로 돌아가기' })
+    )
+
+    expect(navigateMock).toHaveBeenCalledWith('/rooms/room-1', {
+      replace: true,
+      state: {
+        roomId: 'room-1',
+      },
+    })
+    expect(useGameStore.getState().players).toHaveLength(0)
+  })
+
+  it('게임 종료 결과 확인 시 roomId가 없으면 로비로 이동한다', async () => {
+    const user = userEvent.setup()
+
+    useGameStore.getState().resetGame()
+    useGameStore.getState().setGameState({
+      roomId: null,
+      gameId: 'game-1',
+      phase: 'finished',
+      isGameOver: true,
+      players: [],
+      tiles: [],
+      gameResult: {
+        reason: 'disconnect_timeout',
+        winner: {
+          playerId: 'user-2',
+          nickname: '유저2',
+          balance: 530000,
+          assets: 530000,
+        },
+      },
+    })
+
+    renderGamePage({
+      initialEntries: [
+        {
+          pathname: '/game/game-1',
+          state: {
+            gameId: 'game-1',
+          },
+        },
+      ],
+    })
+
+    await user.click(
+      screen.getByRole('button', { name: '대기방으로 돌아가기' })
+    )
+
+    expect(navigateMock).toHaveBeenCalledWith('/lobby', { replace: true })
+    expect(useGameStore.getState().players).toHaveLength(0)
+  })
+
+  it('종료 상태에서는 fatal game error가 있어도 버튼 클릭 전 자동 fallback 이동하지 않는다', async () => {
+    const user = userEvent.setup()
+
+    useGameStore.getState().resetGame()
+    useGameStore.getState().setGameState({
+      roomId: 'room-1',
+      gameId: 'game-1',
+      phase: 'finished',
+      isGameOver: true,
+      players: [],
+      tiles: [],
+      gameResult: {
+        reason: 'max_rounds',
+        winner: {
+          playerId: 'user-1',
+          nickname: '유저1',
+          balance: 300000,
+          assets: 455000,
+        },
+      },
+      lastError: {
+        code: 'GAME_NOT_FOUND',
+        message: '게임을 찾을 수 없습니다.',
+      },
+    })
+
+    renderGamePage()
+
+    expect(
+      screen.queryByText('참가 정보를 다시 확인하고 있습니다...')
+    ).not.toBeInTheDocument()
+    expect(navigateMock).not.toHaveBeenCalled()
+
+    await user.click(
+      screen.getByRole('button', { name: '대기방으로 돌아가기' })
+    )
+
+    expect(navigateMock).toHaveBeenCalledWith('/rooms/room-1', {
+      replace: true,
+      state: {
+        roomId: 'room-1',
+      },
+    })
   })
 })

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -49,6 +49,11 @@ const DEFAULT_MOCK_PLAYER_ID = 'mock-player-1'
 const DEFAULT_MOCK_NICKNAME = '플레이어 1'
 const DEFAULT_GUEST_ID = 'guest-local'
 const MOCK_LOCAL_PLAYER_INDEX = 0
+const FATAL_GAME_ROUTE_ERROR_CODES = new Set([
+  'GAME_NOT_FOUND',
+  'NOT_GAME_MEMBER',
+  'INVALID_GAME_ID',
+])
 const FALLBACK_PROMPT_CHOICES: GamePromptChoice[] = [
   {
     id: 'confirm',
@@ -98,6 +103,8 @@ const GamePage: React.FC = () => {
   >(null)
   const [isExitModalOpen, setIsExitModalOpen] = useState(false)
   const [isLeavePending, setIsLeavePending] = useState(false)
+  const [isRecoveringFromFatalGameRoute, setIsRecoveringFromFatalGameRoute] =
+    useState(false)
   const boardRef = useRef<BoardGameHandle>(null)
   const pendingGameChatEchoesRef = useRef<PendingGameChatEcho[]>([])
 
@@ -334,6 +341,22 @@ const GamePage: React.FC = () => {
     }
   }
 
+  const handleGameResultConfirm = () => {
+    resetGame()
+
+    if (activeRoomId) {
+      navigate(`/rooms/${activeRoomId}`, {
+        replace: true,
+        state: {
+          roomId: activeRoomId,
+        },
+      })
+      return
+    }
+
+    navigate('/lobby', { replace: true })
+  }
+
   const handleRollClick = () => {
     if (
       !isMyTurn ||
@@ -383,8 +406,58 @@ const GamePage: React.FC = () => {
     })
   }
 
+  const isFatalGameRouteError =
+    lastError != null && FATAL_GAME_ROUTE_ERROR_CODES.has(lastError.code)
+  const hasFinishedGameState =
+    isGameOver || phase === 'finished' || gameResult != null
+
+  useEffect(() => {
+    if (!isFatalGameRouteError || hasFinishedGameState) {
+      return
+    }
+
+    setIsRecoveringFromFatalGameRoute(true)
+
+    resetGame()
+
+    if (activeRoomId) {
+      navigate(`/rooms/${activeRoomId}`, {
+        replace: true,
+        state: {
+          roomId: activeRoomId,
+        },
+      })
+      return
+    }
+
+    navigate('/lobby', { replace: true })
+  }, [
+    activeRoomId,
+    hasFinishedGameState,
+    isFatalGameRouteError,
+    navigate,
+    resetGame,
+  ])
+
   const isWaitingForServerState =
-    !USE_GAME_SOCKET_MOCK && storePlayers.length === 0
+    !USE_GAME_SOCKET_MOCK &&
+    !hasFinishedGameState &&
+    !isFatalGameRouteError &&
+    !isRecoveringFromFatalGameRoute &&
+    storePlayers.length === 0
+
+  if (
+    (isFatalGameRouteError || isRecoveringFromFatalGameRoute) &&
+    !hasFinishedGameState
+  ) {
+    return (
+      <div className="flex h-screen w-full items-center justify-center bg-ui-app-bg font-['Inter']">
+        <div className="text-lg font-bold text-[#45556C]">
+          참가 정보를 다시 확인하고 있습니다...
+        </div>
+      </div>
+    )
+  }
 
   if (isWaitingForServerState) {
     return (
@@ -483,6 +556,7 @@ const GamePage: React.FC = () => {
               gameResult={gameResult}
               isGameOver={isGameOver}
               winnerId={winnerId}
+              onGameResultConfirm={handleGameResultConfirm}
             />
           </div>
         </div>


### PR DESCRIPTION
## 📌 관련 이슈

> closes #555 

---

## 📝 작업 내용

게임 종료 이후 프론트에서 함께 발생하던 아래 문제를 정리했습니다.

- 종료 상태(`GAME_OVER`, `players=[]`)인데도 `GamePage`가 `게임 로딩 중...`에 머무를 수 있었음
- stale `/game/:gameId` 진입 시 `GAME_NOT_FOUND` 같은 fatal error가 와도 정상 복귀 흐름을 타지 못할 수 있었음
- 결과 모달 확인 버튼이 홈(`/`) 이동 기준으로 연결되어 있어, 같은 대기방 복귀 의도와 맞지 않았음
- 종료 상태에서 fatal error가 늦게 도착하면 결과 모달 확인 전에 자동 fallback 이동이 먼저 발생할 수 있었음
- 결과 모달 prop 이름도 현재 의미와 어긋나 있었음

이번 수정에서는:

- `GamePage`의 로딩 분기를 종료 상태와 분리했습니다.
- `isGameOver`, `phase === 'finished'`, `gameResult != null`이면 `players=[]`여도 로딩 화면으로 보내지 않도록 수정했습니다.
- `GAME_NOT_FOUND`, `NOT_GAME_MEMBER`, `INVALID_GAME_ID`를 stale game fatal error로 처리하도록 정리했습니다.
- fatal error 발생 시 room 문맥이 있으면 `/rooms/:roomId`, 없으면 `/lobby`로 fallback 이동하도록 했습니다.
- 이 fallback 경로에서 stale game store도 함께 정리하도록 했습니다.
- 다만 종료 상태에서는 fatal error가 있어도 결과 모달 확인 전 자동 fallback 이동이 실행되지 않도록 가드를 추가했습니다.
- 결과 모달 확인 액션은 `GameBoard`가 직접 라우팅하지 않고 `GamePage` 콜백으로 위임하도록 바꿨습니다.
- 결과 모달의 `대기방으로 돌아가기` 버튼 클릭 시 같은 `roomId`의 대기방(`/rooms/:roomId`)으로 이동하도록 연결했습니다.
- 결과 모달 prop 이름도 현재 의미에 맞게 정리했습니다.
  - `backToLobbyLabel` → `returnToWaitingRoomLabel`
  - `onBackToLobby` → `onReturnToWaitingRoom`
- 관련 `GamePage` 회귀 테스트를 추가/보강했습니다.

### 🧠 Task 문서

- `docs/ai/tasks/game-finished-loading-stuck/plan.md`
- `docs/ai/tasks/game-finished-loading-stuck/context.md`
- `docs/ai/tasks/game-finished-loading-stuck/checklist.md`
- `docs/ai/tasks/game-over-return-flow/plan.md`
- `docs/ai/tasks/game-over-return-flow/context.md`
- `docs/ai/tasks/game-over-return-flow/checklist.md`

### 📚 참고한 기준 문서

- `AGENTS.md`
- `docs/ai/manuals/common.md`
- `docs/ai/manuals/game-runtime.md`
- `docs/rules.md`
- `docs/testing.md`

### 🧪 실행한 검증

- `npx vitest run src/pages/GamePage.test.tsx`
- `npm run ai:check:game`
- `npm run ai:self-review -- --files src/pages/GamePage.tsx src/pages/GamePage.test.tsx src/components/board/GameBoard.tsx docs/ai/tasks/game-over-return-flow/plan.md docs/ai/tasks/game-over-return-flow/context.md docs/ai/tasks/game-over-return-flow/checklist.md`
- `npm run lint`
- `npm run build`

### ⚠️ 남은 리스크

- 결과 확인 복귀는 `activeRoomId`를 복구할 수 있다는 가정 위에 동작합니다. `roomId`를 못 찾는 예외 경로는 `/lobby` fallback입니다.
- `GamePage.test.tsx`에는 기존 `act(...)` warning이 남아 있지만 테스트는 통과합니다.
- 종료 직후 백엔드 문맥 정리 타이밍 레이스가 있더라도, 이번 수정은 프론트가 로딩에 갇히거나 버튼 클릭 전 자동 이동하는 문제를 막는 범위입니다.
