### PR TITLE
fix: 특수 즉시이동 분기 제거 및 순차 이동으로 임시 원복 (머지 X)

### DIFF
--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -475,36 +475,6 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       },
       []
     )
-    const movePlayerInstantly = useCallback(
-      async (
-        playerId: PlayerId,
-        to: number,
-        options?: {
-          holdMs?: number
-        }
-      ) => {
-        setIsMoving(true)
-        const holdMs = options?.holdMs ?? 120
-
-        setAnimatedPositions((prev) => ({
-          ...prev,
-          [String(playerId)]: to,
-        }))
-
-        if (holdMs > 0) {
-          await delay(holdMs)
-        }
-
-        setAnimatedPositions((prev) => {
-          const next = { ...prev }
-          delete next[String(playerId)]
-          return next
-        })
-        setIsMoving(false)
-      },
-      []
-    )
-
     const emitMockEndTurn = useCallback(() => {
       if (!isMockMode || !gameId) {
         return
@@ -610,26 +580,11 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
             }
           }
 
-          const rawTrigger =
-            payloadRecord?.trigger ??
-            payloadRecord?.moveTrigger ??
-            payloadRecord?.move_trigger ??
-            eventRecord?.trigger ??
-            eventRecord?.moveTrigger ??
-            eventRecord?.move_trigger
-          const normalizedTrigger =
-            typeof rawTrigger === 'string'
-              ? rawTrigger.trim().toLowerCase()
-              : ''
-          const destinationTileType = TILES[tileIndex]?.type
-          const shouldUseInstantMove =
-            normalizedTrigger === 'move_to_island' ||
-            normalizedTrigger === 'travel' ||
-            normalizedTrigger === 'travel_select' ||
-            (normalizedTrigger === 'chance' && destinationTileType === 'ISLAND')
-          const movePromise = shouldUseInstantMove
-            ? movePlayerInstantly(event.playerId!, tileIndex, { holdMs: 120 })
-            : movePlayerSequentially(event.playerId!, fromIndex, tileIndex)
+          const movePromise = movePlayerSequentially(
+            event.playerId!,
+            fromIndex,
+            tileIndex
+          )
 
           // 애니메이션 시작 (비동기로 실행하여 이벤트 큐의 지연과 맞춤)
           movePromise.then(() => {
@@ -681,7 +636,6 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
         freezeDiceRollValues,
         flashDiceRollAnimation,
         localPlayerId,
-        movePlayerInstantly,
         movePlayerSequentially,
       ]
     )


### PR DESCRIPTION
**확정 나면 바로 복구 pr 머지 하겠습니다 
그전 까지는 머지 X**

---

## 📋 작업 내용

특수 이동(trigger: `move_to_island`, `travel`, `travel_select`, `chance -> island`)에서만 즉시 이동으로 분기되던 로직을 임시 원복했습니다.

- `GameBoard.tsx`에서 `movePlayerInstantly` 함수 제거
- `PLAYER_MOVED` 처리 시 trigger 종류와 관계없이 `movePlayerSequentially`만 사용하도록 변경
- 목적: 팀 합의 전(“모든 이동 순차 애니메이션”) 기준으로 임시 고정하여 연출/모달 타이밍 회귀 최소화

변경 커밋:
- `ae5075c`

---

## 📁 Task 문서 (큰 작업이면 필수)

- plan: (해당 없음, 단일 파일 임시 hotfix)
- context: (해당 없음)
- checklist: (해당 없음)

---

## 📚 참고한 기준 문서

- `AGENTS.md`
- `docs/ai/manuals/common.md`
- `docs/ai/manuals/game-runtime.md`
- `docs/rules.md`
- `docs/testing.md`

---

## ✅ 실행한 검증

- `npm run test -- src/components/board/useBoardEventQueue.test.tsx src/components/board/gameBoardEventQueueUtils.test.ts`
- `npm run lint`
- pre-push hook 통과
- `npm run test`
- `npm run test:coverage`

---

## ⚠️ 남은 리스크

- 특수 이동(무인도 이동/국내여행 선택) 연출이 즉시 이동이 아닌 순차 이동으로 동작하므로, 향후 기획/팀 합의가 “특수 이동은 즉시 이동”으로 확정되면 재조정 필요
- 본 PR은 임시 안정화 목적이며, 최종 연출 정책 확정 후 후속 PR에서 세부 분기 재적용 가능

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결(번호 입력 필요)
- [x] 참고한 기준 문서 PR 본문 기재
- [x] 실행한 검증/남은 리스크 PR 본문 기재

---

## 📸 스크린샷 (선택)

- UI 구조 변경 없음 (애니메이션 분기 로직 변경)
