### PR TITLE
chore: workflow docs 와 local Claude asset guardrail 정리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,6 @@ npm-debug.log*
 .cursor
 
 .agents/
+.claude/
+CLAUDE.md
 .env*

--- a/README.md
+++ b/README.md
@@ -14,3 +14,5 @@ MARBLE POP — 실시간 멀티플레이 보드게임 웹 서비스(로비/방/�
 - [AI Usage Guide](./docs/ai/usage.md): task/TODO/handoff/review 운영 루프
 - [TODO.md](./TODO.md): 현재 task queue
 - [AI Task Workspace](./docs/ai/tasks/README.md): `docs/ai/tasks/<slug>/` 작성 규칙
+- 공용 workflow SSOT: `AGENTS.md`, `docs/*`, `TODO.md`, `scripts/ai/*`
+- `CLAUDE.md`, `.claude/`, 개인 MCP/hook/IDE 설정은 로컬 전용이며 저장소에 커밋하지 않음

--- a/TODO.md
+++ b/TODO.md
@@ -13,6 +13,7 @@
 
 ## Done
 
+- [x] `ai-workflow-pr-split-guidance` - AI Workflow PR Split Guidance (`docs/ai/tasks/ai-workflow-pr-split-guidance/`) - workflow docs의 repo guardrails, PR 분할 기준, 로컬 Claude 자산 비커밋 규칙 정리
 - [x] `vendor-neutral-team-workflow-standardization` - Vendor Neutral Team Workflow Standardization (`docs/ai/tasks/vendor-neutral-team-workflow-standardization/`)
 - [x] `team-adoption-lightweight-governance` - Team Adoption Lightweight Governance (`docs/ai/tasks/team-adoption-lightweight-governance/`)
 - [x] `partial-workflow-gate-large-prs` - Partial Workflow Gate Large Prs (`docs/ai/tasks/partial-workflow-gate-large-prs/`)

--- a/docs/ai/quickstart.md
+++ b/docs/ai/quickstart.md
@@ -13,6 +13,14 @@
 5. `TODO.md`
 6. `docs/ai/tasks/README.md`
 
+## Repository Guardrails
+
+- 공용 workflow SSOT는 `AGENTS.md`, `docs/*`, `TODO.md`, `scripts/ai/*`다.
+- 비사소한 작업은 `TODO.md` 한 줄과 `docs/ai/tasks/<slug>/` 3종 문서를 1:1로 맞춘다.
+- 기존 task를 이어서 할 때는 구현 전에 `npm run ai:session:brief -- <slug>`부터 실행한다.
+- 경로별 manual loading은 `AGENTS.md`를 기준으로 하고, 항상 `docs/rules.md`, `docs/testing.md`를 함께 읽는다.
+- `CLAUDE.md`, `.claude/`, 개인 MCP/hook/IDE 설정은 로컬 전용이며 저장소 PR에 포함하지 않는다.
+
 ## Scenario 1: Small Change
 
 아래 조건이면 task 문서 없이 시작해도 된다.
@@ -126,6 +134,14 @@ EOF
 
 npm run ai:pr-gate -- --files src/pages/waiting-room/page/WaitingRoomPage.tsx src/pages/waiting-room/page/WaitingRoomFlow.test.tsx --pr-body-file /tmp/pr-body.md
 ```
+
+## PR Split Rule Of Thumb
+
+- workflow 설명이나 onboarding 정리는 `README.md`, `docs/ai/*`, task 문서 중심의 docs-only PR로 묶는다.
+- `scripts/ai/*`, `package.json`, `.github/workflows/*`처럼 실행 동작이나 gate를 바꾸는 변경은 docs-only PR과 분리한다.
+- `AGENTS.md`, `docs/ai/manuals/*`, `docs/socket-mock-server.md`처럼 manual loading이나 도메인 규칙을 바꾸는 변경은 문서/자동화 변경과 분리한다.
+- `CLAUDE.md`, `.claude/`, 개인 MCP/hook/IDE 설정은 로컬에만 두고 어떤 PR에도 포함하지 않는다.
+- 한 작업이 문서와 스크립트를 모두 건드리면, 동작 의존성이 없을 때는 docs PR을 먼저 올리고 자동화 PR을 후속으로 나눈다.
 
 ## Scenario 3: High-Risk Realtime Change
 

--- a/docs/ai/tasks/ai-workflow-pr-split-guidance/checklist.md
+++ b/docs/ai/tasks/ai-workflow-pr-split-guidance/checklist.md
@@ -1,0 +1,24 @@
+# Checklist
+
+## Implementation
+
+- [x] 관련 manual과 기존 문서를 읽었다
+- [x] 영향 범위를 정리했다
+- [x] WAT 단계와 역할 분담을 문서에 반영했다
+- [x] README, quickstart, usage에 repo guardrails와 PR split 기준을 반영했다
+- [x] `.gitignore`에 로컬 Claude 자산 ignore를 반영했다
+- [x] task workspace와 `TODO.md`를 연결했다
+
+## Testing
+
+- [x] `npm run ai:workflow:audit`
+- [x] `npm run ai:session:brief -- ai-workflow-pr-split-guidance`
+- [x] `npm run ai:self-review -- --files .gitignore README.md TODO.md docs/ai/quickstart.md docs/ai/usage.md docs/ai/tasks/ai-workflow-pr-split-guidance/plan.md docs/ai/tasks/ai-workflow-pr-split-guidance/context.md docs/ai/tasks/ai-workflow-pr-split-guidance/checklist.md`
+
+## Review
+
+- [x] `docs/rules.md` 기준으로 셀프 리뷰했다
+- [x] `TODO.md` task 한 줄을 최신 상태로 유지했다
+- [x] session handoff notes를 최신 상태로 갱신했다
+- [x] `npm run ai:session:brief -- ai-workflow-pr-split-guidance` 출력이 현재 상태와 맞는다
+- [x] 변경 파일 / 실행한 검증 / 남은 리스크를 정리했다

--- a/docs/ai/tasks/ai-workflow-pr-split-guidance/context.md
+++ b/docs/ai/tasks/ai-workflow-pr-split-guidance/context.md
@@ -1,0 +1,48 @@
+# Context
+
+## Current Behavior
+
+- `docs/ai/quickstart.md`, `docs/ai/usage.md`에는 task/TODO/handoff/validation 루프가 이미 정리되어 있다.
+- 다만 workflow 관련 변경을 어떤 PR 단위로 나눌지, 로컬 Claude 자산을 어떻게 다뤄야 할지는 문서를 처음 읽는 사람이 한눈에 찾기 어렵다.
+- 현재 워크트리에는 `CLAUDE.md`, `.claude/*`, `.gitignore` 변경이 있어 vendor-neutral 규칙과 로컬 자산 처리 기준을 더 명확히 드러낼 필요가 있다.
+
+## Related Files
+
+- `README.md`
+- `AGENTS.md`
+- `docs/ai/quickstart.md`
+- `docs/ai/usage.md`
+- `docs/ai/team-memory.md`
+- `docs/ai/tasks/README.md`
+- `.gitignore`
+- `TODO.md`
+
+## Relevant Manuals
+
+- `docs/ai/manuals/common.md`
+- `docs/rules.md`
+- `docs/testing.md`
+
+## Constraints
+
+- 저장소에는 vendor-neutral 자산만 남겨야 한다.
+- 기존 task/TODO/session brief 루프를 다시 설명하더라도 중복 설명으로 흐름을 복잡하게 만들지 않아야 한다.
+- 로컬 tool 파일 ignore는 사용자 개인 설정을 보호하는 방향이어야 하며, 팀 공용 SSOT를 대체해서는 안 된다.
+
+## Decision Notes
+
+- 새 문서를 추가하지 않고 README/quickstart/usage 앞부분에 repo guardrails와 PR split 기준을 보강한다.
+- `CLAUDE.md`, `.claude/`는 로컬 전용으로 유지하고 `.gitignore`에서 직접 제외한다.
+- PR 분할 기준은 docs-only / automation / domain manual / local-only 자산 네 가지로 정리한다.
+
+## Session Handoff Notes
+
+- 다시 읽을 문서: `README.md`, `docs/ai/quickstart.md`, `docs/ai/usage.md`, `docs/ai/team-memory.md`
+- 바로 이어서 할 단계: docs-only PR 설명을 작성하거나 후속 automation/manual PR이 필요한지 판단한다.
+- pending decision: 없음
+- 검증 재개 지점: 필요 시 `npm run ai:self-review -- --files .gitignore README.md TODO.md docs/ai/quickstart.md docs/ai/usage.md docs/ai/tasks/ai-workflow-pr-split-guidance/plan.md docs/ai/tasks/ai-workflow-pr-split-guidance/context.md docs/ai/tasks/ai-workflow-pr-split-guidance/checklist.md`
+
+## Open Risks
+
+- quickstart와 usage에 비슷한 내용이 추가되므로 표현이 어긋나면 혼선을 만들 수 있다.
+- `.gitignore`가 로컬 tool 파일만 제외하도록 유지되는지 최종 diff에서 다시 확인해야 한다.

--- a/docs/ai/tasks/ai-workflow-pr-split-guidance/plan.md
+++ b/docs/ai/tasks/ai-workflow-pr-split-guidance/plan.md
@@ -1,0 +1,68 @@
+# Plan
+
+## Task
+
+- 작업 이름: AI Workflow PR Split Guidance
+- 작업 slug: ai-workflow-pr-split-guidance
+- 요청 날짜: 2026-03-23
+- 담당 범위: workflow 문서의 repo guardrails/PR 분할 기준 보강, 로컬 Claude 자산 비커밋 정렬
+
+## Goal
+
+- 새 팀원이 workflow 변경을 어떤 단위로 PR로 나눌지 바로 판단할 수 있게 하고, 로컬 Claude 자산이 공용 저장소로 들어오지 않도록 운영 규칙을 더 앞쪽 문서에 드러낸다.
+
+## WAT Workflow
+
+1. 기존 workflow 문서와 vendor-neutral 규칙을 다시 확인한다.
+2. README, quickstart, usage에 repo guardrails와 PR split 기준을 최소 범위로 반영한다.
+3. 로컬 Claude 자산 ignore를 정렬하고 task/TODO/validation 상태를 맞춘다.
+
+## In Scope
+
+- `README.md`에 SSOT와 로컬 tool 파일 비커밋 규칙 추가
+- `docs/ai/quickstart.md`에 repo guardrails와 PR split 기준 추가
+- `docs/ai/usage.md`에 repo guardrails와 PR split guidelines 추가
+- `.gitignore`에 `CLAUDE.md`, `.claude/` 로컬 ignore 반영
+- task workspace와 `TODO.md` 정합성 유지
+
+## Out Of Scope
+
+- `scripts/ai/*` 동작 변경
+- GitHub workflow / gate 로직 변경
+- 제품 코드 또는 도메인 manual의 계약 수정
+
+## Target Files
+
+- `.gitignore`
+- `README.md`
+- `TODO.md`
+- `docs/ai/quickstart.md`
+- `docs/ai/usage.md`
+- `docs/ai/tasks/ai-workflow-pr-split-guidance/plan.md`
+- `docs/ai/tasks/ai-workflow-pr-split-guidance/context.md`
+- `docs/ai/tasks/ai-workflow-pr-split-guidance/checklist.md`
+
+## Task Tracking
+
+- TODO line: - [x] `ai-workflow-pr-split-guidance` - AI Workflow PR Split Guidance (`docs/ai/tasks/ai-workflow-pr-split-guidance/`)
+- Session brief: `npm run ai:session:brief -- ai-workflow-pr-split-guidance`
+- Reopen docs: `docs/ai/tasks/ai-workflow-pr-split-guidance/plan.md`, `context.md`, `checklist.md`, `docs/ai/quickstart.md`, `docs/ai/usage.md`
+
+## Completion Criteria
+
+- README/quickstart/usage를 읽으면 workflow 변경을 docs-only PR / automation PR / manual PR / local-only 자산으로 나누는 기준이 드러난다.
+- `CLAUDE.md`, `.claude/`가 로컬 전용이라는 규칙이 문서와 ignore 양쪽에서 일관되게 보인다.
+- `TODO.md`와 task workspace, session brief 출력이 현재 상태와 맞는다.
+
+## Role Plan
+
+- Planner: 범위와 PR 분할 기준을 정리
+- Implementer: README/quickstart/usage/.gitignore 최소 범위 수정
+- Reviewer: vendor-neutral 규칙과 문서 간 일관성 확인
+- Tester: workflow audit, session brief, self-review 결과 확인
+
+## Test Plan
+
+- `npm run ai:workflow:audit`
+- `npm run ai:session:brief -- ai-workflow-pr-split-guidance`
+- `npm run ai:self-review -- --files .gitignore README.md TODO.md docs/ai/quickstart.md docs/ai/usage.md docs/ai/tasks/ai-workflow-pr-split-guidance/plan.md docs/ai/tasks/ai-workflow-pr-split-guidance/context.md docs/ai/tasks/ai-workflow-pr-split-guidance/checklist.md`

--- a/docs/ai/usage.md
+++ b/docs/ai/usage.md
@@ -13,6 +13,12 @@
 6. `TODO.md`
 7. `docs/ai/tasks/README.md`
 
+## Repository Guardrails
+
+- 공용 workflow SSOT는 `AGENTS.md`, `docs/*`, `TODO.md`, `scripts/ai/*`다.
+- `CLAUDE.md`, `.claude/`, 개인 MCP/hook/IDE 설정 같은 tool-specific runtime file은 로컬 전용으로 두고 저장소에 커밋하지 않는다.
+- 경로별 manual loading 판단은 `AGENTS.md`를 기준으로 하고, 공통 품질 기준은 `docs/rules.md`, `docs/testing.md`를 우선한다.
+
 ## Core Loop
 
 1. `AGENTS.md`, 관련 manual, `docs/rules.md`, `docs/testing.md`를 읽는다.
@@ -27,6 +33,14 @@
 - 새 task는 `npm run ai:task:new -- <slug> [--files ...]`로 만들 수 있다.
 - 다시 시작할 때는 `npm run ai:session:brief -- <slug>`로 읽을 문서, 다음 단계, 검증 후보를 먼저 확인한다.
 - 한 세션에는 가능한 한 한 feature만 다룬다.
+
+## PR Split Guidelines
+
+- workflow 설명, onboarding, task template, PR 본문 예시 같은 문서 변경은 docs-only PR로 묶는다.
+- `scripts/ai/*`, `package.json`, `.github/workflows/*`가 바뀌면 실행 동작과 gate 영향이 있으므로 docs-only PR과 분리한다.
+- `AGENTS.md`, `docs/ai/manuals/*`, `docs/socket-mock-server.md`처럼 manual loading이나 도메인 규칙을 바꾸는 변경은 문서/자동화 변경과 분리한다.
+- `CLAUDE.md`, `.claude/`, 개인 MCP/hook/IDE 설정은 로컬 자산으로 유지하고 어떤 PR에도 포함하지 않는다.
+- 문서와 스크립트를 함께 바꿔야 하는 작업이면, 먼저 docs PR로 의도와 운영 기준을 고정하고 후속 PR에서 자동화를 보강한다.
 
 ## Daily Operating Rhythm
 


### PR DESCRIPTION
  ## 📌 관련 이슈

  > closes #578 

  ---

  ## 📝 작업 내용

  workflow 문서에서 새 팀원이 바로 따라야 하는 repo guardrail과 PR 분할 기준을 더 앞쪽에 드러냈습니다.
  또한 `CLAUDE.md`, `.claude/`를 로컬 전용 자산으로 정리해 공용 저장소 변경과 섞이지 않도록 했습니다.

  ---

  ## 🧠 Task 문서 (큰 작업이면 필수)

  - plan: docs/ai/tasks/ai-workflow-pr-split-guidance/plan.md
  - context: docs/ai/tasks/ai-workflow-pr-split-guidance/context.md
  - checklist: docs/ai/tasks/ai-workflow-pr-split-guidance/checklist.md

  ---

  ## 📋 TODO.md 연결

  - task slug: ai-workflow-pr-split-guidance
  - TODO status: Done
  - TODO entry 확인: TODO.md와 docs/ai/tasks/ai-workflow-pr-split-guidance/가 1:1로 연결됨

  ---

  ## 📚 참고한 기준 문서

  - `AGENTS.md`
  - `docs/rules.md`
  - `docs/testing.md`
  - `docs/ai/manuals/common.md`

  ---

  ## 🧪 실행한 검증

  - `npm run ai:workflow:audit`
  - `npm run ai:session:brief -- ai-workflow-pr-split-guidance`
  - `npm run ai:self-review -- --files .gitignore README.md TODO.md docs/ai/quickstart.md docs/ai/usage.md docs/ai/tasks/ai-workflow-pr-
  split-guidance/plan.md docs/ai/tasks/ai-workflow-pr-split-guidance/context.md docs/ai/tasks/ai-workflow-pr-split-guidance/checklist.md`
  - `npm run lint`
  - `npm run test`
  - `npm run test:coverage`
  - `npm run e2e:ci`
  - `npm run build`

  ---

  ## ⚠️ 남은 리스크

  - `docs/ai/quickstart.md`와 `docs/ai/usage.md`에 유사한 운영 문구가 있어, 이후 workflow 규칙 변경 시 두 문서를 함께 갱신해야 합니다.
  - pre-push 검증 중 `src/pages/GamePage.test.tsx` 계열의 `act(...)` warning이 비차단 상태로 출력되지만, 테스트/커버리지/E2E/빌드는 모두 통
  과했습니다.

  ---

  ## ✅ 체크리스트

  - [x] 로컬에서 정상 동작 확인
  - [x] 불필요한 console.log 제거
  - [x] 관련 이슈 연결 완료
  - [x] 큰 작업이면 task 문서 링크를 남겼다
  - [x] 큰 작업이면 `TODO.md` / task slug 연결을 PR 본문에 남겼다
  - [x] 참고한 기준 문서를 PR 본문에 남겼다
  - [x] 실행한 검증과 남은 리스크를 PR 본문에 적었다

  ---

  ## 📸 스크린샷 (선택)

  해당 없음