### PR TITLE
fix : 게임 큐 소비 일시정지·특수 이동 애니메이션 보정 및 sync full snapshot 복구

### DIFF
--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -251,6 +251,7 @@ interface GameBoardProps {
   isGameOver?: boolean
   winnerId?: PlayerId | null
   onGameResultConfirm?: () => void
+  onBlockingModalChange?: (blocked: boolean) => void
 }
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -320,6 +321,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       isGameOver = false,
       winnerId = null,
       onGameResultConfirm,
+      onBlockingModalChange,
     },
     ref
   ) => {
@@ -472,6 +474,35 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       },
       []
     )
+    const movePlayerInstantly = useCallback(
+      async (
+        playerId: PlayerId,
+        to: number,
+        options?: {
+          holdMs?: number
+        }
+      ) => {
+        setIsMoving(true)
+        const holdMs = options?.holdMs ?? 120
+
+        setAnimatedPositions((prev) => ({
+          ...prev,
+          [String(playerId)]: to,
+        }))
+
+        if (holdMs > 0) {
+          await delay(holdMs)
+        }
+
+        setAnimatedPositions((prev) => {
+          const next = { ...prev }
+          delete next[String(playerId)]
+          return next
+        })
+        setIsMoving(false)
+      },
+      []
+    )
 
     const emitMockEndTurn = useCallback(() => {
       if (!isMockMode || !gameId) {
@@ -578,20 +609,39 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
             }
           }
 
+          const rawTrigger =
+            payloadRecord?.trigger ??
+            payloadRecord?.moveTrigger ??
+            payloadRecord?.move_trigger ??
+            eventRecord?.trigger ??
+            eventRecord?.moveTrigger ??
+            eventRecord?.move_trigger
+          const normalizedTrigger =
+            typeof rawTrigger === 'string'
+              ? rawTrigger.trim().toLowerCase()
+              : ''
+          const destinationTileType = TILES[tileIndex]?.type
+          const shouldUseInstantMove =
+            normalizedTrigger === 'move_to_island' ||
+            normalizedTrigger === 'travel' ||
+            normalizedTrigger === 'travel_select' ||
+            (normalizedTrigger === 'chance' && destinationTileType === 'ISLAND')
+          const movePromise = shouldUseInstantMove
+            ? movePlayerInstantly(event.playerId!, tileIndex, { holdMs: 120 })
+            : movePlayerSequentially(event.playerId!, fromIndex, tileIndex)
+
           // 애니메이션 시작 (비동기로 실행하여 이벤트 큐의 지연과 맞춤)
-          movePlayerSequentially(event.playerId!, fromIndex, tileIndex).then(
-            () => {
-              if (playerKey && playerKey !== 'null') {
-                lastMovePositionRef.current[playerKey] = tileIndex
-              }
-              // 애니메이션 종료 후 도착 처리 (모달 띄우기 등)
-              handleArrivalRef.current(
-                tileIndex,
-                emitMockEndTurn,
-                event.playerId ?? null
-              )
+          movePromise.then(() => {
+            if (playerKey && playerKey !== 'null') {
+              lastMovePositionRef.current[playerKey] = tileIndex
             }
-          )
+            // 애니메이션 종료 후 도착 처리 (모달 띄우기 등)
+            handleArrivalRef.current(
+              tileIndex,
+              emitMockEndTurn,
+              event.playerId ?? null
+            )
+          })
           return
         }
 
@@ -630,6 +680,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
         freezeDiceRollValues,
         flashDiceRollAnimation,
         localPlayerId,
+        movePlayerInstantly,
         movePlayerSequentially,
       ]
     )
@@ -648,15 +699,6 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       [isMockMode, freezeDiceRollValues]
     )
 
-    useBoardEventQueue({
-      enabled: true,
-      playersRef,
-      setStatus,
-      setDice1,
-      setDice2,
-      onEventAnimation: handleEventAnimation,
-      onEventConsumed: handleBoardEventConsumed,
-    })
     useEffect(() => {
       return () => {
         stopDiceRollAnimation()
@@ -963,6 +1005,9 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
 
     // 타이머 관리
     useEffect(() => {
+      stopDiceRollAnimation()
+      setDice1(1)
+      setDice2(1)
       localTimeLeftRef.current = DICE_TIMEOUT
       setIsTimerUrgent(false)
       setPromptTimerLeftSec(null)
@@ -995,7 +1040,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
           setStatus(`${p.name}님은 파산 상태입니다`)
         }
       }
-    }, [curPlayer])
+    }, [curPlayer, stopDiceRollAnimation])
 
     useEffect(() => {
       if (rolling) return
@@ -1800,22 +1845,42 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       '확인'
     )
 
-    const hasBlockingModal =
-      canShowModal &&
-      (buyModalVisible ||
-        buildModalVisible ||
-        cardModal.open ||
-        travelModal.open ||
-        tollModalOpen ||
-        acquisitionModalOpen ||
-        sellModalOpen ||
-        insufficientFundsModal.open ||
-        aiModal.open ||
-        goToIslandModal.open ||
-        islandModal.open ||
-        diceTimerModalOpen ||
-        bankruptModal.open ||
-        gameResultModal.open)
+    const hasBlockingModalOpen =
+      buyModalVisible ||
+      buildModalVisible ||
+      cardModal.open ||
+      travelModal.open ||
+      tollModalOpen ||
+      acquisitionModalOpen ||
+      sellModalOpen ||
+      insufficientFundsModal.open ||
+      aiModal.open ||
+      goToIslandModal.open ||
+      islandModal.open ||
+      diceTimerModalOpen ||
+      bankruptModal.open ||
+      gameResultModal.open
+    const hasBlockingModal = canShowModal && hasBlockingModalOpen
+    const isEventQueuePaused =
+      hasAnimationBlocking ||
+      hasBlockingModalOpen ||
+      travelSelection.active ||
+      promptSubmittingChoice !== null
+
+    useEffect(() => {
+      onBlockingModalChange?.(isEventQueuePaused)
+    }, [isEventQueuePaused, onBlockingModalChange])
+
+    useBoardEventQueue({
+      enabled: true,
+      paused: isEventQueuePaused,
+      playersRef,
+      setStatus,
+      setDice1,
+      setDice2,
+      onEventAnimation: handleEventAnimation,
+      onEventConsumed: handleBoardEventConsumed,
+    })
     const activePlayerId = players[curPlayer]?.id ?? null
     const isAssetActionPhase =
       gamePhase === 'rolling' || gamePhase === 'resolving'

--- a/src/components/board/useBoardEventQueue.ts
+++ b/src/components/board/useBoardEventQueue.ts
@@ -14,6 +14,7 @@ import {
 
 interface UseBoardEventQueueParams {
   enabled: boolean
+  paused?: boolean
   playersRef: MutableRefObject<PlayerState[]>
   setStatus: Dispatch<SetStateAction<string>>
   setDice1: Dispatch<SetStateAction<number>>
@@ -24,6 +25,7 @@ interface UseBoardEventQueueParams {
 
 export function useBoardEventQueue({
   enabled,
+  paused = false,
   playersRef,
   setStatus,
   setDice1,
@@ -52,7 +54,7 @@ export function useBoardEventQueue({
     }
 
     const consumeIfPossible = () => {
-      if (disposed || consumingRef.current) {
+      if (disposed || consumingRef.current || paused) {
         return
       }
 
@@ -127,6 +129,7 @@ export function useBoardEventQueue({
     }
   }, [
     enabled,
+    paused,
     playersRef,
     setStatus,
     setDice1,

--- a/src/hooks/game/useGameState.test.tsx
+++ b/src/hooks/game/useGameState.test.tsx
@@ -5,6 +5,7 @@ type SetupOptions = {
   accessToken: string | null
   mockEnabled?: boolean
   socketConnected?: boolean
+  localGameId?: string | null
   currentTurn?: string | number | null
   revision?: number
   playersLength?: number
@@ -20,6 +21,7 @@ async function setupUseGameState(options: SetupOptions) {
 
   const runtime = {
     accessToken: options.accessToken,
+    localGameId: options.localGameId ?? null,
     currentTurn: options.currentTurn ?? null,
     revision: options.revision ?? 0,
     playersLength: options.playersLength ?? 0,
@@ -87,6 +89,7 @@ async function setupUseGameState(options: SetupOptions) {
     ;(
       useGameStore as typeof useGameStore & {
         getState: () => {
+          gameId: string | null
           players: unknown[]
           revision: number
           phase: string
@@ -94,6 +97,7 @@ async function setupUseGameState(options: SetupOptions) {
         }
       }
     ).getState = () => ({
+      gameId: runtime.localGameId,
       players: createPlayers(runtime.playersLength),
       revision: runtime.revision,
       phase: runtime.phase,
@@ -157,6 +161,7 @@ describe('useGameState', () => {
       accessToken: 'token-1',
       mockEnabled: false,
       socketConnected: false,
+      localGameId: 'game-2',
       revision: 3,
       playersLength: 2,
     })
@@ -166,7 +171,7 @@ describe('useGameState', () => {
     expect(connectSocketWithAuthIfNeeded).toHaveBeenCalledTimes(1)
     expect(emitGameSync).toHaveBeenNthCalledWith(1, {
       gameId: 'game-2',
-      knownRevision: 0,
+      knownRevision: 3,
     })
     expect(emitGameSyncTimer).toHaveBeenCalledTimes(1)
 
@@ -209,7 +214,7 @@ describe('useGameState', () => {
     expect(connectSocketWithAuthIfNeeded).toHaveBeenCalledTimes(1)
     expect(emitGameSync).toHaveBeenCalledWith({
       gameId: 'game-3',
-      knownRevision: 0,
+      knownRevision: -1,
     })
     expect(emitGameSyncTimer).toHaveBeenCalledTimes(1)
   })
@@ -266,5 +271,23 @@ describe('useGameState', () => {
 
     expect(emitGameSync).toHaveBeenCalledTimes(1)
     expect(emitGameSyncTimer).toHaveBeenCalledTimes(1)
+  })
+
+  it('local state가 다른 게임이면 full snapshot sync를 요청한다', async () => {
+    const { useGameState, emitGameSync } = await setupUseGameState({
+      accessToken: 'token-local-mismatch',
+      mockEnabled: false,
+      socketConnected: false,
+      localGameId: 'game-old',
+      revision: 9,
+      playersLength: 4,
+    })
+
+    renderHook(() => useGameState('game-new'))
+
+    expect(emitGameSync).toHaveBeenCalledWith({
+      gameId: 'game-new',
+      knownRevision: -1,
+    })
   })
 })

--- a/src/hooks/game/useGameState.ts
+++ b/src/hooks/game/useGameState.ts
@@ -46,6 +46,7 @@ export const useGameState = (gameId: string | null) => {
     const syncGameState = ({ force = false }: { force?: boolean } = {}) => {
       const gameChanged = syncedGameIdRef.current !== gameId
       const {
+        gameId: localGameId,
         players,
         revision,
         phase: currentPhase,
@@ -56,11 +57,16 @@ export const useGameState = (gameId: string | null) => {
       }
 
       // 초기 진입에서는 같은 게임 상태를 이미 들고 있으면 중복 sync를 생략한다.
-      if (!force && !gameChanged && players.length > 0) return
+      const hasUsableLocalState =
+        localGameId != null &&
+        String(localGameId) === String(gameId) &&
+        players.length > 0
+
+      if (!force && !gameChanged && hasUsableLocalState) return
 
       emitGameSync({
         gameId,
-        knownRevision: gameChanged ? 0 : revision,
+        knownRevision: hasUsableLocalState ? revision : -1,
       })
       syncedGameIdRef.current = gameId
     }


### PR DESCRIPTION
## 📌 개요

게임 진행 중 발생하던 다음 3가지 축 문제를 한 PR에서 함께 보정했습니다.

1. 이벤트 큐가 모달/이동 중에도 소비되어 UI 흐름이 어긋나는 문제
2. 무인도 이동/국내여행 등 특수 이동이 일반 순차 이동처럼 처리되어 연출이 부자연스러운 문제
3. 새로고침/재입장 시 `game:sync`에 `knownRevision`을 잘못 보내 full snapshot을 못 받아 무한 로딩으로 이어지는 문제

---

## 🎯 문제 원인

- 보드 이벤트 큐(`eventQueue`)는 구독 즉시 소비 구조였고, 모달 오픈/프롬프트 응답 대기/애니메이션 진행 상태를 충분히 반영하지 못해 이벤트와 UI 타이밍이 엇갈렸습니다.
- `PLAYER_MOVED`를 동일 로직(순차 이동)으로 처리해 `move_to_island`, `travel_select` 같은 순간 이동성 이벤트도 한 칸 이동 연출로 표시되었습니다.
- `useGameState`에서 sync 요청 시 기존 기준이 `gameChanged ? 0 : revision`이라, 로컬 상태가 비어 있는 새로고침 케이스에도 `0`을 보내는 경우가 발생했습니다.
  - 서버 계약상 `knownRevision <= -1`이어야 full snapshot을 반환합니다.
  - 결과적으로 patch replay 경로로 들어가면서 로컬 상태가 비어 있으면 화면이 로딩에서 벗어나지 못할 수 있었습니다.

---

## 🛠 변경 사항

### 1) 이벤트 큐 소비 일시정지 지원
- 파일: `src/components/board/useBoardEventQueue.ts`
- 변경:
  - `paused?: boolean` 옵션 추가
  - `paused === true`일 때 큐 소비 중단
  - deps에 `paused` 반영

효과:
- 모달/애니메이션/프롬프트 응답 제출 중에는 큐를 멈추고, UI 블로킹 해제 후 다음 이벤트를 소비합니다.

---

### 2) GameBoard에서 큐 pause 조건 통합 + 특수 이동 즉시 처리
- 파일: `src/components/board/GameBoard.tsx`
- 변경:
  - `isEventQueuePaused` 계산 추가
    - `isMoving || rolling`
    - blocking modal open
    - travel selection active
    - prompt submitting 상태
  - `useBoardEventQueue({ paused: isEventQueuePaused })`로 연결
  - `PLAYER_MOVED` 처리 시 trigger 기반 분기 추가
    - instant move 대상:
      - `move_to_island`
      - `travel`
      - `travel_select`
      - `chance` + 목적지가 `ISLAND`
  - `movePlayerInstantly` 유틸 추가(짧은 hold 후 위치 확정)
  - 턴 변경 시 주사위 애니메이션 정리 및 주사위 face 초기화(1,1)

효과:
- 모달이 살짝 먼저 뜨거나, 이동/모달 순서가 꼬이는 현상을 줄였습니다.
- 무인도 이동/여행 계열 연출이 순차 이동의 역주행 느낌 없이 즉시 이동으로 표현됩니다.

---

### 3) sync full snapshot 복구 규칙 반영
- 파일: `src/hooks/game/useGameState.ts`
- 변경:
  - `hasUsableLocalState` 도입
    - 조건: `localGameId === gameId && players.length > 0`
  - sync 요청 기준 변경
    - usable local state 있음: `knownRevision = revision`
    - 그 외(초기 진입/재입장/다른 게임 잔존 상태): `knownRevision = -1`

효과:
- 새로고침/재입장/복구 시 서버에서 full snapshot을 받아 로딩 고정 확률을 줄입니다.

---

### 4) 회귀 방지 테스트 보강
- 파일: `src/hooks/game/useGameState.test.tsx`
- 변경:
  - store mock에 `gameId` 포함
  - 초기 sync 기대값을 새 규칙에 맞춰 갱신
  - `local state가 다른 게임일 때 knownRevision=-1` 신규 케이스 추가

---

## 📂 변경 파일

- `src/components/board/useBoardEventQueue.ts`
- `src/components/board/GameBoard.tsx`
- `src/hooks/game/useGameState.ts`
- `src/hooks/game/useGameState.test.tsx`

---

## ✅ 검증

### 자동 검증
- `npm run lint`
- `npx vitest run src/components/board/useBoardEventQueue.test.tsx`
- `npx vitest run src/components/board/gameBoardEventQueueUtils.test.ts`
- `npx vitest run src/components/board/gameBoardActionHandlers.test.ts`
- `npx vitest run src/hooks/game/useDiceRoll.test.ts`
- `npx vitest run src/hooks/game/useGameState.test.tsx`
- `npx vitest run src/pages/GamePage.test.tsx`
- `npm run build`
- push hook에서 전체 `lint/test/test:coverage` 통과

### 수동 검증 포인트
1. 찬스/이벤트 후 이동 중 모달이 이동 완료 전에 먼저 노출되지 않는지
2. 국내여행 선택 후 `서버 선택 요청` 상태에서 큐 소비가 과도하게 진행되지 않는지
3. 무인도 이동(`move_to_island`) 시 즉시 이동 연출이 적용되는지
4. 새로고침 직후 동일 게임 재입장에서 무한 로딩 없이 snapshot 복구되는지

---

## ⚠️ 리스크 및 한계

- 서버 이벤트 순서가 계약과 다르게 오면(예: prompt/patch 순서 역전) 클라이언트 단독으로 완전 보정은 어렵습니다.
- `GamePage.test.tsx`의 `act(...)` warning은 기존 이슈로 이번 변경에서 신규 발생한 실패는 아닙니다.
- mock/real 서버의 세부 이벤트 payload 차이가 큰 구간은 추가 로그 기반 관찰이 필요합니다.

---

## 🔄 롤백 전략

- 문제 시 다음 커밋 단위로 역순 롤백 가능:
  - `b69c530` (test)
  - `381b572` (sync knownRevision)
  - `8e1aa9e` (GameBoard 흐름)
  - `a83e8f8` (queue pause 훅)

---

## 🧾 관련 커밋

- `a83e8f8` feat(board): support pausing event queue consumption
- `8e1aa9e` fix(board): pause queue during modal flow and instant-move special triggers
- `381b572` fix(game-sync): request full snapshot when local game state is unusable
- `b69c530` test(game-sync): verify knownRevision uses local game identity
