### PR TITLE
feat: 현재 라운드 추가 완료

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -15,6 +15,8 @@
 
 ## Done
 
+- [x] `round-counter` - Round Counter (`docs/ai/tasks/round-counter/`) - 보드판 위 상태 알람에 현재 라운드 번호 표시 추가
+
 - [x] `player-token-ui-fix` - Player Token UI Fix (`docs/ai/tasks/player-token-ui-fix/`) - 플레이어 말 위 숫자 표시 제거
 
 - [x] `global-effect-ui` - Global Effect UI (`docs/ai/tasks/global-effect-ui/`) - 전역 효과 보드 오버레이 및 팝업 신규 추가

--- a/docs/ai/tasks/round-counter/checklist.md
+++ b/docs/ai/tasks/round-counter/checklist.md
@@ -1,0 +1,15 @@
+# round-counter — Checklist
+
+## 구현
+
+- [x] `GameBoardProps`에 `round?: number` 추가
+- [x] `GameBoard` 구조분해에 `round` 추가
+- [x] 턴 변경 `useEffect`에서 `roundLabel` 계산 후 status에 포함
+- [x] `useEffect` 의존성 배열에 `round` 추가
+- [x] `GamePage.tsx`에서 `<BoardGame round={round} />` 전달
+
+## 검증
+
+- [x] `npm run lint` 통과
+- [x] pre-push: `npm run build` 통과
+- [x] pre-push: `npm run e2e:ci` 3건 통과

--- a/docs/ai/tasks/round-counter/context.md
+++ b/docs/ai/tasks/round-counter/context.md
@@ -1,0 +1,11 @@
+# round-counter — Context
+
+## 배경
+
+- `GameSnapshot.round`는 서버에서 매 스냅샷마다 내려오는 현재 라운드 번호다.
+- 기존에 `GamePage.tsx`에서 `round`를 store에서 읽고 있었으나 1라운드 안내 문구 숨기기 용도로만 사용했다.
+- `GameBoard.tsx`의 `board-status` 배너는 현재 플레이어 상태(섬/대기/파산)만 표시했다.
+
+## 변경 동기
+
+플레이어가 게임 중 현재 몇 라운드인지 알 수 없어서, 매 턴 전환 시 보드 위 알람에 라운드 번호를 추가한다.

--- a/docs/ai/tasks/round-counter/plan.md
+++ b/docs/ai/tasks/round-counter/plan.md
@@ -1,0 +1,16 @@
+# round-counter — Plan
+
+## 목표
+
+보드판 위 상태 알람(`board-status`)에 현재 라운드 번호를 표시한다.
+
+## 변경 범위
+
+- `src/components/board/GameBoard.tsx` — `round?: number` prop 추가, status 알람 텍스트에 `· N라운드` 포함
+- `src/pages/GamePage.tsx` — store에서 읽던 `round`를 `<BoardGame>`에 전달
+
+## 설계 결정
+
+- `round`는 서버 `GameSnapshot`에 이미 포함된 값으로, 클라이언트 store에 `s.round`로 존재한다.
+- `maxRound`는 서버 snapshot에 미포함이므로 `N/MAX` 형태는 보류한다.
+- prop을 optional로 두어, 서버가 round를 생략하면 라운드 표시를 graceful하게 생략한다.

--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -352,6 +352,7 @@ interface GameBoardProps {
   gameId?: string | null
   players: PlayerState[]
   curPlayer: number
+  round?: number
   gamePhase?: GamePhase | null
   allowAssetActions?: boolean
   suppressDiceTimerModal?: boolean
@@ -493,6 +494,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       gameId,
       players,
       curPlayer,
+      round,
       gamePhase = null,
       allowAssetActions = false,
       activePrompt = null,
@@ -1221,20 +1223,23 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       setGoToIslandModal({ open: false })
 
       const p = playersRef.current[curPlayer]
+      const roundLabel = round != null ? ` · ${round}라운드` : ''
       if (p) {
         if (p.state === 'island') {
           setStatus(
-            `${p.name}님은 무인도에 있습니다 (${p.skipTurns ?? 0}턴 대기)`
+            `${p.name}님은 무인도에 있습니다 (${p.skipTurns ?? 0}턴 대기)${roundLabel}`
           )
         } else if ((p.skipTurns ?? 0) > 0) {
           setStatus(
-            `${p.name}님은 다음 턴까지 대기 중입니다 (${p.skipTurns}턴)`
+            `${p.name}님은 다음 턴까지 대기 중입니다 (${p.skipTurns}턴)${roundLabel}`
           )
         } else if (p.state === 'bankrupt') {
-          setStatus(`${p.name}님은 파산 상태입니다`)
+          setStatus(`${p.name}님은 파산 상태입니다${roundLabel}`)
+        } else {
+          setStatus(`${p.name}님의 차례입니다${roundLabel}`)
         }
       }
-    }, [curPlayer, stopDiceRollAnimation])
+    }, [curPlayer, round, stopDiceRollAnimation])
 
     useEffect(() => {
       if (!activePrompt || !isBuyPromptOpen) {

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -563,6 +563,7 @@ const GamePage: React.FC = () => {
               gameId={activeGameId}
               players={boardPlayers}
               curPlayer={boardCurPlayer}
+              round={round}
               suppressDiceTimerModal={isExitModalOpen}
               tiles={normalizedTilesForBoard}
               activePrompt={activeBoardPrompt}


### PR DESCRIPTION
## 📌 관련 이슈

> closes #602 

---

## 📝 작업 내용

보드판 위 상태 알람에 현재 라운드 번호를 표시하도록 추가했습니다.

- [GameBoard.tsx](cci:7://file:///Users/loner/Documents/Blue_Marble-frontend/src/components/board/GameBoard.tsx:0:0-0:0)에 `round?: number` prop 추가
- 턴 전환 시 status 알람에 `· N라운드` 표시 (일반/섬/대기/파산 모든 상태 반영)
- [GamePage.tsx](cci:7://file:///Users/loner/Documents/Blue_Marble-frontend/src/pages/GamePage.tsx:0:0-0:0)에서 store의 `round` 값을 `<BoardGame>`에 전달

예시: `홍길동님의 차례입니다 · 3라운드`

---

## 🧠 Task 문서 (큰 작업이면 필수)

- plan: docs/ai/tasks/round-counter/plan.md
- context: docs/ai/tasks/round-counter/context.md
- checklist: docs/ai/tasks/round-counter/checklist.md

---

## 📋 TODO.md 연결

- task slug: `round-counter`
- TODO status: Done
- TODO entry 확인: `- [x] \`round-counter\` - Round Counter (\`docs/ai/tasks/round-counter/\`)`

---

## 📚 참고한 기준 문서

- `AGENTS.md`
- [docs/rules.md](cci:7://file:///Users/loner/Documents/Blue_Marble-frontend/docs/rules.md:0:0-0:0)
- [docs/testing.md](cci:7://file:///Users/loner/Documents/Blue_Marble-frontend/docs/testing.md:0:0-0:0)
- [docs/ai/manuals/game-runtime.md](cci:7://file:///Users/loner/Documents/Blue_Marble-frontend/docs/ai/manuals/game-runtime.md:0:0-0:0)

---

## 🧪 실행한 검증

- `npm run lint`
- `npm run build`
- `npm run e2e:ci`

---

## ⚠️ 남은 리스크

- 서버가 `round`를 생략하면 라운드 표시가 빠짐 (optional prop이므로 graceful 처리됨)
- `maxRound`가 서버 snapshot에 없어 `N/MAX라운드` 형태 표시는 불가

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료
- [x] task 문서 링크를 남겼다
- [x] [TODO.md](cci:7://file:///Users/loner/Documents/Blue_Marble-frontend/TODO.md:0:0-0:0) / task slug 연결을 PR 본문에 남겼다
- [x] 참고한 기준 문서를 PR 본문에 남겼다
- [x] 실행한 검증과 남은 리스크를 PR 본문에 적었다

---

## 📸 스크린샷 (선택)

<img width="1561" height="855" alt="스크린샷 2026-03-24 오전 10 28 43" src="https://github.com/user-attachments/assets/c59f8e44-13c8-473a-8891-13eb827ffe2e" />
