### PR TITLE
fix: 마이페이지 뒤로가기 클릭 영역 수정

### DIFF
--- a/src/pages/MyPage.test.tsx
+++ b/src/pages/MyPage.test.tsx
@@ -65,6 +65,45 @@ describe('MyPage', () => {
     expect(getMyPageProfileMock).not.toHaveBeenCalled()
   })
 
+  it('뒤로가기는 원형 아이콘 버튼에만 연결되고 제목 텍스트는 버튼에 포함되지 않는다', async () => {
+    const user = userEvent.setup()
+
+    useAuthStore.setState({
+      hasHydrated: true,
+      session: createAuthSessionFixture({
+        userId: 'user-1',
+        nickname: '헤더유저',
+        isGuest: false,
+        provider: 'kakao',
+      }),
+    })
+    getMyPageProfileMock.mockResolvedValue({
+      ok: true,
+      profile: {
+        id: 'user-1',
+        nickname: '헤더유저',
+        profileImage: null,
+        stats: {
+          total: 3,
+          wins: 2,
+          losses: 1,
+        },
+      },
+    })
+
+    renderWithProviders(<MyPage />, {
+      initialEntries: ['/my-page'],
+    })
+
+    expect(
+      screen.queryByRole('button', { name: '내 정보' })
+    ).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: '로비로 돌아가기' }))
+
+    expect(navigateMock).toHaveBeenCalledWith('/lobby')
+  })
+
   it('카카오 사용자는 마이페이지에서 닉네임을 변경하고 즉시 반영한다', async () => {
     const user = userEvent.setup()
     useAuthStore.setState({

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -78,15 +78,16 @@ function MyPage() {
         <button
           type="button"
           onClick={() => navigate('/lobby')}
-          className="inline-flex items-center gap-2 rounded-xl px-2 py-1 text-ui-text-primary transition-colors hover:bg-ui-surface-muted"
+          aria-label="로비로 돌아가기"
+          className="inline-flex items-center justify-center rounded-xl p-1 text-ui-text-primary transition-colors hover:bg-ui-surface-muted"
         >
           <span className="flex size-9 items-center justify-center rounded-full border border-ui-border bg-ui-surface-soft">
             <ArrowLeft className="size-4" />
           </span>
-          <span className="text-xl font-bold leading-none text-ui-text-strong">
-            내 정보
-          </span>
         </button>
+        <span className="ml-2 text-xl font-bold leading-none text-ui-text-strong">
+          내 정보
+        </span>
       </header>
 
       <main className="relative mx-auto max-w-5xl px-4 py-8 sm:px-6">


### PR DESCRIPTION
## 📌 관련 이슈

> closes #600

---

## 📝 작업 내용

- 마이페이지 헤더에서 뒤로가기 버튼과 `내 정보` 텍스트를 분리했습니다.
- 뒤로가기 클릭 영역을 원형 아이콘 버튼으로 제한하고, 버튼 접근성 이름을 `로비로 돌아가기`로 명시했습니다.
- 헤더 제목이 버튼에 포함되지 않는지와 뒤로가기 이동 동작을 검증하는 테스트를 추가했습니다.

---

## 🧠 Task 문서 (큰 작업이면 필수)

- plan: N/A
- context: N/A
- checklist: N/A

---

## 📋 TODO.md 연결

- task slug: N/A
- TODO status: N/A
- TODO entry 확인: N/A

---

## 📚 참고한 기준 문서

- `AGENTS.md`
- `docs/ai/manuals/common.md`
- `docs/rules.md`
- `docs/testing.md`

---

## 🧪 실행한 검증

- `npx vitest run src/pages/MyPage.test.tsx`
- `npm run ai:self-review`
- `npm run lint`
- `npm run build`

---

## ⚠️ 남은 리스크

- 현재 확인된 추가 리스크는 없습니다.

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료
- [ ] 큰 작업이면 task 문서 링크를 남겼다
- [ ] 큰 작업이면 `TODO.md` / task slug 연결을 PR 본문에 남겼다
- [x] 참고한 기준 문서를 PR 본문에 남겼다
- [x] 실행한 검증과 남은 리스크를 PR 본문에 적었다

---

## 📸 스크린샷 (선택)

> UI 변경이 있을 경우 첨부해주세요.
