### PR TITLE
docs: 프론트 README 하이브리드 리프레시

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,15 @@
 > 단순히 화면을 연결하는 데서 끝나지 않고, 로비-대기방-게임으로 이어지는 흐름을  
 > 프론트엔드에서 예측 가능하게 유지하도록 상태 관리, 실시간 이벤트 처리, mock/real 환경 분리를 함께 설계했습니다.
 
+`MARBLE POP Frontend`는 로그인 이후의 사용자 흐름을 웹에서 안정적으로 이어주는 클라이언트입니다. REST 조회는 TanStack Query로, 게임과 프레즌스 같은 실시간 상태는 Socket.IO와 Zustand로 정리하고, 개발 단계에서는 MSW와 socket mock server를 병행해 mock/real 경로를 같은 UI에서 검증할 수 있게 구성했습니다.
+
+### 프론트엔드가 맡는 역할
+
+- 로그인 이후 라우팅, 세션 복구, 페이지 진입 제어
+- 로비, 대기방, 게임 화면의 상태 렌더링과 사용자 입력 전달
+- REST 응답과 실시간 socket 이벤트를 하나의 UI 상태로 정렬
+- mock/real 런타임 전환, 테스트, 문서화
+
 ---
 
 ## :link: 배포 링크
@@ -30,6 +39,142 @@
 |                                       마이페이지                                        |
 | :-------------------------------------------------------------------------------------: |
 | <img src="./docs/project/assets/readme/my-page.png" alt="MARBLE POP 마이페이지 화면" /> |
+
+---
+
+## 🏗️ 아키텍처
+
+```mermaid
+flowchart LR
+    B["Browser"] --> APP["React + Vite App"]
+    APP --> QUERY["TanStack Query"]
+    APP --> STORE["Zustand / UI State"]
+    APP --> MOCK["MSW / Socket Mock"]
+
+    QUERY --> REST["REST API"]
+    STORE --> SIO["Socket.IO"]
+
+    REST --> BE["Backend"]
+    SIO --> BE
+    MOCK -. local dev / demo .- APP
+```
+
+- 일반 모드에서는 REST와 Socket.IO로 백엔드와 통신합니다.
+- mock 모드에서는 MSW와 local socket mock server를 사용해 페이지 흐름과 실시간 상호작용을 로컬에서 검증합니다.
+- 페이지는 의도를 드러내고, 상세 흐름은 hook/controller/api 계층으로 분리하는 구조를 유지합니다.
+
+---
+
+## 🗂️ 프로젝트 구조
+
+```text
+.
+├─ src/
+│  ├─ pages/
+│  │  ├─ lobby/                # 로비 페이지 및 방 진입 흐름
+│  │  ├─ waiting-room/         # 대기방 lifecycle, ready/start/leave
+│  │  └─ GamePage.tsx          # 게임 런타임 화면 조합
+│  ├─ features/presence/       # 접속자 목록, DM, unread badge
+│  ├─ services/socket/         # socket contract adapter / emit handler
+│  ├─ stores/                  # zustand store
+│  ├─ mocks/                   # MSW mock handler
+│  └─ contracts/socket/        # socket schema / policy
+├─ mock-socket-server/         # 로컬 socket mock server
+├─ e2e/                        # Playwright 시나리오
+├─ docs/project/               # 공개용 프로젝트 문서 / README 자산
+└─ scripts/ai/                 # repo workflow / validation 도구
+```
+
+---
+
+## 🚀 빠르게 실행하기
+
+### 1. 저장소 클론 및 의존성 설치
+
+```bash
+git clone https://github.com/modoo-marble-team/Blue_Marble-frontend.git
+cd Blue_Marble-frontend
+npm install
+```
+
+### 2. 환경 변수 준비
+
+```bash
+cp .env.example .env.development.local
+```
+
+- `.env.example`는 기본값 예시입니다.
+- `.env.development.local`은 개인 로컬 override 용도로 사용합니다.
+- `npm run env:mock`, `npm run env:real`은 `.env.development`를 각각 mock/real 템플릿으로 바꾸고, 있으면 `.env.development.local`의 mock 관련 플래그도 함께 맞춰줍니다.
+
+### 3. 실행 모드 선택
+
+실백엔드 연결:
+
+```bash
+npm run env:real
+npm run dev
+```
+
+mock 기반 로컬 검증:
+
+```bash
+npm run env:mock
+```
+
+별도 터미널에서 socket mock server 실행:
+
+```bash
+npm run socket:mock
+```
+
+개발 서버 실행:
+
+```bash
+npm run dev
+```
+
+### 4. 확인
+
+| 경로                    | 설명                                        |
+| ----------------------- | ------------------------------------------- |
+| `http://localhost:5173` | Vite 개발 서버                              |
+| `npm run env:show`      | 현재 `.env.development` mock/real 모드 확인 |
+
+---
+
+## 🔧 주요 환경 변수
+
+| 변수                        | 기본값 예시                 | 설명                                                 |
+| --------------------------- | --------------------------- | ---------------------------------------------------- |
+| `VITE_API_URL`              | `http://localhost:3000/api` | REST API base URL                                    |
+| `VITE_SOCKET_URL`           | `http://localhost:3000`     | Socket.IO base URL                                   |
+| `VITE_USE_SOCKET_MOCK`      | `false`                     | 개발 환경에서 MSW + socket mock 경로를 사용할지 결정 |
+| `VITE_ENABLE_DEMO_MOCK`     | `false`                     | 배포/데모 환경에서도 mock 모드를 강제로 켤지 결정    |
+| `VITE_ALLOW_ALL_MOCK_TURNS` | `false`                     | mock 게임에서 턴 제한을 무시할지 결정                |
+
+> mock 모드를 켜면 MSW와 socket mock server 기준으로 화면 흐름을 검증합니다.
+
+---
+
+## 🧪 자주 쓰는 명령어
+
+| 명령어                          | 설명                                       |
+| ------------------------------- | ------------------------------------------ |
+| `npm run dev`                   | Vite 개발 서버 실행                        |
+| `npm run env:mock`              | `.env.development`를 mock 모드로 전환      |
+| `npm run env:real`              | `.env.development`를 real 모드로 전환      |
+| `npm run env:show`              | 현재 mock/real 모드 확인                   |
+| `npm run socket:mock`           | 로컬 socket mock server 실행               |
+| `npm run lint`                  | ESLint 실행                                |
+| `npm run test`                  | Vitest 전체 실행                           |
+| `npm run test:coverage`         | 커버리지 포함 테스트 실행                  |
+| `npm run e2e:ci`                | 기본 Playwright 시나리오 실행              |
+| `npm run build`                 | TypeScript build + Vite production build   |
+| `npm run ai:check:lobby`        | 로비 / presence / room-chat 관련 최소 검증 |
+| `npm run ai:check:waiting-room` | 대기방 관련 최소 검증                      |
+| `npm run ai:check:game`         | 게임 런타임 관련 최소 검증                 |
+| `npm run ai:self-review`        | 변경 파일 기준 self-review 출력            |
 
 ---
 
@@ -66,85 +211,43 @@
 
 ### FE
 
-| 이름   | 역할                                                                                                                                                                                    |
-| ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 최진명 | 팀장, 랜딩·로그인·헤더·로비·DM·채팅·채팅방·대기방·마이페이지·게임 내 채팅 구현, 게임 외 프론트 전반 담당, 컨텍스트 정리·협업 워크플로우·테스트/검증 체계 정리, 일부 게임 오류 수정 지원 |
-| 우재민 | 게임 로직                                                                                                                                                                               |
-| 김재윤 | 게임 UI                                                                                                                                                                                 |
+| 이름   | 역할                                                                                                                                                                |
+| ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 최진명 | 팀장, 랜딩·로그인·헤더·로비·접속자목록·DM·채팅·채팅창·대기방·마이페이지·게임 내 채팅 구현, 컨텍스트 정리·협업 워크플로우·테스트/검증 체계 정리, 게임 오류 수정 지원 |
+| 우재민 | 게임 소켓 계약 정규화, 스토어 상태 동기화, 호환 계층 유지 책임                                                                                                      |
+| 김재윤 | 보드 렌더 구조 유지, 이동·모달·이벤트 연출 UX 품질 책임                                                                                                             |
+
+---
 
 ## 📑 프로젝트 규칙
 
-### Branch Strategy
+자세한 협업 규칙과 문서화 기준은 [Project Conventions](./docs/project/conventions.md)를 참고해주세요.
 
-> - `main`, `develop` 보호 브랜치 운영
-> - 기능 작업은 브랜치를 분리한 뒤 PR로 병합
-> - 직접 push보다 review 기반 병합 우선
+- `main`, `develop` 보호 브랜치를 운영하고 PR 기반 병합을 우선합니다.
+- 커밋은 `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `build` 접두사를 사용합니다.
+- PR 본문에는 작업 내용, 실행한 검증, 남은 리스크를 남깁니다.
+- 사용자 흐름이나 계약이 바뀌면 관련 문서와 테스트를 함께 갱신합니다.
 
-### Git Convention
+---
 
-> 1. 적절한 커밋 접두사 작성
-> 2. 변경 의도가 드러나는 메시지 작성
-> 3. 필요한 경우 이슈 번호를 함께 연결
+## :clipboard: 문서
 
-> | 접두사   | 설명                     |
-> | -------- | ------------------------ |
-> | Feat     | 새로운 기능 구현         |
-> | Fix      | 버그 수정                |
-> | Docs     | 문서 추가 및 수정        |
-> | Refactor | 동작 변경 없는 구조 개선 |
-> | Test     | 테스트 추가 및 수정      |
-> | Chore    | 기타 작업                |
-> | Build    | 빌드, 환경 설정          |
+### 프로젝트 내부 문서
 
-### Pull Request
+- [Project Conventions](./docs/project/conventions.md)
+- [README Screenshot Assets](./docs/project/assets/readme/README.md)
+- [Architecture Assets Guide](./docs/project/assets/architecture/README.md)
+- [API Spec Summary](./docs/project/specs/api-spec.md)
+- [ERD Summary](./docs/project/specs/erd.md)
+- [Requirements Summary](./docs/project/specs/requirements.md)
+- [Screen Spec Summary](./docs/project/specs/screen-spec.md)
+- [Table Schema Summary](./docs/project/specs/table-schema.md)
+- [Demo Video Note](./docs/project/presentations/demo-video.md)
 
-> ### Title
->
-> - 제목은 변경 의도가 바로 보이도록 작성합니다.
+### 외부 명세 / 협업 문서
 
-> ### PR Type
->
-> - [ ] FEAT: 새로운 기능 구현
-> - [ ] FIX: 버그 수정
-> - [ ] DOCS: 문서 추가 및 수정
-> - [ ] REFACTOR: 코드 리팩토링
-> - [ ] TEST: 테스트 관련
-> - [ ] BUILD: 빌드, 환경 설정
-> - [ ] CHORE: 기타 작업
-
-> ### Description
->
-> - 무엇을 바꿨는지, 왜 바꿨는지, 어떤 검증을 했는지 작성합니다.
-
-> ### Discussion
->
-> - 추후 논의가 필요한 사항이나 남은 리스크를 작성합니다.
-
-### Code Convention
-
-> FE
->
-> - 페이지는 의도를 드러내고 상세 로직은 hook / controller / api 계층으로 분리
-> - 같은 종류의 훅과 반환 형태는 일관성 유지
-> - 이벤트 핸들러는 `handle*` 네이밍 사용
-> - mock 경로와 real 경로가 함께 존재하는 코드는 양쪽 흐름을 함께 검토
-> - 테스트는 구현 세부보다 사용자 행동과 계약을 검증
-
-### Communication Rules
-
-> - 주요 의사결정은 PR, 이슈, 문서에 기록
-> - 사용자 흐름 또는 계약이 바뀌면 관련 문서와 테스트를 함께 갱신
-
-## :clipboard: Documents
-
-> [📜 API 명세서](https://docs.google.com/spreadsheets/d/191cFJ97qyWzeAJm5DEqTf6SO6p8mqWBE/edit?pli=1&gid=2141226886#gid=2141226886)
->
-> [📜 요구사항 정의서](https://docs.google.com/spreadsheets/d/15Lu2YYq1VlnJbam9ADfLuEq_uTMY8umN/edit?gid=919594060#gid=919594060)
->
-> [📜 ERD / 소켓 명세서](https://github.com/modoo-marble-team/docs/tree/main)
->
-> [📜 테이블 명세서](https://docs.google.com/spreadsheets/d/1Xq0YsYCvV3xzFYTsfubVfVqsGeOol7Ah/edit?gid=507107377#gid=507107377)
->
-> [📜 화면 정의서 / 와이어프레임 / 플로우 차트](https://www.figma.com/design/3yixlZLiKnWieKVFpM7n9j/%ED%8C%80%ED%94%84%EB%A1%9C%EC%A0%9D%ED%8A%B8-%EC%BA%90%EC%A3%BC%EC%96%BC-%EB%B8%8C%EB%A3%A8%EB%A7%88%EB%B8%94?node-id=0-1&t=ZohHKxxh86rbb8Fq-1)
->
-> [📜 Project Conventions](./docs/project/conventions.md)
+- [API 명세서](https://docs.google.com/spreadsheets/d/191cFJ97qyWzeAJm5DEqTf6SO6p8mqWBE/edit?pli=1&gid=2141226886#gid=2141226886)
+- [요구사항 정의서](https://docs.google.com/spreadsheets/d/15Lu2YYq1VlnJbam9ADfLuEq_uTMY8umN/edit?gid=919594060#gid=919594060)
+- [ERD / 소켓 명세서 Docs Repo](https://github.com/modoo-marble-team/docs/tree/main)
+- [테이블 명세서](https://docs.google.com/spreadsheets/d/1Xq0YsYCvV3xzFYTsfubVfVqsGeOol7Ah/edit?gid=507107377#gid=507107377)
+- [화면 정의서 / 와이어프레임 / 플로우 차트](https://www.figma.com/design/3yixlZLiKnWieKVFpM7n9j/%ED%8C%80%ED%94%84%EB%A1%9C%EC%A0%9D%ED%8A%B8-%EC%BA%90%EC%A3%BC%EC%96%BC-%EB%B8%8C%EB%A3%A8%EB%A7%88%EB%B8%94?node-id=0-1&t=ZohHKxxh86rbb8Fq-1)

--- a/TODO.md
+++ b/TODO.md
@@ -30,7 +30,7 @@
 
 - [x] `sell-modal-server-driven` - Sell Modal Server Driven (`docs/ai/tasks/sell-modal-server-driven/`) - 강제호출 매각모달 팝업 제거 및 채팅창 라운드 표출 갱신
 - [x] `git-flow-rebase-safeguards` - Git Flow Rebase Safeguards (`docs/ai/tasks/git-flow-rebase-safeguards/`) - ai:git-flow의 branch 생성 전 / push 전 rebase 정책을 실행 결과와 사용 문서에서 더 명확히 드러내도록 정리
-- [x] `public-readme-project-docs` - Public Readme Project Docs (`docs/ai/tasks/public-readme-project-docs/`) - 루트 README를 대외용 소개 문서로 재구성하고 `docs/project/` 공개 문서 구조를 추가
+- [x] `public-readme-project-docs` - Public Readme Project Docs (`docs/ai/tasks/public-readme-project-docs/`) - 루트 README를 대외 소개와 개발자 온보딩을 함께 담는 하이브리드 문서로 보강하고 `docs/project/` 공개 문서 구조를 유지
 - [x] `game-ux-improvements` - Game UX Improvements (`docs/ai/tasks/game-ux-improvements/`) - 무인도 문구, 20라운드 표기, 여행 애니메이션 단축 등 UX 개선 모음
 
 - [x] `sort-by-total-assets` - Sort By Total Assets (`docs/ai/tasks/sort-by-total-assets/`) - 왕관 및 플레이어 패널 순위를 보유금 대신 총자산 기준으로 변경

--- a/docs/ai/tasks/public-readme-project-docs/checklist.md
+++ b/docs/ai/tasks/public-readme-project-docs/checklist.md
@@ -8,12 +8,15 @@
 - [x] 최소 범위로 구현했다
 - [x] mock/real 경로를 함께 확인했다
 - [x] 타입/contract 변경이 있으면 관련 코드도 같이 수정했다
+- [x] README에 프론트 역할 / 아키텍처 / 프로젝트 구조 / 빠른 실행 섹션을 추가했다
+- [x] `.env.example`, `package.json`, `src/vite-env.d.ts` 기준으로 환경 변수와 명령어 설명을 맞췄다
+- [x] 프로젝트 규칙 섹션을 축약하고 `docs/project/conventions.md` 링크 중심으로 정리했다
 
 ## Testing
 
 - [x] 최소 검증 명령을 직접 추가했다
-- [x] `npx prettier --check README.md docs/project docs/ai/tasks/public-readme-project-docs TODO.md`
-- [x] `npm run ai:self-review -- --files ...`
+- [x] `npx prettier --check README.md docs/ai/tasks/public-readme-project-docs TODO.md`
+- [x] `npm run ai:self-review -- --files README.md docs/ai/tasks/public-readme-project-docs/plan.md docs/ai/tasks/public-readme-project-docs/context.md docs/ai/tasks/public-readme-project-docs/checklist.md TODO.md`
 
 ## Review
 

--- a/docs/ai/tasks/public-readme-project-docs/context.md
+++ b/docs/ai/tasks/public-readme-project-docs/context.md
@@ -4,6 +4,7 @@
 
 - 루트 `README.md`는 대외용 프로젝트 소개, 외부 명세 링크, 실제 서비스 스크린샷 갤러리를 포함한다
 - `docs/project/` 아래에 공개용 문서 구조와 README 자산 규칙이 정리되어 있다
+- 다만 README 안에는 프론트 실행 방법, mock/real 환경 전환, 주요 `VITE_*` 환경 변수, 프로젝트 구조 요약이 충분히 드러나지 않는다
 
 ## Related Files
 
@@ -32,17 +33,19 @@
 
 ## Decision Notes
 
-- 루트 README는 대외용 프로젝트 소개 중심으로 재작성하고, 상세 규칙과 명세서는 `docs/project/`로 분리한다
+- 루트 README는 대외용 프로젝트 소개를 유지하되, 프론트 개발자 온보딩 정보도 함께 담는 하이브리드 형태로 정리한다
 - 코드에서 확인 가능한 사실은 실제 내용으로 채우고, 외부에서 확정해야 하는 값은 `TODO` 자리표시자로 남긴다
 - `public/`에 README 전용 이미지를 섞는 대안은 앱 자산과 문서 자산 경계가 흐려져 제외했다
+- 백엔드 README의 구조는 참고하되, DB/Redis/JWT 같은 서버 전용 설명은 그대로 가져오지 않고 `VITE_*` 설정과 mock/real 실행 흐름으로 치환한다
 
 ## Session Handoff Notes
 
 - 다음 세션에서 다시 읽을 문서: `README.md`, `docs/project/*`, `docs/ai/tasks/public-readme-project-docs/*`
 - 바로 이어서 할 1개 단계: 실제 배포 URL / 발표 자료 / 팀원 정보를 README 템플릿에 반영
 - pending decision / blocker: 공개 가능한 배포 링크와 최종 팀 소개 정보가 아직 없음
-- 검증 재개 지점: prettier check와 self-review 결과 확인 후 TODO / task 상태 마감
+- 검증 재개 지점: README 명령어와 `.env.example` / `package.json` / `src/vite-env.d.ts` 일치 여부 재확인
 
 ## Open Risks
 
 - 현재 README에는 실제 배포 링크, 발표 자료, 팀원 정보가 비어 있어 후속 입력이 필요하다
+- README의 실행 예시는 현재 프론트 저장소 기준과 일치하지만, 백엔드/배포 방식이 바뀌면 환경 변수와 실행 절차도 함께 갱신해야 한다

--- a/docs/ai/tasks/public-readme-project-docs/plan.md
+++ b/docs/ai/tasks/public-readme-project-docs/plan.md
@@ -9,8 +9,9 @@
 
 ## Goal
 
-- 저장소의 짧은 개발자용 README를 대외용 프로젝트 소개 문서로 재구성한다
-- 스크린샷, 아키텍처, 명세서, 협업 규칙을 `docs/project/` 아래에 분리해 README에서 안정적으로 링크할 수 있게 만든다
+- 루트 README를 대외 소개와 개발자 온보딩을 함께 담는 하이브리드 문서로 정리한다
+- 스크린샷, 아키텍처, 명세서, 협업 규칙을 `docs/project/` 아래 구조와 연결해 README에서 안정적으로 링크할 수 있게 만든다
+- 백엔드 README처럼 빠른 실행, 환경 변수, 프로젝트 구조, 명령어를 프론트 기준으로 보강한다
 
 ## WAT Workflow
 
@@ -50,8 +51,9 @@
 
 ## Completion Criteria
 
-- 루트 README만 읽어도 MARBLE POP의 핵심 흐름과 문서 링크 구조를 이해할 수 있다
+- 루트 README만 읽어도 MARBLE POP의 핵심 흐름, 프론트 역할, 실행 방법, 문서 링크 구조를 이해할 수 있다
 - 명세서와 README용 자산을 어디에 넣어야 하는지 저장소 내부 문서로 바로 알 수 있다
+- `package.json`, `.env.example`, `src/vite-env.d.ts` 기준과 어긋나는 README 실행/환경 변수 설명이 없다
 - 기존 AI / 개발자 문서는 유지되고 대외용 프로젝트 문서와 섞이지 않는다
 
 ## Role Plan
@@ -63,5 +65,5 @@
 
 ## Test Plan
 
-- `npx prettier --check README.md docs/project docs/ai/tasks/public-readme-project-docs TODO.md`
-- `npm run ai:self-review -- --files README.md docs/project/conventions.md docs/project/assets/readme/README.md docs/project/assets/architecture/README.md docs/project/specs/api-spec.md docs/project/specs/requirements.md docs/project/specs/erd.md docs/project/specs/table-schema.md docs/project/specs/screen-spec.md docs/project/presentations/demo-video.md docs/ai/tasks/public-readme-project-docs/plan.md docs/ai/tasks/public-readme-project-docs/context.md docs/ai/tasks/public-readme-project-docs/checklist.md TODO.md`
+- `npx prettier --check README.md docs/ai/tasks/public-readme-project-docs TODO.md`
+- `npm run ai:self-review -- --files README.md docs/ai/tasks/public-readme-project-docs/plan.md docs/ai/tasks/public-readme-project-docs/context.md docs/ai/tasks/public-readme-project-docs/checklist.md TODO.md`


### PR DESCRIPTION
## 📌 관련 이슈

> closes #635

---

## 📝 작업 내용

- 루트 `README.md`를 대외 소개와 개발자 온보딩을 함께 담는 하이브리드 문서로 보강했습니다.
- 프론트 역할 설명, 아키텍처 다이어그램, 프로젝트 구조, 빠르게 실행하기, 주요 환경 변수, 자주 쓰는 명령어를 현재 저장소 기준으로 정리했습니다.
- 실제 배포 링크를 반영하고, 팀 소개 역할 문구와 이름 표시를 현재 공개 정보 기준으로 정리했습니다.
- README 하단 순서를 `문서 → 사용 스택 → 팀 동료 → 프로젝트 규칙`으로 재배치해 재참조 빈도가 높은 정보를 더 빨리 찾을 수 있게 했습니다.
- `public-readme-project-docs` task 문서와 `TODO.md` 설명도 이번 README 방향에 맞게 갱신했습니다.

---

## 🧠 Task 문서 (큰 작업이면 필수)

- plan: docs/ai/tasks/public-readme-project-docs/plan.md
- context: docs/ai/tasks/public-readme-project-docs/context.md
- checklist: docs/ai/tasks/public-readme-project-docs/checklist.md

---

## 📋 TODO.md 연결

- task slug: public-readme-project-docs
- TODO status: Done
- TODO entry 확인: `TODO.md`의 `public-readme-project-docs` 설명을 README 하이브리드 리프레시 기준으로 갱신했습니다.

---

## 📚 참고한 기준 문서

- AGENTS.md
- docs/ai/manuals/common.md
- docs/rules.md
- docs/testing.md
- 추가 manual / 문서 경로: N/A

---

## 🧪 실행한 검증

- `npx prettier --check README.md docs/ai/tasks/public-readme-project-docs TODO.md`
- `npx prettier --write README.md`
- `npm run ai:self-review -- --files README.md docs/ai/tasks/public-readme-project-docs/plan.md docs/ai/tasks/public-readme-project-docs/context.md docs/ai/tasks/public-readme-project-docs/checklist.md TODO.md`
- pre-push 훅 통과: `npm run lint`, `npm run test`, `npm run test:coverage`, `npm run e2e:ci`, `npm run build`

---

## ⚠️ 남은 리스크

- README의 발표 자료 등 일부 정보는 여전히 placeholder 또는 후속 입력 대상입니다.
- 실행 절차와 환경 변수 설명은 현재 `package.json`, `.env.example`, `src/vite-env.d.ts` 기준에 맞췄지만, 배포 방식이나 mock 전략이 바뀌면 README도 함께 갱신해야 합니다.
- 팀 소개 표는 `<nobr>`로 이름 줄바꿈을 방지했지만, 아주 좁은 화면이나 일부 뷰어에서는 표 전체 폭 때문에 줄바꿈이 생길 가능성은 있습니다.

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료
- [x] 큰 작업이면 task 문서 링크를 남겼다
- [x] 큰 작업이면 `TODO.md` / task slug 연결을 PR 본문에 남겼다
- [x] 참고한 기준 문서를 PR 본문에 남겼다
- [x] 실행한 검증과 남은 리스크를 PR 본문에 적었다
