### PR TITLE
fix: 게임 종료 시 라운드 배지 표시를 20/20으로 고정

### DIFF
--- a/src/pages/GamePage.test.tsx
+++ b/src/pages/GamePage.test.tsx
@@ -207,6 +207,16 @@ function renderGamePage(options?: {
   )
 }
 
+const getRoundBadge = (): HTMLElement => {
+  const badge = screen.getByText('Round').parentElement
+
+  if (!badge) {
+    throw new Error('Round badge was not rendered.')
+  }
+
+  return badge
+}
+
 describe('GamePage chat flow', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -239,6 +249,29 @@ describe('GamePage chat flow', () => {
   afterEach(() => {
     useGameStore.getState().resetGame()
     useAuthStore.setState({ session: null })
+  })
+
+  it('라운드 배지는 현재 round 값을 그대로 표시한다', () => {
+    useGameStore.getState().setGameState({
+      round: 7,
+    })
+
+    renderGamePage()
+
+    expect(getRoundBadge()).toHaveTextContent('7')
+    expect(getRoundBadge()).toHaveTextContent('/ 20')
+  })
+
+  it('라운드 배지는 20을 초과하면 20으로 clamp해서 표시한다', () => {
+    useGameStore.getState().setGameState({
+      round: 21,
+    })
+
+    renderGamePage()
+
+    expect(getRoundBadge()).toHaveTextContent('20')
+    expect(getRoundBadge()).toHaveTextContent('/ 20')
+    expect(getRoundBadge()).not.toHaveTextContent('21')
   })
 
   it('renders a local chat message immediately and avoids duplicates when the server echo arrives', async () => {

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -49,6 +49,7 @@ const DEFAULT_MOCK_PLAYER_ID = 'mock-player-1'
 const DEFAULT_MOCK_NICKNAME = '플레이어 1'
 const DEFAULT_GUEST_ID = 'guest-local'
 const MOCK_LOCAL_PLAYER_INDEX = 0
+const MAX_ROUND_BADGE_VALUE = 20
 const FATAL_GAME_ROUTE_ERROR_CODES = new Set([
   'GAME_NOT_FOUND',
   'NOT_GAME_MEMBER',
@@ -148,6 +149,10 @@ const GamePage: React.FC = () => {
     currentUserId
       ? currentUserId
       : effectiveCurrentTurn
+  const displayedRoundBadgeValue = Math.min(
+    Math.max(round ?? 1, 1),
+    MAX_ROUND_BADGE_VALUE
+  )
 
   const boardPlayers = useMemo(
     () => mapStorePlayersToBoardPlayers(storePlayers),
@@ -632,12 +637,15 @@ const GamePage: React.FC = () => {
 
       <div className="absolute bottom-10 right-10 z-20 flex flex-col items-center gap-4">
         {/* Round Badge */}
-        <div className="flex items-baseline gap-1.5 rounded-full border-[3px] border-white bg-[#EFF5FF] px-6 py-2.5 shadow-[0_8px_16px_rgba(36,95,229,0.12)]">
+        <div
+          aria-label="현재 라운드 배지"
+          className="flex items-baseline gap-1.5 rounded-full border-[3px] border-white bg-[#EFF5FF] px-6 py-2.5 shadow-[0_8px_16px_rgba(36,95,229,0.12)]"
+        >
           <span className="text-[28px] font-black leading-none tracking-tighter text-[#245FE5]">
-            {round ?? 1}
+            {displayedRoundBadgeValue}
           </span>
           <span className="text-xl font-bold leading-none tracking-tight text-[#8BA3CB]">
-            / 20
+            / {MAX_ROUND_BADGE_VALUE}
           </span>
           <span className="ml-1 text-base font-black uppercase leading-none tracking-widest text-[#5E708D]">
             Round


### PR DESCRIPTION
## 📌 관련 이슈

> closes #623

---

## 📝 작업 내용

- `GamePage` 우측 하단 라운드 배지 전용 표시값을 `1..20` 범위로 clamp했습니다.
- store의 실제 `round` 값과 `BoardGame`에 전달하는 `round` prop은 그대로 유지했습니다.
- `GamePage.test.tsx`에 일반 표시(`7 / 20`)와 상한 clamp(`21 -> 20`) 회귀 테스트를 추가했습니다.

---

## 🧠 Task 문서 (큰 작업이면 필수)

- plan: docs/ai/tasks/current-round-badge-style/plan.md
- context: docs/ai/tasks/current-round-badge-style/context.md
- checklist: docs/ai/tasks/current-round-badge-style/checklist.md

---

## 📋 TODO.md 연결

- task slug: current-round-badge-style
- TODO status: Done
- TODO entry 확인: TODO.md와 docs/ai/tasks/current-round-badge-style/가 1:1로 연결되어 있으며, 이번 변경은 해당 task의 후속 수정입니다.

---

## 📚 참고한 기준 문서

- `AGENTS.md`
- `docs/ai/manuals/common.md`
- `docs/rules.md`
- `docs/testing.md`
- `docs/ai/manuals/game-runtime.md`

---

## 🧪 실행한 검증

- `npm run lint`
- `npx vitest run src/pages/GamePage.test.tsx`
- `npm run ai:check:game`
- `npm run ai:check:build`
- `npm run ai:self-review -- --files src/pages/GamePage.tsx src/pages/GamePage.test.tsx`
- `npm run ai:pr-gate -- --files src/pages/GamePage.tsx src/pages/GamePage.test.tsx --pr-body-file /tmp/round-badge-pr-body.md`

---

## ⚠️ 남은 리스크

- `GamePage.test.tsx` 실행 시 기존 `act(...)` warning은 그대로 남아 있으며, 이번 PR에서는 라운드 배지 표시 문제만 다룹니다.

---

## ✅ 체크리스트

- [ ] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료
- [x] 큰 작업이면 task 문서 링크를 남겼다
- [x] 큰 작업이면 `TODO.md` / task slug 연결을 PR 본문에 남겼다
- [x] 참고한 기준 문서를 PR 본문에 남겼다
- [x] 실행한 검증과 남은 리스크를 PR 본문에 적었다

---

## 📸 스크린샷 (선택)

> UI 변경이 있을 경우 첨부해주세요.