### PR TITLE
fix: 게임 종료 총자산/결과 모달을 서버 권위 기준으로 정렬

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -17,6 +17,7 @@
 ## Done
 
 - [x] `current-round-badge-style` - Current Round Badge Style (`docs/ai/tasks/current-round-badge-style/`) - 게임 화면 현재 라운드 뱃지를 더 자연스럽게 보이도록 정리
+- [x] `panel-total-assets-authoritative` - Panel Total Assets Authoritative (`docs/ai/tasks/panel-total-assets-authoritative/`) - GAME_OVER 이벤트와 reconnect snapshot을 `gameResult`로 복구해 우측 패널/종료 결과를 서버 권위 기준으로 정렬
 - [x] `add-round-display-ui` - Add Round Display UI (`docs/ai/tasks/add-round-display-ui/`) - 주사위 버튼 상단에 서버 round 정보를 표시하는 디자인 UI 추가
 - [x] `feat-round-progress` - Remove Round/Turn Progress UI (`docs/ai/tasks/feat-round-progress/`) - 화면에 상시 노출되던 (1/20 턴) 및 Turn X / 20 UI를 모두 제거하고, 최초 1턴에만 시작 안내 문구가 나오도록 원상복구
 - [x] `fix-round-display` - Fix Round Display (`docs/ai/tasks/fix-round-display/`) - 서버 패치의 turn 값을 라운드 변수에 제약 없이 즉각 반영하고, UI의 '라운드' 문자열을 '턴'으로 교체

--- a/docs/ai/tasks/panel-total-assets-authoritative/checklist.md
+++ b/docs/ai/tasks/panel-total-assets-authoritative/checklist.md
@@ -1,0 +1,31 @@
+# Checklist
+
+## Implementation
+
+- [x] 관련 manual과 기존 문서를 읽었다
+- [x] authoritative source와 종료 payload 우선순위를 정리했다
+- [x] `GamePage`에 패널 전용 총자산 view model을 추가했다
+- [x] 진행 중 패널 숫자/정렬/왕관 기준을 `totalAssets` 우선으로 맞췄다
+- [x] 종료 후 패널 숫자와 순서를 `rankings.final_assets` 또는 `winner.assets` 기준으로 보정했다
+- [x] 종료 결과 모달은 authoritative `gameResult`가 있을 때만 열리도록 정렬했다
+- [x] `GAME_OVER` event를 adapter에서 `gameResult`로 승격하도록 보강했다
+- [x] reconnect finished snapshot에서 `gameResult`가 없을 때 최소 종료 결과를 재구성하도록 보강했다
+- [x] `PlayerPanel` 라벨 의미와 주석을 총자산 기준으로 맞췄다
+
+## Testing
+
+- [x] `npx vitest run src/services/socket/gameContractAdapters.test.ts src/pages/GamePage.test.tsx`
+- [x] `npm run ai:check:game`
+- [x] `npm run ai:check:build`
+- [x] `npm run lint`
+
+## Review
+
+- [x] `npm run ai:self-review`를 실행했다
+- [x] mock/store/render 경로가 이번 변경과 함께 움직이는지 확인했다
+- [x] 종료 payload와 진행 중 snapshot의 우선순위가 충돌하지 않는지 확인했다
+- [x] authoritative `gameResult`가 없을 때 종료 액션이 숨겨지는지 확인했다
+- [x] live `GAME_OVER` event만 있어도 결과 source가 복구되는지 확인했다
+- [x] reconnect finished snapshot 합성 규칙이 종료 모달 source와 충돌하지 않는지 확인했다
+- [x] `TODO.md` task 한 줄과 task 문서 3종을 맞췄다
+- [x] 변경 파일 / 실행한 검증 / 남은 리스크를 정리했다

--- a/docs/ai/tasks/panel-total-assets-authoritative/context.md
+++ b/docs/ai/tasks/panel-total-assets-authoritative/context.md
@@ -1,0 +1,59 @@
+# Context
+
+## Current Behavior
+
+- 우측 플레이어 패널은 기존에 `money` 중심으로 정렬되고 왕관도 보유금 기준으로 표시됐다
+- 백엔드와의 확인 결과 진행 중 총자산은 `players[].totalAssets` patch/snapshot으로 내려오고, 게임 종료 자산은 `gameResult.rankings[].final_assets` 또는 `gameResult.winner.assets`가 authoritative 값이다
+- 추가 확인 결과 live 종료의 canonical source는 `game:patch.events[].type === "GAME_OVER"`이며, reconnect snapshot에는 `gameResult`가 없을 수 있다
+- 기존 종료 모달은 `isGameOver`만 켜져도 먼저 열리고, authoritative `gameResult`가 없으면 로컬 fallback 계산으로 결과를 보여줄 수 있었다
+- 따라서 우측 패널과 종료 결과 모달이 서로 다른 기준을 쓰면 사용자 입장에서 누가 앞서는지 헷갈릴 수 있다
+
+## Related Files
+
+- `docs/ai/manuals/common.md`
+- `docs/rules.md`
+- `docs/testing.md`
+- `docs/ai/manuals/game-runtime.md`
+- `src/pages/GamePage.tsx`
+- `src/pages/GamePage.test.tsx`
+- `src/components/board/GameBoard.tsx`
+- `src/components/game/panels/PlayerPanel.tsx`
+- `src/services/socket/gameContractAdapters.ts`
+- `src/services/socket/gameContractAdapters.test.ts`
+- `TODO.md`
+
+## Relevant Manuals
+
+- `docs/ai/manuals/common.md`
+- `docs/rules.md`
+- `docs/testing.md`
+- `docs/ai/manuals/game-runtime.md`
+
+## Constraints
+
+- 프론트가 로컬 계산값을 canonical source로 승격하지 않는다
+- 진행 중에는 서버 `totalAssets`가 있으면 그것을 우선 사용하고, 없을 때만 기존 fallback을 유지한다
+- 종료 후에는 패널과 결과 모달 모두 authoritative 종료 payload를 우선하되, reconnect snapshot에서는 server field 조합으로 최소 결과를 재구성한다
+- `GamePage.tsx`, `GameBoard.tsx`는 game-runtime high-risk 경로이므로 테스트와 build 근거를 남긴다
+
+## Decision Notes
+
+- `GamePage` 안에 패널 전용 view model을 만들어 표시값, 정렬 기준, 왕관 기준을 한 번에 계산한다
+- `rankings`가 있으면 패널도 ranking 순서와 `final_assets`를 그대로 따른다
+- `winner`만 있는 종료 payload는 승자 행 자산만 `winner.assets`로 보정하고 승자를 최상단으로 배치한다
+- 종료 모달은 authoritative `gameResult`가 있을 때만 열고, 로컬 fallback 자산 계산은 socket runtime 결과 source로 쓰지 않는다
+- adapter가 `GAME_OVER` event를 synthetic `gameResult` patch로 승격해 UI가 raw event를 직접 읽지 않게 한다
+- reconnect finished snapshot에 `gameResult`가 없으면 `winnerId + players[].totalAssets` 기준 최소 `gameResult`를 합성한다
+- `PlayerPanel` UI 컴포넌트는 동작 변경 없이 총자산 기준 주석만 정리한다
+
+## Session Handoff Notes
+
+- 다음 세션에서 다시 읽을 문서: `docs/ai/manuals/game-runtime.md`, `src/pages/GamePage.tsx`, 이 task 문서 3종
+- 바로 이어서 할 1개 단계: 필요하면 reconnect finished state 전용 안내 문구/배너를 추가 보정한다
+- pending decision / blocker: 없음
+- 검증 재개 지점: `npx vitest run src/services/socket/gameContractAdapters.test.ts src/pages/GamePage.test.tsx`
+
+## Open Risks
+
+- `src/pages/GamePage.test.tsx` 실행 시 기존 `act(...)` warning은 계속 출력된다
+- `src/components/board/GameBoard.tsx`의 기존 `react-hooks/exhaustive-deps` warning은 이번 범위 밖이라 그대로 남는다

--- a/docs/ai/tasks/panel-total-assets-authoritative/plan.md
+++ b/docs/ai/tasks/panel-total-assets-authoritative/plan.md
@@ -1,0 +1,78 @@
+# Plan
+
+## Task
+
+- 작업 이름: Panel Total Assets Authoritative
+- 작업 slug: panel-total-assets-authoritative
+- 요청 날짜: 2026-03-24
+- 담당 범위: 우측 플레이어 패널 총자산과 종료 결과 모달이 모두 서버 권위 종료 payload 기준으로 맞도록 정렬하고, `GAME_OVER` event 계약을 프론트 `gameResult` 상태로 복구
+
+## Goal
+
+- 우측 플레이어 패널이 진행 중에는 서버 `players[].totalAssets`를 우선 사용해 현재 우세 플레이어를 보여준다
+- 게임 종료 후에는 `gameResult.rankings[].final_assets` 또는 `gameResult.winner.assets`와 같은 값으로 패널을 맞춘다
+- 종료 결과 모달은 authoritative `gameResult`가 있을 때만 열어 패널과 결과 숫자가 서로 어긋나지 않게 정리한다
+- live 종료는 `game:patch.events[].GAME_OVER`, reconnect 종료는 finished snapshot 기준으로도 같은 `gameResult` 상태를 복구한다
+
+## WAT Workflow
+
+1. 현재 우측 패널과 종료 결과 모달의 데이터 source 차이를 정리한다
+2. adapter가 `GAME_OVER` event와 reconnect finished snapshot을 `gameResult`로 정규화하도록 보강한다
+3. UI는 계속 `store.gameResult`만 읽도록 유지하고 회귀 테스트와 최소 검증을 실행한다
+
+## In Scope
+
+- `src/pages/GamePage.tsx`
+- `src/pages/GamePage.test.tsx`
+- `src/components/board/GameBoard.tsx`
+- `src/components/game/panels/PlayerPanel.tsx`
+- `src/services/socket/gameContractAdapters.ts`
+- `src/services/socket/gameContractAdapters.test.ts`
+- `TODO.md`
+
+## Out Of Scope
+
+- 게임 소켓 계약 자체 변경
+- store 타입 구조 변경
+- 결과 모달 레이아웃 또는 문구 개편
+
+## Target Files
+
+- `src/pages/GamePage.tsx`
+- `src/pages/GamePage.test.tsx`
+- `src/components/board/GameBoard.tsx`
+- `src/components/game/panels/PlayerPanel.tsx`
+- `src/services/socket/gameContractAdapters.ts`
+- `src/services/socket/gameContractAdapters.test.ts`
+- `TODO.md`
+
+## Task Tracking
+
+- TODO line: - [x] `panel-total-assets-authoritative` - Panel Total Assets Authoritative (`docs/ai/tasks/panel-total-assets-authoritative/`)
+- Session brief: `npm run ai:session:brief -- panel-total-assets-authoritative`
+- Reopen docs: `docs/ai/tasks/panel-total-assets-authoritative/plan.md`, `context.md`, `checklist.md`
+
+## Completion Criteria
+
+- 우측 패널 총자산 숫자가 `money`가 아니라 서버 `totalAssets`를 우선 사용한다
+- 우측 패널 정렬과 왕관 기준이 총자산 기준으로 동작한다
+- 게임 종료 시 패널이 `rankings.final_assets` 또는 `winner.assets`와 일치한다
+- `isGameOver=true`만으로는 종료 모달이 열리지 않고 authoritative `gameResult`가 있을 때만 열린다
+- `GAME_OVER` event만 와도 adapter가 `gameResult`를 복구해 종료 모달 source를 만든다
+- reconnect finished snapshot에 `gameResult`가 없어도 최소 종료 결과를 재구성한다
+- `npx vitest run src/services/socket/gameContractAdapters.test.ts src/pages/GamePage.test.tsx`, `npm run ai:check:game`, `npm run ai:check:build`, `npm run lint`, `npm run ai:self-review` 결과를 남긴다
+
+## Role Plan
+
+- Planner: authoritative source와 종료 payload 우선순위 정리
+- Implementer: `gameContractAdapters`가 종료 event/snapshot을 `gameResult`로 복구하도록 구현
+- Reviewer: 총자산 정렬/왕관/종료 모달 authoritative source 정합성 확인
+- Tester: 회귀 테스트와 game/build/lint/self-review 실행
+
+## Test Plan
+
+- `npx vitest run src/services/socket/gameContractAdapters.test.ts src/pages/GamePage.test.tsx`
+- `npm run ai:check:game`
+- `npm run ai:check:build`
+- `npm run lint`
+- `npm run ai:self-review -- --files src/pages/GamePage.tsx src/pages/GamePage.test.tsx src/components/board/GameBoard.tsx src/components/game/panels/PlayerPanel.tsx src/services/socket/gameContractAdapters.ts src/services/socket/gameContractAdapters.test.ts TODO.md docs/ai/tasks/panel-total-assets-authoritative/plan.md docs/ai/tasks/panel-total-assets-authoritative/context.md docs/ai/tasks/panel-total-assets-authoritative/checklist.md`

--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -1413,58 +1413,20 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       open: false,
     })
 
+    const hasAuthoritativeGameResult = Boolean(
+      gameResult?.winner ||
+      (Array.isArray(gameResult?.rankings) && gameResult.rankings.length > 0)
+    )
+
     useEffect(() => {
-      const shouldOpenGameResultModal = isGameOver || gameResult != null
+      const shouldOpenGameResultModal = hasAuthoritativeGameResult
       if (shouldOpenGameResultModal) {
         setGameResultModal((prev) => (prev.open ? prev : { open: true }))
         return
       }
 
       setGameResultModal({ open: false })
-    }, [gameResult, isGameOver])
-
-    const getPlayerResults = useCallback(() => {
-      const results = players.map((player, index) => {
-        let propertyValue = 0
-        let cityCount = 0
-
-        Object.entries(tileOwners).forEach(([tileId, owner]) => {
-          if (String(owner.ownerId) !== String(player.id)) {
-            return
-          }
-
-          const tile = boardTiles[Number(tileId)]
-          propertyValue += tile?.price ?? 0
-          cityCount++
-        })
-
-        const isBankrupt =
-          player.state === 'bankrupt' || player.money <= 0 || false
-
-        return {
-          id: String(player.id),
-          nickname: player.name || `Player ${index + 1}`,
-          money: player.money,
-          totalAsset: player.money + propertyValue,
-          ownedCityCount: cityCount,
-          isBankrupt,
-        }
-      })
-
-      return results.sort((left, right) => {
-        if (left.isBankrupt && !right.isBankrupt) {
-          return 1
-        }
-        if (!left.isBankrupt && right.isBankrupt) {
-          return -1
-        }
-        return right.totalAsset - left.totalAsset
-      })
-    }, [boardTiles, players, tileOwners])
-    const fallbackPlayerResults = useMemo(
-      () => getPlayerResults(),
-      [getPlayerResults]
-    )
+    }, [hasAuthoritativeGameResult])
     const serverResultRows = useMemo(() => {
       const rankings = gameResult?.rankings
       if (!rankings || rankings.length === 0) {
@@ -1499,13 +1461,8 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
         return [winnerResultRow]
       }
 
-      return fallbackPlayerResults.map((result) => ({
-        id: result.id,
-        nickname: result.nickname,
-        totalAssetText: formatWon(result.totalAsset),
-        ownedCityCountText: `${result.ownedCityCount}개`,
-      }))
-    }, [fallbackPlayerResults, serverResultRows, winnerResultRow])
+      return []
+    }, [serverResultRows, winnerResultRow])
     const resultModalWinnerName = useMemo(() => {
       if (gameResult?.winner?.nickname) {
         return gameResult.winner.nickname
@@ -1526,11 +1483,8 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
         )
       }
 
-      return (
-        fallbackPlayerResults.find((result) => !result.isBankrupt)?.nickname ??
-        '승리자'
-      )
-    }, [fallbackPlayerResults, gameResult, serverResultRows, winnerId])
+      return '승리자'
+    }, [gameResult, serverResultRows, winnerId])
 
     function handleBankruptConfirm() {
       const { onDoneCallback } = bankruptModal

--- a/src/components/game/panels/PlayerPanel.tsx
+++ b/src/components/game/panels/PlayerPanel.tsx
@@ -14,7 +14,7 @@ interface Player {
 interface PlayerPanelProps {
   player: Player
   isActive: boolean
-  isRichest?: boolean // 보유금 1위일 때 왕관 표시
+  isRichest?: boolean // 총자산 1위일 때 왕관 표시
   isBankrupt?: boolean
 }
 
@@ -62,7 +62,7 @@ const PlayerPanel: React.FC<PlayerPanelProps> = ({
       )}
       {/* ── 아바타 + 왕관 ── */}
       <div className="relative shrink-0">
-        {/* 왕관 — 보유금 1위 */}
+        {/* 왕관 — 총자산 1위 */}
         {isRichest && (
           <span
             style={{

--- a/src/pages/GamePage.test.tsx
+++ b/src/pages/GamePage.test.tsx
@@ -117,10 +117,22 @@ vi.mock('../components/board/GameBoard', () => ({
       onGameResultConfirm?: () => void
     }
   >(function MockBoardGame(props, ref) {
+    const gameResult = props.gameResult as
+      | {
+          rankings?: unknown[]
+          winner?: unknown | null
+        }
+      | null
+      | undefined
+    const hasAuthoritativeGameResult = Boolean(
+      gameResult?.winner ||
+      (Array.isArray(gameResult?.rankings) && gameResult.rankings.length > 0)
+    )
+
     return (
       <div ref={ref} data-testid="mock-board-game">
         게임 보드
-        {Boolean(props.isGameOver || props.gameResult) && (
+        {hasAuthoritativeGameResult && (
           <button type="button" onClick={props.onGameResultConfirm}>
             대기방으로 돌아가기
           </button>
@@ -163,7 +175,34 @@ vi.mock('../components/game/modals/promptModalMapping', () => ({
 }))
 
 vi.mock('../components/game/panels/PlayerPanel', () => ({
-  default: () => <div>플레이어 패널</div>,
+  default: ({
+    player,
+    isActive,
+    isRichest,
+    isBankrupt,
+  }: {
+    player: {
+      id: string
+      nickname?: string
+      money?: number
+      totalAssets?: number
+    }
+    isActive: boolean
+    isRichest?: boolean
+    isBankrupt?: boolean
+  }) => (
+    <div
+      data-testid="mock-player-panel"
+      data-player-id={player.id}
+      data-is-active={String(isActive)}
+      data-is-richest={String(Boolean(isRichest))}
+      data-is-bankrupt={String(Boolean(isBankrupt))}
+    >
+      <span>{player.nickname}</span>
+      <span>{`money:${player.money ?? 0}`}</span>
+      <span>{`assets:${player.totalAssets ?? 'none'}`}</span>
+    </div>
+  ),
 }))
 
 vi.mock('../features/room-chat/DevRoomChatControlPanel', () => ({
@@ -215,6 +254,21 @@ const getRoundBadge = (): HTMLElement => {
   }
 
   return badge
+}
+
+const getPlayerPanels = (): HTMLElement[] =>
+  screen.getAllByTestId('mock-player-panel')
+
+const getPlayerPanelById = (playerId: string): HTMLElement => {
+  const panel = getPlayerPanels().find(
+    (candidate) => candidate.dataset.playerId === playerId
+  )
+
+  if (!panel) {
+    throw new Error(`Player panel for ${playerId} was not rendered.`)
+  }
+
+  return panel
 }
 
 describe('GamePage chat flow', () => {
@@ -272,6 +326,129 @@ describe('GamePage chat flow', () => {
     expect(getRoundBadge()).toHaveTextContent('20')
     expect(getRoundBadge()).toHaveTextContent('/ 20')
     expect(getRoundBadge()).not.toHaveTextContent('21')
+  })
+
+  it('우측 패널은 totalAssets를 우선 표시하고 그 기준으로 정렬과 왕관을 표시한다', () => {
+    useGameStore.getState().setGameState({
+      players: [
+        createPlayer({
+          id: 'user-1',
+          nickname: '유저1',
+          balance: 5000,
+          totalAssets: 5000,
+        }),
+        createPlayer({
+          id: 'user-2',
+          nickname: '유저2',
+          color: '#0000ff',
+          balance: 1000,
+          totalAssets: 9000,
+        }),
+      ],
+    })
+
+    renderGamePage()
+
+    expect(getPlayerPanels().map((panel) => panel.dataset.playerId)).toEqual([
+      'user-2',
+      'user-1',
+    ])
+    expect(getPlayerPanelById('user-2')).toHaveTextContent('money:1000')
+    expect(getPlayerPanelById('user-2')).toHaveTextContent('assets:9000')
+    expect(getPlayerPanelById('user-2').dataset.isRichest).toBe('true')
+    expect(getPlayerPanelById('user-1').dataset.isRichest).toBe('false')
+  })
+
+  it('게임 종료 시 rankings 기준으로 우측 패널 순서와 자산을 맞춘다', () => {
+    useGameStore.getState().setGameState({
+      phase: 'finished',
+      isGameOver: true,
+      players: [
+        createPlayer({
+          id: 'user-1',
+          nickname: '유저1',
+          balance: 3000,
+          totalAssets: 3000,
+        }),
+        createPlayer({
+          id: 'user-2',
+          nickname: '유저2',
+          color: '#0000ff',
+          balance: 7000,
+          totalAssets: 7000,
+        }),
+      ],
+      gameResult: {
+        reason: 'max_rounds',
+        rankings: [
+          {
+            rank: 1,
+            player_id: 'user-1',
+            nickname: '유저1',
+            final_assets: 12000,
+            is_winner: true,
+          },
+          {
+            rank: 2,
+            player_id: 'user-2',
+            nickname: '유저2',
+            final_assets: 11000,
+            is_winner: false,
+          },
+        ],
+      },
+    })
+
+    renderGamePage()
+
+    expect(getPlayerPanels().map((panel) => panel.dataset.playerId)).toEqual([
+      'user-1',
+      'user-2',
+    ])
+    expect(getPlayerPanelById('user-1')).toHaveTextContent('assets:12000')
+    expect(getPlayerPanelById('user-1').dataset.isRichest).toBe('true')
+    expect(getPlayerPanelById('user-2')).toHaveTextContent('assets:11000')
+  })
+
+  it('게임 종료 시 winner만 있어도 우측 패널 승자 자산을 winner.assets로 보정한다', () => {
+    useGameStore.getState().setGameState({
+      phase: 'finished',
+      isGameOver: true,
+      winnerId: 'user-2',
+      players: [
+        createPlayer({
+          id: 'user-1',
+          nickname: '유저1',
+          balance: 5000,
+          totalAssets: 8000,
+        }),
+        createPlayer({
+          id: 'user-2',
+          nickname: '유저2',
+          color: '#0000ff',
+          balance: 3000,
+          totalAssets: 6000,
+        }),
+      ],
+      gameResult: {
+        reason: 'disconnect_timeout',
+        winner: {
+          playerId: 'user-2',
+          nickname: '유저2',
+          balance: 3000,
+          assets: 13000,
+        },
+      },
+    })
+
+    renderGamePage()
+
+    expect(getPlayerPanels().map((panel) => panel.dataset.playerId)).toEqual([
+      'user-2',
+      'user-1',
+    ])
+    expect(getPlayerPanelById('user-2')).toHaveTextContent('assets:13000')
+    expect(getPlayerPanelById('user-2').dataset.isRichest).toBe('true')
   })
 
   it('renders a local chat message immediately and avoids duplicates when the server echo arrives', async () => {
@@ -402,6 +579,39 @@ describe('GamePage chat flow', () => {
 
     expect(screen.queryByText('게임 로딩 중...')).not.toBeInTheDocument()
     expect(screen.getByTestId('mock-board-game')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: '대기방으로 돌아가기' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('authoritative gameResult가 있으면 종료 결과 액션을 노출한다', () => {
+    useGameStore.getState().resetGame()
+    useGameStore.getState().setGameState({
+      roomId: 'room-1',
+      gameId: 'game-1',
+      phase: 'finished',
+      isGameOver: true,
+      players: [],
+      tiles: [],
+      gameResult: {
+        reason: 'max_rounds',
+        rankings: [
+          {
+            rank: 1,
+            player_id: 'user-1',
+            nickname: '유저1',
+            final_assets: 455000,
+            is_winner: true,
+          },
+        ],
+      },
+    })
+
+    renderGamePage()
+
+    expect(
+      screen.getByRole('button', { name: '대기방으로 돌아가기' })
+    ).toBeInTheDocument()
   })
 
   it('종료 상태가 아니고 players가 비어 있으면 기존처럼 로딩 화면을 렌더한다', () => {

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -22,7 +22,7 @@ import {
   emitPromptResponse,
 } from '../services/socket/game.handler'
 import { useGameStore } from '../stores/game.store'
-import type { GamePromptChoice } from '../types/domain'
+import type { GamePromptChoice, GameRanking, PlayerId } from '../types/domain'
 import {
   findBoardCurrentPlayerIndex,
   mapStorePlayersToBoardPlayers,
@@ -62,6 +62,81 @@ const FALLBACK_PROMPT_CHOICES: GamePromptChoice[] = [
     value: 'confirm',
   },
 ]
+
+type PlayerPanelViewModel = {
+  id: string
+  nickname: string
+  color?: string
+  money: number
+  totalAssets: number
+  originalIndex: number
+  isActive: boolean
+  isBankrupt: boolean
+  isRichest: boolean
+}
+
+const toComparablePlayerId = (playerId: PlayerId | null | undefined) =>
+  playerId == null ? null : String(playerId)
+
+const comparePlayerPanelsByAssets = (
+  left: Pick<
+    PlayerPanelViewModel,
+    'isBankrupt' | 'totalAssets' | 'money' | 'originalIndex'
+  >,
+  right: Pick<
+    PlayerPanelViewModel,
+    'isBankrupt' | 'totalAssets' | 'money' | 'originalIndex'
+  >
+) => {
+  const leftBankrupt = left.isBankrupt ? 1 : 0
+  const rightBankrupt = right.isBankrupt ? 1 : 0
+
+  if (leftBankrupt !== rightBankrupt) {
+    return leftBankrupt - rightBankrupt
+  }
+
+  if (left.totalAssets !== right.totalAssets) {
+    return right.totalAssets - left.totalAssets
+  }
+
+  if (left.money !== right.money) {
+    return right.money - left.money
+  }
+
+  return left.originalIndex - right.originalIndex
+}
+
+const applyRichestFlag = (
+  players: PlayerPanelViewModel[],
+  richestPlayerId: string | null
+) =>
+  players.map((player) => ({
+    ...player,
+    isRichest: richestPlayerId !== null && player.id === richestPlayerId,
+  }))
+
+const mapRankingToPanelPlayer = (
+  ranking: GameRanking,
+  index: number,
+  basePlayerById: Map<string, PlayerPanelViewModel>,
+  activePlayerId: string | null
+): PlayerPanelViewModel => {
+  const rankingPlayerId = String(ranking.player_id)
+  const basePlayer = basePlayerById.get(rankingPlayerId)
+
+  return {
+    id: rankingPlayerId,
+    nickname: basePlayer?.nickname ?? ranking.nickname,
+    color: basePlayer?.color,
+    money: basePlayer?.money ?? 0,
+    totalAssets: ranking.final_assets,
+    originalIndex: basePlayer?.originalIndex ?? index,
+    isActive:
+      basePlayer?.isActive ?? activePlayerId === String(ranking.player_id),
+    isBankrupt: basePlayer?.isBankrupt ?? false,
+    isRichest: Boolean(ranking.is_winner || ranking.rank === 1),
+  }
+}
 
 interface GamePageLocationState {
   roomId?: string
@@ -153,6 +228,7 @@ const GamePage: React.FC = () => {
     Math.max(round ?? 1, 1),
     MAX_ROUND_BADGE_VALUE
   )
+  const activePlayerId = toComparablePlayerId(normalizedCurrentTurn)
 
   const boardPlayers = useMemo(
     () => mapStorePlayersToBoardPlayers(storePlayers),
@@ -276,17 +352,111 @@ const GamePage: React.FC = () => {
 
   const diceRoll = useDiceRoll()
 
-  const playerTotalAssetsMap = useMemo(
-    () =>
-      new Map(
-        boardPlayers.map((player, index) => [
-          player.id,
-          storePlayers[index]?.totalAssets,
-        ])
-      ),
-    [boardPlayers, storePlayers]
-  )
-  const maxMoney = Math.max(...boardPlayers.map((player) => player.money))
+  const panelPlayers = useMemo(() => {
+    const basePanelPlayers: PlayerPanelViewModel[] = storePlayers.map(
+      (storePlayer, index) => {
+        const boardPlayer = boardPlayers[index]
+        const playerId = String(storePlayer.id)
+        const money = storePlayer.balance ?? boardPlayer?.money ?? 0
+
+        return {
+          id: playerId,
+          nickname:
+            storePlayer.nickname || boardPlayer?.name || `Player ${index + 1}`,
+          color: storePlayer.color || boardPlayer?.color,
+          money,
+          totalAssets: storePlayer.totalAssets ?? money,
+          originalIndex: index,
+          isActive: activePlayerId === playerId,
+          isBankrupt:
+            Boolean(storePlayer.is_bankrupt) ||
+            storePlayer.state === 'bankrupt' ||
+            money <= 0,
+          isRichest: false,
+        }
+      }
+    )
+
+    const basePlayerById = new Map(
+      basePanelPlayers.map((player) => [player.id, player])
+    )
+
+    if (gameResult?.rankings && gameResult.rankings.length > 0) {
+      const rankedPlayers = [...gameResult.rankings]
+        .sort((left, right) => left.rank - right.rank)
+        .map((ranking, index) =>
+          mapRankingToPanelPlayer(
+            ranking,
+            index,
+            basePlayerById,
+            activePlayerId
+          )
+        )
+      const rankedPlayerIds = new Set(rankedPlayers.map((player) => player.id))
+      const remainingPlayers = basePanelPlayers
+        .filter((player) => !rankedPlayerIds.has(player.id))
+        .sort(comparePlayerPanelsByAssets)
+
+      return applyRichestFlag(
+        [...rankedPlayers, ...remainingPlayers],
+        rankedPlayers[0]?.id ?? null
+      )
+    }
+
+    if (gameResult?.winner) {
+      const winner = gameResult.winner
+      const winnerPlayerId = String(winner.playerId)
+      const winnerBaseExists = basePanelPlayers.some(
+        (player) => player.id === winnerPlayerId
+      )
+      const winnerPanelPlayers = winnerBaseExists
+        ? basePanelPlayers.map((player) =>
+            player.id === winnerPlayerId
+              ? {
+                  ...player,
+                  money: winner.balance,
+                  totalAssets: winner.assets,
+                }
+              : player
+          )
+        : [
+            ...basePanelPlayers,
+            {
+              id: winnerPlayerId,
+              nickname: winner.nickname,
+              color: undefined,
+              money: winner.balance,
+              totalAssets: winner.assets,
+              originalIndex: basePanelPlayers.length,
+              isActive: activePlayerId === winnerPlayerId,
+              isBankrupt: false,
+              isRichest: false,
+            },
+          ]
+
+      return applyRichestFlag(
+        [...winnerPanelPlayers].sort((left, right) => {
+          const leftWinner = left.id === winnerPlayerId ? 1 : 0
+          const rightWinner = right.id === winnerPlayerId ? 1 : 0
+
+          if (leftWinner !== rightWinner) {
+            return rightWinner - leftWinner
+          }
+
+          return comparePlayerPanelsByAssets(left, right)
+        }),
+        winnerPlayerId
+      )
+    }
+
+    const sortedPlayers = [...basePanelPlayers].sort(
+      comparePlayerPanelsByAssets
+    )
+    const richestPlayerId =
+      sortedPlayers.find((player) => !player.isBankrupt)?.id ?? null
+
+    return applyRichestFlag(sortedPlayers, richestPlayerId)
+  }, [activePlayerId, boardPlayers, gameResult, storePlayers])
   const currentPlayerState = boardPlayers[boardCurPlayer]
   const isCurrentPlayerBankrupt =
     currentPlayerState?.money <= 0 || currentPlayerState?.state === 'bankrupt'
@@ -597,41 +767,21 @@ const GamePage: React.FC = () => {
         </div>
 
         <div className="flex h-full w-[320px] shrink-0 flex-col gap-4 overflow-y-auto py-8">
-          {[...boardPlayers]
-            .map((player, index) => ({
-              ...player,
-              originalIndex: index,
-              totalAssets: playerTotalAssetsMap.get(player.id) ?? player.money,
-            }))
-            .sort((left, right) => {
-              const leftBankrupt = left.money <= 0 ? 1 : 0
-              const rightBankrupt = right.money <= 0 ? 1 : 0
-              if (leftBankrupt !== rightBankrupt) {
-                return leftBankrupt - rightBankrupt
-              }
-
-              if (left.money !== right.money) {
-                return right.money - left.money
-              }
-
-              return left.originalIndex - right.originalIndex
-            })
-            .map((player) => (
-              <PlayerPanel
-                key={player.id}
-                player={{
-                  id: String(player.id),
-                  name: player.name ?? `Player ${player.id + 1}`,
-                  nickname: player.name ?? `Player ${player.id + 1}`,
-                  color: player.color,
-                  money: player.money,
-                  totalAssets: player.totalAssets,
-                }}
-                isActive={player.originalIndex === boardCurPlayer}
-                isRichest={player.money > 0 && player.money === maxMoney}
-                isBankrupt={player.money <= 0}
-              />
-            ))}
+          {panelPlayers.map((player) => (
+            <PlayerPanel
+              key={player.id}
+              player={{
+                id: player.id,
+                nickname: player.nickname,
+                color: player.color,
+                money: player.money,
+                totalAssets: player.totalAssets,
+              }}
+              isActive={player.isActive}
+              isRichest={player.isRichest}
+              isBankrupt={player.isBankrupt}
+            />
+          ))}
         </div>
       </div>
 

--- a/src/services/socket/gameContractAdapters.test.ts
+++ b/src/services/socket/gameContractAdapters.test.ts
@@ -340,6 +340,82 @@ describe('gameContractAdapters', () => {
     })
   })
 
+  it('synthesizes reconnect gameResult from finished snapshot when authoritative gameResult is missing', () => {
+    const normalized = normalizeSnapshotPayload(
+      {
+        gameId: 'game-finished-reconnect',
+        revision: 23,
+        phase: 'GAME_OVER',
+        winner_id: 'player-2',
+        is_game_over: true,
+        players: [
+          {
+            id: 'player-1',
+            nickname: 'alpha',
+            balance: 300,
+            totalAssets: 600,
+          },
+          {
+            id: 'player-2',
+            nickname: 'beta',
+            balance: 250,
+            totalAssets: 600,
+          },
+        ],
+        tiles: [],
+      },
+      { envelopeRevision: 23 }
+    )
+
+    expect(normalized).not.toBeNull()
+    expect(normalized?.gameResult).toEqual({
+      reason: 'max_rounds',
+      rankings: [
+        {
+          rank: 1,
+          player_id: 'player-2',
+          nickname: 'beta',
+          final_assets: 6000000,
+          is_winner: true,
+        },
+        {
+          rank: 2,
+          player_id: 'player-1',
+          nickname: 'alpha',
+          final_assets: 6000000,
+          is_winner: false,
+        },
+      ],
+      winner: {
+        playerId: 'player-2',
+        nickname: 'beta',
+        balance: 2500000,
+        assets: 6000000,
+      },
+    })
+  })
+
+  it('keeps finished reconnect snapshot result empty for all-disconnected exception', () => {
+    const normalized = normalizeSnapshotPayload(
+      {
+        gameId: 'game-finished-disconnected',
+        revision: 24,
+        phase: 'GAME_OVER',
+        is_game_over: true,
+        players: [],
+        tiles: [],
+      },
+      { envelopeRevision: 24 }
+    )
+
+    expect(normalized).not.toBeNull()
+    expect(normalized?.gameResult).toEqual({
+      reason: 'disconnect_timeout',
+      rankings: undefined,
+      winner: null,
+    })
+  })
+
   it('normalizes object-shaped snapshot collections', () => {
     const normalized = normalizeSnapshotPayload(
       {
@@ -694,6 +770,133 @@ describe('gameContractAdapters', () => {
         op: 'set',
         path: 'gameResult',
         value: { reason: 'round_limit', rankings: undefined, winner: null },
+      },
+    ])
+  })
+
+  it('synthesizes gameResult, winnerId, and isGameOver patches from GAME_OVER events', () => {
+    const normalized = normalizePatchEnvelopePayload({
+      gameId: 'game-over-event-patch',
+      revision: 93,
+      patch: [{ op: 'set', path: 'phase', value: 'GAME_OVER' }],
+      events: [
+        {
+          type: 'GAME_OVER',
+          reason: 'player_left',
+          winner: {
+            playerId: 1,
+            nickname: 'host',
+            balance: 100,
+            assets: 500,
+          },
+          rankings: [
+            {
+              rank: 1,
+              playerId: 1,
+              nickname: 'host',
+              finalAssets: 500,
+              isWinner: true,
+            },
+            {
+              rank: 2,
+              playerId: 2,
+              nickname: 'guest',
+              finalAssets: 300,
+              isWinner: false,
+            },
+          ],
+        } as unknown as ServerEvent,
+      ],
+    })
+
+    expect(normalized.patch).toEqual([
+      { op: 'set', path: 'phase', value: 'finished' },
+      {
+        op: 'set',
+        path: 'gameResult',
+        value: {
+          reason: 'player_left',
+          rankings: [
+            {
+              rank: 1,
+              player_id: 1,
+              nickname: 'host',
+              final_assets: 5000000,
+              is_winner: true,
+            },
+            {
+              rank: 2,
+              player_id: 2,
+              nickname: 'guest',
+              final_assets: 3000000,
+              is_winner: false,
+            },
+          ],
+          winner: {
+            playerId: 1,
+            nickname: 'host',
+            balance: 1000000,
+            assets: 5000000,
+          },
+        },
+      },
+      { op: 'set', path: 'winnerId', value: 1 },
+      { op: 'set', path: 'isGameOver', value: true },
+    ])
+  })
+
+  it('does not duplicate authoritative 종료 patches when gameResult fields already exist', () => {
+    const normalized = normalizePatchEnvelopePayload({
+      gameId: 'game-over-event-existing',
+      revision: 94,
+      patch: [
+        { op: 'set', path: 'winner_id', value: 1 },
+        { op: 'set', path: 'is_game_over', value: 1 },
+        {
+          op: 'set',
+          path: 'game_result',
+          value: {
+            reason: 'disconnect_timeout',
+            winner: {
+              playerId: 1,
+              nickname: 'host',
+              balance: 100,
+              assets: 500,
+            },
+          },
+        },
+      ],
+      events: [
+        {
+          type: 'GAME_OVER',
+          reason: 'disconnect_timeout',
+          winner: {
+            playerId: 1,
+            nickname: 'host',
+            balance: 100,
+            assets: 500,
+          },
+          rankings: [],
+        } as unknown as ServerEvent,
+      ],
+    })
+
+    expect(normalized.patch).toEqual([
+      { op: 'set', path: 'winnerId', value: 1 },
+      { op: 'set', path: 'isGameOver', value: true },
+      {
+        op: 'set',
+        path: 'gameResult',
+        value: {
+          reason: 'disconnect_timeout',
+          rankings: undefined,
+          winner: {
+            playerId: 1,
+            nickname: 'host',
+            balance: 1000000,
+            assets: 5000000,
+          },
+        },
       },
     ])
   })

--- a/src/services/socket/gameContractAdapters.ts
+++ b/src/services/socket/gameContractAdapters.ts
@@ -712,6 +712,9 @@ const normalizeGameResultReason = (value: unknown): GameResult['reason'] => {
   if (normalizedReason === 'bankrupt') {
     return 'bankrupt'
   }
+  if (normalizedReason === 'player_left') {
+    return 'player_left'
+  }
 
   return 'max_rounds'
 }
@@ -865,6 +868,128 @@ const resolveWinnerIdFromGameResult = (
   return null
 }
 
+const normalizeGameOverEventResult = (
+  eventPayload: unknown
+): GameSnapshot['gameResult'] | null => {
+  if (!isRecord(eventPayload)) {
+    return null
+  }
+
+  const eventType =
+    toStringOrNull(eventPayload.type) ??
+    toStringOrNull(eventPayload.eventType) ??
+    toStringOrNull(eventPayload.event_type)
+  if (eventType?.trim().toUpperCase() !== 'GAME_OVER') {
+    return null
+  }
+
+  const nestedPayload =
+    eventPayload.payload && isRecord(eventPayload.payload)
+      ? (eventPayload.payload as Record<string, unknown>)
+      : null
+
+  return normalizeGameResultPayload({
+    reason:
+      eventPayload.reason ?? nestedPayload?.reason ?? nestedPayload?.endReason,
+    winner: eventPayload.winner ?? nestedPayload?.winner,
+    rankings:
+      eventPayload.rankings ??
+      eventPayload.results ??
+      nestedPayload?.rankings ??
+      nestedPayload?.results,
+  })
+}
+
+const createSnapshotRankingEntries = (
+  players: Player[],
+  winnerId: PlayerId | null
+): GameRanking[] =>
+  players
+    .map((player, index) => ({
+      player_id: player.id,
+      nickname: player.nickname,
+      final_assets: player.totalAssets ?? player.balance,
+      is_winner: winnerId != null && String(player.id) === String(winnerId),
+      originalIndex: index,
+    }))
+    .sort((left, right) => {
+      if (left.final_assets !== right.final_assets) {
+        return right.final_assets - left.final_assets
+      }
+
+      const leftWinner = left.is_winner ? 1 : 0
+      const rightWinner = right.is_winner ? 1 : 0
+      if (leftWinner !== rightWinner) {
+        return rightWinner - leftWinner
+      }
+
+      return left.originalIndex - right.originalIndex
+    })
+    .map((ranking, index) => ({
+      rank: index + 1,
+      player_id: ranking.player_id,
+      nickname: ranking.nickname,
+      final_assets: ranking.final_assets,
+      is_winner: ranking.is_winner,
+    }))
+
+const synthesizeGameResultFromFinishedSnapshot = (
+  snapshotPayload: Record<string, unknown>,
+  players: Player[],
+  winnerId: PlayerId | null,
+  isGameOver: boolean,
+  existingGameResult: GameSnapshot['gameResult'] | null
+): GameSnapshot['gameResult'] | null => {
+  if (existingGameResult || !isGameOver) {
+    return existingGameResult
+  }
+
+  const allDisconnected =
+    players.length > 0 &&
+    players.every((player) => player.state === 'disconnected')
+  const fallbackReason =
+    winnerId == null && (players.length === 0 || allDisconnected)
+      ? 'disconnect_timeout'
+      : 'max_rounds'
+  const reason = normalizeGameResultReason(
+    snapshotPayload.reason ??
+      snapshotPayload.endReason ??
+      snapshotPayload.gameOverReason ??
+      snapshotPayload.game_over_reason ??
+      fallbackReason
+  )
+
+  if (players.length === 0 || allDisconnected) {
+    return {
+      reason,
+      rankings: undefined,
+      winner: null,
+    }
+  }
+
+  const rankings = createSnapshotRankingEntries(players, winnerId)
+  const resolvedWinnerId = winnerId ?? rankings[0]?.player_id ?? null
+  const winnerPlayer =
+    resolvedWinnerId == null
+      ? null
+      : (players.find(
+          (player) => String(player.id) === String(resolvedWinnerId)
+        ) ?? null)
+
+  return {
+    reason,
+    rankings: rankings.length > 0 ? rankings : undefined,
+    winner: winnerPlayer
+      ? {
+          playerId: winnerPlayer.id,
+          nickname: winnerPlayer.nickname,
+          balance: winnerPlayer.balance,
+          assets: winnerPlayer.totalAssets ?? winnerPlayer.balance,
+        }
+      : null,
+  }
+}
+
 export const normalizeSnapshotPayload = (
   snapshotPayload: unknown,
   options: SnapshotNormalizeOptions
@@ -883,6 +1008,8 @@ export const normalizeSnapshotPayload = (
     : isRecord(snapshotPayload.tiles)
       ? Object.values(snapshotPayload.tiles)
       : []
+  const normalizedPlayers = playersRaw.map(normalizePlayerFromSnapshot)
+  const normalizedTiles = tilesRaw.map(normalizeTileFromSnapshot)
   const currentPlayerId = toPlayerIdOrNull(
     snapshotPayload.currentPlayerId ??
       snapshotPayload.current_player_id ??
@@ -901,6 +1028,13 @@ export const normalizeSnapshotPayload = (
   const normalizedIsGameOver =
     Boolean(snapshotPayload.isGameOver ?? snapshotPayload.is_game_over) ||
     normalizedPhase === 'finished'
+  const resolvedGameResult = synthesizeGameResultFromFinishedSnapshot(
+    snapshotPayload,
+    normalizedPlayers,
+    normalizedWinnerId,
+    normalizedIsGameOver,
+    normalizedGameResult
+  )
 
   return {
     roomId: toStringOrNull(snapshotPayload.roomId),
@@ -910,8 +1044,8 @@ export const normalizeSnapshotPayload = (
       null,
     revision: toFiniteInt(snapshotPayload.revision, options.envelopeRevision),
     phase: normalizedPhase,
-    players: playersRaw.map(normalizePlayerFromSnapshot),
-    tiles: tilesRaw.map(normalizeTileFromSnapshot),
+    players: normalizedPlayers,
+    tiles: normalizedTiles,
     currentPlayerId,
     currentTurn: currentPlayerId,
     round: toFiniteInt(snapshotPayload.round, roundFromTurn),
@@ -930,7 +1064,7 @@ export const normalizeSnapshotPayload = (
         snapshotPayload.globalEffect ??
         snapshotPayload.global_effect
     ),
-    gameResult: normalizedGameResult,
+    gameResult: resolvedGameResult,
     isGameOver: normalizedIsGameOver,
     winnerId: normalizedWinnerId,
   }
@@ -1165,18 +1299,64 @@ const normalizePatchOperation = (operation: GamePatchOperation) => {
 
 export const normalizePatchEnvelopePayload = (
   payload: GamePatchEnvelope
-): GamePatchEnvelope => ({
-  ...payload,
-  revision: toFiniteInt(payload.revision, 0),
-  patch: Array.isArray(payload.patch)
+): GamePatchEnvelope => {
+  const normalizedPatch = Array.isArray(payload.patch)
     ? payload.patch.map(normalizePatchOperation)
-    : [],
-  events: Array.isArray(payload.events)
-    ? payload.events
-        .map(normalizeServerEvent)
-        .filter((event): event is ServerEvent => event !== null)
-    : [],
-})
+    : []
+  const rawEvents = Array.isArray(payload.events) ? payload.events : []
+  const normalizedEvents = rawEvents
+    .map(normalizeServerEvent)
+    .filter((event): event is ServerEvent => event !== null)
+  const gameResultFromEvent =
+    rawEvents
+      .map(normalizeGameOverEventResult)
+      .find((result) => result !== null) ?? null
+
+  const hasTopLevelSetPatch = (
+    pathKey: 'gameResult' | 'winnerId' | 'isGameOver'
+  ) =>
+    normalizedPatch.some((operation) => {
+      if (operation.op !== 'set') {
+        return false
+      }
+
+      const pathSegments = toPathSegments(operation.path)
+      return pathSegments.length === 1 && pathSegments[0] === pathKey
+    })
+
+  const syntheticPatch = [...normalizedPatch]
+
+  if (gameResultFromEvent && !hasTopLevelSetPatch('gameResult')) {
+    syntheticPatch.push({
+      op: 'set',
+      path: 'gameResult',
+      value: gameResultFromEvent,
+    })
+  }
+
+  if (gameResultFromEvent && !hasTopLevelSetPatch('winnerId')) {
+    syntheticPatch.push({
+      op: 'set',
+      path: 'winnerId',
+      value: resolveWinnerIdFromGameResult(gameResultFromEvent),
+    })
+  }
+
+  if (gameResultFromEvent && !hasTopLevelSetPatch('isGameOver')) {
+    syntheticPatch.push({
+      op: 'set',
+      path: 'isGameOver',
+      value: true,
+    })
+  }
+
+  return {
+    ...payload,
+    revision: toFiniteInt(payload.revision, 0),
+    patch: syntheticPatch,
+    events: normalizedEvents,
+  }
+}
 
 export const normalizeTimerSyncPayload = (
   payload: unknown

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -123,6 +123,7 @@ export type GameRanking = {
 export type GameResult = {
   reason:
     | 'bankrupt'
+    | 'player_left'
     | 'round_limit'
     | 'last_player_standing'
     | 'max_rounds'


### PR DESCRIPTION
## 📌 관련 이슈

> closes #627

---

## 📝 작업 내용

- 우측 플레이어 패널이 진행 중에는 서버 `players[].totalAssets`를 우선 표시하고, 정렬과 왕관 기준도 총자산 중심으로 맞췄습니다.
- 종료 결과 모달은 authoritative `gameResult`가 있을 때만 열리도록 정리해, 우측 패널과 결과창이 서로 다른 숫자를 보여주지 않게 했습니다.
- live `GAME_OVER` 이벤트와 reconnect finished snapshot을 프론트 `gameResult` 상태로 복구하도록 adapter를 보강했습니다.

---

## 🧠 Task 문서 (큰 작업이면 필수)

- plan: `docs/ai/tasks/panel-total-assets-authoritative/plan.md`
- context: `docs/ai/tasks/panel-total-assets-authoritative/context.md`
- checklist: `docs/ai/tasks/panel-total-assets-authoritative/checklist.md`

---

## 📋 TODO.md 연결

- task slug: `panel-total-assets-authoritative`
- TODO status: `Done`
- TODO entry 확인: `TODO.md`의 완료 항목과 `docs/ai/tasks/panel-total-assets-authoritative/` 3종 문서를 1:1로 맞췄습니다.

---

## 📚 참고한 기준 문서

- `AGENTS.md`
- `docs/ai/manuals/common.md`
- `docs/rules.md`
- `docs/testing.md`
- `docs/ai/manuals/game-runtime.md`
- `docs/socket-mock-server.md`

---

## 🧪 실행한 검증

- `npx vitest run src/services/socket/gameContractAdapters.test.ts src/pages/GamePage.test.tsx`
- `npm run ai:check:game`
- `npm run ai:check:build`
- `npm run lint`
- `npm run ai:self-review -- --files TODO.md docs/ai/tasks/panel-total-assets-authoritative/checklist.md docs/ai/tasks/panel-total-assets-authoritative/context.md docs/ai/tasks/panel-total-assets-authoritative/plan.md src/components/board/GameBoard.tsx src/components/game/panels/PlayerPanel.tsx src/pages/GamePage.test.tsx src/pages/GamePage.tsx src/services/socket/gameContractAdapters.test.ts src/services/socket/gameContractAdapters.ts src/types/domain.ts`

---

## ⚠️ 남은 리스크

- `npm run lint`는 기존 [GameBoard.tsx](/Users/admin/Desktop/Blue_Marble-frontend/src/components/board/GameBoard.tsx#L916)의 `react-hooks/exhaustive-deps` warning 1건 때문에 warning 종료입니다.
- `src/pages/GamePage.test.tsx` 실행 시 기존 `act(...)` warning이 계속 출력됩니다.

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료
- [x] 큰 작업이면 task 문서 링크를 남겼다
- [x] 큰 작업이면 `TODO.md` / task slug 연결을 PR 본문에 남겼다
- [x] 참고한 기준 문서를 PR 본문에 남겼다
- [x] 실행한 검증과 남은 리스크를 PR 본문에 적었다

---

## 📸 스크린샷 (선택)

- UI 변경이 있지만 별도 스크린샷은 생략했습니다.
