### PR TITLE
fix: 라운드 뱃지 스타일 개선

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -15,6 +15,7 @@
 
 ## Done
 
+- [x] `current-round-badge-style` - Current Round Badge Style (`docs/ai/tasks/current-round-badge-style/`) - 게임 화면 현재 라운드 뱃지를 더 자연스럽게 보이도록 정리
 - [x] `add-round-display-ui` - Add Round Display UI (`docs/ai/tasks/add-round-display-ui/`) - 주사위 버튼 상단에 서버 round 정보를 표시하는 디자인 UI 추가
 - [x] `feat-round-progress` - Remove Round/Turn Progress UI (`docs/ai/tasks/feat-round-progress/`) - 화면에 상시 노출되던 (1/20 턴) 및 Turn X / 20 UI를 모두 제거하고, 최초 1턴에만 시작 안내 문구가 나오도록 원상복구
 - [x] `fix-round-display` - Fix Round Display (`docs/ai/tasks/fix-round-display/`) - 서버 패치의 turn 값을 라운드 변수에 제약 없이 즉각 반영하고, UI의 '라운드' 문자열을 '턴'으로 교체

--- a/docs/ai/tasks/current-round-badge-style/checklist.md
+++ b/docs/ai/tasks/current-round-badge-style/checklist.md
@@ -1,0 +1,29 @@
+# Checklist
+
+## Implementation
+
+- [x] 관련 manual과 기존 문서를 읽었다
+- [x] 영향 범위를 정리했다
+- [x] WAT 단계와 역할 분담을 문서에 반영했다
+- [x] 최소 범위로 구현했다
+- [x] mock/real 경로를 함께 확인했다
+- [x] 타입/contract 변경이 있으면 관련 코드도 같이 수정했다
+
+## Testing
+
+- [x] `npm run lint`
+- [x] `npm run ai:check:game`
+- [x] `npm run ai:check:build`
+
+## Review
+
+- [x] Planner 기준 정리 완료
+- [x] Implementer 범위 구현 완료
+- [x] Reviewer self-review 확인
+- [x] Tester 검증 실행
+- [x] `docs/rules.md` 기준으로 셀프 리뷰했다
+- [x] 리다이렉트, cleanup, 중복 구독, 에러 처리 경계를 확인했다
+- [x] `TODO.md` task 한 줄을 최신 상태로 유지했다
+- [x] session handoff notes를 최신 상태로 갱신했다
+- [x] `npm run ai:session:brief -- current-round-badge-style` 출력이 현재 상태와 맞는다
+- [x] 변경 파일 / 실행한 검증 / 남은 리스크를 정리했다

--- a/docs/ai/tasks/current-round-badge-style/context.md
+++ b/docs/ai/tasks/current-round-badge-style/context.md
@@ -1,0 +1,47 @@
+# Context
+
+## Current Behavior
+
+- `src/pages/GamePage.tsx`는 우측 하단 HUD에 현재 라운드 뱃지를 직접 렌더링한다
+- 기존 뱃지는 카드형 박스에 `1/20 round`를 크게 표시해 주변 HUD 대비 다소 무겁고 시선이 튀는 인상이 있었다
+- 이번 변경은 라운드 숫자를 중심에 두고 `/ 20`, `Round`를 보조 정보로 재배치해 더 자연스럽게 읽히도록 조정한다
+
+## Related Files
+
+- `docs/ai/manuals/common.md`
+- `docs/rules.md`
+- `docs/testing.md`
+- `docs/ai/manuals/game-runtime.md`
+- `src/pages/GamePage.tsx`
+- `TODO.md`
+
+## Relevant Manuals
+
+- `docs/ai/manuals/common.md`
+- `docs/rules.md`
+- `docs/testing.md`
+- `docs/ai/manuals/game-runtime.md`
+
+## Constraints
+
+- 라운드 값은 기존 store 구독값(`round ?? 1`)을 그대로 사용한다
+- `GamePage.tsx`의 게임 채팅, prompt, fallback, runtime 상태 흐름은 건드리지 않는다
+- UI 렌더링 경로 변경이므로 game-runtime high-risk 분류에 맞는 검증과 문서 근거를 남긴다
+
+## Decision Notes
+
+- rounded rectangle 대신 rounded-full badge로 바꿔 HUD 칩처럼 보이게 했다
+- 강조 색상은 숫자에 집중하고 `/ 20`, `Round`는 보조 톤으로 내려 정보 우선순위를 분명히 했다
+- 라운드 계산 로직을 따로 분리하거나 새 컴포넌트로 추출하는 대안은 이번 범위가 단일 스타일 조정이라 제외했다
+
+## Session Handoff Notes
+
+- 다음 세션에서 다시 읽을 문서: `docs/ai/manuals/game-runtime.md`, `src/pages/GamePage.tsx`, 이 task 문서 3종
+- 바로 이어서 할 1개 단계: 필요하면 PR 리뷰 의견에 맞춰 HUD 스타일만 추가 보정한다
+- pending decision / blocker: 없음
+- 검증 재개 지점: `npm run ai:check:game`
+
+## Open Risks
+
+- `src/pages/GamePage.test.tsx`의 기존 `act(...)` 경고는 이번 변경과 무관하게 계속 출력된다
+- 스타일 변경이지만 `GamePage.tsx` 경로 특성상 build 및 game check 결과를 PR 본문에 분명히 남겨야 한다

--- a/docs/ai/tasks/current-round-badge-style/plan.md
+++ b/docs/ai/tasks/current-round-badge-style/plan.md
@@ -1,0 +1,62 @@
+# Plan
+
+## Task
+
+- 작업 이름: Current Round Badge Style
+- 작업 slug: current-round-badge-style
+- 요청 날짜: 2026-03-24
+- 담당 범위: `GamePage` 현재 라운드 뱃지의 시각적 밸런스를 더 자연스럽게 다듬고, high-risk PR gate 근거를 함께 정리
+
+## Goal
+
+- 게임 화면 우측 하단의 현재 라운드 뱃지가 주변 HUD와 더 자연스럽게 어우러지도록 스타일을 정리한다
+- 숫자, `/ 20`, `Round` 텍스트의 비중과 간격을 조정해 정보 인지가 더 직관적으로 되게 한다
+- `GamePage.tsx`가 high-risk 경로인 만큼 task 문서, TODO 연결, game-runtime manual 근거, 검증 결과를 같이 남긴다
+
+## WAT Workflow
+
+1. 범위와 완료 기준을 문서로 고정한다
+2. 최소 범위 구현과 필요한 문서/테스트 수정 범위를 정리한다
+3. 가장 좁은 검증부터 실행하고 handoff 상태를 남긴다
+
+## In Scope
+
+- `src/pages/GamePage.tsx`
+- `TODO.md`
+
+## Out Of Scope
+
+- 게임 로직, 소켓 계약, store 상태 구조 변경
+- 라운드 값 계산 방식이나 최대 라운드 규칙 변경
+- 다른 HUD 요소의 스타일 개편
+
+## Target Files
+
+- `src/pages/GamePage.tsx`
+- `TODO.md`
+
+## Task Tracking
+
+- TODO line: - [ ] `current-round-badge-style` - Current Round Badge Style (`docs/ai/tasks/current-round-badge-style/`)
+- Session brief: `npm run ai:session:brief -- current-round-badge-style`
+- Reopen docs: `docs/ai/tasks/current-round-badge-style/plan.md`, `context.md`, `checklist.md`, 관련 manuals
+
+## Completion Criteria
+
+- 현재 라운드 배지가 숫자 중심으로 더 간결하고 자연스럽게 보인다
+- `src/pages/GamePage.tsx` 외 게임 런타임 동작은 변경하지 않는다
+- task 문서와 `TODO.md`가 현재 상태와 맞는다
+- `npm run lint`, `npm run ai:check:game`, `npm run ai:check:build`가 통과한다
+
+## Role Plan
+
+- Planner: 범위 / 완료 기준 / 참고 문서 정리
+- Implementer: 최소 범위 구현
+- Reviewer: diff / self-review / 위험 신호 확인
+- Tester: 검증 명령 실행과 결과 정리
+
+## Test Plan
+
+- `npm run lint`
+- `npm run ai:check:game`
+- `npm run ai:check:build`

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -632,12 +632,15 @@ const GamePage: React.FC = () => {
 
       <div className="absolute bottom-10 right-10 z-20 flex flex-col items-center gap-4">
         {/* Round Badge */}
-        <div className="flex items-center gap-3 rounded-2xl bg-white/95 px-7 py-3 shadow-[0_20px_50px_rgba(0,0,0,0.12)] backdrop-blur-sm border border-white/20">
-          <span className="text-4xl font-black tracking-tighter text-[#1e293b]">
-            {round ?? 1}/20
+        <div className="flex items-baseline gap-1.5 rounded-full border-[3px] border-white bg-[#EFF5FF] px-6 py-2.5 shadow-[0_8px_16px_rgba(36,95,229,0.12)]">
+          <span className="text-[28px] font-black leading-none tracking-tighter text-[#245FE5]">
+            {round ?? 1}
           </span>
-          <span className="text-2xl font-black tracking-tight text-[#1e293b]">
-            round
+          <span className="text-xl font-bold leading-none tracking-tight text-[#8BA3CB]">
+            / 20
+          </span>
+          <span className="ml-1 text-base font-black uppercase leading-none tracking-widest text-[#5E708D]">
+            Round
           </span>
         </div>
         <RollButton


### PR DESCRIPTION
## 📌 관련 이슈

> closes #619

---

## 📝 작업 내용

> 게임 화면의 현재 라운드 배지 스타일을 더 자연스럽고 읽기 쉽게 정리하고, high-risk 경로 변경에 맞는 task 문서와 검증 근거를 추가했습니다.

---

## 🧠 Task 문서 (큰 작업이면 필수)

- plan: docs/ai/tasks/current-round-badge-style/plan.md
- context: docs/ai/tasks/current-round-badge-style/context.md
- checklist: docs/ai/tasks/current-round-badge-style/checklist.md

---

## 📋 TODO.md 연결

- task slug: current-round-badge-style
- TODO status: Done
- TODO entry 확인: TODO.md와 docs/ai/tasks/current-round-badge-style/가 1:1로 연결됨

---

## 📚 참고한 기준 문서

- `AGENTS.md`
- `docs/rules.md`
- `docs/testing.md`
- 추가 manual / 문서 경로: `docs/ai/manuals/common.md`, `docs/ai/manuals/game-runtime.md`

---

## 🧪 실행한 검증

- `npx prettier --check src/pages/GamePage.tsx`
- `npx vitest run src/pages/GamePage.test.tsx`
- `npm run lint`
- `npm run ai:check:game`
- `npm run ai:check:build`
- `npm run ai:self-review -- --files src/pages/GamePage.tsx docs/ai/tasks/current-round-badge-style/plan.md docs/ai/tasks/current-round-badge-style/context.md docs/ai/tasks/current-round-badge-style/checklist.md TODO.md`

---

## ⚠️ 남은 리스크

- `src/pages/GamePage.test.tsx` 실행 시 기존 `act(...)` 경고는 계속 출력되지만, 이번 변경으로 새 실패는 발생하지 않았습니다.
- 스타일 변경이지만 game runtime 경로 특성상 추후 HUD 추가 변경 시에도 같은 수준의 검증과 task 근거를 유지해야 합니다.

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료
- [x] 큰 작업이면 task 문서 링크를 남겼다
- [x] 큰 작업이면 `TODO.md` / task slug 연결을 PR 본문에 남겼다
- [x] 참고한 기준 문서를 PR 본문에 남겼다
- [x] 실행한 검증과 남은 리스크를 PR 본문에 적었다

---

## 📸 스크린샷 (선택)

<img width="2032" height="1162" alt="스크린샷 2026-03-24 오후 9 25 05" src="https://github.com/user-attachments/assets/f72ead4d-79bd-480f-8d91-2db30ede07c0" />

