### PR TITLE
fix: 국내여행 모달 선노출/보유금 부족 후 BUILD 모달 플리커 타이밍 이슈 보정

### DIFF
--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -1108,6 +1108,12 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
     }, [activePrompt, isBuyPromptOpen])
 
     useEffect(() => {
+      if (!activePrompt || !isBuildPromptOpen) {
+        setDismissedBuildPromptId(null)
+      }
+    }, [activePrompt, isBuildPromptOpen])
+
+    useEffect(() => {
       if (
         !isDiceTimerPromptOpen ||
         promptTimerLeftSec === null ||
@@ -1165,13 +1171,53 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
         return
       }
 
+      const promptPlayerId =
+        activePrompt?.playerId != null ? String(activePrompt.playerId) : null
+      const shouldDelayTravelModalOpen = shouldDelayPromptModalByMovement({
+        promptPlayerId,
+        pendingMovePlayerIdSet,
+        animatedPositions,
+        isMoving: isMoving || rolling,
+      })
+      if (shouldDelayTravelModalOpen) {
+        return
+      }
+
+      const travelPromptTileId = getPromptPayloadNumber(activePrompt, [
+        'tileId',
+        'tile_id',
+        'targetTileId',
+        'target_tile_id',
+        'toTileId',
+        'to_tile_id',
+      ])
+      const promptPlayerPosition =
+        promptPlayerId != null
+          ? players.find((player) => String(player.id) === promptPlayerId)?.pos
+          : players[curPlayer]?.pos
+      if (
+        travelPromptTileId != null &&
+        promptPlayerPosition != null &&
+        promptPlayerPosition !== travelPromptTileId
+      ) {
+        return
+      }
+
       if (!travelModal.open && !travelSelection.active) {
         setTravelModal({ open: true })
       }
     }, [
+      activePrompt,
       activePrompt?.id,
+      activePrompt?.playerId,
+      animatedPositions,
+      curPlayer,
       dismissedTravelPromptId,
       isTravelPromptOpen,
+      isMoving,
+      pendingMovePlayerIdSet,
+      players,
+      rolling,
       travelModal.open,
       travelSelection.active,
     ])
@@ -1203,6 +1249,19 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
     const [dismissedBuyPromptId, setDismissedBuyPromptId] = useState<
       string | null
     >(null)
+    const [dismissedBuildPromptId, setDismissedBuildPromptId] = useState<
+      string | null
+    >(null)
+    useEffect(() => {
+      if (
+        promptSubmittingChoice === null &&
+        dismissedBuildPromptId != null &&
+        activePrompt?.id === dismissedBuildPromptId
+      ) {
+        setDismissedBuildPromptId(null)
+      }
+    }, [activePrompt?.id, dismissedBuildPromptId, promptSubmittingChoice])
+
     const [aiModal, setAiModal] = useState<AIPenaltyModalState>({
       open: false,
       status: 'loading',
@@ -1474,6 +1533,9 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
 
     function handleInsufficientFundsConfirm() {
       const { promptChoiceValue } = insufficientFundsModal
+      if (isBuildPromptOpen && activePrompt?.id) {
+        setDismissedBuildPromptId(activePrompt.id)
+      }
       setInsufficientFundsModal(INITIAL_INSUFFICIENT_FUNDS_MODAL_STATE)
 
       submitPromptChoice(promptChoiceValue ?? null)
@@ -1832,6 +1894,8 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
 
     const isBuyPromptDismissed =
       activePrompt?.id != null && dismissedBuyPromptId === activePrompt.id
+    const isBuildPromptDismissed =
+      activePrompt?.id != null && dismissedBuildPromptId === activePrompt.id
 
     const scaledBoardSize = BOARD_RENDER_BASE_SIZE * boardScale
     const diceTimerModalOpen = !suppressDiceTimerModal && isDiceTimerPromptOpen
@@ -1856,6 +1920,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       canShowModal &&
       buildModalOpen &&
       !shouldDelayPromptModal &&
+      !isBuildPromptDismissed &&
       !insufficientFundsModal.open
     const tollModalVisible =
       canShowModal && tollModalOpen && !shouldDelayPromptModal
@@ -2463,7 +2528,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
           onConfirm={handleCardConfirm}
         />
         <TravelModal
-          open={canShowModal && travelModal.open}
+          open={canShowModal && !shouldDelayPromptModal && travelModal.open}
           onConfirm={handleTravelConfirm}
           onCancel={handleTravelCancel}
           showCancel={false}


### PR DESCRIPTION
## 🧠 Task 문서 (큰 작업이면 필수)

- plan: docs/ai/tasks/chance-move-direction-animation/plan.md
- context: docs/ai/tasks/chance-move-direction-animation/context.md
- checklist: docs/ai/tasks/chance-move-direction-animation/checklist.md

## 📋 TODO.md 연결

- task slug: chance-move-direction-animation
- TODO status: In Progress
- TODO entry 확인: TODO.md와 docs/ai/tasks/chance-move-direction-animation/가 1:1로 연결되어 있습니다.

## 📚 참고한 기준 문서

- `AGENTS.md`
- `docs/ai/manuals/common.md`
- `docs/ai/manuals/game-runtime.md`
- `docs/rules.md`
- `docs/testing.md`

## 🎯 변경 요약

이번 PR은 게임 런타임에서 체감되는 모달/애니메이션 타이밍 불일치를 줄이는 데 집중했습니다.

- 국내여행(Travel) prompt가 말 이동 연출 완료 전에 먼저 노출되는 문제를 보정했습니다.
- 보유금 부족 확인 직후 `BUILD_OR_SKIP` 모달이 0.1초가량 스치듯 다시 보였다가 닫히는 플리커를 차단했습니다.
- 서버 authoritative 흐름(이벤트 큐 소비 순서 + prompt 노출 시점)을 깨지 않도록, 화면 노출 조건만 최소 범위로 조정했습니다.

## 🔧 상세 변경 사항

### 1) Travel 모달 노출 타이밍 보정
- 파일: `src/components/board/GameBoard.tsx`
- 변경 목적: `PLAYER_MOVED` 연출 완료 전 `TRAVEL_SELECT` prompt가 먼저 렌더되어 “말이 아직 이동 중인데 모달이 먼저 뜨는” 현상 방지
- 변경 내용:
  - 이벤트 큐 상태(`isMoving`, `rolling`, pending arrival state)를 고려한 prompt 노출 지연 조건을 강화
  - 이동이 끝난 뒤에만 Travel prompt 모달이 열리도록 가드 정리
- 기대 결과:
  - 국내여행 칸 도착 시, “이동 연출 완료 → 모달 노출” 순서가 일관되게 유지됨

### 2) 보유금 부족 이후 Build 모달 플리커 제거
- 파일: `src/components/board/GameBoard.tsx`
- 변경 목적: `InsufficientFundsModal` 확인 직후 기존 `BUILD_OR_SKIP`가 순간적으로 다시 보이는 현상 제거
- 변경 내용:
  - `insufficientFundsModal` 상태와 prompt 표시 조건의 우선순위를 조정
  - 모달 visibility 계산 시 충돌 상태를 명시적으로 배제
- 기대 결과:
  - 잔액 부족 알림 확인 후 build 관련 모달이 재노출되지 않음

## 🧪 실행한 검증

- `npx eslint src/components/board/GameBoard.tsx`
- `npm run test -- src/components/board/gameBoardEventQueueUtils.test.ts src/components/board/useBoardEventQueue.test.tsx`
- `npm run test -- src/pages/GamePage.test.tsx`
- `npm run lint`
- `npm run build`
- `npx playwright test e2e/waiting-room-start-flow.spec.ts --reporter=line`

## ✅ 확인 포인트 (리뷰어 체크리스트)

- Travel prompt가 이동 연출 중 조기 노출되지 않는지
- 보유금 부족 확인 후 Build 모달 플리커가 사라졌는지
- prompt/이벤트 큐 소비 순서가 기존 계약(서버 authoritative)을 깨지 않는지
- mock/real socket 모드 모두에서 회귀가 없는지

## ⚠️ 남은 리스크

- 서버에서 동일 턴에 prompt/event 순서를 비정상적으로 빠르게 연속 발행하는 케이스가 추가되면, UI 타이밍 조건을 한 번 더 미세 조정할 수 있습니다.
- `GameBoard.tsx`가 여전히 큰 컴포넌트라 모달 가시성 조건이 분산되어 있으며, 향후 모달 라우팅 훅 분리 리팩터링이 필요합니다.
- `src/pages/GamePage.test.tsx`는 통과하지만 기존 `act(...)` warning이 일부 남아 있어, 테스트 안정성 측면에서 후속 정리가 필요합니다.
