### PR TITLE
fix: 게임 결과 모달 보유도시 및 이벤트칸 Travel 애니메이션 수정

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,6 +6,7 @@
 
 ## In Progress
 
+- [ ] `game-board-result-and-travel-fix` - Game Board Result And Travel Fix (`docs/ai/tasks/game-board-result-and-travel-fix/`) - 결과 모달 보유도시 수를 종료 시점 타일 소유 정보로 복구하고 이벤트칸 오인 travel 애니메이션을 수정
 - [ ] `island-speed-and-exit-modal-style` - Island Speed and Exit Modal Style (`docs/ai/tasks/island-speed-and-exit-modal-style/`) - 무인도 이동 속도 개선 및 게임 종료 모달 스타일 통일
 - [ ] `board-sot-sync` - Board SoT sync + initial full sync (`docs/ai/tasks/board-sot-sync/`) - 보드판 SoT를 백엔드 기준으로 전환하고 최초 sync knownRevision=-1 요청 반영
 - [ ] `chance-move-direction-animation` - Chance Move Direction Animation (`docs/ai/tasks/chance-move-direction-animation/`) - chance 이동 방향 힌트 기반 순차 애니메이션 보정 및 검증

--- a/docs/ai/tasks/game-board-result-and-travel-fix/checklist.md
+++ b/docs/ai/tasks/game-board-result-and-travel-fix/checklist.md
@@ -1,0 +1,13 @@
+# Checklist
+
+- [x] 결과 모달 보유도시 계산 helper 추가
+- [x] `GameBoard` 결과 row 생성에서 `ownedCityCountText` 하드코딩 제거
+- [x] 보유도시 helper 테스트 추가
+- [x] travel 애니메이션 판정 helper 추가
+- [x] `fromIndex === 20` 하드코딩 제거
+- [x] 이벤트칸/무인도/여행칸/trigger 기반 travel 판정 테스트 추가
+- [x] `npx vitest run src/components/board/gameBoardResultUtils.test.ts`
+- [x] `npx vitest run src/components/board/gameBoardEventQueueUtils.test.ts`
+- [x] `npm run lint`
+- [x] `npm run ai:check:game`
+- [x] `npm run ai:check:build`

--- a/docs/ai/tasks/game-board-result-and-travel-fix/context.md
+++ b/docs/ai/tasks/game-board-result-and-travel-fix/context.md
@@ -1,0 +1,25 @@
+# Context
+
+## Background
+
+- 게임 종료 결과 모달은 총자산은 서버 authoritative 값으로 잘 표시하지만, `보유도시`는 `GameBoard` 내부에서 `'-'`로 고정돼 실제 값이 나오지 않았다.
+- 동시에 `PLAYER_MOVED` 애니메이션 분기에는 `fromIndex === 20` 하드코딩이 남아 있어, 광주와 춘천 사이 이벤트칸 출발 이동도 travel 이동처럼 빠르게 재생되고 있었다.
+- 현재 보드 정의에서 `20`번 칸은 `TRAVEL`이 아니라 `EVENT`다.
+
+## Current Decision
+
+- 결과 모달의 보유도시 수는 backend payload를 늘리지 않고, 종료 시점 `tiles.owner_id/ownerId`에서 `PROPERTY` 타일 개수를 계산해 표시한다.
+- 빠른 travel 이동 분기는 숫자 인덱스 하드코딩을 제거하고, `trigger === 'travel'` 또는 출발 타일 타입이 `TRAVEL` / `ISLAND`인지로만 판단한다.
+
+## Relevant Manuals
+
+- `AGENTS.md`
+- `docs/ai/manuals/common.md`
+- `docs/rules.md`
+- `docs/testing.md`
+- `docs/ai/manuals/game-runtime.md`
+
+## Risks
+
+- `보유도시` 정의는 현재 프론트에서 `PROPERTY` 타일 개수로 해석한다. 추후 도메인 정의가 달라지면 helper 기준도 같이 수정해야 한다.
+- travel 이동 분기는 더 이상 `20번 칸`을 특별취급하지 않으므로, 과거 문서/기억에 남은 UX 전제와 현재 보드 정의가 어긋난 부분은 이번 수정으로 현재 보드 정의 쪽에 맞춘다.

--- a/docs/ai/tasks/game-board-result-and-travel-fix/plan.md
+++ b/docs/ai/tasks/game-board-result-and-travel-fix/plan.md
@@ -1,0 +1,45 @@
+# Plan
+
+## Task
+
+- 작업 이름: Game Board Result And Travel Fix
+- 작업 slug: `game-board-result-and-travel-fix`
+- 요청 날짜: 2026-03-25
+- 담당 범위: 게임 결과 모달의 보유도시 표시 복구와 이벤트칸 오인 travel 애니메이션 수정
+
+## Goal
+
+- 게임 종료 결과 모달이 각 플레이어의 보유도시 수를 `-`가 아니라 종료 시점 타일 소유 정보 기준으로 표시한다
+- 광주-이벤트-춘천 사이 이벤트칸(`id: 20`) 출발 이동에 잘못 붙던 빠른 travel 애니메이션을 제거한다
+- `src/components/board/**` high-risk 경로 변경에 필요한 task 문서, TODO 연결, manual, 검증 근거를 함께 남긴다
+
+## In Scope
+
+- `src/components/board/GameBoard.tsx`
+- `src/components/board/gameBoardResultUtils.ts`
+- `src/components/board/gameBoardResultUtils.test.ts`
+- `src/components/board/gameBoardEventQueueUtils.ts`
+- `src/components/board/gameBoardEventQueueUtils.test.ts`
+- `TODO.md`
+
+## Out Of Scope
+
+- `GameResult` / socket contract / backend payload 변경
+- 대기방, 로비, 게임 패널 등 다른 UI 경로 수정
+- travel prompt 자체의 흐름이나 서버 이벤트 shape 변경
+
+## Completion Criteria
+
+- 결과 모달의 `보유도시`가 `PROPERTY` 타일 소유 개수를 `n개` 형식으로 표시한다
+- `winner`만 있는 종료 payload에서도 `0개` 포함 정상 표기한다
+- 빠른 travel 이동은 `trigger === 'travel'` 또는 출발 타일이 `TRAVEL` / `ISLAND`일 때만 적용된다
+- 이벤트칸(`EVENT`) 출발 이동은 일반 이동 속도를 유지한다
+- `npm run lint`, 관련 Vitest, `npm run ai:check:game`, `npm run ai:check:build`가 통과한다
+
+## Test Plan
+
+- `npx vitest run src/components/board/gameBoardResultUtils.test.ts`
+- `npx vitest run src/components/board/gameBoardEventQueueUtils.test.ts`
+- `npm run lint`
+- `npm run ai:check:game`
+- `npm run ai:check:build`

--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -57,10 +57,12 @@ import {
   resolveBoardCardModalContentFromEvent,
   resolveBoardEventTileIndex,
   resolveChanceMoveAnimationHint,
+  shouldApplyTravelMoveAnimation,
   shouldDelayPromptModalByMovement,
   type BoardEventAnimationKind,
   type BoardMoveDirection,
 } from './gameBoardEventQueueUtils'
+import { buildGameResultModalRows } from './gameBoardResultUtils'
 
 import { getBuildCost, getTollCost } from './board.constants'
 
@@ -867,11 +869,11 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
             }
           }
 
-          const isTravelMove =
-            normalizedTrigger === 'travel' ||
-            fromIndex === 8 ||
-            fromIndex === 16 ||
-            fromIndex === 20
+          const isTravelMove = shouldApplyTravelMoveAnimation({
+            normalizedTrigger,
+            fromIndex,
+            tiles: boardTiles,
+          })
           if (isTravelMove && event.playerId != null) {
             startTravelTokenFx(event.playerId, 1600)
           }
@@ -1467,34 +1469,13 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
 
       return [...rankings].sort((left, right) => left.rank - right.rank)
     }, [gameResult])
-    const winnerResultRow = useMemo(() => {
-      const winner = gameResult?.winner
-      if (!winner) {
-        return null
-      }
-
-      return {
-        id: String(winner.playerId),
-        nickname: winner.nickname,
-        totalAssetText: formatWon(winner.assets),
-        ownedCityCountText: '-',
-      }
-    }, [gameResult])
     const resultModalRows = useMemo(() => {
-      if (serverResultRows.length > 0) {
-        return serverResultRows.map((result) => ({
-          id: String(result.player_id),
-          nickname: result.nickname,
-          totalAssetText: formatWon(result.final_assets),
-          ownedCityCountText: '-',
-        }))
-      }
-      if (winnerResultRow) {
-        return [winnerResultRow]
-      }
-
-      return []
-    }, [serverResultRows, winnerResultRow])
+      return buildGameResultModalRows({
+        rankings: serverResultRows,
+        winner: gameResult?.winner,
+        tiles,
+      })
+    }, [gameResult?.winner, serverResultRows, tiles])
     const resultModalWinnerName = useMemo(() => {
       if (gameResult?.winner?.nickname) {
         return gameResult.winner.nickname

--- a/src/components/board/gameBoardEventQueueUtils.test.ts
+++ b/src/components/board/gameBoardEventQueueUtils.test.ts
@@ -10,6 +10,7 @@ import {
   resolveChanceMoveAnimationHint,
   resolveBoardCardModalContentFromEvent,
   resolveBoardEventAnimationKind,
+  shouldApplyTravelMoveAnimation,
   shouldDelayPromptModalByMovement,
 } from './gameBoardEventQueueUtils'
 
@@ -389,5 +390,66 @@ describe('gameBoardEventQueueUtils', () => {
     }
 
     expect(resolveChanceMoveAnimationHint(event)).toBeNull()
+  })
+
+  it('applies fast travel animation when trigger is travel', () => {
+    expect(
+      shouldApplyTravelMoveAnimation({
+        normalizedTrigger: 'travel',
+        fromIndex: 4,
+        tiles,
+      })
+    ).toBe(true)
+  })
+
+  it('applies fast travel animation when departing from travel or island tile', () => {
+    const movementTiles: TileData[] = [
+      { id: 0, name: 'Start', type: 'START' },
+      { id: 1, name: 'Island', type: 'ISLAND' },
+      { id: 2, name: 'Travel', type: 'TRAVEL' },
+      { id: 3, name: 'Event', type: 'EVENT' },
+    ]
+
+    expect(
+      shouldApplyTravelMoveAnimation({
+        normalizedTrigger: '',
+        fromIndex: 1,
+        tiles: movementTiles,
+      })
+    ).toBe(true)
+
+    expect(
+      shouldApplyTravelMoveAnimation({
+        normalizedTrigger: '',
+        fromIndex: 2,
+        tiles: movementTiles,
+      })
+    ).toBe(true)
+  })
+
+  it('does not apply fast travel animation when departing from event tile', () => {
+    const movementTiles: TileData[] = [
+      { id: 19, name: '광주', type: 'PROPERTY', color: '#66BB6A', price: 1000 },
+      { id: 20, name: '이벤트', type: 'EVENT' },
+      { id: 21, name: '춘천', type: 'PROPERTY', color: '#7E57C2', price: 1000 },
+    ]
+
+    expect(
+      shouldApplyTravelMoveAnimation({
+        normalizedTrigger: '',
+        fromIndex: 1,
+        tiles: movementTiles,
+      })
+    ).toBe(false)
+  })
+
+  it('does not apply fast travel animation when source tile is missing', () => {
+    expect(
+      shouldApplyTravelMoveAnimation({
+        normalizedTrigger: '',
+        fromIndex: 99,
+        tiles,
+      })
+    ).toBe(false)
   })
 })

--- a/src/components/board/gameBoardEventQueueUtils.ts
+++ b/src/components/board/gameBoardEventQueueUtils.ts
@@ -26,6 +26,23 @@ export type ChanceMoveAnimationHint = {
   steps: number
 }
 
+export const shouldApplyTravelMoveAnimation = ({
+  normalizedTrigger,
+  fromIndex,
+  tiles,
+}: {
+  normalizedTrigger: string
+  fromIndex: number
+  tiles: TileData[]
+}) => {
+  if (normalizedTrigger === 'travel') {
+    return true
+  }
+
+  const fromTileType = tiles[fromIndex]?.type
+  return fromTileType === 'TRAVEL' || fromTileType === 'ISLAND'
+}
+
 const normalizeEventType = (type: unknown) =>
   typeof type === 'string' ? type.trim().toUpperCase() : ''
 

--- a/src/components/board/gameBoardResultUtils.test.ts
+++ b/src/components/board/gameBoardResultUtils.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildGameResultModalRows,
+  countOwnedCitiesByPlayer,
+} from './gameBoardResultUtils'
+
+describe('gameBoardResultUtils', () => {
+  it('PROPERTY/property/city/transportType=PROPERTY 타일만 플레이어별 보유도시로 집계한다', () => {
+    const ownedCityCountByPlayer = countOwnedCitiesByPlayer([
+      { owner_id: 'p1', type: 'PROPERTY' },
+      { ownerId: 'p1', type: 'property' },
+      { owner_id: 'p1', type: 'city' },
+      { owner_id: 'p2', transportType: 'PROPERTY' },
+      { owner_id: 'p2', type: 'CHANCE' },
+      { owner_id: 'p2', type: 'START' },
+      { owner_id: null, type: 'PROPERTY' },
+      { type: 'PROPERTY' },
+    ])
+
+    expect(ownedCityCountByPlayer.get('p1')).toBe(3)
+    expect(ownedCityCountByPlayer.get('p2')).toBe(1)
+  })
+
+  it('건물 단계가 높아도 도시 수는 타일 개수만 센다', () => {
+    const ownedCityCountByPlayer = countOwnedCitiesByPlayer([
+      { owner_id: 'p1', type: 'PROPERTY' },
+      { owner_id: 'p1', type: 'PROPERTY' },
+      { owner_id: 'p1', type: 'PROPERTY' },
+    ])
+
+    expect(ownedCityCountByPlayer.get('p1')).toBe(3)
+  })
+
+  it('rankings 기반 결과 row에 실제 보유도시 수를 붙인다', () => {
+    const rows = buildGameResultModalRows({
+      rankings: [
+        {
+          rank: 1,
+          player_id: 'p1',
+          nickname: 'Alpha',
+          final_assets: 842000,
+          is_winner: true,
+        },
+        {
+          rank: 2,
+          player_id: 'p2',
+          nickname: 'Beta',
+          final_assets: 677000,
+          is_winner: false,
+        },
+      ],
+      tiles: [
+        { owner_id: 'p1', type: 'PROPERTY' },
+        { owner_id: 'p1', type: 'city' },
+        { owner_id: 'p2', type: 'PROPERTY' },
+        { owner_id: 'p2', type: 'EVENT' },
+      ],
+    })
+
+    expect(rows).toEqual([
+      expect.objectContaining({
+        id: 'p1',
+        nickname: 'Alpha',
+        ownedCityCountText: '2개',
+      }),
+      expect.objectContaining({
+        id: 'p2',
+        nickname: 'Beta',
+        ownedCityCountText: '1개',
+      }),
+    ])
+  })
+
+  it('winner만 있는 결과 payload에서도 보유도시 수를 표시하고 없으면 0개를 사용한다', () => {
+    const rows = buildGameResultModalRows({
+      winner: {
+        playerId: 'p9',
+        nickname: 'Winner',
+        balance: 330000,
+        assets: 455000,
+      },
+      tiles: [{ owner_id: 'p1', type: 'PROPERTY' }],
+    })
+
+    expect(rows).toEqual([
+      expect.objectContaining({
+        id: 'p9',
+        nickname: 'Winner',
+        ownedCityCountText: '0개',
+      }),
+    ])
+  })
+})

--- a/src/components/board/gameBoardResultUtils.ts
+++ b/src/components/board/gameBoardResultUtils.ts
@@ -1,0 +1,111 @@
+import { formatWon } from '../../lib/utils'
+import type { GameRanking, GameResult } from '../../types/domain'
+
+type GameResultTilePayload = {
+  owner_id?: string | number | null
+  ownerId?: string | number | null
+  type?: string
+  transportType?: string
+}
+
+export interface GameResultModalRowViewModel {
+  id: string
+  nickname: string
+  totalAssetText: string
+  ownedCityCountText: string
+}
+
+function isPropertyTile(tile: GameResultTilePayload) {
+  const transportType =
+    typeof tile.transportType === 'string'
+      ? tile.transportType.trim().toUpperCase()
+      : ''
+
+  if (transportType === 'PROPERTY') {
+    return true
+  }
+
+  if (typeof tile.type !== 'string') {
+    return false
+  }
+
+  const normalizedType = tile.type.trim()
+  if (!normalizedType) {
+    return false
+  }
+
+  const upperType = normalizedType.toUpperCase()
+  if (upperType === 'PROPERTY') {
+    return true
+  }
+
+  const lowerType = normalizedType.toLowerCase()
+  return lowerType === 'property' || lowerType === 'city'
+}
+
+function getOwnedCityCountText(
+  playerId: string | number,
+  ownedCityCountByPlayer: Map<string, number>
+) {
+  return `${ownedCityCountByPlayer.get(String(playerId)) ?? 0}개`
+}
+
+export function countOwnedCitiesByPlayer(tiles: GameResultTilePayload[]) {
+  const ownedCityCountByPlayer = new Map<string, number>()
+
+  tiles.forEach((tile) => {
+    if (!isPropertyTile(tile)) {
+      return
+    }
+
+    const ownerId = tile.owner_id ?? tile.ownerId ?? null
+    if (ownerId == null) {
+      return
+    }
+
+    const playerId = String(ownerId)
+    ownedCityCountByPlayer.set(
+      playerId,
+      (ownedCityCountByPlayer.get(playerId) ?? 0) + 1
+    )
+  })
+
+  return ownedCityCountByPlayer
+}
+
+export function buildGameResultModalRows(params: {
+  rankings?: GameRanking[]
+  winner?: GameResult['winner'] | null
+  tiles?: GameResultTilePayload[]
+}): GameResultModalRowViewModel[] {
+  const { rankings, winner, tiles = [] } = params
+  const ownedCityCountByPlayer = countOwnedCitiesByPlayer(tiles)
+
+  if (rankings && rankings.length > 0) {
+    return rankings.map((ranking) => ({
+      id: String(ranking.player_id),
+      nickname: ranking.nickname,
+      totalAssetText: formatWon(ranking.final_assets),
+      ownedCityCountText: getOwnedCityCountText(
+        ranking.player_id,
+        ownedCityCountByPlayer
+      ),
+    }))
+  }
+
+  if (winner) {
+    return [
+      {
+        id: String(winner.playerId),
+        nickname: winner.nickname,
+        totalAssetText: formatWon(winner.assets),
+        ownedCityCountText: getOwnedCityCountText(
+          winner.playerId,
+          ownedCityCountByPlayer
+        ),
+      },
+    ]
+  }
+
+  return []
+}


### PR DESCRIPTION
## 📌 관련 이슈

> closes #633

---

## 📝 작업 내용

- 게임 종료 결과 모달의 `보유도시`를 종료 시점 타일 소유 정보 기준으로 계산해 `n개` 형식으로 표시하도록 복구했습니다.
- 광주-이벤트-춘천 사이 이벤트칸(`id: 20`) 출발 이동이 travel 이동으로 오인되던 하드코딩을 제거하고, 실제 출발 타일 타입과 `trigger === 'travel'` 기준으로만 빠른 이동 애니메이션을 적용하도록 정리했습니다.
- `src/components/board/**` high-risk 경로 변경이라 task 문서와 `TODO.md` 연결을 함께 추가했습니다.

---

## 🧠 Task 문서 (큰 작업이면 필수)

- plan: docs/ai/tasks/game-board-result-and-travel-fix/plan.md
- context: docs/ai/tasks/game-board-result-and-travel-fix/context.md
- checklist: docs/ai/tasks/game-board-result-and-travel-fix/checklist.md

---

## 📋 TODO.md 연결

- task slug: game-board-result-and-travel-fix
- TODO status: In Progress
- TODO entry 확인: TODO.md의 `game-board-result-and-travel-fix` 한 줄과 task 문서 3종을 1:1로 연결했습니다.

---

## 📚 참고한 기준 문서

- AGENTS.md
- docs/ai/manuals/common.md
- docs/rules.md
- docs/testing.md
- docs/ai/manuals/game-runtime.md

---

## 🧪 실행한 검증

- `npx vitest run src/components/board/gameBoardResultUtils.test.ts`
- `npx vitest run src/components/board/gameBoardEventQueueUtils.test.ts`
- `npm run lint`
- `npm run ai:check:game`
- `npm run build`
- `npm run ai:check:build`
- `npm run ai:self-review -- --files TODO.md docs/ai/tasks/game-board-result-and-travel-fix/plan.md docs/ai/tasks/game-board-result-and-travel-fix/context.md docs/ai/tasks/game-board-result-and-travel-fix/checklist.md src/components/board/GameBoard.tsx src/components/board/gameBoardResultUtils.ts src/components/board/gameBoardResultUtils.test.ts src/components/board/gameBoardEventQueueUtils.ts src/components/board/gameBoardEventQueueUtils.test.ts`

---

## ⚠️ 남은 리스크

- `보유도시`는 현재 프론트에서 `PROPERTY` 타일 개수로 계산합니다. 도메인 정의가 달라지면 helper 기준을 같이 수정해야 합니다.
- 빠른 이동 애니메이션은 이제 `TRAVEL`, `ISLAND`, `trigger === 'travel'`에만 적용됩니다. 다른 특수 이동도 같은 속도로 처리해야 하면 판정 helper를 확장해야 합니다.

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료
- [x] 큰 작업이면 task 문서 링크를 남겼다
- [x] 큰 작업이면 `TODO.md` / task slug 연결을 PR 본문에 남겼다
- [x] 참고한 기준 문서를 PR 본문에 남겼다
- [x] 실행한 검증과 남은 리스크를 PR 본문에 적었다
