### PR TITLE
fix: 플레이어 말 위에 숫자가 표시되는 UI 이슈해결

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -13,6 +13,8 @@
 
 ## Done
 
+- [x] `player-token-ui-fix` - Player Token UI Fix (`docs/ai/tasks/player-token-ui-fix/`) - 플레이어 말 위 숫자 표시 제거
+
 - [x] `global-effect-ui` - Global Effect UI (`docs/ai/tasks/global-effect-ui/`) - 전역 효과 보드 오버레이 및 팝업 신규 추가
 - [x] `island-modal-text-fix` - Island Modal Text Fix (`docs/ai/tasks/island-modal-text-fix/`) - 무인도 팝업 문항 고정 및 남은 턴수 상시 표시
 - [x] `blue-marble-cheatsheet-refresh` - Blue Marble Cheatsheet Refresh (`docs/ai/tasks/blue-marble-cheatsheet-refresh/`) - 일반 Claude Code 치트시트를 프로젝트 전용 운영 가이드로 재작성

--- a/docs/ai/tasks/player-token-ui-fix/checklist.md
+++ b/docs/ai/tasks/player-token-ui-fix/checklist.md
@@ -1,0 +1,12 @@
+# checklist
+
+## 구현
+
+- [x] `PlayerToken`에서 숫자(`player.id + 1`) 렌더링 제거
+- [x] 섬 아이콘(🏝️) 및 skipTurns 배지 유지 확인
+
+## 검증
+
+- [x] 로컬 dev 서버에서 플레이어 말에 숫자 미표시 육안 확인
+- [x] `npm run lint` 통과
+- [x] `git push` pre-push 훅(E2E + build) 통과

--- a/docs/ai/tasks/player-token-ui-fix/context.md
+++ b/docs/ai/tasks/player-token-ui-fix/context.md
@@ -1,0 +1,16 @@
+# context
+
+## 배경
+
+게임 서버 접속 시 플레이어 말(원형 토큰) 안에 플레이어 번호(1·2·3·4)가 표시되어 시각적으로 불필요한 정보를 노출하였다.
+
+## 영향 파일
+
+| 파일                                 | 변경 내용                                       |
+| ------------------------------------ | ----------------------------------------------- |
+| `src/components/board/BoardTile.tsx` | PlayerToken 내 `player.id + 1` 숫자 렌더링 제거 |
+
+## 참고
+
+- 섬(🏝️) 아이콘과 skipTurns 배지는 유지
+- `docs/ai/manuals/game-runtime.md` 경로 기준 high-risk 파일이므로 Workflow Gate 적용

--- a/docs/ai/tasks/player-token-ui-fix/plan.md
+++ b/docs/ai/tasks/player-token-ui-fix/plan.md
@@ -1,0 +1,13 @@
+# plan
+
+TODO line: `player-token-ui-fix`
+Session brief: 플레이어 말 내부에 표시되던 id+1 숫자를 제거하는 순수 UI 수정
+
+## 목표
+
+`BoardTile.tsx`의 `PlayerToken` 컴포넌트에서 플레이어 번호 숫자 렌더링을 제거한다.
+
+## 변경 범위
+
+- `src/components/board/BoardTile.tsx` — PlayerToken 내 숫자 렌더링 조건식 제거
+- 소켓·스토어·게임 로직 변경 없음

--- a/src/components/board/BoardTile.tsx
+++ b/src/components/board/BoardTile.tsx
@@ -47,6 +47,7 @@ export const PlayerToken = React.memo<TokenProps>(
           borderRadius: '50%',
           backgroundColor: player.color,
           border: '2.5px solid white',
+
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
@@ -57,13 +58,7 @@ export const PlayerToken = React.memo<TokenProps>(
           boxShadow: '0 2px 6px rgba(0,0,0,0.35)',
         }}
       >
-        {isIsland ? (
-          <span style={{ fontSize: 10 }}>🏝️</span>
-        ) : typeof player.id === 'number' ? (
-          player.id + 1
-        ) : (
-          player.id
-        )}
+        {isIsland && <span style={{ fontSize: 10 }}>🏝️</span>}
         {(player.skipTurns ?? 0) > 0 && (
           <div
             style={{


### PR DESCRIPTION
## 📌 관련 이슈

> closes #585


---

## 📝 작업 내용

게임 보드에서 플레이어 말(PlayerToken) 내부에 표시되던 플레이어 번호 숫자(player.id + 1)를 제거했습니다.

- BoardTile.tsx > PlayerToken 컴포넌트에서 숫자 렌더링 로직 제거
- 섬 감금 상태 아이콘(🏝️)과 skipTurns 배지는 그대로 유지
- 단일 컴포넌트, 단일 파일의 UI 표시 변경으로 기능·소켓 계약·스토어에 영향 없음

---

## 🧠 Task 문서 (큰 작업이면 필수)

- plan: docs/ai/tasks/player-token-ui-fix/plan.md
- context: docs/ai/tasks/player-token-ui-fix/context.md
- checklist: docs/ai/tasks/player-token-ui-fix/checklist.md

---

## 📋 TODO.md 연결

- task slug: player-token-ui-fix
- TODO status: Done
- TODO entry 확인: player-token-ui-fix — 플레이어 말 숫자 표시 제거

---

## 📚 참고한 기준 문서

- AGENTS.md
- docs/rules.md
- docs/testing.md
- docs/ai/manuals/game-runtime.md


---

## 🧪 실행한 검증


- 로컬 개발 서버(npm run dev) 에서 게임 보드 진입 후 플레이어 말에 숫자가 표시되지 않음을 육안 확인
- npm run lint

---

## ⚠️ 남은 리스크

 - 현재 확인된 추가 리스크는 없습니다.

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료
- [x] 큰 작업이면 task 문서 링크를 남겼다
- [x] 큰 작업이면 `TODO.md` / task slug 연결을 PR 본문에 남겼다
- [x] 참고한 기준 문서를 PR 본문에 남겼다
- [x] 실행한 검증과 남은 리스크를 PR 본문에 적었다

---

## 📸 스크린샷 (선택)

<img width="1561" height="858" alt="스크린샷 2026-03-23 오후 5 03 15" src="https://github.com/user-attachments/assets/a1d9ad22-bcb3-4a73-9ea0-0c9645921e38" />

