### PR TITLE
fix: 실서버 global effect snapshot/patch alias 정규화 보강

### DIFF
--- a/src/services/socket/gameContractAdapters.test.ts
+++ b/src/services/socket/gameContractAdapters.test.ts
@@ -228,6 +228,34 @@ describe('gameContractAdapters', () => {
     })
   })
 
+  it('normalizes active global effect from snapshot aliases', () => {
+    const normalized = normalizeSnapshotPayload(
+      {
+        gameId: 'game-global-effect',
+        revision: 18,
+        phase: 'RESOLVING',
+        players: [],
+        tiles: [],
+        active_global_effect: {
+          effect: 'pandemic',
+          type: 'toll_multiplier',
+          duration: '3',
+          multiplier: '0.5',
+          description: '통행료가 50%로 감소합니다.',
+        },
+      },
+      { envelopeRevision: 18 }
+    )
+
+    expect(normalized?.activeGlobalEffect).toEqual({
+      effect: 'PANDEMIC',
+      type: 'TOLL_MULTIPLIER',
+      duration: 3,
+      multiplier: 0.5,
+      description: '통행료가 50%로 감소합니다.',
+    })
+  })
+
   it('normalizes game over snapshot aliases and infers isGameOver from finished phase', () => {
     const normalized = normalizeSnapshotPayload(
       {
@@ -654,6 +682,51 @@ describe('gameContractAdapters', () => {
         op: 'set',
         path: 'gameResult',
         value: { reason: 'round_limit', rankings: undefined, winner: null },
+      },
+    ])
+  })
+
+  it('normalizes patch aliases for active global effect fields', () => {
+    const normalized = normalizePatchEnvelopePayload({
+      gameId: 'game-global-effect-patch',
+      revision: 92,
+      patch: [
+        {
+          op: 'set',
+          path: 'active_global_effect',
+          value: {
+            effect: 'festival',
+            type: 'toll_multiplier',
+            duration: '2',
+            multiplier: '2',
+            description: '통행료가 2배로 증가합니다.',
+          },
+        },
+        {
+          op: 'set',
+          path: 'active_global_effect.duration',
+          value: '1',
+        },
+      ],
+      events: [],
+    })
+
+    expect(normalized.patch).toEqual([
+      {
+        op: 'set',
+        path: 'activeGlobalEffect',
+        value: {
+          effect: 'FESTIVAL',
+          type: 'TOLL_MULTIPLIER',
+          duration: 2,
+          multiplier: 2,
+          description: '통행료가 2배로 증가합니다.',
+        },
+      },
+      {
+        op: 'set',
+        path: 'activeGlobalEffect.duration',
+        value: 1,
       },
     ])
   })

--- a/src/services/socket/gameContractAdapters.ts
+++ b/src/services/socket/gameContractAdapters.ts
@@ -1,4 +1,5 @@
 import type {
+  GlobalEffectState,
   GamePatchEnvelope,
   GamePatchOperation,
   GamePrompt,
@@ -82,6 +83,18 @@ const PLAYER_STATE_TO_INTERNAL_MAP: Record<string, Player['state']> = {
   LOCKED: 'locked',
   BANKRUPT: 'bankrupt',
 }
+
+const GLOBAL_EFFECT_ENUM_VALUES = [
+  'PANDEMIC',
+  'FESTIVAL',
+  'INFLATION',
+  'DEFLATION',
+] as const
+
+const GLOBAL_EFFECT_MODE_ENUM_VALUES = [
+  'TOLL_MULTIPLIER',
+  'PRICE_MULTIPLIER',
+] as const
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null
@@ -301,6 +314,114 @@ export const normalizePhase = (phase: unknown): GameSnapshot['phase'] => {
 
   const normalizedPhase = phase.trim().toUpperCase()
   return PHASE_TO_INTERNAL_MAP[normalizedPhase] ?? 'waiting'
+}
+
+const normalizeGlobalEffectEnum = (
+  value: unknown
+): GlobalEffectState['effect'] | null => {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    return null
+  }
+
+  const normalized = value.trim().toUpperCase()
+  if (
+    GLOBAL_EFFECT_ENUM_VALUES.includes(
+      normalized as (typeof GLOBAL_EFFECT_ENUM_VALUES)[number]
+    )
+  ) {
+    return normalized as GlobalEffectState['effect']
+  }
+
+  return null
+}
+
+const normalizeGlobalEffectMode = (
+  value: unknown
+): GlobalEffectState['type'] | null => {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    return null
+  }
+
+  const normalized = value.trim().toUpperCase()
+  if (
+    GLOBAL_EFFECT_MODE_ENUM_VALUES.includes(
+      normalized as (typeof GLOBAL_EFFECT_MODE_ENUM_VALUES)[number]
+    )
+  ) {
+    return normalized as GlobalEffectState['type']
+  }
+
+  return null
+}
+
+const resolveDefaultGlobalEffectMode = (
+  effect: GlobalEffectState['effect']
+): GlobalEffectState['type'] =>
+  effect === 'PANDEMIC' || effect === 'FESTIVAL'
+    ? 'TOLL_MULTIPLIER'
+    : 'PRICE_MULTIPLIER'
+
+const resolveDefaultGlobalEffectMultiplier = (
+  effect: GlobalEffectState['effect']
+) => (effect === 'PANDEMIC' || effect === 'DEFLATION' ? 0.5 : 2)
+
+const normalizeGlobalEffectPayload = (
+  effectPayload: unknown
+): GlobalEffectState | null => {
+  if (!isRecord(effectPayload)) {
+    return null
+  }
+
+  const normalizedEffect =
+    normalizeGlobalEffectEnum(
+      effectPayload.effect ??
+        effectPayload.effectType ??
+        effectPayload.effect_type ??
+        effectPayload.globalEffect ??
+        effectPayload.global_effect
+    ) ??
+    normalizeGlobalEffectEnum(effectPayload.type) ??
+    null
+
+  if (!normalizedEffect) {
+    return null
+  }
+
+  const normalizedMode =
+    normalizeGlobalEffectMode(
+      effectPayload.type ??
+        effectPayload.effectMode ??
+        effectPayload.effect_mode ??
+        effectPayload.mode
+    ) ?? resolveDefaultGlobalEffectMode(normalizedEffect)
+
+  const durationRaw = toFiniteNumber(
+    effectPayload.duration ??
+      effectPayload.remainingRounds ??
+      effectPayload.remaining_rounds ??
+      effectPayload.remainingTurns ??
+      effectPayload.remaining_turns
+  )
+  const multiplierRaw = toFiniteNumber(
+    effectPayload.multiplier ??
+      effectPayload.factor ??
+      effectPayload.rate ??
+      effectPayload.value
+  )
+
+  return {
+    type: normalizedMode,
+    effect: normalizedEffect,
+    duration: durationRaw != null ? Math.max(0, Math.trunc(durationRaw)) : 3,
+    multiplier:
+      multiplierRaw != null
+        ? multiplierRaw
+        : resolveDefaultGlobalEffectMultiplier(normalizedEffect),
+    description:
+      toStringOrNull(
+        effectPayload.description ?? effectPayload.message ?? effectPayload.text
+      ) ?? `${normalizedEffect} effect is active.`,
+  }
 }
 
 export const normalizePromptChoiceValue = (choice: unknown): string =>
@@ -793,6 +914,12 @@ export const normalizeSnapshotPayload = (
         snapshotPayload.pending_prompt ??
         snapshotPayload.pendingPrompt
     ),
+    activeGlobalEffect: normalizeGlobalEffectPayload(
+      snapshotPayload.activeGlobalEffect ??
+        snapshotPayload.active_global_effect ??
+        snapshotPayload.globalEffect ??
+        snapshotPayload.global_effect
+    ),
     gameResult: normalizedGameResult,
     isGameOver: normalizedIsGameOver,
     winnerId: normalizedWinnerId,
@@ -842,6 +969,9 @@ const normalizePathSegment = (segment: string | number): string | number => {
   if (segment === 'winner_id') return 'winnerId'
   if (segment === 'is_game_over') return 'isGameOver'
   if (segment === 'game_result') return 'gameResult'
+  if (segment === 'active_global_effect') return 'activeGlobalEffect'
+  if (segment === 'global_effect') return 'activeGlobalEffect'
+  if (segment === 'globalEffect') return 'activeGlobalEffect'
   if (segment === 'building_level') return 'building'
   if (segment === 'buildingLevel') return 'building'
   if (segment === 'tile_type') return 'type'
@@ -908,6 +1038,10 @@ const normalizePatchSetValue = (
     return normalizePromptPayload(value)
   }
 
+  if (pathSegments.length === 1 && firstSegment === 'activeGlobalEffect') {
+    return normalizeGlobalEffectPayload(value)
+  }
+
   if (
     pathSegments.length === 2 &&
     firstSegment === 'players' &&
@@ -940,6 +1074,25 @@ const normalizePatchSetValue = (
 
   if (lastSegment === 'position') {
     return toFiniteInt(value, 0)
+  }
+
+  if (lastSegment === 'duration' && pathSegments[0] === 'activeGlobalEffect') {
+    return Math.max(0, toFiniteInt(value, 0))
+  }
+
+  if (
+    lastSegment === 'multiplier' &&
+    pathSegments[0] === 'activeGlobalEffect'
+  ) {
+    return toFiniteNumber(value) ?? 1
+  }
+
+  if (lastSegment === 'effect' && pathSegments[0] === 'activeGlobalEffect') {
+    return normalizeGlobalEffectEnum(value) ?? value
+  }
+
+  if (lastSegment === 'type' && pathSegments[0] === 'activeGlobalEffect') {
+    return normalizeGlobalEffectMode(value) ?? value
   }
 
   if (lastSegment === 'balance') {


### PR DESCRIPTION
## 🧠 Task 문서 (큰 작업이면 필수)

- plan: docs/ai/tasks/chance-move-direction-animation/plan.md
- context: docs/ai/tasks/chance-move-direction-animation/context.md
- checklist: docs/ai/tasks/chance-move-direction-animation/checklist.md

## 📋 TODO.md 연결

- task slug: chance-move-direction-animation
- TODO status: In Progress
- TODO entry 확인: TODO.md에 task slug가 등록되어 있고 task 문서 3종과 연결되어 있습니다.

## 📚 참고한 기준 문서

- `AGENTS.md`
- `docs/ai/manuals/common.md`
- `docs/ai/manuals/game-runtime.md`
- `docs/rules.md`
- `docs/testing.md`

## 📌 변경 목적

실서버 기준 전역 효과(Global Effect) 데이터가 들어와도 프론트에서 누락되지 않도록
socket adapter 정규화 경로를 보강했습니다.

## 🔧 변경 사항

- `src/services/socket/gameContractAdapters.ts`
  - snapshot 정규화 시 아래 필드를 `activeGlobalEffect`로 통합 매핑
    - `activeGlobalEffect`
    - `active_global_effect`
    - `globalEffect`
    - `global_effect`
  - patch path alias 정규화 추가
    - `active_global_effect` → `activeGlobalEffect`
    - `global_effect` → `activeGlobalEffect`
    - `globalEffect` → `activeGlobalEffect`
  - 전역효과 객체 정규화 로직 추가
    - effect: `PANDEMIC/FESTIVAL/INFLATION/DEFLATION`
    - mode(type): `TOLL_MULTIPLIER/PRICE_MULTIPLIER`
    - duration/multiplier/description 정규화 및 fallback 처리

- `src/services/socket/gameContractAdapters.test.ts`
  - snapshot alias 케이스 추가
  - patch alias 케이스 추가

## 🧪 실행한 검증

- `npm run test -- src/services/socket/gameContractAdapters.test.ts`
- `npx eslint src/services/socket/gameContractAdapters.ts src/services/socket/gameContractAdapters.test.ts`
- `npm run lint`
- `npm run build`

## ⚠️ 남은 리스크

- 실서버가 전역효과 필드에 추가 enum 또는 다른 키 구조를 도입하면 adapter 보강이 필요합니다.
- 현재는 adapter 정규화 중심 수정이며, 전역효과 UI 연출 디테일(아이콘 애니메이션/사운드)은 후속 PR에서 다룹니다.
