### PR TITLE
fix: room chat / DM 긴 메시지 overflow 및 300자 제한 정리

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -17,6 +17,9 @@
 
 ## Done
 
+- [x] `chat-message-limit-300` - Chat Message Limit 300 (`docs/ai/tasks/chat-message-limit-300/`) - room chat과 DM에 300자 하드 제한을 입력/송신/contract/mock/test 기준으로 통일
+- [x] `chat-bubble-overflow-fix` - Chat Bubble Overflow Fix (`docs/ai/tasks/chat-bubble-overflow-fix/`) - 긴 메시지가 말풍선을 뚫고 가로 스크롤을 만드는 문제를 RoomChat/DM 공통 스타일로 정리
+
 - [x] `waiting-room-authoritative-resume-refresh` - Waiting Room Authoritative Resume Refresh (`docs/ai/tasks/waiting-room-authoritative-resume-refresh/`) - game 종료 후 waiting-room 복귀를 background join revalidation으로 교정하고 room create/join presence 반영을 follow-up refresh로 보강
 - [x] `waiting-room-resume-bootstrap-presence-resync` - Waiting Room Resume Bootstrap Presence Resync (`docs/ai/tasks/waiting-room-resume-bootstrap-presence-resync/`) - 게임 종료 후 대기방 복귀 무한 로딩을 bootstrap snapshot으로 해소하고 waiting-room에서도 lobby_updated 기반 presence 재동기화를 수행
 - [x] `presence-realtime-room-transitions` - Presence Realtime Room Transitions (`docs/ai/tasks/presence-realtime-room-transitions/`) - 로비/대기방 이동 시 접속자 목록 상태가 stale하게 남는 경로를 room membership override와 lobby presence resync로 정리

--- a/docs/ai/tasks/chat-bubble-overflow-fix/checklist.md
+++ b/docs/ai/tasks/chat-bubble-overflow-fix/checklist.md
@@ -1,0 +1,27 @@
+# Checklist
+
+## Implementation
+
+- [x] 관련 manual과 기존 문서를 읽었다
+- [x] 영향 범위를 정리했다
+- [x] WAT 단계와 역할 분담을 문서에 반영했다
+- [x] 최소 범위로 구현했다
+- [x] mock/real 경로를 함께 확인했다
+- [x] 타입/contract 변경이 없음을 확인했다
+
+## Testing
+
+- [x] `npx vitest run src/features/room-chat/RoomChat.test.tsx src/features/presence/components/DirectMessagePanel.test.tsx`
+- [x] `npm run ai:check:lobby`
+- [x] `npm run lint`
+- [x] `npm run build`, Playwright는 이번 레이아웃/클래스 보강 diff 기준으로 미실행
+
+## Review
+
+- [x] `docs/rules.md` 기준으로 셀프 리뷰했다
+- [x] 공용 채팅 / DM / mock-real 공유 UI 경계를 확인했다
+- [x] `TODO.md` task 한 줄을 최신 상태로 유지했다
+- [x] session handoff notes를 최신 상태로 갱신했다
+- [x] `npm run ai:session:brief -- chat-bubble-overflow-fix` 출력이 현재 상태와 맞는다
+- [x] `npm run ai:self-review -- --files ...`를 실행했다
+- [x] 변경 파일 / 실행한 검증 / 남은 리스크를 정리했다

--- a/docs/ai/tasks/chat-bubble-overflow-fix/context.md
+++ b/docs/ai/tasks/chat-bubble-overflow-fix/context.md
@@ -1,0 +1,48 @@
+# Context
+
+## Current Behavior
+
+- RoomChat과 DM 패널의 메시지 말풍선은 `max-w`만 있고 긴 텍스트 줄바꿈 방어 규칙이 없다.
+- 긴 URL, 공백 없는 영문 문자열, 매우 긴 토큰이 들어오면 말풍선 높이가 늘지 않고 가로로 밀리며 채팅창에 가로 스크롤이 생긴다.
+- RoomChat은 대기방/게임에서 공용으로 쓰이므로 한 번 수정하면 두 채팅창에 같이 반영된다.
+
+## Related Files
+
+- `src/features/room-chat/RoomChat.tsx`
+- `src/features/presence/components/DirectMessagePanel.tsx`
+- `src/features/room-chat/RoomChat.test.tsx`
+- `src/features/presence/components/DirectMessagePanel.test.tsx`
+- `src/pages/waiting-room/components/WaitingRoomChatBox.tsx`
+- `src/pages/GamePage.tsx`
+
+## Relevant Manuals
+
+- `docs/ai/manuals/common.md`
+- `docs/ai/manuals/lobby.md`
+- `docs/rules.md`
+- `docs/testing.md`
+
+## Constraints
+
+- `RoomChat`과 `DirectMessagePanel`의 props / 메시지 타입 / 정렬 규칙은 유지한다.
+- DM unread, mock/real socket 경로, 대기방/게임 채팅 송신 계약은 건드리지 않는다.
+- 길이 제한은 backend/mock/socket contract와 함께 움직여야 하므로 이번 작업에 포함하지 않는다.
+- DEV 제어 패널은 사용자용 채팅창 범위가 아니므로 제외한다.
+
+## Decision Notes
+
+- 새 공용 유틸 없이 RoomChat과 DM 패널에 같은 줄바꿈 클래스를 직접 적용한다.
+- 실무형 기본 UX로 `whitespace-pre-wrap`을 사용해 사용자가 입력한 줄바꿈은 보존하고, `break-words`와 `[overflow-wrap:anywhere]`로 공백 없는 문자열도 감기게 한다.
+- 가로 스크롤 방지는 메시지 리스트 컨테이너와 메시지 행 모두에 `min-w-0` / `overflow-x-hidden`을 두는 방식으로 처리한다.
+
+## Session Handoff Notes
+
+- 다음 세션에서 다시 읽을 문서: `docs/ai/tasks/chat-bubble-overflow-fix/*`, `docs/ai/manuals/lobby.md`, `docs/testing.md`
+- 바로 이어서 할 1개 단계: 없음. 후속이 필요하면 긴 닉네임 overflow나 multiline 입력 UX를 별도 task로 분리
+- pending decision / blocker: 없음
+- 검증 재개 지점: `npx vitest run src/features/room-chat/RoomChat.test.tsx src/features/presence/components/DirectMessagePanel.test.tsx`, `npm run ai:check:lobby`, `npm run lint`, `npm run ai:self-review -- --files ...` 실행 완료
+
+## Open Risks
+
+- jsdom에서는 실제 줄바꿈 레이아웃을 시각적으로 검증할 수 없으므로 클래스 적용 여부 중심으로 테스트해야 한다.
+- 긴 닉네임 overflow와 multiline 입력 UX는 이번 요청 범위 밖이라 후속 UX 개선 여지가 남아 있다.

--- a/docs/ai/tasks/chat-bubble-overflow-fix/plan.md
+++ b/docs/ai/tasks/chat-bubble-overflow-fix/plan.md
@@ -1,0 +1,69 @@
+# Plan
+
+## Task
+
+- 작업 이름: Chat Bubble Overflow Fix
+- 작업 slug: chat-bubble-overflow-fix
+- 요청 날짜: 2026-03-25
+- 담당 범위: 사용자용 채팅 UI 말풍선 overflow와 테스트 정리
+
+## Goal
+
+- 긴 메시지가 말풍선을 뚫고 한 줄로 늘어나며 채팅창에 가로 스크롤을 만드는 문제를 없앤다.
+- RoomChat을 쓰는 대기방/게임 채팅과 DM 패널에 같은 사용자 경험을 맞춘다.
+- 소켓 계약이나 메시지 길이 제한 변경 없이 레이아웃 문제만 해결한다.
+
+## WAT Workflow
+
+1. task 문서와 TODO를 만들어 범위 / 완료 기준 / 검증 명령을 고정한다.
+2. 공용 채팅과 DM 패널 말풍선에 줄바꿈 / overflow 방어 규칙을 최소 범위로 넣는다.
+3. 긴 공백 없는 문자열 회귀 테스트와 최소 검증을 실행하고 문서를 완료 상태로 맞춘다.
+
+## In Scope
+
+- `src/features/room-chat/RoomChat.tsx`
+- `src/features/presence/components/DirectMessagePanel.tsx`
+- 관련 Vitest 회귀 테스트
+- task 문서와 TODO 상태 정리
+
+## Out Of Scope
+
+- 채팅 입력창을 textarea 기반으로 재설계
+- 메시지 길이 제한 추가
+- 소켓 payload, mock server, unread 규칙 변경
+- DEV 전용 제어 패널 UI 수정
+
+## Target Files
+
+- `src/features/room-chat/RoomChat.tsx`
+- `src/features/presence/components/DirectMessagePanel.tsx`
+- `src/features/room-chat/RoomChat.test.tsx`
+- `src/features/presence/components/DirectMessagePanel.test.tsx`
+- `docs/ai/tasks/chat-bubble-overflow-fix/*`
+- `TODO.md`
+
+## Task Tracking
+
+- TODO line: - [ ] `chat-bubble-overflow-fix` - Chat Bubble Overflow Fix (`docs/ai/tasks/chat-bubble-overflow-fix/`)
+- Session brief: `npm run ai:session:brief -- chat-bubble-overflow-fix`
+- Reopen docs: `docs/ai/tasks/chat-bubble-overflow-fix/plan.md`, `context.md`, `checklist.md`, 관련 manuals
+
+## Completion Criteria
+
+- 긴 URL / 공백 없는 문자열도 RoomChat과 DM 말풍선 안에서 여러 줄로 감긴다.
+- 사용자용 채팅창에 가로 스크롤이 생기지 않는다.
+- 대기방/게임/DM이 공통 규칙으로 동작한다.
+- 관련 Vitest와 lobby 최소 검증이 통과한다.
+
+## Role Plan
+
+- Planner: 범위 / 완료 기준 / 위험 요소 정리
+- Implementer: 공용 채팅과 DM 패널 최소 수정
+- Reviewer: overflow, mock/real 영향, 테스트 누락 점검
+- Tester: 긴 문자열 회귀 테스트와 최소 검증 실행
+
+## Test Plan
+
+- `npx vitest run src/features/room-chat/RoomChat.test.tsx src/features/presence/components/DirectMessagePanel.test.tsx`
+- `npm run ai:check:lobby`
+- `npm run ai:self-review -- --files TODO.md docs/ai/tasks/chat-bubble-overflow-fix/plan.md docs/ai/tasks/chat-bubble-overflow-fix/context.md docs/ai/tasks/chat-bubble-overflow-fix/checklist.md src/features/room-chat/RoomChat.tsx src/features/room-chat/RoomChat.test.tsx src/features/presence/components/DirectMessagePanel.tsx src/features/presence/components/DirectMessagePanel.test.tsx`

--- a/docs/ai/tasks/chat-message-limit-300/checklist.md
+++ b/docs/ai/tasks/chat-message-limit-300/checklist.md
@@ -1,0 +1,27 @@
+# Checklist
+
+## Implementation
+
+- [x] 관련 manual과 기존 문서를 읽었다
+- [x] 영향 범위를 정리했다
+- [x] WAT 단계와 역할 분담을 문서에 반영했다
+- [x] 공통 상수와 송신 정규화 규칙을 추가했다
+- [x] room chat / DM 입력창에 300자 제한을 적용했다
+- [x] mock/real send contract와 mock gateway를 같은 기준으로 맞췄다
+
+## Testing
+
+- [x] `npx vitest run src/features/room-chat/RoomChat.test.tsx src/features/presence/components/DirectMessagePanel.test.tsx src/features/presence/direct-message/useDirectMessageController.test.tsx src/features/presence/direct-message/directMessageSocket.test.ts src/pages/waiting-room/socket/mockGateway.test.ts src/pages/GamePage.test.tsx src/pages/waiting-room/socket/socket.test.ts`
+- [x] `npm run ai:check:lobby`
+- [x] `npm run lint`
+- [x] `npm run build`
+
+## Review
+
+- [x] `docs/rules.md` 기준으로 셀프 리뷰했다
+- [x] local optimistic state / socket emit / mock path 일치 여부를 확인했다
+- [x] `TODO.md` task 한 줄을 최신 상태로 유지했다
+- [x] session handoff notes를 최신 상태로 갱신했다
+- [x] `npm run ai:session:brief -- chat-message-limit-300` 출력이 현재 상태와 맞는다
+- [x] `npm run ai:self-review -- --files ...`를 실행했다
+- [x] 변경 파일 / 실행한 검증 / 남은 리스크를 정리했다

--- a/docs/ai/tasks/chat-message-limit-300/context.md
+++ b/docs/ai/tasks/chat-message-limit-300/context.md
@@ -1,0 +1,55 @@
+# Context
+
+## Current Behavior
+
+- RoomChat과 DirectMessagePanel은 현재 공백 입력만 막고, 최대 길이 제한 없이 단일 line input으로 메시지를 받는다.
+- room chat / DM 송신 경계마다 `trim()` 처리 여부가 제각각이라 길이 제한을 추가하면 local optimistic state, socket emit, mock path가 쉽게 어긋날 수 있다.
+- `send_chat`, `dm_send` send schema에는 최대 길이 제한이 없어 mock server도 초장문 payload를 그대로 허용한다.
+
+## Related Files
+
+- `src/features/room-chat/RoomChat.tsx`
+- `src/features/presence/components/DirectMessagePanel.tsx`
+- `src/features/presence/direct-message/useDirectMessageController.ts`
+- `src/features/presence/direct-message/directMessageSocket.ts`
+- `src/pages/waiting-room/socket/socket.ts`
+- `src/pages/waiting-room/socket/mockGateway.ts`
+- `src/pages/GamePage.tsx`
+- `src/contracts/socket/schemas.ts`
+- `docs/socket-mock-server.md`
+
+## Relevant Manuals
+
+- `docs/ai/manuals/common.md`
+- `docs/ai/manuals/lobby.md`
+- `docs/ai/manuals/waiting-room.md`
+- `docs/ai/manuals/game-runtime.md`
+- `docs/socket-mock-server.md`
+- `docs/rules.md`
+- `docs/testing.md`
+
+## Constraints
+
+- room chat / DM 모두 300자 하드 제한을 같은 기준으로 적용한다.
+- 입력창은 기존 single-line input을 유지하고, 글자 수 카운터나 textarea 전환은 하지 않는다.
+- 수신 스키마(`chat`, `dm_receive`)는 이번 변경 범위 밖이다.
+- DEV 제어 패널 입력창과 backend 별도 예외 경로는 이번 범위에서 제외한다.
+
+## Decision Notes
+
+- 최대 길이와 trim/slice 규칙이 여러 레이어에서 반복되므로 공통 상수 파일에 300자와 정규화 함수를 둔다.
+- local optimistic message가 socket emit payload와 다르면 echo dedupe가 흔들리므로 `GamePage`와 `useDirectMessageController`에서 socket helper 호출 전에 먼저 정규화한다.
+- mock/real contract 드리프트를 줄이기 위해 `send_chat`, `dm_send` send schema와 mock gateway도 같은 300자 기준을 사용한다.
+
+## Session Handoff Notes
+
+- 다음 세션에서 다시 읽을 문서: `docs/ai/tasks/chat-message-limit-300/*`, `docs/ai/manuals/lobby.md`, `docs/ai/manuals/waiting-room.md`, `docs/ai/manuals/game-runtime.md`
+- 바로 이어서 할 1개 단계: 없음. 후속이 필요하면 수신 schema 제한 강화나 visible counter를 별도 task로 분리한다.
+- pending decision / blocker: 없음
+- 검증 재개 지점: `npx vitest run src/features/room-chat/RoomChat.test.tsx src/features/presence/components/DirectMessagePanel.test.tsx src/features/presence/direct-message/useDirectMessageController.test.tsx src/features/presence/direct-message/directMessageSocket.test.ts src/pages/waiting-room/socket/mockGateway.test.ts src/pages/GamePage.test.tsx src/pages/waiting-room/socket/socket.test.ts`, `npm run ai:check:lobby`, `npm run lint`, `npm run build`, `npm run ai:self-review -- --files ...` 실행 완료
+
+## Open Risks
+
+- 입력 `maxLength`만으로는 programmatic send를 막을 수 없으므로 송신 경계에서도 같은 300자 정규화가 필요하다.
+- receive schema를 그대로 두므로 외부 서버가 300자 초과 수신 메시지를 보내면 화면에서는 그대로 보일 수 있다.
+- jsdom 입력 테스트는 실제 모바일 IME 동작까지 보장하지 않으므로 브라우저 수동 확인이 추가로 유효하다.

--- a/docs/ai/tasks/chat-message-limit-300/plan.md
+++ b/docs/ai/tasks/chat-message-limit-300/plan.md
@@ -1,0 +1,91 @@
+# Plan
+
+## Task
+
+- 작업 이름: Chat Message Limit 300
+- 작업 slug: chat-message-limit-300
+- 요청 날짜: 2026-03-25
+- 담당 범위: 사용자용 room chat / DM 300자 제한과 계약/테스트 정리
+
+## Goal
+
+- 공용 채팅과 DM에 같은 300자 하드 제한을 적용한다.
+- 입력 UI, local optimistic state, mock/real socket 송신, send contract가 모두 같은 정규화 규칙을 사용하게 만든다.
+- 수신 계약과 DEV 제어 패널은 건드리지 않고 사용자용 채팅 경계만 안정화한다.
+
+## WAT Workflow
+
+1. task 문서와 TODO를 만들어 범위 / 완료 기준 / 검증 명령을 고정한다.
+2. 공통 상수와 송신 정규화 규칙을 입력 UI / room chat / DM / waiting-room socket 경계에 적용한다.
+3. send contract, mock server, 문서를 300자 기준으로 맞추고 관련 Vitest + repo 검증으로 마감한다.
+
+## In Scope
+
+- `src/constants/chat.ts`
+- `src/features/room-chat/RoomChat.tsx`
+- `src/features/presence/components/DirectMessagePanel.tsx`
+- `src/features/presence/direct-message/useDirectMessageController.ts`
+- `src/features/presence/direct-message/directMessageSocket.ts`
+- `src/pages/waiting-room/socket/socket.ts`
+- `src/pages/waiting-room/socket/mockGateway.ts`
+- `src/pages/GamePage.tsx`
+- `src/contracts/socket/schemas.ts`
+- 관련 Vitest와 socket mock server 문서
+- task 문서와 TODO 상태 정리
+
+## Out Of Scope
+
+- textarea 전환, 글자 수 카운터, 경고 색상 추가
+- `chat` / `dm_receive` 수신 스키마 제한 강화
+- DEV 제어 패널 입력창 제한
+- 채팅 기능/구독 흐름/DM unread 정책 재설계
+
+## Target Files
+
+- `src/constants/chat.ts`
+- `src/features/room-chat/RoomChat.tsx`
+- `src/features/room-chat/RoomChat.test.tsx`
+- `src/features/presence/components/DirectMessagePanel.tsx`
+- `src/features/presence/components/DirectMessagePanel.test.tsx`
+- `src/features/presence/direct-message/useDirectMessageController.ts`
+- `src/features/presence/direct-message/useDirectMessageController.test.tsx`
+- `src/features/presence/direct-message/directMessageSocket.ts`
+- `src/features/presence/direct-message/directMessageSocket.test.ts`
+- `src/pages/waiting-room/socket/socket.ts`
+- `src/pages/waiting-room/socket/socket.test.ts`
+- `src/pages/waiting-room/socket/mockGateway.ts`
+- `src/pages/waiting-room/socket/mockGateway.test.ts`
+- `src/pages/GamePage.tsx`
+- `src/pages/GamePage.test.tsx`
+- `src/contracts/socket/schemas.ts`
+- `docs/socket-mock-server.md`
+- `docs/ai/tasks/chat-message-limit-300/*`
+- `TODO.md`
+
+## Task Tracking
+
+- TODO line: - [ ] `chat-message-limit-300` - Chat Message Limit 300 (`docs/ai/tasks/chat-message-limit-300/`)
+- Session brief: `npm run ai:session:brief -- chat-message-limit-300`
+- Reopen docs: `docs/ai/tasks/chat-message-limit-300/plan.md`, `context.md`, `checklist.md`, 관련 manuals
+
+## Completion Criteria
+
+- RoomChat과 DirectMessagePanel 입력창이 300자를 초과 입력하지 않는다.
+- room chat / DM 송신 경계가 `trim() + 300자 제한`으로 정규화되어 local state와 emit payload가 일치한다.
+- `send_chat`, `dm_send` send contract와 mock server가 300자 제한을 따른다.
+- 관련 Vitest, `ai:check:lobby`, `lint`, `build`가 통과한다.
+
+## Role Plan
+
+- Planner: 범위 / 정규화 위치 / 제외 범위 정리
+- Implementer: 입력/송신 경계와 contract/mock/doc 반영
+- Reviewer: local state, mock/real, contract 불일치 여부 점검
+- Tester: 관련 Vitest와 repo 검증 실행
+
+## Test Plan
+
+- `npx vitest run src/features/room-chat/RoomChat.test.tsx src/features/presence/components/DirectMessagePanel.test.tsx src/features/presence/direct-message/useDirectMessageController.test.tsx src/features/presence/direct-message/directMessageSocket.test.ts src/pages/waiting-room/socket/mockGateway.test.ts src/pages/GamePage.test.tsx src/pages/waiting-room/socket/socket.test.ts`
+- `npm run ai:check:lobby`
+- `npm run lint`
+- `npm run build`
+- `npm run ai:self-review -- --files TODO.md docs/ai/tasks/chat-message-limit-300/plan.md docs/ai/tasks/chat-message-limit-300/context.md docs/ai/tasks/chat-message-limit-300/checklist.md docs/socket-mock-server.md src/constants/chat.ts src/features/room-chat/RoomChat.tsx src/features/room-chat/RoomChat.test.tsx src/features/presence/components/DirectMessagePanel.tsx src/features/presence/components/DirectMessagePanel.test.tsx src/features/presence/direct-message/useDirectMessageController.ts src/features/presence/direct-message/useDirectMessageController.test.tsx src/features/presence/direct-message/directMessageSocket.ts src/features/presence/direct-message/directMessageSocket.test.ts src/pages/waiting-room/socket/socket.ts src/pages/waiting-room/socket/socket.test.ts src/pages/waiting-room/socket/mockGateway.ts src/pages/waiting-room/socket/mockGateway.test.ts src/pages/GamePage.tsx src/pages/GamePage.test.tsx src/contracts/socket/schemas.ts`

--- a/docs/socket-mock-server.md
+++ b/docs/socket-mock-server.md
@@ -20,6 +20,7 @@ npm run socket:mock
 - `send_chat` 룸 브로드캐스트
 - `dm_send` -> `dm_receive` 전달
 - DM 정책: 송신자/수신자 중 `playing` 상태가 있으면 차단
+- 사용자용 `send_chat`, `dm_send` 메시지는 `trim()` 후 최대 300자까지 허용
 - `toggle_ready` 준비 상태 토글 + `player_ready` 브로드캐스트
 - `start_game` 시작 조건 검증 + `game_start` 브로드캐스트
 - 방장 퇴장 시 `host_changed` 브로드캐스트

--- a/src/constants/chat.ts
+++ b/src/constants/chat.ts
@@ -1,0 +1,7 @@
+// 사용자용 room chat / DM 최대 글자 수
+export const CHAT_MESSAGE_MAX_LENGTH = 300
+
+// 채팅 입력은 trim 후 최대 길이만 남기고 송신 경계에서 재사용
+export function normalizeChatMessage(message: string) {
+  return message.trim().slice(0, CHAT_MESSAGE_MAX_LENGTH)
+}

--- a/src/contracts/socket/schemas.ts
+++ b/src/contracts/socket/schemas.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { CHAT_MESSAGE_MAX_LENGTH } from '../../constants/chat'
 import { SOCKET_EVENTS } from './events'
 
 // 사용자 상태 enum을 계약 스키마로 고정
@@ -28,7 +29,7 @@ export const userStatusChangedEventSchema = z.object({
 
 export const directMessageSendEventSchema = z.object({
   receiver_id: z.string().min(1),
-  message: z.string().trim().min(1),
+  message: z.string().trim().min(1).max(CHAT_MESSAGE_MAX_LENGTH),
   client_message_id: z.string().min(1).optional(),
 })
 
@@ -50,7 +51,7 @@ export const leaveRoomEventSchema = z.object({
 
 export const sendChatEventSchema = z.object({
   room_id: z.string().min(1),
-  message: z.string().trim().min(1),
+  message: z.string().trim().min(1).max(CHAT_MESSAGE_MAX_LENGTH),
 })
 
 export const toggleReadyEventSchema = z.object({

--- a/src/features/presence/components/DirectMessagePanel.test.tsx
+++ b/src/features/presence/components/DirectMessagePanel.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
+import { CHAT_MESSAGE_MAX_LENGTH } from '../../../constants/chat'
 import { createOnlineUserFixture } from '../../../test/fixtures'
 import { DirectMessagePanel } from './DirectMessagePanel'
 import type { DirectMessage } from '../types'
@@ -102,6 +103,38 @@ describe('DirectMessagePanel', () => {
     expect(input.value).toBe('')
   })
 
+  it('입력창은 300자까지만 유지하고 전송 값도 같은 길이로 맞춘다', async () => {
+    const user = userEvent.setup()
+    const onSendMessage = vi.fn()
+    const overlongMessage = 'a'.repeat(CHAT_MESSAGE_MAX_LENGTH + 20)
+    const expectedMessage = overlongMessage.slice(0, CHAT_MESSAGE_MAX_LENGTH)
+
+    render(
+      <DirectMessagePanel
+        user={createOnlineUserFixture({
+          id: 'user-2',
+          nickname: '상대',
+        })}
+        currentUserId="user-1"
+        messages={[]}
+        onClose={vi.fn()}
+        onSendMessage={onSendMessage}
+      />
+    )
+
+    const input = screen.getByPlaceholderText(
+      '메시지를 입력하세요...'
+    ) as HTMLInputElement
+
+    await user.type(input, overlongMessage)
+    expect(input).toHaveAttribute('maxLength', String(CHAT_MESSAGE_MAX_LENGTH))
+    expect(input.value).toHaveLength(CHAT_MESSAGE_MAX_LENGTH)
+
+    await user.click(screen.getByRole('button', { name: 'DM 전송' }))
+
+    expect(onSendMessage).toHaveBeenCalledWith(expectedMessage)
+  })
+
   it('닫기 버튼 클릭 시 onClose를 호출한다', async () => {
     const user = userEvent.setup()
     const onClose = vi.fn()
@@ -121,5 +154,33 @@ describe('DirectMessagePanel', () => {
 
     await user.click(screen.getByRole('button', { name: 'DM 닫기' }))
     expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('긴 공백 없는 메시지도 말풍선 줄바꿈 클래스로 렌더링한다', () => {
+    const longMessage =
+      'https://example.com/' + 'superlongdmsegment'.repeat(14) + '/message'
+
+    render(
+      <DirectMessagePanel
+        user={createOnlineUserFixture({
+          id: 'user-2',
+          nickname: '상대',
+        })}
+        currentUserId="user-1"
+        messages={[
+          createDirectMessage({
+            id: 'dm-long',
+            content: longMessage,
+          }),
+        ]}
+        onClose={vi.fn()}
+        onSendMessage={vi.fn()}
+      />
+    )
+
+    const messageBubble = screen.getByText(longMessage)
+    expect(messageBubble.className).toContain('whitespace-pre-wrap')
+    expect(messageBubble.className).toContain('break-words')
+    expect(messageBubble.className).toContain('[overflow-wrap:anywhere]')
   })
 })

--- a/src/features/presence/components/DirectMessagePanel.tsx
+++ b/src/features/presence/components/DirectMessagePanel.tsx
@@ -3,6 +3,10 @@ import { SendHorizontal, X } from 'lucide-react'
 import { motion } from 'framer-motion'
 import { Avatar } from '../../../components/avatar/Avatar'
 import { cn } from '../../../lib/utils'
+import {
+  CHAT_MESSAGE_MAX_LENGTH,
+  normalizeChatMessage,
+} from '../../../constants/chat'
 import type { DirectMessage, OnlineUser } from '../types'
 
 // 1:1 채팅 패널 렌더링 입력값 타입
@@ -85,7 +89,7 @@ export function DirectMessagePanel({
 
       <div
         ref={messageListRef}
-        className="ui-scrollbar h-[320px] overflow-y-auto bg-ui-surface px-4 py-3"
+        className="ui-scrollbar h-[320px] overflow-x-hidden overflow-y-auto bg-ui-surface px-4 py-3"
       >
         {sortedMessages.length === 0 ? (
           <p className="flex h-full items-center justify-center text-sm font-medium text-ui-text-subtle">
@@ -100,13 +104,13 @@ export function DirectMessagePanel({
                 <div
                   key={message.id}
                   className={cn(
-                    'flex flex-col',
+                    'flex min-w-0 w-full flex-col',
                     isMine ? 'items-end' : 'items-start'
                   )}
                 >
                   <div
                     className={cn(
-                      'max-w-[75%] rounded-2xl px-3 py-2 text-sm font-medium',
+                      'min-w-0 w-fit max-w-[75%] whitespace-pre-wrap break-words [overflow-wrap:anywhere] rounded-2xl px-3 py-2 text-sm font-medium',
                       isMine
                         ? 'rounded-br-md bg-ui-brand text-white'
                         : 'rounded-bl-md bg-ui-surface-soft text-ui-text-primary'
@@ -129,7 +133,7 @@ export function DirectMessagePanel({
         onSubmit={(event) => {
           event.preventDefault()
 
-          const normalizedMessage = inputMessage.trim()
+          const normalizedMessage = normalizeChatMessage(inputMessage)
 
           // 공백 메시지는 전송하지 않음
           if (!normalizedMessage) {
@@ -144,6 +148,7 @@ export function DirectMessagePanel({
           type="text"
           value={inputMessage}
           onChange={(event) => setInputMessage(event.target.value)}
+          maxLength={CHAT_MESSAGE_MAX_LENGTH}
           placeholder="메시지를 입력하세요..."
           className="h-9 flex-1 rounded-xl border border-ui-border bg-ui-surface-muted px-3 text-sm text-ui-text-primary outline-none placeholder:text-ui-text-subtle focus:border-ui-brand focus:ring-2 focus:ring-ui-brand/20"
           autoComplete="off"

--- a/src/features/presence/direct-message/directMessageSocket.test.ts
+++ b/src/features/presence/direct-message/directMessageSocket.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { CHAT_MESSAGE_MAX_LENGTH } from '../../../constants/chat'
 import type { DirectMessageReceiveSocketPayload } from '../types'
 
 interface MockSocket {
@@ -96,6 +97,22 @@ describe('directMessageSocket', () => {
     expect(socket.emit).toHaveBeenCalledWith('dm_send', {
       receiver_id: 'user-2',
       message: '안녕하세요',
+    })
+  })
+
+  it('real 모드에서 sendDirectMessage는 300자 초과 메시지를 잘라서 emit한다', async () => {
+    const { module, socket } = await loadDirectMessageSocketModule(false, true)
+    const overlongMessage = ` ${'a'.repeat(CHAT_MESSAGE_MAX_LENGTH + 25)} `
+    const expectedMessage = 'a'.repeat(CHAT_MESSAGE_MAX_LENGTH)
+
+    module.sendDirectMessage({
+      receiverId: 'user-2',
+      message: overlongMessage,
+    })
+
+    expect(socket.emit).toHaveBeenCalledWith('dm_send', {
+      receiver_id: 'user-2',
+      message: expectedMessage,
     })
   })
 

--- a/src/features/presence/direct-message/directMessageSocket.ts
+++ b/src/features/presence/direct-message/directMessageSocket.ts
@@ -1,5 +1,6 @@
 import { connectSocketWithAuthIfNeeded, socket } from '../../../lib/socket'
 import { IS_SOCKET_MOCK_ENABLED } from '../../../config/env'
+import { normalizeChatMessage } from '../../../constants/chat'
 import type {
   DirectMessageReceiveSocketPayload,
   DirectMessageSendSocketPayload,
@@ -84,7 +85,7 @@ export function sendDirectMessage({
   message,
   clientMessageId,
 }: SendDirectMessageParams) {
-  const normalizedMessage = message.trim()
+  const normalizedMessage = normalizeChatMessage(message)
 
   // 공백 메시지는 전송하지 않음
   if (normalizedMessage.length === 0) {

--- a/src/features/presence/direct-message/useDirectMessageController.test.tsx
+++ b/src/features/presence/direct-message/useDirectMessageController.test.tsx
@@ -1,5 +1,6 @@
 import { act, renderHook } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { CHAT_MESSAGE_MAX_LENGTH } from '../../../constants/chat'
 import {
   createAuthSessionFixture,
   createOnlineUserFixture,
@@ -125,6 +126,37 @@ describe('useDirectMessageController', () => {
       clientMessageId: expect.any(String),
     })
     expect(result.current.directMessagesByUserId['user-2']).toHaveLength(1)
+  })
+
+  it('300자 초과 DM 전송 시 로컬 메시지와 socket payload를 모두 300자로 맞춘다', () => {
+    const lobbyUser = createOnlineUserFixture({
+      id: 'user-2',
+      nickname: '로비 유저',
+      status: 'lobby',
+    })
+    const overlongMessage = ` ${'가'.repeat(CHAT_MESSAGE_MAX_LENGTH + 8)} `
+    const expectedMessage = '가'.repeat(CHAT_MESSAGE_MAX_LENGTH)
+
+    const { result } = renderDirectMessageControllerHook({
+      users: [lobbyUser],
+    })
+
+    act(() => {
+      result.current.openDirectMessage(lobbyUser)
+    })
+
+    act(() => {
+      result.current.sendDirectMessage(overlongMessage)
+    })
+
+    expect(sendDirectMessageSocketMock).toHaveBeenCalledWith({
+      receiverId: 'user-2',
+      message: expectedMessage,
+      clientMessageId: expect.any(String),
+    })
+    expect(result.current.directMessagesByUserId['user-2'][0]?.content).toBe(
+      expectedMessage
+    )
   })
 
   it('대상 유저가 playing 상태가 되면 DM 창을 닫는다', () => {

--- a/src/features/presence/direct-message/useDirectMessageController.ts
+++ b/src/features/presence/direct-message/useDirectMessageController.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { AuthSession } from '../../auth/session/types'
+import { normalizeChatMessage } from '../../../constants/chat'
 import {
   sendDirectMessage as sendDirectMessageSocket,
   subscribeDirectMessageSocketEvents,
@@ -179,8 +180,10 @@ export function useDirectMessageController({
   // 로컬 DM 목록에 메시지를 추가하고 소켓 전송 실행
   const sendDirectMessage = useCallback(
     (message: string) => {
+      const normalizedMessage = normalizeChatMessage(message)
+
       // 대상 사용자 또는 세션이 없으면 전송 중단
-      if (!dmTargetUser || !session) {
+      if (!dmTargetUser || !session || normalizedMessage.length === 0) {
         return
       }
 
@@ -195,7 +198,7 @@ export function useDirectMessageController({
         id: clientMessageId,
         senderId: session.userId,
         senderNickname: session.nickname,
-        content: message,
+        content: normalizedMessage,
         sentAt: new Date().toISOString(),
       }
 
@@ -210,7 +213,7 @@ export function useDirectMessageController({
 
       sendDirectMessageSocket({
         receiverId: dmTargetUser.id,
-        message,
+        message: normalizedMessage,
         clientMessageId,
       })
     },

--- a/src/features/room-chat/RoomChat.test.tsx
+++ b/src/features/room-chat/RoomChat.test.tsx
@@ -1,6 +1,7 @@
 import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
+import { CHAT_MESSAGE_MAX_LENGTH } from '../../constants/chat'
 import { renderWithProviders } from '../../test/renderWithProviders'
 import RoomChat from './RoomChat'
 
@@ -60,6 +61,31 @@ describe('RoomChat', () => {
     expect(input.value).toBe('')
   })
 
+  it('입력창은 300자까지만 유지하고 전송 값도 같은 길이로 맞춘다', async () => {
+    const user = userEvent.setup()
+    const onSendMessage = vi.fn()
+    const overlongMessage = 'a'.repeat(CHAT_MESSAGE_MAX_LENGTH + 12)
+    const expectedMessage = overlongMessage.slice(0, CHAT_MESSAGE_MAX_LENGTH)
+
+    renderWithProviders(
+      <RoomChat
+        currentUserId="me"
+        onSendMessage={onSendMessage}
+        messages={[]}
+      />
+    )
+
+    const input = screen.getByPlaceholderText('메시지...') as HTMLInputElement
+
+    await user.type(input, overlongMessage)
+    expect(input).toHaveAttribute('maxLength', String(CHAT_MESSAGE_MAX_LENGTH))
+    expect(input.value).toHaveLength(CHAT_MESSAGE_MAX_LENGTH)
+
+    await user.click(screen.getByRole('button', { name: '➤' }))
+
+    expect(onSendMessage).toHaveBeenCalledWith(expectedMessage)
+  })
+
   it('공백 입력은 전송하지 않는다', async () => {
     const user = userEvent.setup()
     const onSendMessage = vi.fn()
@@ -91,5 +117,32 @@ describe('RoomChat', () => {
     expect(
       screen.getByPlaceholderText('메시지를 입력하세요...')
     ).toBeInTheDocument()
+  })
+
+  it('긴 공백 없는 메시지도 말풍선 줄바꿈 클래스로 렌더링한다', () => {
+    const longMessage =
+      'https://example.com/' + 'verylongsegment'.repeat(16) + '/chat-overflow'
+
+    renderWithProviders(
+      <RoomChat
+        currentUserId="me"
+        onSendMessage={vi.fn()}
+        messages={[
+          {
+            id: 'm-long',
+            sender_id: 'user-2',
+            sender_nickname: '상대',
+            content: longMessage,
+            timestamp: '2026-03-03T10:02:00.000Z',
+            type: 'talk',
+          },
+        ]}
+      />
+    )
+
+    const messageBubble = screen.getByText(longMessage)
+    expect(messageBubble.className).toContain('whitespace-pre-wrap')
+    expect(messageBubble.className).toContain('break-words')
+    expect(messageBubble.className).toContain('[overflow-wrap:anywhere]')
   })
 })

--- a/src/features/room-chat/RoomChat.tsx
+++ b/src/features/room-chat/RoomChat.tsx
@@ -2,6 +2,10 @@ import { useEffect, useRef, useState } from 'react'
 import { MessageSquare } from 'lucide-react'
 import type { ChatMessage } from '../../types/domain'
 import { cn } from '../../lib/utils'
+import {
+  CHAT_MESSAGE_MAX_LENGTH,
+  normalizeChatMessage,
+} from '../../constants/chat'
 
 // 공통 채팅 박스 렌더링 입력값 타입
 interface RoomChatProps {
@@ -41,7 +45,7 @@ export default function RoomChat({
   // 채팅 입력 submit 처리
   function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault()
-    const normalizedInput = input.trim()
+    const normalizedInput = normalizeChatMessage(input)
 
     // 공백 입력은 전송하지 않음
     if (!normalizedInput) {
@@ -72,7 +76,7 @@ export default function RoomChat({
 
         <div
           ref={messagesContainerRef}
-          className="ui-scrollbar min-h-0 flex-1 space-y-3 overflow-y-auto bg-ui-surface px-3 py-3"
+          className="ui-scrollbar min-h-0 flex-1 space-y-3 overflow-x-hidden overflow-y-auto bg-ui-surface px-3 py-3"
         >
           {messages.map((message) => {
             const isMine = message.sender_id === currentUserId
@@ -81,19 +85,19 @@ export default function RoomChat({
               <div
                 key={message.id}
                 className={cn(
-                  'flex flex-col',
+                  'flex min-w-0 w-full flex-col',
                   isMine ? 'items-end' : 'items-start'
                 )}
               >
-                <div className="mb-0.5 px-0.5">
-                  <span className="text-[11px] font-medium text-ui-text-subtle">
+                <div className="mb-0.5 max-w-[85%] px-0.5">
+                  <span className="block truncate text-[11px] font-medium text-ui-text-subtle">
                     {message.sender_nickname}
                   </span>
                 </div>
 
                 <div
                   className={cn(
-                    'max-w-[85%] px-3 py-2 text-sm leading-snug font-medium shadow-sm',
+                    'min-w-0 w-fit max-w-[85%] whitespace-pre-wrap break-words [overflow-wrap:anywhere] px-3 py-2 text-sm leading-snug font-medium shadow-sm',
                     isMine
                       ? 'rounded-[16px_0_16px_16px] bg-ui-brand text-white'
                       : 'rounded-[0_16px_16px_16px] border border-ui-border bg-ui-surface-soft text-ui-text-primary'
@@ -115,6 +119,7 @@ export default function RoomChat({
               type="text"
               value={input}
               onChange={(event) => setInput(event.target.value)}
+              maxLength={CHAT_MESSAGE_MAX_LENGTH}
               placeholder={inputPlaceholder}
               className="w-full bg-transparent text-sm font-medium text-ui-text-primary placeholder:text-ui-text-subtle outline-none"
             />

--- a/src/pages/GamePage.test.tsx
+++ b/src/pages/GamePage.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import GamePage from './GamePage'
 import { useGameStore } from '../stores/game.store'
 import { useAuthStore } from '../features/auth/session/store'
+import { CHAT_MESSAGE_MAX_LENGTH } from '../constants/chat'
 import { createAuthSessionFixture } from '../test/fixtures'
 import { renderWithProviders } from '../test/renderWithProviders'
 import type { Player } from '../types/domain'
@@ -543,6 +544,27 @@ describe('GamePage chat flow', () => {
     })
 
     expect(screen.getAllByText('ㅎㅇㅎㅇ')).toHaveLength(1)
+  })
+
+  it('게임 채팅 입력과 낙관적 메시지는 300자로 제한된다', async () => {
+    const user = userEvent.setup()
+    const overlongMessage = 'z'.repeat(CHAT_MESSAGE_MAX_LENGTH + 18)
+    const expectedMessage = overlongMessage.slice(0, CHAT_MESSAGE_MAX_LENGTH)
+
+    renderGamePage()
+
+    await act(async () => {
+      await user.type(screen.getByPlaceholderText('메시지...'), overlongMessage)
+      await user.keyboard('{Enter}')
+    })
+
+    expect(sendWaitingRoomChatMock).toHaveBeenCalledWith({
+      roomId: 'room-1',
+      senderId: 'user-1',
+      senderNickname: '유저1',
+      message: expectedMessage,
+    })
+    expect(await screen.findByText(expectedMessage)).toBeInTheDocument()
   })
 
   it('게임 나가기 성공 시 leave API 호출 후 로비로 이동하고 game store를 초기화한다', async () => {

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -18,6 +18,7 @@ import { useGameState } from '../hooks/game/useGameState'
 import { useTurn } from '../hooks/game/useTurn'
 import { playBgm, stopBgm } from '../lib/bgm'
 import { socket } from '../lib/socket'
+import { normalizeChatMessage } from '../constants/chat'
 import {
   emitGameAction,
   emitPromptResponse,
@@ -328,12 +329,18 @@ const GamePage: React.FC = () => {
       return
     }
 
+    const normalizedContent = normalizeChatMessage(content)
+
+    if (!normalizedContent) {
+      return
+    }
+
     const senderId = currentUserId ?? DEFAULT_GUEST_ID
     const optimisticMessage = createOptimisticGameChatMessage({
       roomId: activeRoomId,
       senderId,
       senderNickname: currentNickname,
-      message: content,
+      message: normalizedContent,
     })
 
     pendingGameChatEchoesRef.current = [
@@ -341,7 +348,7 @@ const GamePage: React.FC = () => {
       {
         id: optimisticMessage.id,
         senderId,
-        content,
+        content: normalizedContent,
         createdAtMs: Date.parse(optimisticMessage.timestamp),
       },
     ]
@@ -352,7 +359,7 @@ const GamePage: React.FC = () => {
       roomId: activeRoomId,
       senderId,
       senderNickname: currentNickname,
-      message: content,
+      message: normalizedContent,
     })
   }
 

--- a/src/pages/waiting-room/socket/mockGateway.test.ts
+++ b/src/pages/waiting-room/socket/mockGateway.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
+import { CHAT_MESSAGE_MAX_LENGTH } from '../../../constants/chat'
 
 type MockGatewayModule = typeof import('./mockGateway')
 
@@ -6,6 +7,43 @@ type MockGatewayModule = typeof import('./mockGateway')
 async function loadMockGateway(): Promise<MockGatewayModule> {
   vi.resetModules()
   return import('./mockGateway')
+}
+
+interface LoadedMockGatewayWithSocket {
+  gateway: MockGatewayModule
+  registerListener: (
+    eventName: string,
+    listener: (payload: unknown) => void
+  ) => void
+}
+
+async function loadMockGatewayWithSocket(): Promise<LoadedMockGatewayWithSocket> {
+  vi.resetModules()
+
+  const listenersMap = new Map<string, Array<(payload: unknown) => void>>()
+  const registerListener = (
+    eventName: string,
+    listener: (payload: unknown) => void
+  ) => {
+    const listeners = listenersMap.get(eventName) ?? []
+    listeners.push(listener)
+    listenersMap.set(eventName, listeners)
+  }
+
+  vi.doMock('../../../lib/socket', () => ({
+    socket: {
+      listeners: vi.fn(
+        (eventName: string) => listenersMap.get(eventName) ?? []
+      ),
+    },
+  }))
+
+  const gateway = await import('./mockGateway')
+
+  return {
+    gateway,
+    registerListener,
+  }
 }
 
 // 코드 기반 에러 검증 헬퍼
@@ -96,6 +134,35 @@ describe('mockGateway DEV control', () => {
     expect(lobbyRoom).toBeTruthy()
     expect(lobbyRoom?.currentPlayers).toBe(1)
     expect(lobbyRoom?.status).toBe('waiting')
+  })
+
+  it('긴 대기방 채팅도 300자로 정규화해 저장하고 브로드캐스트한다', async () => {
+    const { gateway, registerListener } = await loadMockGatewayWithSocket()
+    const onChat = vi.fn()
+    const overlongMessage = ` ${'x'.repeat(CHAT_MESSAGE_MAX_LENGTH + 14)} `
+    const expectedMessage = 'x'.repeat(CHAT_MESSAGE_MAX_LENGTH)
+
+    registerListener('chat', onChat)
+
+    gateway.mockSendWaitingRoomChat({
+      roomId: 'room-5',
+      senderId: 'room-5-user-1',
+      senderNickname: '플레이어1',
+      message: overlongMessage,
+    })
+
+    const chatMessages =
+      gateway.mockDevGetWaitingRoomSnapshot('room-5').chatMessages
+    const lastChatMessage = chatMessages[chatMessages.length - 1]
+
+    expect(lastChatMessage?.content).toBe(expectedMessage)
+    expect(onChat).toHaveBeenCalledWith(
+      expect.objectContaining({
+        room_id: 'room-5',
+        sender_id: 'room-5-user-1',
+        message: expectedMessage,
+      })
+    )
   })
 })
 

--- a/src/pages/waiting-room/socket/mockGateway.ts
+++ b/src/pages/waiting-room/socket/mockGateway.ts
@@ -1,4 +1,5 @@
 import { socket } from '../../../lib/socket'
+import { normalizeChatMessage } from '../../../constants/chat'
 import { ROOM_PASSWORD_PATTERN } from '../../../constants/room'
 import { setMockOnlineUserStatus } from '../../../features/presence/mock/mockData'
 import { mockLobbyRooms } from '../../lobby/mockData'
@@ -670,7 +671,7 @@ export function mockSendWaitingRoomChat({
   senderNickname,
   message,
 }: MockSendChatParams) {
-  const normalizedMessage = message.trim()
+  const normalizedMessage = normalizeChatMessage(message)
 
   // 공백 메시지는 저장/브로드캐스트하지 않음
   if (normalizedMessage.length === 0) {

--- a/src/pages/waiting-room/socket/socket.test.ts
+++ b/src/pages/waiting-room/socket/socket.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { CHAT_MESSAGE_MAX_LENGTH } from '../../../constants/chat'
+
+interface MockSocket {
+  on: ReturnType<typeof vi.fn>
+  off: ReturnType<typeof vi.fn>
+  emit: ReturnType<typeof vi.fn>
+}
+
+interface LoadedWaitingRoomSocketModule {
+  socket: MockSocket
+  mockSendWaitingRoomChatMock: ReturnType<typeof vi.fn>
+  module: typeof import('./socket')
+}
+
+async function loadWaitingRoomSocketModule(
+  useSocketMock: boolean
+): Promise<LoadedWaitingRoomSocketModule> {
+  vi.resetModules()
+  vi.stubEnv('VITE_USE_SOCKET_MOCK', useSocketMock ? 'true' : 'false')
+
+  const socket: MockSocket = {
+    on: vi.fn(),
+    off: vi.fn(),
+    emit: vi.fn(),
+  }
+  const mockSendWaitingRoomChatMock = vi.fn()
+
+  vi.doMock('../../../lib/socket', () => ({
+    socket,
+    connectSocketWithAuthIfNeeded: vi.fn(),
+  }))
+  vi.doMock('./mockGateway', () => ({
+    mockEnterWaitingRoomSocket: vi.fn(),
+    mockLeaveWaitingRoomSocket: vi.fn(),
+    mockSendWaitingRoomChat: mockSendWaitingRoomChatMock,
+  }))
+
+  const module = await import('./socket')
+
+  return {
+    socket,
+    mockSendWaitingRoomChatMock,
+    module,
+  }
+}
+
+describe('waiting-room socket send chat', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+    vi.unstubAllEnvs()
+    vi.resetModules()
+  })
+
+  it('real 모드에서 sendWaitingRoomChat는 trim 후 300자로 잘라 send_chat emit을 호출한다', async () => {
+    const { module, socket } = await loadWaitingRoomSocketModule(false)
+    const overlongMessage = ` ${'a'.repeat(CHAT_MESSAGE_MAX_LENGTH + 16)} `
+    const expectedMessage = 'a'.repeat(CHAT_MESSAGE_MAX_LENGTH)
+
+    module.sendWaitingRoomChat({
+      roomId: 'room-1',
+      senderId: 'user-1',
+      senderNickname: '유저1',
+      message: overlongMessage,
+    })
+
+    expect(socket.emit).toHaveBeenCalledWith('send_chat', {
+      room_id: 'room-1',
+      message: expectedMessage,
+    })
+  })
+
+  it('mock 모드에서 sendWaitingRoomChat는 trim 후 300자로 잘라 mock gateway를 호출한다', async () => {
+    const { module, mockSendWaitingRoomChatMock, socket } =
+      await loadWaitingRoomSocketModule(true)
+    const overlongMessage = ` ${'b'.repeat(CHAT_MESSAGE_MAX_LENGTH + 10)} `
+    const expectedMessage = 'b'.repeat(CHAT_MESSAGE_MAX_LENGTH)
+
+    module.sendWaitingRoomChat({
+      roomId: 'room-2',
+      senderId: 'user-2',
+      senderNickname: '유저2',
+      message: overlongMessage,
+    })
+
+    expect(mockSendWaitingRoomChatMock).toHaveBeenCalledWith({
+      roomId: 'room-2',
+      senderId: 'user-2',
+      senderNickname: '유저2',
+      message: expectedMessage,
+    })
+    expect(socket.emit).not.toHaveBeenCalled()
+  })
+
+  it('공백 메시지는 real/mock 모드 모두 전송하지 않는다', async () => {
+    const { module: realModule, socket: realSocket } =
+      await loadWaitingRoomSocketModule(false)
+    const {
+      module: mockModule,
+      socket: mockSocket,
+      mockSendWaitingRoomChatMock,
+    } = await loadWaitingRoomSocketModule(true)
+
+    realModule.sendWaitingRoomChat({
+      roomId: 'room-1',
+      senderId: 'user-1',
+      senderNickname: '유저1',
+      message: '   ',
+    })
+    mockModule.sendWaitingRoomChat({
+      roomId: 'room-1',
+      senderId: 'user-1',
+      senderNickname: '유저1',
+      message: '\n\t',
+    })
+
+    expect(realSocket.emit).not.toHaveBeenCalled()
+    expect(mockSocket.emit).not.toHaveBeenCalled()
+    expect(mockSendWaitingRoomChatMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/pages/waiting-room/socket/socket.ts
+++ b/src/pages/waiting-room/socket/socket.ts
@@ -1,5 +1,6 @@
 import { connectSocketWithAuthIfNeeded, socket } from '../../../lib/socket'
 import { IS_SOCKET_MOCK_ENABLED } from '../../../config/env'
+import { normalizeChatMessage } from '../../../constants/chat'
 import {
   mockEnterWaitingRoomSocket,
   mockLeaveWaitingRoomSocket,
@@ -129,19 +130,25 @@ export function sendWaitingRoomChat({
   senderNickname,
   message,
 }: SendWaitingRoomChatParams) {
+  const normalizedMessage = normalizeChatMessage(message)
+
+  if (normalizedMessage.length === 0) {
+    return
+  }
+
   if (USE_WAITING_ROOM_SOCKET_MOCK) {
     mockSendWaitingRoomChat({
       roomId,
       senderId,
       senderNickname,
-      message,
+      message: normalizedMessage,
     })
     return
   }
 
   const payload: SendChatSocketPayload = {
     room_id: roomId,
-    message,
+    message: normalizedMessage,
   }
   socket.emit(WAITING_ROOM_EVENT_NAMES.sendChat, payload)
 }


### PR DESCRIPTION
## 📌 관련 이슈

> closes #642

---

## 📝 작업 내용

- RoomChat과 DM 말풍선에 줄바꿈/overflow 방어 규칙을 적용해 긴 공백 없는 메시지도 말풍선 안에서 감기도록 정리했습니다.
- RoomChat과 DirectMessagePanel 입력창에 `maxLength=300`을 적용하고, `trim() + slice(0, 300)` 규칙을 공통 정규화로 통일했습니다.
- local optimistic state, mock/real socket 송신, `send_chat` / `dm_send` send schema, mock server 문서를 300자 기준에 맞춰 정렬했습니다.
- room chat / DM / waiting-room socket / GamePage / mock gateway 회귀 테스트를 추가했습니다.

---

## 🧠 Task 문서 (큰 작업이면 필수)

- plan: docs/ai/tasks/chat-bubble-overflow-fix/plan.md
- context: docs/ai/tasks/chat-bubble-overflow-fix/context.md
- checklist: docs/ai/tasks/chat-bubble-overflow-fix/checklist.md
- plan: docs/ai/tasks/chat-message-limit-300/plan.md
- context: docs/ai/tasks/chat-message-limit-300/context.md
- checklist: docs/ai/tasks/chat-message-limit-300/checklist.md

---

## 📋 TODO.md 연결

- task slug: chat-bubble-overflow-fix, chat-message-limit-300
- TODO status: Done
- TODO entry 확인: TODO.md Done 섹션에 `chat-bubble-overflow-fix`, `chat-message-limit-300` 두 slug 모두 반영 완료

---

## 📚 참고한 기준 문서

- `AGENTS.md`
- `docs/ai/manuals/common.md`
- `docs/rules.md`
- `docs/testing.md`
- `docs/ai/manuals/lobby.md`
- `docs/ai/manuals/waiting-room.md`
- `docs/ai/manuals/game-runtime.md`
- `docs/socket-mock-server.md`

---

## 🧪 실행한 검증

- `npx vitest run src/features/room-chat/RoomChat.test.tsx src/features/presence/components/DirectMessagePanel.test.tsx src/features/presence/direct-message/useDirectMessageController.test.tsx src/features/presence/direct-message/directMessageSocket.test.ts src/pages/waiting-room/socket/mockGateway.test.ts src/pages/GamePage.test.tsx src/pages/waiting-room/socket/socket.test.ts`
- `npm run ai:check:lobby`
- `npm run ai:check:waiting-room`
- `npm run ai:check:game`
- `npm run lint`
- `npm run build`
- `npm run ai:self-review -- --files TODO.md docs/ai/tasks/chat-message-limit-300/plan.md docs/ai/tasks/chat-message-limit-300/context.md docs/ai/tasks/chat-message-limit-300/checklist.md docs/socket-mock-server.md src/constants/chat.ts src/features/room-chat/RoomChat.tsx src/features/room-chat/RoomChat.test.tsx src/features/presence/components/DirectMessagePanel.tsx src/features/presence/components/DirectMessagePanel.test.tsx src/features/presence/direct-message/useDirectMessageController.ts src/features/presence/direct-message/useDirectMessageController.test.tsx src/features/presence/direct-message/directMessageSocket.ts src/features/presence/direct-message/directMessageSocket.test.ts src/pages/waiting-room/socket/socket.ts src/pages/waiting-room/socket/socket.test.ts src/pages/waiting-room/socket/mockGateway.ts src/pages/waiting-room/socket/mockGateway.test.ts src/pages/GamePage.tsx src/pages/GamePage.test.tsx src/contracts/socket/schemas.ts`
- `npm run ai:session:brief -- chat-message-limit-300`

---

## ⚠️ 남은 리스크

- send contract만 300자로 고정되어 있어 외부 서버가 `chat`, `dm_receive`에서 300자 초과 메시지를 보내면 화면에는 그대로 표시될 수 있습니다.
- 글자 수 카운터나 경고 색상은 추가하지 않았습니다. 현재는 입력이 300자에서 멈추는 형태입니다.
- 모바일 IME와 실브라우저에서의 입력 체감은 추가 수동 확인 여지가 있습니다.

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료
- [x] 큰 작업이면 task 문서 링크를 남겼다
- [x] 큰 작업이면 `TODO.md` / task slug 연결을 PR 본문에 남겼다
- [x] 참고한 기준 문서를 PR 본문에 남겼다
- [x] 실행한 검증과 남은 리스크를 PR 본문에 적었다

---

## 📸 스크린샷 (선택)

> UI 변경이 있을 경우 첨부해주세요.
