### PR TITLE
fix: 게임 종료 후 대기방 복귀와 방 이동 접속자 상태 동기화

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -16,6 +16,10 @@
 
 ## Done
 
+- [x] `waiting-room-authoritative-resume-refresh` - Waiting Room Authoritative Resume Refresh (`docs/ai/tasks/waiting-room-authoritative-resume-refresh/`) - game 종료 후 waiting-room 복귀를 background join revalidation으로 교정하고 room create/join presence 반영을 follow-up refresh로 보강
+- [x] `waiting-room-resume-bootstrap-presence-resync` - Waiting Room Resume Bootstrap Presence Resync (`docs/ai/tasks/waiting-room-resume-bootstrap-presence-resync/`) - 게임 종료 후 대기방 복귀 무한 로딩을 bootstrap snapshot으로 해소하고 waiting-room에서도 lobby_updated 기반 presence 재동기화를 수행
+- [x] `presence-realtime-room-transitions` - Presence Realtime Room Transitions (`docs/ai/tasks/presence-realtime-room-transitions/`) - 로비/대기방 이동 시 접속자 목록 상태가 stale하게 남는 경로를 room membership override와 lobby presence resync로 정리
+- [x] `waiting-room-presence-contract-alignment` - Waiting Room Presence Contract Alignment (`docs/ai/tasks/waiting-room-presence-contract-alignment/`) - game 종료 후 resume room 경로와 로비/대기방 접속자 상태 동기화를 백엔드 계약에 맞게 정렬
 - [x] `game-runtime-warning-cleanup` - Game Runtime Warning Cleanup (`docs/ai/tasks/game-runtime-warning-cleanup/`) - GameBoard deps warning과 GamePage.test act warning을 기능 변경 없이 정리
 - [x] `current-round-badge-style` - Current Round Badge Style (`docs/ai/tasks/current-round-badge-style/`) - 게임 화면 현재 라운드 뱃지를 더 자연스럽게 보이도록 정리
 - [x] `panel-total-assets-authoritative` - Panel Total Assets Authoritative (`docs/ai/tasks/panel-total-assets-authoritative/`) - GAME_OVER 이벤트와 reconnect snapshot을 `gameResult`로 복구해 우측 패널/종료 결과를 서버 권위 기준으로 정렬

--- a/docs/ai/tasks/presence-realtime-room-transitions/checklist.md
+++ b/docs/ai/tasks/presence-realtime-room-transitions/checklist.md
@@ -1,0 +1,8 @@
+# Checklist
+
+- [x] `mergeOnlineUsersWithRoomPlayers`에 waiting-room 전용 status override 옵션 추가
+- [x] waiting-room에서 room 참가자를 `includeMissingPlayers + overrideExistingStatus`로 병합
+- [x] `lobby_updated` 수신 시 presence snapshot refresh 추가
+- [x] online users model 테스트 보강
+- [x] WaitingRoomPage 접속자 목록 회귀 테스트 갱신
+- [x] lobby hooks 테스트 추가

--- a/docs/ai/tasks/presence-realtime-room-transitions/context.md
+++ b/docs/ai/tasks/presence-realtime-room-transitions/context.md
@@ -1,0 +1,24 @@
+# Context
+
+## Background
+
+- backend 새 계약에서는 `online_users`가 authoritative snapshot이지만, room membership 변화 직후 snapshot 전파가 늦을 수 있다.
+- waiting-room은 이미 현재 room의 `players`와 `status`를 알고 있으므로, 그 범위에서는 online snapshot보다 더 강한 로컬 truth를 가질 수 있다.
+
+## Current Problems
+
+- 다른 사용자가 대기방에 들어와도 접속자 목록에는 잠시 `로비`로 남는다.
+- `online_users` snapshot에 없는 room player는 waiting-room 접속자 목록에서 아예 빠질 수 있다.
+- lobby는 `lobby_updated` 시 방 목록만 다시 읽고 presence snapshot은 재동기화하지 않아, 다른 사용자의 join/leave 직후 stale 상태가 남을 수 있다.
+
+## Key Files
+
+- `src/features/presence/online-users/onlineUsersModel.ts`
+- `src/pages/waiting-room/page/WaitingRoomPage.tsx`
+- `src/pages/lobby/hooks.ts`
+
+## Constraints
+
+- `useOnlineUsersSocket()` 반환 형태와 `LobbyPage`의 전체 구조는 유지한다.
+- waiting-room status override는 현재 room 참가자에만 한정한다.
+- mock/real socket 경로 모두 같은 화면 정책을 유지해야 한다.

--- a/docs/ai/tasks/presence-realtime-room-transitions/plan.md
+++ b/docs/ai/tasks/presence-realtime-room-transitions/plan.md
@@ -1,0 +1,38 @@
+# Plan
+
+## Task
+
+- 작업 이름: Presence Realtime Room Transitions
+- 요청 날짜: 2026-03-25
+- 담당 범위: 로비/대기방 접속자 목록 실시간 상태 반영
+
+## Goal
+
+- 대기방에서는 현재 room 참가자를 `room.players + room.status` 기준으로 즉시 `in_room`/`playing`으로 보이게 한다.
+- 로비에서는 `lobby_updated` 직후 접속자 snapshot을 다시 읽어 다른 사용자의 room 이동이 새로고침 없이 반영되게 한다.
+
+## In Scope
+
+- `src/features/presence/online-users/**`
+- `src/pages/waiting-room/page/WaitingRoomPage.tsx`
+- `src/pages/lobby/hooks.ts`
+- 관련 Vitest 보강
+
+## Out Of Scope
+
+- backend presence 이벤트 계약 변경
+- waiting-room resume loading follow-up
+- DM 정책 또는 접속자 목록 정렬 정책 변경
+
+## Completion Criteria
+
+- waiting-room에서는 stale `online_users`가 `lobby`여도 현재 room 참가자는 `대기방` 또는 `게임중`으로 보인다.
+- waiting-room에서는 `online_users` snapshot에 없는 현재 room 참가자도 접속자 목록에 보인다.
+- lobby에서는 `lobby_updated` 수신 시 room query invalidation과 함께 `requestOnlineUsersSnapshotSync()`가 호출된다.
+- model/page/hook 테스트가 새 정책 기준으로 통과한다.
+
+## Test Plan
+
+- `npx vitest run src/features/presence/online-users/onlineUsersModel.test.ts src/pages/waiting-room/page/WaitingRoomPage.test.tsx src/pages/lobby/hooks.test.tsx`
+- `npm run lint`
+- 필요 시 `npm run ai:check:lobby`

--- a/docs/ai/tasks/waiting-room-authoritative-resume-refresh/checklist.md
+++ b/docs/ai/tasks/waiting-room-authoritative-resume-refresh/checklist.md
@@ -1,0 +1,7 @@
+# Checklist
+
+- [x] resume room 경로에서 bootstrap snapshot 이후 background `joinWaitingRoom()` revalidation 추가
+- [x] join 응답보다 먼저 온 `room_updated`가 있으면 join 결과 무시
+- [x] presence refresh helper에 follow-up refresh 옵션 추가
+- [x] `lobby_updated` / local leave / game leave 성공 경로에 follow-up refresh 적용
+- [x] onlineUsersSocket / lifecycle / socketSync / actions / lobby / game 테스트 보강

--- a/docs/ai/tasks/waiting-room-authoritative-resume-refresh/context.md
+++ b/docs/ai/tasks/waiting-room-authoritative-resume-refresh/context.md
@@ -1,0 +1,17 @@
+# Context
+
+## Background
+
+- 기존 `waiting-room-resume-bootstrap-presence-resync` 작업으로 game 종료 후 waiting-room 복귀 무한 로딩은 해소했다.
+- 하지만 resume 경로가 `lastRoomSnapshot`을 즉시 보여준 뒤 authoritative room snapshot으로 다시 덮지 않아서, 실제로는 로비에 나간 플레이어가 waiting-room player/ready 상태로 남아 보였다.
+- waiting-room과 lobby는 `lobby_updated -> requestOnlineUsersSnapshotSync()`를 이미 수행했지만, 다른 사용자의 room create/join 직후에는 `/users/online` snapshot 반영이 살짝 늦어 접속자 목록이 stale하게 남는 경우가 있었다.
+
+## Current Decision
+
+- resume 경로는 bootstrap snapshot을 유지하되, 항상 background `joinWaitingRoom()`으로 authoritative room snapshot을 재검증한다.
+- presence refresh helper는 optional follow-up refresh를 지원하고, room create/join/leave처럼 snapshot 반영 시차가 있는 경로에서 이를 사용한다.
+
+## Risks
+
+- background join refresh는 backend가 idempotent rejoin을 허용한다는 전제에 의존한다.
+- follow-up refresh는 추가 REST 요청 1회를 발생시키므로, `lobby_updated` burst 시 요청 수가 약간 늘 수 있다.

--- a/docs/ai/tasks/waiting-room-authoritative-resume-refresh/plan.md
+++ b/docs/ai/tasks/waiting-room-authoritative-resume-refresh/plan.md
@@ -1,0 +1,43 @@
+# Plan
+
+## Task
+
+- 작업 이름: Waiting Room Authoritative Resume Refresh
+- 요청 날짜: 2026-03-25
+- 담당 범위: waiting-room resume authoritative refresh / presence follow-up refresh
+
+## Goal
+
+- game 종료 후 waiting-room 복귀 시 bootstrap snapshot이 stale player/ready 상태를 오래 보여주지 않게 한다.
+- 다른 사용자의 room create/join 이동이 로비/대기방 접속자 목록에 더 빠르게 반영되게 한다.
+
+## In Scope
+
+- `src/pages/waiting-room/controller/lifecycle.ts`
+- `src/features/presence/online-users/**`
+- `src/pages/lobby/hooks.ts`
+- `src/pages/waiting-room/controller/socketSync.ts`
+- `src/pages/waiting-room/controller/actions.ts`
+- `src/pages/GamePage.tsx`
+- 관련 Vitest
+
+## Out Of Scope
+
+- backend contract 변경
+- waiting-room seat UI 재설계
+- presence source of truth 재정의
+
+## Completion Criteria
+
+- resume room 경로는 bootstrap snapshot이 있더라도 background `joinWaitingRoom()`으로 authoritative snapshot을 다시 적용한다.
+- `room_updated`가 join refresh보다 먼저 오면 join 결과가 최신 socket snapshot을 덮지 않는다.
+- `lobby_updated`와 local leave 이후 presence refresh는 즉시 1회 + follow-up 1회로 동작한다.
+- 관련 lifecycle/socketSync/lobby/game/presence 테스트가 새 동작을 검증한다.
+
+## Test Plan
+
+- `npx vitest run src/features/presence/online-users/onlineUsersSocket.test.ts src/pages/waiting-room/controller/lifecycle.test.ts src/pages/waiting-room/controller/socketSync.test.ts src/pages/waiting-room/controller/actions.test.ts src/pages/lobby/hooks.test.tsx src/pages/GamePage.test.tsx`
+- `npm run lint`
+- `npm run ai:check:waiting-room`
+- `npm run ai:check:lobby`
+- `npm run build`

--- a/docs/ai/tasks/waiting-room-presence-contract-alignment/checklist.md
+++ b/docs/ai/tasks/waiting-room-presence-contract-alignment/checklist.md
@@ -1,0 +1,10 @@
+# Checklist
+
+- [x] `GamePage` 종료 복귀 시 `resumeRoomMembership` route state 추가
+- [x] waiting-room lifecycle에 resume room 경로 추가
+- [x] resume 경로에서 `joinWaitingRoom()` 제거, `enterWaitingRoomSocket()` + `requestOnlineUsersSnapshotSync()`만 수행
+- [x] `room_updated` 수신 시 loading 종료 처리 추가
+- [x] waiting-room leave / game leave 성공 후 접속자 snapshot 재동기화 추가
+- [x] online users merge helper가 existing status를 보존하도록 조정
+- [x] waiting-room / lobby 접속자 목록이 fallback status를 missing user에만 적용하도록 정렬
+- [x] lifecycle/actions/model/page 테스트 보강

--- a/docs/ai/tasks/waiting-room-presence-contract-alignment/context.md
+++ b/docs/ai/tasks/waiting-room-presence-contract-alignment/context.md
@@ -1,0 +1,31 @@
+# Context
+
+## Background
+
+- backend 계약이 바뀌면서 room membership / presence authoritative 전환 시점이 REST와 snapshot 중심으로 정리되었다.
+- `POST /rooms`, `POST /rooms/:roomId/join`, `POST /rooms/:roomId/leave`, `POST /rooms/:roomId/start`, game 종료 finalize가 membership + presence를 확정한다.
+- `enter_room` / `leave_room`은 room socket 구독 제어만 담당하고 membership / presence를 바꾸지 않는다.
+- `online_users`는 authoritative snapshot, `user_status_changed`는 빠른 증분 반영이다.
+
+## Current Problems
+
+- game 종료 후 `GamePage -> /rooms/:roomId` 복귀가 waiting-room lifecycle에서 새 room 참가처럼 `joinWaitingRoom()`을 다시 호출한다.
+- waiting-room / lobby 접속자 목록은 existing `online_users` status를 `room.status` 기반 fallback으로 덮어써 stale 상태를 더 오래 보여줄 수 있다.
+- waiting-room leave, game leave 이후에는 접속자 목록 재동기화 요청이 없어 새로고침 전까지 `playing` / `in_room`이 남는 사례가 있다.
+
+## Key Files
+
+- `src/pages/GamePage.tsx`
+- `src/pages/waiting-room/page/WaitingRoomPage.tsx`
+- `src/pages/waiting-room/hooks/hooks.ts`
+- `src/pages/waiting-room/controller/lifecycle.ts`
+- `src/pages/waiting-room/controller/actions.ts`
+- `src/features/presence/online-users/onlineUsersModel.ts`
+- `src/pages/lobby/LobbyPage.tsx`
+
+## Constraints
+
+- `useWaitingRoomController`는 조립 계층으로 유지하고 상세 전이는 lifecycle/actions에 둔다.
+- `leaveWaitingRoom` API 성공 전에 `leave_room`을 먼저 보내면 안 된다.
+- 접속자 목록 반환 형태와 `useOnlineUsersSocket()` API는 유지한다.
+- mock 모드와 실제 모드에 보이는 동작 차이를 만들지 않는다.

--- a/docs/ai/tasks/waiting-room-presence-contract-alignment/plan.md
+++ b/docs/ai/tasks/waiting-room-presence-contract-alignment/plan.md
@@ -1,0 +1,43 @@
+# Plan
+
+## Task
+
+- 작업 이름: Waiting Room Presence Contract Alignment
+- 요청 날짜: 2026-03-25
+- 담당 범위: game 종료 복귀 / waiting-room lifecycle / lobby-presence 동기화
+
+## Goal
+
+- game 종료 후 waiting-room 복귀를 새 `join`이 아니라 기존 room membership resume으로 처리한다.
+- 대기방/로비 접속자 목록이 `online_users` authoritative snapshot을 기준으로 보이도록 정렬한다.
+- leave 성공 직후 presence stale 때문에 새로고침해야 정상화되는 경로를 줄인다.
+
+## In Scope
+
+- `src/pages/GamePage.tsx`
+- `src/pages/waiting-room/**`
+- `src/features/presence/online-users/**`
+- 필요 시 `src/pages/lobby/LobbyPage.tsx`
+- 관련 Vitest 보강
+
+## Out Of Scope
+
+- backend room cleanup 정책 자체 수정
+- waiting-room seat UI 스타일 변경
+- DM unread 정책 변경
+- game socket contract 자체 변경
+
+## Completion Criteria
+
+- game 종료 후 waiting-room으로 돌아갈 때 `/rooms/:roomId/join` 재호출 없이 room socket 구독만 복구한다.
+- resume 직후 첫 `room_updated`를 authoritative room snapshot으로 반영하고, 그 전까지는 loading 상태를 유지한다.
+- `mergeOnlineUsersWithRoomPlayers` / `mergeOnlineUsersWithCurrentUser`는 기존 `online_users` status를 덮어쓰지 않고 missing user만 fallback status로 보강한다.
+- waiting-room leave / game leave 후 접속자 목록 재동기화 요청이 발생한다.
+- 관련 lifecycle/actions/model/page 테스트가 새 계약 기준으로 통과한다.
+
+## Test Plan
+
+- `npx vitest run src/pages/waiting-room/controller/lifecycle.test.ts src/pages/waiting-room/controller/actions.test.ts src/features/presence/online-users/onlineUsersModel.test.ts src/pages/GamePage.test.tsx src/pages/waiting-room/page/WaitingRoomPage.test.tsx`
+- `npm run lint`
+- `npm run build`
+- `npm run ai:check:game`

--- a/docs/ai/tasks/waiting-room-resume-bootstrap-presence-resync/checklist.md
+++ b/docs/ai/tasks/waiting-room-resume-bootstrap-presence-resync/checklist.md
@@ -1,0 +1,8 @@
+# Checklist
+
+- [x] `game_start` 이동 state에 `lastRoomSnapshot` 전달
+- [x] game 종료 복귀 state에 `lastRoomSnapshot` 전달
+- [x] waiting-room controller/lifecycle에 `resumeBootstrapSnapshot` 추가
+- [x] resume bootstrap snapshot이 있으면 loading 없이 room/chat 상태 즉시 복구
+- [x] waiting-room `lobby_updated`에서 전역 presence resync 수행
+- [x] lifecycle / socketSync / page / game 테스트 보강

--- a/docs/ai/tasks/waiting-room-resume-bootstrap-presence-resync/context.md
+++ b/docs/ai/tasks/waiting-room-resume-bootstrap-presence-resync/context.md
@@ -1,0 +1,25 @@
+# Context
+
+## Background
+
+- waiting-room presence contract 정렬 이후에도 game 종료 복귀 시 resume 경로가 첫 `room_updated`만 기다려 loading에 고착될 수 있었다.
+- waiting-room 접속자 목록은 현재 room 참가자 override는 수행하지만, 다른 room의 membership 변화는 waiting-room에서 전역 resync하지 않아 stale 상태가 남을 수 있었다.
+
+## Current Problems
+
+- game 종료 후 `대기방으로 돌아가기`를 눌러도 waiting-room이 계속 로딩 상태로 남는다.
+- waiting-room에서 다른 사용자가 방을 만들거나 나가도 접속자 목록이 바로 갱신되지 않는다.
+
+## Key Files
+
+- `src/pages/GamePage.tsx`
+- `src/pages/waiting-room/page/WaitingRoomPage.tsx`
+- `src/pages/waiting-room/hooks/hooks.ts`
+- `src/pages/waiting-room/controller/lifecycle.ts`
+- `src/pages/waiting-room/controller/socketSync.ts`
+
+## Constraints
+
+- backend 추가 엔드포인트 없이 현재 route state와 socket 이벤트만으로 해결한다.
+- bootstrap snapshot은 초기 렌더 용도이며, 이후 authoritative source는 `room_updated`와 `online_users`다.
+- 현재 room `removed` cleanup semantics는 유지한다.

--- a/docs/ai/tasks/waiting-room-resume-bootstrap-presence-resync/plan.md
+++ b/docs/ai/tasks/waiting-room-resume-bootstrap-presence-resync/plan.md
@@ -1,0 +1,40 @@
+# Plan
+
+## Task
+
+- 작업 이름: Waiting Room Resume Bootstrap Presence Resync
+- 요청 날짜: 2026-03-25
+- 담당 범위: game 종료 후 waiting-room resume bootstrap / waiting-room 전역 presence resync
+
+## Goal
+
+- game 종료 후 waiting-room 복귀가 `room_updated`만 기다리다 무한 로딩되는 경로를 제거한다.
+- waiting-room에서도 `lobby_updated`를 전역 presence 재동기화 신호로 사용해 다른 사용자의 room 이동이 바로 접속자 목록에 반영되게 한다.
+
+## In Scope
+
+- `src/pages/GamePage.tsx`
+- `src/pages/waiting-room/**`
+- 관련 Vitest 보강
+
+## Out Of Scope
+
+- backend contract 변경
+- 로비 접속자 목록 병합 정책 재설계
+- waiting-room seat / DM UI 변경
+
+## Completion Criteria
+
+- `game -> waiting-room` 복귀 시 `resumeRoomMembership + lastRoomSnapshot` state가 전달된다.
+- resume bootstrap snapshot이 있으면 waiting-room이 즉시 room/chat 상태를 그리며 loading을 해제한다.
+- waiting-room의 모든 `lobby_updated` 수신은 `requestOnlineUsersSnapshotSync()`를 호출한다.
+- 현재 방 `removed`는 기존 cleanup 동작을 유지한다.
+- lifecycle/socketSync/page/game 테스트가 새 경로를 검증한다.
+
+## Test Plan
+
+- `npx vitest run src/pages/waiting-room/controller/lifecycle.test.ts src/pages/GamePage.test.tsx src/pages/waiting-room/page/WaitingRoomPage.test.tsx src/pages/waiting-room/controller/socketSync.test.ts`
+- `npm run lint`
+- `npm run ai:check:waiting-room`
+- `npm run ai:check:lobby`
+- `npm run build`

--- a/src/features/presence/online-users/onlineUsersModel.test.ts
+++ b/src/features/presence/online-users/onlineUsersModel.test.ts
@@ -79,10 +79,34 @@ describe('mergeOnlineUsersWithCurrentUser', () => {
       })
     )
   })
+
+  it('현재 사용자가 이미 snapshot에 있으면 기존 status를 유지한다', () => {
+    const merged = mergeOnlineUsersWithCurrentUser(
+      [
+        createOnlineUserFixture({
+          id: 'user-1',
+          nickname: '테스터',
+          status: 'in_room',
+        }),
+      ],
+      {
+        id: 'user-1',
+        nickname: '테스터',
+        status: 'lobby',
+      }
+    )
+
+    expect(merged).toContainEqual(
+      expect.objectContaining({
+        id: 'user-1',
+        status: 'in_room',
+      })
+    )
+  })
 })
 
 describe('mergeOnlineUsersWithRoomPlayers', () => {
-  it('room.players 기준으로 참가자 상태와 닉네임을 덮어쓴다', () => {
+  it('기본 옵션에서는 room.players 기준으로 닉네임은 보강하되 기존 online status는 유지한다', () => {
     const merged = mergeOnlineUsersWithRoomPlayers(
       [
         createOnlineUserFixture({
@@ -110,7 +134,7 @@ describe('mergeOnlineUsersWithRoomPlayers', () => {
       expect.objectContaining({
         id: 'user-1',
         nickname: '방장',
-        status: 'in_room',
+        status: 'lobby',
         avatarText: '방',
       })
     )
@@ -123,7 +147,37 @@ describe('mergeOnlineUsersWithRoomPlayers', () => {
     )
   })
 
-  it('online snapshot에 없는 room player는 기본값으로 다시 추가하지 않는다', () => {
+  it('overrideExistingStatus 옵션이 켜지면 existing status를 room status로 덮어쓴다', () => {
+    const merged = mergeOnlineUsersWithRoomPlayers(
+      [
+        createOnlineUserFixture({
+          id: 'user-1',
+          nickname: '이전닉네임',
+          status: 'lobby',
+          avatarText: '이',
+        }),
+      ],
+      [
+        {
+          id: 'user-1',
+          nickname: '방장',
+        },
+      ],
+      'in_room',
+      { overrideExistingStatus: true }
+    )
+
+    expect(merged).toContainEqual(
+      expect.objectContaining({
+        id: 'user-1',
+        nickname: '방장',
+        status: 'in_room',
+        avatarText: '방',
+      })
+    )
+  })
+
+  it('기본 옵션에서는 online snapshot에 없는 room player를 다시 추가하지 않는다', () => {
     const merged = mergeOnlineUsersWithRoomPlayers(
       [
         createOnlineUserFixture({
@@ -145,7 +199,7 @@ describe('mergeOnlineUsersWithRoomPlayers', () => {
     expect(merged.find((user) => user.id === 'user-2')).toBeUndefined()
   })
 
-  it('옵션을 주면 snapshot에 없는 room player도 fallback으로 포함할 수 있다', () => {
+  it('waiting-room 옵션을 주면 snapshot에 없는 room player도 fallback으로 포함할 수 있다', () => {
     const merged = mergeOnlineUsersWithRoomPlayers(
       [],
       [
@@ -155,7 +209,10 @@ describe('mergeOnlineUsersWithRoomPlayers', () => {
         },
       ],
       'in_room',
-      { includeMissingPlayers: true }
+      {
+        includeMissingPlayers: true,
+        overrideExistingStatus: true,
+      }
     )
 
     expect(merged).toContainEqual(

--- a/src/features/presence/online-users/onlineUsersModel.ts
+++ b/src/features/presence/online-users/onlineUsersModel.ts
@@ -24,6 +24,7 @@ function createOnlineUserViewModel(user: OnlineUserPayload): OnlineUser {
 
 interface MergeOnlineUsersWithRoomPlayersOptions {
   includeMissingPlayers?: boolean
+  overrideExistingStatus?: boolean
 }
 
 // 접속자 payload를 UI 전용 접속자 모델로 매핑
@@ -46,12 +47,14 @@ export function mergeOnlineUsersWithCurrentUser(
     users.map((user) => [user.id, user])
   )
 
+  const existingUser = usersById.get(currentUser.id)
+
   usersById.set(
     currentUser.id,
     createOnlineUserViewModel({
       id: currentUser.id,
       nickname: currentUser.nickname,
-      status: currentUser.status,
+      status: existingUser?.status ?? currentUser.status,
     })
   )
 
@@ -59,8 +62,8 @@ export function mergeOnlineUsersWithCurrentUser(
 }
 
 // room.players를 기준으로 현재 방 참가자의 상태를 접속자 목록에 반영한다.
-// source of truth는 여전히 online snapshot이며, 명시적으로 허용한 경우에만
-// snapshot에 없는 room player를 목록에 추가한다.
+// 기본 source of truth는 online snapshot이지만, waiting-room처럼 현재 room membership이
+// 더 강한 local truth인 화면에서는 상태 override와 missing player 보강을 허용한다.
 export function mergeOnlineUsersWithRoomPlayers(
   users: OnlineUser[],
   players: Array<{
@@ -70,7 +73,8 @@ export function mergeOnlineUsersWithRoomPlayers(
   status: Extract<OnlineUserPayload['status'], 'in_room' | 'playing'>,
   options: MergeOnlineUsersWithRoomPlayersOptions = {}
 ) {
-  const { includeMissingPlayers = false } = options
+  const { includeMissingPlayers = false, overrideExistingStatus = false } =
+    options
   const usersById = new Map<string, OnlineUser>(
     users.map((user) => [user.id, user])
   )
@@ -87,7 +91,10 @@ export function mergeOnlineUsersWithRoomPlayers(
       createOnlineUserViewModel({
         id: player.id,
         nickname: player.nickname,
-        status,
+        status:
+          existingUser && !overrideExistingStatus
+            ? existingUser.status
+            : status,
       })
     )
   })

--- a/src/features/presence/online-users/onlineUsersSocket.test.ts
+++ b/src/features/presence/online-users/onlineUsersSocket.test.ts
@@ -151,4 +151,65 @@ describe('onlineUsersSocket', () => {
 
     expect(connected.connectSocketWithAuthIfNeededMock).toHaveBeenCalledTimes(1)
   })
+
+  it('requestOnlineUsersSnapshotSync는 즉시 refresh 요청을 보내고 mock 모드에서는 스냅샷도 즉시 브로드캐스트한다', async () => {
+    const addEventListenerSpy = vi.spyOn(window, 'addEventListener')
+    const dispatchEventSpy = vi.spyOn(window, 'dispatchEvent')
+    const mockListener = vi.fn()
+    window.addEventListener('online-users-refresh-request', mockListener)
+
+    const { module, listenerMock } = await loadOnlineUsersSocketModule(
+      true,
+      false,
+      [
+        {
+          id: 'user-1',
+          nickname: '마블왕',
+          status: 'in_room',
+        },
+      ]
+    )
+
+    module.requestOnlineUsersSnapshotSync()
+
+    expect(dispatchEventSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'online-users-refresh-request',
+      })
+    )
+    expect(listenerMock).toHaveBeenCalledTimes(1)
+
+    window.removeEventListener('online-users-refresh-request', mockListener)
+    addEventListenerSpy.mockRestore()
+    dispatchEventSpy.mockRestore()
+  })
+
+  it('requestOnlineUsersSnapshotSync는 follow-up 옵션이 있으면 짧은 지연 뒤 한 번 더 요청한다', async () => {
+    const dispatchEventSpy = vi.spyOn(window, 'dispatchEvent')
+    const { module, listenerMock } = await loadOnlineUsersSocketModule(
+      true,
+      false,
+      [
+        {
+          id: 'user-1',
+          nickname: '마블왕',
+          status: 'lobby',
+        },
+      ]
+    )
+
+    module.requestOnlineUsersSnapshotSync({
+      includeFollowUpRefresh: true,
+    })
+
+    expect(dispatchEventSpy).toHaveBeenCalledTimes(1)
+    expect(listenerMock).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(400)
+
+    expect(dispatchEventSpy).toHaveBeenCalledTimes(2)
+    expect(listenerMock).toHaveBeenCalledTimes(2)
+
+    dispatchEventSpy.mockRestore()
+  })
 })

--- a/src/features/presence/online-users/onlineUsersSocket.ts
+++ b/src/features/presence/online-users/onlineUsersSocket.ts
@@ -12,7 +12,12 @@ export const ONLINE_USER_STATUS_CHANGED_EVENT_NAME = 'user_status_changed'
 export const ONLINE_USERS_REFRESH_REQUEST_EVENT_NAME =
   'online-users-refresh-request'
 const SOCKET_MOCK_INTERVAL_MS = 5_000
+const ONLINE_USERS_FOLLOW_UP_REFRESH_DELAY_MS = 400
 const USE_SOCKET_MOCK = IS_SOCKET_MOCK_ENABLED
+
+interface RequestOnlineUsersSnapshotSyncOptions {
+  includeFollowUpRefresh?: boolean
+}
 
 // 테스트용 리스너 접근을 위한 socket 타입 확장
 interface SocketWithListeners {
@@ -64,11 +69,29 @@ export function ensureOnlineUsersSocketConnection() {
   connectSocketWithAuthIfNeeded()
 }
 
-// 로컬 사용자 상태 변화 직후 접속자 스냅샷 재동기화를 요청
-export function requestOnlineUsersSnapshotSync() {
+function emitOnlineUsersRefreshRequest() {
+  if (USE_SOCKET_MOCK) {
+    emitMockOnlineUsersSnapshot()
+  }
+
   if (typeof window === 'undefined') {
     return
   }
 
   window.dispatchEvent(new Event(ONLINE_USERS_REFRESH_REQUEST_EVENT_NAME))
+}
+
+// 로컬 사용자 상태 변화 직후 접속자 스냅샷 재동기화를 요청
+export function requestOnlineUsersSnapshotSync(
+  options: RequestOnlineUsersSnapshotSyncOptions = {}
+) {
+  emitOnlineUsersRefreshRequest()
+
+  if (!options.includeFollowUpRefresh || typeof window === 'undefined') {
+    return
+  }
+
+  window.setTimeout(() => {
+    emitOnlineUsersRefreshRequest()
+  }, ONLINE_USERS_FOLLOW_UP_REFRESH_DELAY_MS)
 }

--- a/src/pages/GamePage.test.tsx
+++ b/src/pages/GamePage.test.tsx
@@ -9,6 +9,7 @@ import { useAuthStore } from '../features/auth/session/store'
 import { createAuthSessionFixture } from '../test/fixtures'
 import { renderWithProviders } from '../test/renderWithProviders'
 import type { Player } from '../types/domain'
+import type { WaitingRoomSnapshot } from './waiting-room/api/types'
 
 vi.mock('../config/env', () => ({
   IS_DEMO_MOCK_ENABLED: false,
@@ -25,6 +26,7 @@ const {
   toastErrorMock,
   leaveRoomFromGameMock,
   getGameLeaveErrorMessageMock,
+  requestOnlineUsersSnapshotSyncMock,
 } = vi.hoisted(() => {
   const handlers = new Map<string, Set<(payload: unknown) => void>>()
 
@@ -49,6 +51,7 @@ const {
     toastErrorMock: vi.fn(),
     leaveRoomFromGameMock: vi.fn(),
     getGameLeaveErrorMessageMock: vi.fn(),
+    requestOnlineUsersSnapshotSyncMock: vi.fn(),
   }
 })
 
@@ -79,6 +82,10 @@ vi.mock('../lib/socket', () => ({
 
 vi.mock('../pages/waiting-room/socket/socket', () => ({
   sendWaitingRoomChat: sendWaitingRoomChatMock,
+}))
+
+vi.mock('../features/presence/online-users/onlineUsersSocket', () => ({
+  requestOnlineUsersSnapshotSync: requestOnlineUsersSnapshotSyncMock,
 }))
 
 vi.mock('../hooks/game/useGameState', () => ({
@@ -219,6 +226,26 @@ const createPlayer = (overrides: Partial<Player> = {}): Player => ({
   is_in_jail: false,
   jail_turn_count: 0,
   is_bankrupt: false,
+  ...overrides,
+})
+
+const createWaitingRoomSnapshot = (
+  overrides: Partial<WaitingRoomSnapshot> = {}
+): WaitingRoomSnapshot => ({
+  roomId: 'room-1',
+  title: '테스트 방',
+  status: 'waiting',
+  maxPlayers: 4,
+  isPrivate: false,
+  players: [
+    {
+      id: 'user-1',
+      nickname: '유저1',
+      isReady: false,
+      isHost: true,
+    },
+  ],
+  chatMessages: [],
   ...overrides,
 })
 
@@ -538,6 +565,10 @@ describe('GamePage chat flow', () => {
       })
     })
 
+    expect(requestOnlineUsersSnapshotSyncMock).toHaveBeenCalledWith({
+      includeFollowUpRefresh: true,
+    })
+
     await waitFor(() => {
       expect(navigateMock).toHaveBeenCalledWith('/lobby', { replace: true })
     })
@@ -730,6 +761,7 @@ describe('GamePage chat flow', () => {
 
   it('게임 종료 결과 확인 시 같은 대기방으로 이동하고 game store를 초기화한다', async () => {
     const user = userEvent.setup()
+    const lastRoomSnapshot = createWaitingRoomSnapshot()
 
     setTestGameState({
       roomId: 'room-1',
@@ -747,7 +779,18 @@ describe('GamePage chat flow', () => {
       },
     })
 
-    renderGamePage()
+    renderGamePage({
+      initialEntries: [
+        {
+          pathname: '/game/game-1',
+          state: {
+            gameId: 'game-1',
+            roomId: 'room-1',
+            lastRoomSnapshot,
+          },
+        },
+      ],
+    })
 
     await user.click(
       screen.getByRole('button', { name: '대기방으로 돌아가기' })
@@ -757,6 +800,8 @@ describe('GamePage chat flow', () => {
       replace: true,
       state: {
         roomId: 'room-1',
+        resumeRoomMembership: true,
+        lastRoomSnapshot,
       },
     })
     expect(useGameStore.getState().players).toHaveLength(0)
@@ -804,6 +849,7 @@ describe('GamePage chat flow', () => {
 
   it('종료 상태에서는 fatal game error가 있어도 버튼 클릭 전 자동 fallback 이동하지 않는다', async () => {
     const user = userEvent.setup()
+    const lastRoomSnapshot = createWaitingRoomSnapshot()
 
     resetAndSetTestGameState({
       roomId: 'room-1',
@@ -827,7 +873,18 @@ describe('GamePage chat flow', () => {
       },
     })
 
-    renderGamePage()
+    renderGamePage({
+      initialEntries: [
+        {
+          pathname: '/game/game-1',
+          state: {
+            gameId: 'game-1',
+            roomId: 'room-1',
+            lastRoomSnapshot,
+          },
+        },
+      ],
+    })
 
     expect(
       screen.queryByText('참가 정보를 다시 확인하고 있습니다...')
@@ -842,6 +899,8 @@ describe('GamePage chat flow', () => {
       replace: true,
       state: {
         roomId: 'room-1',
+        resumeRoomMembership: true,
+        lastRoomSnapshot,
       },
     })
   })

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -10,6 +10,7 @@ import PlayerPanel from '../components/game/panels/PlayerPanel'
 import GlobalEffectModal from '../components/game/GlobalEffectModal'
 import { IS_SOCKET_MOCK_ENABLED } from '../config/env'
 import { useAuthStore } from '../features/auth/session/store'
+import { requestOnlineUsersSnapshotSync } from '../features/presence/online-users/onlineUsersSocket'
 import { DevRoomChatControlPanel } from '../features/room-chat/DevRoomChatControlPanel'
 import RoomChat from '../features/room-chat/RoomChat'
 import { useDiceRoll } from '../hooks/game/useDiceRoll'
@@ -37,7 +38,10 @@ import {
 } from './game/gameChat'
 import { getGameLeaveErrorMessage, leaveRoomFromGame } from './game/api'
 import { sendWaitingRoomChat } from './waiting-room/socket/socket'
-import type { ChatEventPayload } from './waiting-room/api/types'
+import type {
+  ChatEventPayload,
+  WaitingRoomSnapshot,
+} from './waiting-room/api/types'
 
 const USE_GAME_SOCKET_MOCK = IS_SOCKET_MOCK_ENABLED
 const ALLOW_ALL_MOCK_TURNS =
@@ -141,6 +145,7 @@ const mapRankingToPanelPlayer = (
 interface GamePageLocationState {
   roomId?: string
   gameId?: string
+  lastRoomSnapshot?: WaitingRoomSnapshot
 }
 
 const GamePage: React.FC = () => {
@@ -176,6 +181,7 @@ const GamePage: React.FC = () => {
     gameSession.gameId ??
     null
   const activeRoomId = locationState?.roomId ?? gameSession.roomId ?? null
+  const lastRoomSnapshot = locationState?.lastRoomSnapshot ?? null
   const [promptSubmittingChoice, setPromptSubmittingChoice] = useState<
     string | null
   >(null)
@@ -530,6 +536,9 @@ const GamePage: React.FC = () => {
         userId: currentUserId ?? undefined,
       })
 
+      requestOnlineUsersSnapshotSync({
+        includeFollowUpRefresh: true,
+      })
       resetGame()
       setIsExitModalOpen(false)
       navigate('/lobby', { replace: true })
@@ -550,6 +559,8 @@ const GamePage: React.FC = () => {
         replace: true,
         state: {
           roomId: activeRoomId,
+          resumeRoomMembership: true,
+          ...(lastRoomSnapshot ? { lastRoomSnapshot } : {}),
         },
       })
       return

--- a/src/pages/lobby/hooks.test.tsx
+++ b/src/pages/lobby/hooks.test.tsx
@@ -1,0 +1,104 @@
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useLobbyRoomsQuery } from './hooks'
+
+const {
+  useQueryMock,
+  useQueryClientMock,
+  invalidateQueriesMock,
+  connectSocketWithAuthIfNeededMock,
+  requestOnlineUsersSnapshotSyncMock,
+  socketOnMock,
+  socketOffMock,
+  lobbyUpdatedHandlerRef,
+} = vi.hoisted(() => ({
+  useQueryMock: vi.fn(),
+  useQueryClientMock: vi.fn(),
+  invalidateQueriesMock: vi.fn(),
+  connectSocketWithAuthIfNeededMock: vi.fn(),
+  requestOnlineUsersSnapshotSyncMock: vi.fn(),
+  socketOnMock: vi.fn(),
+  socketOffMock: vi.fn(),
+  lobbyUpdatedHandlerRef: {
+    current: null as (() => void) | null,
+  },
+}))
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: useQueryMock,
+  useQueryClient: useQueryClientMock,
+}))
+
+vi.mock('../../lib/socket', () => ({
+  connectSocketWithAuthIfNeeded: connectSocketWithAuthIfNeededMock,
+  socket: {
+    on: socketOnMock,
+    off: socketOffMock,
+  },
+}))
+
+vi.mock('../../features/presence/online-users/onlineUsersSocket', () => ({
+  requestOnlineUsersSnapshotSync: requestOnlineUsersSnapshotSyncMock,
+}))
+
+describe('useLobbyRoomsQuery', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    lobbyUpdatedHandlerRef.current = null
+
+    useQueryClientMock.mockReturnValue({
+      invalidateQueries: invalidateQueriesMock,
+    })
+    useQueryMock.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+    })
+    socketOnMock.mockImplementation(
+      (eventName: string, handler: (() => void) | undefined) => {
+        if (eventName === 'lobby_updated' && handler) {
+          lobbyUpdatedHandlerRef.current = handler
+        }
+      }
+    )
+  })
+
+  it('lobby_updated 수신 시 방 목록 invalidate와 presence snapshot refresh를 함께 요청한다', () => {
+    renderHook(() =>
+      useLobbyRoomsQuery({
+        searchRoom: '',
+        roomFilter: 'ALL',
+        excludePrivateRoom: false,
+      })
+    )
+
+    act(() => {
+      lobbyUpdatedHandlerRef.current?.()
+    })
+
+    expect(invalidateQueriesMock).toHaveBeenCalledWith({
+      queryKey: ['lobby', 'rooms'],
+    })
+    expect(requestOnlineUsersSnapshotSyncMock).toHaveBeenCalledWith({
+      includeFollowUpRefresh: true,
+    })
+  })
+
+  it('언마운트 시 lobby_updated 리스너를 해제한다', () => {
+    const { unmount } = renderHook(() =>
+      useLobbyRoomsQuery({
+        searchRoom: '',
+        roomFilter: 'ALL',
+        excludePrivateRoom: false,
+      })
+    )
+
+    const subscribedHandler = lobbyUpdatedHandlerRef.current
+    unmount()
+
+    expect(socketOffMock).toHaveBeenCalledWith(
+      'lobby_updated',
+      subscribedHandler
+    )
+  })
+})

--- a/src/pages/lobby/hooks.ts
+++ b/src/pages/lobby/hooks.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { IS_SOCKET_MOCK_ENABLED } from '../../config/env'
+import { requestOnlineUsersSnapshotSync } from '../../features/presence/online-users/onlineUsersSocket'
 import { connectSocketWithAuthIfNeeded, socket } from '../../lib/socket'
 import { getLobbyRooms, type GetLobbyRoomsParams } from './api'
 
@@ -17,6 +18,9 @@ export function useLobbyRoomsQuery(params: GetLobbyRoomsParams) {
     const handleLobbyUpdated = () => {
       queryClient.invalidateQueries({
         queryKey: ['lobby', 'rooms'],
+      })
+      requestOnlineUsersSnapshotSync({
+        includeFollowUpRefresh: true,
       })
     }
 

--- a/src/pages/waiting-room/controller/actions.test.ts
+++ b/src/pages/waiting-room/controller/actions.test.ts
@@ -11,6 +11,7 @@ const {
   toggleWaitingReadyMock,
   getWaitingRoomErrorMessageMock,
   leaveWaitingRoomSocketMock,
+  requestOnlineUsersSnapshotSyncMock,
   sendWaitingRoomChatMock,
 } = vi.hoisted(() => ({
   leaveWaitingRoomMock: vi.fn(),
@@ -18,6 +19,7 @@ const {
   toggleWaitingReadyMock: vi.fn(),
   getWaitingRoomErrorMessageMock: vi.fn(),
   leaveWaitingRoomSocketMock: vi.fn(),
+  requestOnlineUsersSnapshotSyncMock: vi.fn(),
   sendWaitingRoomChatMock: vi.fn(),
 }))
 
@@ -31,6 +33,10 @@ vi.mock('../api/api', () => ({
 vi.mock('../socket/socket', () => ({
   leaveWaitingRoomSocket: leaveWaitingRoomSocketMock,
   sendWaitingRoomChat: sendWaitingRoomChatMock,
+}))
+
+vi.mock('../../../features/presence/online-users/onlineUsersSocket', () => ({
+  requestOnlineUsersSnapshotSync: requestOnlineUsersSnapshotSyncMock,
 }))
 
 function createRoomSnapshot(): WaitingRoomSnapshot {
@@ -120,6 +126,9 @@ describe('useWaitingRoomActions', () => {
     })
     expect(leaveWaitingRoomSocketMock).toHaveBeenCalledWith({
       roomId: 'room-5',
+    })
+    expect(requestOnlineUsersSnapshotSyncMock).toHaveBeenCalledWith({
+      includeFollowUpRefresh: true,
     })
     expect(params.setIsLeavePending).toHaveBeenLastCalledWith(false)
     expect(params.hasLeftRoomRef.current).toBe(true)

--- a/src/pages/waiting-room/controller/actions.ts
+++ b/src/pages/waiting-room/controller/actions.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect } from 'react'
 import type { Dispatch, MutableRefObject, SetStateAction } from 'react'
 import type { AuthSession } from '../../../features/auth/session/types'
+import { requestOnlineUsersSnapshotSync } from '../../../features/presence/online-users/onlineUsersSocket'
 import {
   getWaitingRoomErrorMessage,
   leaveWaitingRoom,
@@ -119,6 +120,9 @@ export function useWaitingRoomActions({
           // leave API 성공 이후에만 leave_room 소켓 이벤트 전송
           leaveWaitingRoomSocket({
             roomId: targetRoomId,
+          })
+          requestOnlineUsersSnapshotSync({
+            includeFollowUpRefresh: true,
           })
           hasLeftRoomRef.current = true
 

--- a/src/pages/waiting-room/controller/lifecycle.test.ts
+++ b/src/pages/waiting-room/controller/lifecycle.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from '@testing-library/react'
+import { act, renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createAuthSessionFixture } from '../../../test/fixtures'
 import { useWaitingRoomLifecycle } from './lifecycle'
@@ -54,6 +54,8 @@ function createLifecycleParams(overrides: Record<string, unknown> = {}) {
     session,
     fallbackRoomTitle: 'fallback',
     preJoinedSnapshot: null,
+    resumeRoomMembership: false,
+    resumeBootstrapSnapshot: null,
     hasReceivedRoomUpdatedRef: { current: false },
     hasEnteredRoomRef: { current: false },
     hasLeftRoomRef: { current: false },
@@ -142,14 +144,103 @@ describe('useWaitingRoomLifecycle', () => {
     expect(params.setIsRoomLoading).toHaveBeenLastCalledWith(false)
   })
 
-  it('room_updated를 이미 받은 경우에는 뒤늦은 join 응답이 room 상태를 다시 덮지 않는다', async () => {
-    const joinedSnapshot = createPreJoinedSnapshot()
-    joinWaitingRoomMock.mockResolvedValue(joinedSnapshot)
+  it('resume room 경로에서 bootstrap snapshot이 있으면 즉시 상태를 복구하고 background join refresh를 시작한다', async () => {
+    const resumeBootstrapSnapshot = createPreJoinedSnapshot()
+    const refreshedSnapshot = {
+      ...resumeBootstrapSnapshot,
+      players: [
+        { id: 'user-1', nickname: '테스터', isReady: false, isHost: true },
+        { id: 'user-2', nickname: '상대', isReady: false, isHost: false },
+      ],
+    }
+    joinWaitingRoomMock.mockResolvedValue(refreshedSnapshot)
     const params = createLifecycleParams({
-      hasReceivedRoomUpdatedRef: { current: true },
+      resumeRoomMembership: true,
+      resumeBootstrapSnapshot,
     })
 
     renderHook(() => useWaitingRoomLifecycle(params))
+
+    expect(params.setRoom).toHaveBeenCalledWith(resumeBootstrapSnapshot)
+    expect(params.setChatMessages).toHaveBeenCalledWith(
+      resumeBootstrapSnapshot.chatMessages
+    )
+    expect(params.setIsRoomLoading).toHaveBeenCalledWith(false)
+    expect(enterWaitingRoomSocketMock).toHaveBeenCalledWith({
+      roomId: 'room-5',
+    })
+    expect(requestOnlineUsersSnapshotSyncMock).toHaveBeenCalledTimes(1)
+
+    await waitFor(() => {
+      expect(joinWaitingRoomMock).toHaveBeenCalledWith({
+        roomId: 'room-5',
+        userId: 'user-1',
+        nickname: '테스터',
+        fallbackTitle: 'fallback',
+      })
+    })
+
+    expect(params.setRoom).toHaveBeenCalledWith(refreshedSnapshot)
+    expect(params.setChatMessages).toHaveBeenCalledWith(
+      refreshedSnapshot.chatMessages
+    )
+  })
+
+  it('resume room 경로에서 bootstrap snapshot이 없으면 loading을 유지한 채 authoritative join refresh를 기다린다', async () => {
+    const joinedSnapshot = createPreJoinedSnapshot()
+    joinWaitingRoomMock.mockResolvedValue(joinedSnapshot)
+    const params = createLifecycleParams({
+      resumeRoomMembership: true,
+    })
+
+    renderHook(() => useWaitingRoomLifecycle(params))
+
+    expect(params.setRoom).not.toHaveBeenCalled()
+    expect(params.setChatMessages).not.toHaveBeenCalled()
+    expect(params.setIsRoomLoading).toHaveBeenCalledWith(true)
+    expect(enterWaitingRoomSocketMock).toHaveBeenCalledWith({
+      roomId: 'room-5',
+    })
+    expect(requestOnlineUsersSnapshotSyncMock).toHaveBeenCalledTimes(1)
+    expect(params.hasEnteredRoomRef.current).toBe(true)
+    expect(params.hasLeftRoomRef.current).toBe(false)
+
+    await waitFor(() => {
+      expect(joinWaitingRoomMock).toHaveBeenCalledWith({
+        roomId: 'room-5',
+        userId: 'user-1',
+        nickname: '테스터',
+        fallbackTitle: 'fallback',
+      })
+    })
+
+    expect(params.setRoom).toHaveBeenCalledWith(joinedSnapshot)
+    expect(params.setChatMessages).toHaveBeenCalledWith(
+      joinedSnapshot.chatMessages
+    )
+    expect(params.setIsRoomLoading).toHaveBeenLastCalledWith(false)
+  })
+
+  it('room_updated가 join 응답보다 먼저 오면 뒤늦은 join 응답이 room 상태를 다시 덮지 않는다', async () => {
+    const joinedSnapshot = createPreJoinedSnapshot()
+    let resolveJoin: ((snapshot: WaitingRoomSnapshot) => void) | undefined
+    joinWaitingRoomMock.mockReturnValue(
+      new Promise<WaitingRoomSnapshot>((resolve) => {
+        resolveJoin = resolve
+      })
+    )
+    const params = createLifecycleParams({
+      resumeRoomMembership: true,
+    })
+
+    renderHook(() => useWaitingRoomLifecycle(params))
+
+    params.hasReceivedRoomUpdatedRef.current = true
+
+    await act(async () => {
+      resolveJoin?.(joinedSnapshot)
+      await Promise.resolve()
+    })
 
     await waitFor(() => {
       expect(joinWaitingRoomMock).toHaveBeenCalled()

--- a/src/pages/waiting-room/controller/lifecycle.ts
+++ b/src/pages/waiting-room/controller/lifecycle.ts
@@ -12,6 +12,8 @@ interface UseWaitingRoomLifecycleParams {
   session: AuthSession | null
   fallbackRoomTitle?: string
   preJoinedSnapshot?: WaitingRoomSnapshot | null
+  resumeRoomMembership?: boolean
+  resumeBootstrapSnapshot?: WaitingRoomSnapshot | null
   hasReceivedRoomUpdatedRef: MutableRefObject<boolean>
   hasEnteredRoomRef: MutableRefObject<boolean>
   hasLeftRoomRef: MutableRefObject<boolean>
@@ -28,6 +30,8 @@ export function useWaitingRoomLifecycle({
   session,
   fallbackRoomTitle,
   preJoinedSnapshot,
+  resumeRoomMembership = false,
+  resumeBootstrapSnapshot,
   hasReceivedRoomUpdatedRef,
   hasEnteredRoomRef,
   hasLeftRoomRef,
@@ -66,6 +70,78 @@ export function useWaitingRoomLifecycle({
       return
     }
 
+    const activeSession = session
+    let isMounted = true
+
+    async function syncJoinedRoomSnapshot(options?: {
+      keepCurrentRoomOnError?: boolean
+    }) {
+      try {
+        const joinedRoom = await joinWaitingRoom({
+          roomId,
+          userId: activeSession.userId,
+          nickname: activeSession.nickname,
+          fallbackTitle: fallbackRoomTitle,
+        })
+
+        // 언마운트 이후 또는 더 최신 room_updated 수신 이후 응답은 무시
+        if (!isMounted || hasReceivedRoomUpdatedRef.current) {
+          return
+        }
+
+        setRoom(joinedRoom)
+        setChatMessages(joinedRoom.chatMessages)
+      } catch (error) {
+        if (!isMounted || hasReceivedRoomUpdatedRef.current) {
+          return
+        }
+
+        setRoomErrorMessage(
+          getWaitingRoomErrorMessage(error, '대기방 입장에 실패했습니다.')
+        )
+
+        if (!options?.keepCurrentRoomOnError) {
+          setRoom(null)
+          setChatMessages([])
+        }
+      } finally {
+        // 마운트 중이고 socket 최신 snapshot이 없을 때만 로딩 종료
+        if (isMounted && !hasReceivedRoomUpdatedRef.current) {
+          setIsRoomLoading(false)
+        }
+      }
+    }
+
+    if (resumeRoomMembership) {
+      setRoomErrorMessage(null)
+
+      const hasResumeBootstrapSnapshot =
+        resumeBootstrapSnapshot?.roomId === roomId
+
+      if (hasResumeBootstrapSnapshot) {
+        setRoom(resumeBootstrapSnapshot)
+        setChatMessages(resumeBootstrapSnapshot.chatMessages)
+        setIsRoomLoading(false)
+      } else {
+        setIsRoomLoading(true)
+      }
+
+      if (!hasEnteredRoomRef.current) {
+        enterWaitingRoomSocket({ roomId })
+        requestOnlineUsersSnapshotSync()
+        hasEnteredRoomRef.current = true
+        hasLeftRoomRef.current = false
+      }
+
+      void syncJoinedRoomSnapshot({
+        keepCurrentRoomOnError: hasResumeBootstrapSnapshot,
+      })
+
+      return () => {
+        isMounted = false
+      }
+    }
+
     // 사전 조인 초기화가 끝난 동일 roomId는 재조인 생략
     if (
       hasInitializedPreJoinRef.current &&
@@ -94,49 +170,19 @@ export function useWaitingRoomLifecycle({
       return
     }
 
-    const activeSession = session
-    let isMounted = true
-
     async function joinRoom() {
       setIsRoomLoading(true)
       setRoomErrorMessage(null)
+      await syncJoinedRoomSnapshot()
 
-      try {
-        const joinedRoom = await joinWaitingRoom({
-          roomId,
-          userId: activeSession.userId,
-          nickname: activeSession.nickname,
-          fallbackTitle: fallbackRoomTitle,
-        })
-
-        // 언마운트 이후에는 상태 반영을 건너뜀
-        if (!isMounted) {
-          return
-        }
-
-        if (!hasReceivedRoomUpdatedRef.current) {
-          setRoom(joinedRoom)
-          setChatMessages(joinedRoom.chatMessages)
-        }
-        enterWaitingRoomSocket({ roomId })
-        requestOnlineUsersSnapshotSync()
-        hasEnteredRoomRef.current = true
-        hasLeftRoomRef.current = false
-      } catch (error) {
-        // 언마운트 이후에는 에러 반영을 건너뜀
-        if (!isMounted) {
-          return
-        }
-
-        setRoomErrorMessage(
-          getWaitingRoomErrorMessage(error, '대기방 입장에 실패했습니다.')
-        )
-      } finally {
-        // 마운트된 상태에서만 로딩 종료 반영
-        if (isMounted) {
-          setIsRoomLoading(false)
-        }
+      if (!isMounted) {
+        return
       }
+
+      enterWaitingRoomSocket({ roomId })
+      requestOnlineUsersSnapshotSync()
+      hasEnteredRoomRef.current = true
+      hasLeftRoomRef.current = false
     }
 
     joinRoom()
@@ -152,6 +198,8 @@ export function useWaitingRoomLifecycle({
     hasLeftRoomRef,
     preJoinedRoomId,
     preJoinedSnapshot,
+    resumeRoomMembership,
+    resumeBootstrapSnapshot,
     roomId,
     session,
     setChatMessages,

--- a/src/pages/waiting-room/controller/socketSync.test.ts
+++ b/src/pages/waiting-room/controller/socketSync.test.ts
@@ -93,13 +93,16 @@ interface SocketSyncHookParams {
   onRoomRemoved: () => void
   setRoom: Dispatch<SetStateAction<WaitingRoomSnapshot | null>>
   setChatMessages: Dispatch<SetStateAction<WaitingRoomSnapshot['chatMessages']>>
+  setIsRoomLoading: Dispatch<SetStateAction<boolean>>
   setRoomMock: ReturnType<typeof vi.fn>
   setChatMessagesMock: ReturnType<typeof vi.fn>
+  setIsRoomLoadingMock: ReturnType<typeof vi.fn>
 }
 
 function createBaseParams(): SocketSyncHookParams {
   const setRoomMock = vi.fn()
   const setChatMessagesMock = vi.fn()
+  const setIsRoomLoadingMock = vi.fn()
 
   return {
     roomId: 'room-5',
@@ -117,8 +120,12 @@ function createBaseParams(): SocketSyncHookParams {
     setChatMessages: setChatMessagesMock as unknown as Dispatch<
       SetStateAction<WaitingRoomSnapshot['chatMessages']>
     >,
+    setIsRoomLoading: setIsRoomLoadingMock as unknown as Dispatch<
+      SetStateAction<boolean>
+    >,
     setRoomMock,
     setChatMessagesMock,
+    setIsRoomLoadingMock,
   }
 }
 
@@ -269,7 +276,40 @@ describe('useWaitingRoomSocketSync', () => {
     expect(unsubscribeMock).toHaveBeenCalledTimes(1)
   })
 
-  it('lobby_updated removed는 현재 방 삭제일 때만 상태를 비우고 콜백을 호출한다', () => {
+  it('현재 방이 아닌 lobby_updated도 접속자 snapshot 재동기화를 요청한다', () => {
+    const params = createBaseParams()
+    renderHook(() => useWaitingRoomSocketSync(params))
+
+    const handlers = subscribeWaitingRoomSocketEventsMock.mock
+      .calls[0]?.[0] as {
+      onLobbyUpdated: (payload: LobbyUpdatedEventPayload) => void
+    }
+
+    act(() => {
+      handlers.onLobbyUpdated({
+        action: 'status_changed',
+        room: {
+          id: 'room-other',
+          title: '다른 방',
+          status: 'waiting',
+          is_private: false,
+          current_players: 2,
+          max_players: 4,
+          host_id: 'user-9',
+          host_nickname: '다른방장',
+        },
+      })
+    })
+
+    expect(requestOnlineUsersSnapshotSyncMock).toHaveBeenCalledWith({
+      includeFollowUpRefresh: true,
+    })
+    expect(params.setRoomMock).not.toHaveBeenCalledWith(null)
+    expect(params.setChatMessagesMock).not.toHaveBeenCalledWith([])
+    expect(params.onRoomRemoved).not.toHaveBeenCalled()
+  })
+
+  it('현재 방 removed lobby_updated는 cleanup과 접속자 snapshot 재동기화를 함께 수행한다', () => {
     const params = createBaseParams()
     renderHook(() => useWaitingRoomSocketSync(params))
 
@@ -282,24 +322,14 @@ describe('useWaitingRoomSocketSync', () => {
       handlers.onLobbyUpdated({
         action: 'removed',
         room: {
-          id: 'room-other',
-        },
-      })
-    })
-
-    expect(params.setRoomMock).not.toHaveBeenCalledWith(null)
-    expect(params.setChatMessagesMock).not.toHaveBeenCalledWith([])
-    expect(params.onRoomRemoved).not.toHaveBeenCalled()
-
-    act(() => {
-      handlers.onLobbyUpdated({
-        action: 'removed',
-        room: {
           id: 'room-5',
         },
       })
     })
 
+    expect(requestOnlineUsersSnapshotSyncMock).toHaveBeenCalledWith({
+      includeFollowUpRefresh: true,
+    })
     expect(params.setRoomMock).toHaveBeenCalledWith(null)
     expect(params.setChatMessagesMock).toHaveBeenCalledWith([])
     expect(params.onRoomRemoved).toHaveBeenCalledTimes(1)
@@ -328,6 +358,7 @@ describe('useWaitingRoomSocketSync', () => {
       createJoinedRoomSnapshotPayload()
     )
     expect(params.setChatMessagesMock).toHaveBeenCalledWith([])
+    expect(params.setIsRoomLoadingMock).toHaveBeenCalledWith(false)
     expect(requestOnlineUsersSnapshotSyncMock).toHaveBeenCalledTimes(1)
     expect(params.hasReceivedRoomUpdatedRef.current).toBe(true)
   })

--- a/src/pages/waiting-room/controller/socketSync.ts
+++ b/src/pages/waiting-room/controller/socketSync.ts
@@ -23,6 +23,7 @@ interface UseWaitingRoomSocketSyncParams {
   onRoomRemoved: () => void
   setRoom: Dispatch<SetStateAction<WaitingRoomSnapshot | null>>
   setChatMessages: Dispatch<SetStateAction<WaitingRoomChatMessage[]>>
+  setIsRoomLoading: Dispatch<SetStateAction<boolean>>
 }
 
 // 대기방 소켓 이벤트를 구독해 room/chat 상태를 동기화
@@ -35,6 +36,7 @@ export function useWaitingRoomSocketSync({
   onRoomRemoved,
   setRoom,
   setChatMessages,
+  setIsRoomLoading,
 }: UseWaitingRoomSocketSyncParams) {
   useEffect(() => {
     if (!roomId || !session) {
@@ -120,9 +122,14 @@ export function useWaitingRoomSocketSync({
         const latestRoomSnapshot = mapWaitingRoomSnapshotPayload(payload)
         setRoom(latestRoomSnapshot)
         setChatMessages(latestRoomSnapshot.chatMessages)
+        setIsRoomLoading(false)
         requestOnlineUsersSnapshotSync()
       },
       onLobbyUpdated: (payload: LobbyUpdatedEventPayload) => {
+        requestOnlineUsersSnapshotSync({
+          includeFollowUpRefresh: true,
+        })
+
         if (payload.room.id !== targetRoomId) {
           return
         }
@@ -147,6 +154,7 @@ export function useWaitingRoomSocketSync({
     roomId,
     session,
     setChatMessages,
+    setIsRoomLoading,
     setRoom,
   ])
 }

--- a/src/pages/waiting-room/hooks/hooks.ts
+++ b/src/pages/waiting-room/hooks/hooks.ts
@@ -20,6 +20,8 @@ interface UseWaitingRoomControllerParams {
   session: AuthSession | null
   fallbackRoomTitle?: string
   preJoinedSnapshot?: WaitingRoomSnapshot | null
+  resumeRoomMembership?: boolean
+  resumeBootstrapSnapshot?: WaitingRoomSnapshot | null
   onGameStart: (payload: GameStartEventPayload) => void
   onRoomRemoved: () => void
 }
@@ -30,6 +32,8 @@ export function useWaitingRoomController({
   session,
   fallbackRoomTitle,
   preJoinedSnapshot,
+  resumeRoomMembership = false,
+  resumeBootstrapSnapshot,
   onGameStart,
   onRoomRemoved,
 }: UseWaitingRoomControllerParams) {
@@ -88,6 +92,8 @@ export function useWaitingRoomController({
     session,
     fallbackRoomTitle,
     preJoinedSnapshot,
+    resumeRoomMembership,
+    resumeBootstrapSnapshot,
     hasReceivedRoomUpdatedRef,
     hasEnteredRoomRef,
     hasLeftRoomRef,
@@ -109,6 +115,7 @@ export function useWaitingRoomController({
     onRoomRemoved: handleRoomRemoved,
     setRoom,
     setChatMessages,
+    setIsRoomLoading,
   })
 
   // 현재 세션 사용자 정보 조회

--- a/src/pages/waiting-room/page/WaitingRoomPage.test.tsx
+++ b/src/pages/waiting-room/page/WaitingRoomPage.test.tsx
@@ -253,6 +253,7 @@ describe('WaitingRoomPage interaction', () => {
       state: {
         gameId: 'game-123',
         roomId: 'room-5',
+        lastRoomSnapshot: waitingRoomControllerStateRef.current?.room,
       },
     })
   })
@@ -387,7 +388,7 @@ describe('WaitingRoomPage interaction', () => {
     })
   })
 
-  it('대기방 접속자 목록은 room.players 기준으로 현재 방 참가자를 in_room 상태로 보정한다', async () => {
+  it('대기방 접속자 목록은 room 참가자의 stale online status를 대기방 상태로 보정한다', async () => {
     useOnlineUsersSocketMock.mockReturnValue({
       data: [
         {
@@ -411,12 +412,17 @@ describe('WaitingRoomPage interaction', () => {
 
     renderWaitingRoomPage()
 
+    const userListPanel = screen.getByText('접속자 목록').closest('aside')
+
+    expect(userListPanel).not.toBeNull()
     await waitFor(() => {
-      expect(screen.getAllByText('대기방')).toHaveLength(2)
+      expect(
+        within(userListPanel as HTMLElement).getAllByText('대기방')
+      ).toHaveLength(2)
     })
   })
 
-  it('online snapshot에 없는 room player는 접속자 목록에 다시 추가하지 않는다', async () => {
+  it('online snapshot에 없는 room player도 현재 room 참가자면 접속자 목록에 포함한다', async () => {
     useOnlineUsersSocketMock.mockReturnValue({
       data: [
         {
@@ -436,10 +442,13 @@ describe('WaitingRoomPage interaction', () => {
     const userListPanel = screen.getByText('접속자 목록').closest('aside')
 
     expect(userListPanel).not.toBeNull()
-    expect(within(userListPanel as HTMLElement).getByText('1명')).toBeVisible()
+    expect(within(userListPanel as HTMLElement).getByText('2명')).toBeVisible()
     expect(
-      within(userListPanel as HTMLElement).queryByText('상대방')
-    ).not.toBeInTheDocument()
+      within(userListPanel as HTMLElement).getByText('상대방')
+    ).toBeVisible()
+    expect(
+      within(userListPanel as HTMLElement).getAllByText('대기방')
+    ).toHaveLength(2)
   })
 
   it('초기 진입(POP)에서는 location.state의 preJoinedSnapshot을 재사용하지 않는다', () => {
@@ -514,6 +523,64 @@ describe('WaitingRoomPage interaction', () => {
     expect(useWaitingRoomControllerMock).toHaveBeenCalledWith(
       expect.objectContaining({
         preJoinedSnapshot,
+      })
+    )
+  })
+
+  it('게임 종료 복귀 state가 있으면 preJoinedSnapshot 없이 resumeRoomMembership과 bootstrap snapshot을 전달한다', () => {
+    navigationTypeMock.mockReturnValue('PUSH')
+    const lastRoomSnapshot: WaitingRoomSnapshot = {
+      roomId: 'room-5',
+      title: '테스트 방',
+      status: 'waiting',
+      maxPlayers: 4,
+      isPrivate: false,
+      players: [
+        {
+          id: 'user-1',
+          nickname: '테스터',
+          isReady: false,
+          isHost: true,
+        },
+      ],
+      chatMessages: [],
+    }
+
+    renderWaitingRoomPage({
+      initialEntries: [
+        {
+          pathname: '/rooms/room-5',
+          state: {
+            roomId: 'room-5',
+            roomTitle: '테스트 방',
+            resumeRoomMembership: true,
+            lastRoomSnapshot,
+            preJoinedSnapshot: {
+              roomId: 'room-5',
+              title: '테스트 방',
+              status: 'waiting',
+              maxPlayers: 4,
+              isPrivate: false,
+              players: [
+                {
+                  id: 'user-1',
+                  nickname: '테스터',
+                  isReady: false,
+                  isHost: true,
+                },
+              ],
+              chatMessages: [],
+            },
+          },
+        },
+      ],
+    })
+
+    expect(useWaitingRoomControllerMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        preJoinedSnapshot: null,
+        resumeRoomMembership: true,
+        resumeBootstrapSnapshot: lastRoomSnapshot,
       })
     )
   })

--- a/src/pages/waiting-room/page/WaitingRoomPage.tsx
+++ b/src/pages/waiting-room/page/WaitingRoomPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { AnimatePresence } from 'framer-motion'
 import toast from 'react-hot-toast'
 import {
@@ -41,6 +41,8 @@ interface WaitingRoomLocationState {
   roomId?: string
   roomTitle?: string
   preJoinedSnapshot?: WaitingRoomSnapshot
+  resumeRoomMembership?: boolean
+  lastRoomSnapshot?: WaitingRoomSnapshot
 }
 
 const DEFAULT_WAITING_ROOM_TITLE = '즐거운 게임 한판!'
@@ -71,18 +73,31 @@ function WaitingRoomPage() {
   const locationState = location.state as WaitingRoomLocationState | null
   const isSameRoomState = locationState?.roomId === currentRoomId
   const shouldUsePreJoinedSnapshot = navigationType !== 'POP'
+  const resumeRoomMembership = Boolean(
+    isSameRoomState && locationState?.resumeRoomMembership
+  )
   const selectedRoomTitle = isSameRoomState ? locationState?.roomTitle : null
   const preJoinedSnapshot =
-    isSameRoomState && shouldUsePreJoinedSnapshot
+    !resumeRoomMembership && isSameRoomState && shouldUsePreJoinedSnapshot
       ? (locationState?.preJoinedSnapshot ?? null)
       : null
+  const resumeBootstrapSnapshot =
+    resumeRoomMembership && isSameRoomState
+      ? (locationState?.lastRoomSnapshot ?? null)
+      : null
+  const latestRoomSnapshotRef = useRef<WaitingRoomSnapshot | null>(
+    preJoinedSnapshot ?? resumeBootstrapSnapshot
+  )
 
   const handleGameStart = useCallback(
     (payload: GameStartEventPayload) => {
+      const lastRoomSnapshot = latestRoomSnapshotRef.current
+
       navigate(`/game/${payload.game_id}`, {
         state: {
           gameId: payload.game_id,
           roomId: payload.room_id,
+          ...(lastRoomSnapshot ? { lastRoomSnapshot } : {}),
         },
       })
     },
@@ -116,9 +131,15 @@ function WaitingRoomPage() {
     session,
     fallbackRoomTitle: selectedRoomTitle ?? undefined,
     preJoinedSnapshot,
+    resumeRoomMembership,
+    resumeBootstrapSnapshot,
     onGameStart: handleGameStart,
     onRoomRemoved: handleRoomRemoved,
   })
+
+  useEffect(() => {
+    latestRoomSnapshotRef.current = room
+  }, [room])
 
   const {
     data: users = [],
@@ -135,7 +156,11 @@ function WaitingRoomPage() {
     const mergedUsers = mergeOnlineUsersWithRoomPlayers(
       users,
       room.players,
-      roomStatus
+      roomStatus,
+      {
+        includeMissingPlayers: true,
+        overrideExistingStatus: true,
+      }
     )
 
     return mergeOnlineUsersWithCurrentUser(mergedUsers, {
@@ -301,12 +326,12 @@ function WaitingRoomPage() {
             Array.from({ length: 4 }).map((_, index) => (
               <div
                 key={`waiting-seat-skeleton-${index}`}
-                className="h-full min-h-[260px] animate-pulse rounded-[34px] bg-ui-surface-soft"
+                className="h-full min-h-65 animate-pulse rounded-[34px] bg-ui-surface-soft"
               />
             ))}
 
           {!isRoomLoading && roomErrorMessage && (
-            <article className="col-span-full flex min-h-[260px] flex-col items-center justify-center rounded-[34px] border border-ui-danger-border bg-ui-danger-bg p-6 text-center">
+            <article className="col-span-full flex min-h-65 flex-col items-center justify-center rounded-[34px] border border-ui-danger-border bg-ui-danger-bg p-6 text-center">
               <p className="text-base font-semibold text-ui-danger">
                 대기방 정보를 불러오지 못했습니다.
               </p>
@@ -335,10 +360,10 @@ function WaitingRoomPage() {
         <div
           className={cn(
             'flex min-h-0 flex-col gap-3 xl:h-full xl:flex-row xl:items-stretch',
-            isUserListOpen ? 'xl:w-[620px]' : 'xl:w-[412px]'
+            isUserListOpen ? 'xl:w-155' : 'xl:w-103'
           )}
         >
-          <div className="min-h-0 xl:h-full xl:w-[340px] xl:shrink-0">
+          <div className="min-h-0 xl:h-full xl:w-85 xl:shrink-0">
             <WaitingRoomSidePanel
               messages={chatMessages}
               currentUserId={session.userId}


### PR DESCRIPTION
## 📌 관련 이슈

> closes #631

---

## 📝 작업 내용

- 게임 종료 후 `대기방으로 돌아가기` 경로를 bootstrap snapshot + background `/rooms/:id/join` 재검증으로 보강해 stale player/ready 상태가 오래 남지 않도록 정리했습니다.
- waiting-room과 lobby에서 `lobby_updated` 이후 접속자 snapshot을 즉시 1회 + follow-up 1회 다시 읽게 해, 다른 사용자의 방 생성/입장/퇴장이 새로고침 없이 더 빨리 반영되도록 맞췄습니다.
- waiting-room에서는 현재 room membership을 접속자 목록의 강한 로컬 truth로 유지하고, mock/real 소켓 모두 같은 visible behavior를 유지하도록 테스트와 task 문서를 같이 정리했습니다.

---

## 🧠 Task 문서 (큰 작업이면 필수)

- plan:
  - `docs/ai/tasks/waiting-room-presence-contract-alignment/plan.md`
  - `docs/ai/tasks/waiting-room-resume-bootstrap-presence-resync/plan.md`
  - `docs/ai/tasks/presence-realtime-room-transitions/plan.md`
  - `docs/ai/tasks/waiting-room-authoritative-resume-refresh/plan.md`
- context:
  - `docs/ai/tasks/waiting-room-presence-contract-alignment/context.md`
  - `docs/ai/tasks/waiting-room-resume-bootstrap-presence-resync/context.md`
  - `docs/ai/tasks/presence-realtime-room-transitions/context.md`
  - `docs/ai/tasks/waiting-room-authoritative-resume-refresh/context.md`
- checklist:
  - `docs/ai/tasks/waiting-room-presence-contract-alignment/checklist.md`
  - `docs/ai/tasks/waiting-room-resume-bootstrap-presence-resync/checklist.md`
  - `docs/ai/tasks/presence-realtime-room-transitions/checklist.md`
  - `docs/ai/tasks/waiting-room-authoritative-resume-refresh/checklist.md`

---

## 📋 TODO.md 연결

- task slug: `waiting-room-presence-contract-alignment`, `waiting-room-resume-bootstrap-presence-resync`, `presence-realtime-room-transitions`, `waiting-room-authoritative-resume-refresh`
- TODO status: 모두 `Done`
- TODO entry 확인: `TODO.md`에 4개 task slug와 설명을 반영했습니다.

---

## 📚 참고한 기준 문서

- `AGENTS.md`
- `docs/rules.md`
- `docs/testing.md`
- 추가 manual / 문서 경로:
  - `docs/ai/manuals/common.md`
  - `docs/ai/manuals/lobby.md`
  - `docs/ai/manuals/waiting-room.md`
  - `docs/ai/manuals/game-runtime.md`
  - `docs/socket-mock-server.md`

---

## 🧪 실행한 검증

- `npx vitest run src/features/presence/online-users/onlineUsersSocket.test.ts src/pages/waiting-room/controller/lifecycle.test.ts src/pages/waiting-room/controller/socketSync.test.ts src/pages/waiting-room/controller/actions.test.ts src/pages/lobby/hooks.test.tsx src/pages/GamePage.test.tsx`
- `npm run lint`
- `npm run ai:check:waiting-room`
- `npm run ai:check:lobby`
- `npm run ai:check:game`
- `npm run build`
- `npm run ai:self-review -- --files TODO.md docs/ai/tasks/waiting-room-authoritative-resume-refresh/plan.md docs/ai/tasks/waiting-room-authoritative-resume-refresh/context.md docs/ai/tasks/waiting-room-authoritative-resume-refresh/checklist.md src/features/presence/online-users/onlineUsersSocket.ts src/features/presence/online-users/onlineUsersSocket.test.ts src/pages/waiting-room/controller/lifecycle.ts src/pages/waiting-room/controller/lifecycle.test.ts src/pages/waiting-room/controller/socketSync.ts src/pages/waiting-room/controller/socketSync.test.ts src/pages/waiting-room/controller/actions.ts src/pages/waiting-room/controller/actions.test.ts src/pages/lobby/hooks.ts src/pages/lobby/hooks.test.tsx src/pages/GamePage.tsx src/pages/GamePage.test.tsx`

---

## ⚠️ 남은 리스크

- resume 직후에는 bootstrap snapshot이 아주 짧게 보였다가 authoritative join refresh 결과로 교체될 수 있습니다.
- `lobby_updated` follow-up refresh는 `/users/online`을 한 번 더 읽는 방어 로직이라, 서버 snapshot 반영이 더 늦는 경우 아주 짧은 지연은 남을 수 있습니다.
- 이번 PR에서는 Playwright E2E까지는 추가 실행하지 않았습니다.

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료
- [x] 큰 작업이면 task 문서 링크를 남겼다
- [x] 큰 작업이면 `TODO.md` / task slug 연결을 PR 본문에 남겼다
- [x] 참고한 기준 문서를 PR 본문에 남겼다
- [x] 실행한 검증과 남은 리스크를 PR 본문에 적었다

---

## 📸 스크린샷 (선택)

- 없음
