### PR TITLE
feat: 대기방/게임 그룹 채팅 sender grouping UI 적용

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -17,6 +17,7 @@
 
 ## Done
 
+- [x] `group-chat-sender-grouping-ui` - Group Chat Sender Grouping UI (`docs/ai/tasks/group-chat-sender-grouping-ui/`) - 대기방/게임 공용 채팅을 sender grouping, 아바타, 이름 강조, 역할 badge 기반 실무형 그룹 채팅 UI로 정리
 - [x] `chat-message-limit-300` - Chat Message Limit 300 (`docs/ai/tasks/chat-message-limit-300/`) - room chat과 DM에 300자 하드 제한을 입력/송신/contract/mock/test 기준으로 통일
 - [x] `chat-bubble-overflow-fix` - Chat Bubble Overflow Fix (`docs/ai/tasks/chat-bubble-overflow-fix/`) - 긴 메시지가 말풍선을 뚫고 가로 스크롤을 만드는 문제를 RoomChat/DM 공통 스타일로 정리
 

--- a/docs/ai/tasks/group-chat-sender-grouping-ui/checklist.md
+++ b/docs/ai/tasks/group-chat-sender-grouping-ui/checklist.md
@@ -1,0 +1,28 @@
+# Checklist
+
+## Implementation
+
+- [x] 관련 manual과 기존 문서를 읽었다
+- [x] 영향 범위를 정리했다
+- [x] WAT 단계와 역할 분담을 문서에 반영했다
+- [x] `RoomChat`에 sender metadata와 message grouping UI를 추가했다
+- [x] 대기방/게임에서 sender metadata를 주입했다
+- [x] DM/overflow/300자 제한 기존 동작을 유지했다
+
+## Testing
+
+- [x] `npx vitest run src/features/room-chat/RoomChat.test.tsx src/pages/waiting-room/page/WaitingRoomPage.test.tsx src/pages/GamePage.test.tsx`
+- [x] `npm run ai:check:lobby`
+- [x] `npm run ai:check:waiting-room`
+- [x] `npm run ai:check:game`
+- [x] `npm run lint`
+
+## Review
+
+- [x] `docs/rules.md` 기준으로 셀프 리뷰했다
+- [x] grouping / badge / optimistic chat 회귀 여부를 확인했다
+- [x] `TODO.md` task 한 줄을 최신 상태로 유지했다
+- [x] session handoff notes를 최신 상태로 갱신했다
+- [x] `npm run ai:session:brief -- group-chat-sender-grouping-ui` 출력이 현재 상태와 맞는다
+- [x] `npm run ai:self-review -- --files ...`를 실행했다
+- [x] 변경 파일 / 실행한 검증 / 남은 리스크를 정리했다

--- a/docs/ai/tasks/group-chat-sender-grouping-ui/context.md
+++ b/docs/ai/tasks/group-chat-sender-grouping-ui/context.md
@@ -1,0 +1,52 @@
+# Context
+
+## Current Behavior
+
+- `RoomChat`은 모든 메시지 위에 작은 회색 닉네임을 반복 출력하는 단순 채팅 UI다.
+- 대기방/게임 채팅은 같은 공용 `RoomChat`을 쓰지만 sender metadata가 없어 host/현재 턴 플레이어 같은 역할을 메시지에서 바로 구분하기 어렵다.
+- 1:1 DM은 상대가 고정이라 헤더만으로도 구분 가능하므로 이번 문제의 직접 대상이 아니다.
+
+## Related Files
+
+- `src/features/room-chat/RoomChat.tsx`
+- `src/pages/waiting-room/components/WaitingRoomChatBox.tsx`
+- `src/pages/waiting-room/components/WaitingRoomSidePanel.tsx`
+- `src/pages/waiting-room/page/WaitingRoomPage.tsx`
+- `src/pages/GamePage.tsx`
+- `src/components/avatar/Avatar.tsx`
+
+## Relevant Manuals
+
+- `docs/ai/manuals/common.md`
+- `docs/ai/manuals/lobby.md`
+- `docs/ai/manuals/waiting-room.md`
+- `docs/ai/manuals/game-runtime.md`
+- `docs/rules.md`
+- `docs/testing.md`
+
+## Constraints
+
+- 적용 범위는 대기방/게임 공용 채팅만이다.
+- 300자 제한과 overflow 방지 규칙은 유지해야 한다.
+- `RoomChat`은 공용 컴포넌트로 유지하되, DM 패널은 건드리지 않는다.
+- mock/real 채팅 payload shape나 optimistic 채팅 로직은 바꾸지 않는다.
+
+## Decision Notes
+
+- 실무형 그룹 채팅 UX는 `연속 메시지 grouping + 첫 메시지에만 아바타/이름` 패턴으로 구현한다.
+- sender별 고정 색상은 말풍선 전체가 아니라 avatar/accent/name에만 쓰고, 말풍선은 현재의 내 메시지/상대 메시지 색 구분을 유지한다.
+- 대기방은 host 여부를 기준으로 `HOST` badge를 주고, 게임은 현재 active player만 `TURN` badge를 준다.
+- 게임 sender metadata는 이미 계산된 `panelPlayers`의 `color`/`isActive`를 재사용한다.
+
+## Session Handoff Notes
+
+- 다음 세션에서 다시 읽을 문서: `docs/ai/tasks/group-chat-sender-grouping-ui/*`, `docs/ai/manuals/lobby.md`, `docs/ai/manuals/waiting-room.md`, `docs/ai/manuals/game-runtime.md`
+- 바로 이어서 할 1개 단계: 없음
+- pending decision / blocker: 없음
+- 검증 재개 지점: `npx vitest run src/features/room-chat/RoomChat.test.tsx src/pages/waiting-room/page/WaitingRoomPage.test.tsx src/pages/GamePage.test.tsx`, `npm run ai:check:lobby`, `npm run ai:check:waiting-room`, `npm run ai:check:game`, `npm run lint`, `npm run build`, `npm run ai:self-review -- --files ...` 실행 완료
+
+## Open Risks
+
+- 현재 턴 badge는 sender identity 기준으로 표시되므로, 과거 메시지도 현재 active player라면 `TURN`을 보일 수 있다.
+- 그룹화 기준 5분 window는 UI 판단용이므로 서버 시간이 비정상적이면 그룹 경계가 어색할 수 있다.
+- GamePage 테스트에서는 기존 TURN 표시 UI와 채팅 badge를 구분해 스코프 기반으로 검증해야 한다.

--- a/docs/ai/tasks/group-chat-sender-grouping-ui/plan.md
+++ b/docs/ai/tasks/group-chat-sender-grouping-ui/plan.md
@@ -1,0 +1,79 @@
+# Plan
+
+## Task
+
+- 작업 이름: Group Chat Sender Grouping UI
+- 작업 slug: group-chat-sender-grouping-ui
+- 요청 날짜: 2026-03-25
+- 담당 범위: 대기방/게임 공용 채팅을 실무형 그룹 채팅 패턴으로 개선
+
+## Goal
+
+- `RoomChat`을 대기방/게임 공용 그룹 채팅에 맞는 sender grouping UI로 바꾼다.
+- 수신 메시지에서 누가 말했는지 아바타, 이름, 역할 badge로 즉시 구분되게 만든다.
+- DM 패널은 유지하고, 기존 overflow/300자 제한/낙관적 채팅 동작은 그대로 보존한다.
+
+## WAT Workflow
+
+1. task 문서와 TODO를 만들어 범위 / 완료 기준 / 검증 명령을 고정한다.
+2. `RoomChat`에 sender metadata와 message grouping 로직을 추가하고 실무형 그룹 채팅 레이아웃으로 정리한다.
+3. 대기방/게임에서 sender metadata를 주입하고 관련 테스트 + repo 검증으로 마감한다.
+
+## In Scope
+
+- `src/features/room-chat/RoomChat.tsx`
+- `src/pages/waiting-room/components/WaitingRoomChatBox.tsx`
+- `src/pages/waiting-room/components/WaitingRoomSidePanel.tsx`
+- `src/pages/waiting-room/page/WaitingRoomPage.tsx`
+- `src/pages/GamePage.tsx`
+- 관련 Vitest
+- task 문서와 TODO 상태 정리
+
+## Out Of Scope
+
+- 1:1 DM 패널 UI 재설계
+- 메시지 시간 표시, 읽음 상태, read receipt
+- 유저별 말풍선 색상 분기
+- 멀티 badge stacking, 멘션, 리액션
+
+## Target Files
+
+- `src/features/room-chat/RoomChat.tsx`
+- `src/features/room-chat/RoomChat.test.tsx`
+- `src/pages/waiting-room/components/WaitingRoomChatBox.tsx`
+- `src/pages/waiting-room/components/WaitingRoomSidePanel.tsx`
+- `src/pages/waiting-room/page/WaitingRoomPage.tsx`
+- `src/pages/waiting-room/page/WaitingRoomPage.test.tsx`
+- `src/pages/GamePage.tsx`
+- `src/pages/GamePage.test.tsx`
+- `docs/ai/tasks/group-chat-sender-grouping-ui/*`
+- `TODO.md`
+
+## Task Tracking
+
+- TODO line: - [ ] `group-chat-sender-grouping-ui` - Group Chat Sender Grouping UI (`docs/ai/tasks/group-chat-sender-grouping-ui/`)
+- Session brief: `npm run ai:session:brief -- group-chat-sender-grouping-ui`
+- Reopen docs: `docs/ai/tasks/group-chat-sender-grouping-ui/plan.md`, `context.md`, `checklist.md`, 관련 manuals
+
+## Completion Criteria
+
+- `RoomChat`이 연속된 동일 sender 메시지를 5분 window 기준으로 그룹화한다.
+- 수신 그룹 첫 메시지에만 아바타 + 닉네임 + 역할 badge가 보이고, 후속 메시지는 이름 반복 없이 이어진다.
+- 대기방에서는 host 메시지에 `HOST`, 게임에서는 현재 턴 플레이어 메시지에 `TURN` badge가 보인다.
+- overflow/300자 제한/낙관적 echo dedupe 관련 기존 동작이 유지된다.
+
+## Role Plan
+
+- Planner: 범위 / sender metadata 규칙 / badge 정책 정리
+- Implementer: `RoomChat` 그룹 채팅 UI와 대기방/게임 연결 구현
+- Reviewer: grouping / badge / 기존 채팅 회귀 여부 점검
+- Tester: RoomChat / WaitingRoomPage / GamePage 관련 Vitest와 repo 검증 실행
+
+## Test Plan
+
+- `npx vitest run src/features/room-chat/RoomChat.test.tsx src/pages/waiting-room/page/WaitingRoomPage.test.tsx src/pages/GamePage.test.tsx`
+- `npm run ai:check:lobby`
+- `npm run ai:check:waiting-room`
+- `npm run ai:check:game`
+- `npm run lint`
+- `npm run ai:self-review -- --files TODO.md docs/ai/tasks/group-chat-sender-grouping-ui/plan.md docs/ai/tasks/group-chat-sender-grouping-ui/context.md docs/ai/tasks/group-chat-sender-grouping-ui/checklist.md src/features/room-chat/RoomChat.tsx src/features/room-chat/RoomChat.test.tsx src/pages/waiting-room/components/WaitingRoomChatBox.tsx src/pages/waiting-room/components/WaitingRoomSidePanel.tsx src/pages/waiting-room/page/WaitingRoomPage.tsx src/pages/waiting-room/page/WaitingRoomPage.test.tsx src/pages/GamePage.tsx src/pages/GamePage.test.tsx`

--- a/src/features/room-chat/RoomChat.test.tsx
+++ b/src/features/room-chat/RoomChat.test.tsx
@@ -145,4 +145,76 @@ describe('RoomChat', () => {
     expect(messageBubble.className).toContain('break-words')
     expect(messageBubble.className).toContain('[overflow-wrap:anywhere]')
   })
+
+  it('같은 sender의 연속 메시지는 하나의 sender header로 그룹화한다', () => {
+    renderWithProviders(
+      <RoomChat
+        currentUserId="me"
+        onSendMessage={vi.fn()}
+        senderMetaById={{
+          'user-2': {
+            badgeLabel: 'HOST',
+            displayName: '상대',
+          },
+        }}
+        messages={[
+          {
+            id: 'm1',
+            sender_id: 'user-2',
+            sender_nickname: '상대',
+            content: '첫 번째 메시지',
+            timestamp: '2026-03-03T10:00:00.000Z',
+            type: 'talk',
+          },
+          {
+            id: 'm2',
+            sender_id: 'user-2',
+            sender_nickname: '상대',
+            content: '두 번째 메시지',
+            timestamp: '2026-03-03T10:04:00.000Z',
+            type: 'talk',
+          },
+        ]}
+      />
+    )
+
+    expect(screen.getAllByText('상대')).toHaveLength(1)
+    expect(screen.getAllByText('HOST')).toHaveLength(1)
+    expect(screen.getByText('첫 번째 메시지')).toBeInTheDocument()
+    expect(screen.getByText('두 번째 메시지')).toBeInTheDocument()
+  })
+
+  it('같은 sender라도 5분을 넘기면 새 그룹으로 분리한다', () => {
+    renderWithProviders(
+      <RoomChat
+        currentUserId="me"
+        onSendMessage={vi.fn()}
+        senderMetaById={{
+          'user-2': {
+            displayName: '상대',
+          },
+        }}
+        messages={[
+          {
+            id: 'm1',
+            sender_id: 'user-2',
+            sender_nickname: '상대',
+            content: '이전 메시지',
+            timestamp: '2026-03-03T10:00:00.000Z',
+            type: 'talk',
+          },
+          {
+            id: 'm2',
+            sender_id: 'user-2',
+            sender_nickname: '상대',
+            content: '새 그룹 메시지',
+            timestamp: '2026-03-03T10:06:00.000Z',
+            type: 'talk',
+          },
+        ]}
+      />
+    )
+
+    expect(screen.getAllByText('상대')).toHaveLength(2)
+  })
 })

--- a/src/features/room-chat/RoomChat.tsx
+++ b/src/features/room-chat/RoomChat.tsx
@@ -1,11 +1,19 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { MessageSquare } from 'lucide-react'
+import { Avatar } from '../../components/avatar/Avatar'
 import type { ChatMessage } from '../../types/domain'
 import { cn } from '../../lib/utils'
 import {
   CHAT_MESSAGE_MAX_LENGTH,
   normalizeChatMessage,
 } from '../../constants/chat'
+
+export interface RoomChatSenderMeta {
+  avatarColor?: string
+  accentColor?: string
+  badgeLabel?: string
+  displayName?: string
+}
 
 // 공통 채팅 박스 렌더링 입력값 타입
 interface RoomChatProps {
@@ -16,6 +24,36 @@ interface RoomChatProps {
   title?: string
   currentUserId?: string
   inputPlaceholder?: string
+  senderMetaById?: Record<string, RoomChatSenderMeta>
+}
+
+interface RoomChatMessageGroup {
+  key: string
+  senderId: string
+  senderNickname: string
+  meta?: RoomChatSenderMeta
+  isMine: boolean
+  messages: ChatMessage[]
+}
+
+const MESSAGE_GROUP_WINDOW_MS = 5 * 60 * 1000
+
+function getMessageTimestampMs(timestamp: string) {
+  const parsedTimestamp = Date.parse(timestamp)
+
+  return Number.isNaN(parsedTimestamp) ? null : parsedTimestamp
+}
+
+function withAlpha(color: string | undefined, alphaHex: string) {
+  if (!color) {
+    return undefined
+  }
+
+  if (/^#[0-9a-fA-F]{6}$/.test(color)) {
+    return `${color}${alphaHex}`
+  }
+
+  return undefined
 }
 
 // 대기방/게임 공용 채팅 UI 렌더링
@@ -27,10 +65,46 @@ export default function RoomChat({
   title = 'CHAT',
   currentUserId = 'me',
   inputPlaceholder = '메시지...',
+  senderMetaById,
 }: RoomChatProps) {
   const [input, setInput] = useState('')
   const messagesContainerRef = useRef<HTMLDivElement | null>(null)
   const canSend = input.trim().length > 0
+  const messageGroups = useMemo<RoomChatMessageGroup[]>(() => {
+    return messages.reduce<RoomChatMessageGroup[]>((groups, message) => {
+      const currentGroup = groups[groups.length - 1]
+      const previousMessage =
+        currentGroup?.messages[currentGroup.messages.length - 1] ?? null
+      const previousTimestampMs = previousMessage
+        ? getMessageTimestampMs(previousMessage.timestamp)
+        : null
+      const currentTimestampMs = getMessageTimestampMs(message.timestamp)
+      const isWithinGroupWindow =
+        previousTimestampMs != null &&
+        currentTimestampMs != null &&
+        currentTimestampMs - previousTimestampMs <= MESSAGE_GROUP_WINDOW_MS
+
+      if (
+        currentGroup &&
+        currentGroup.senderId === message.sender_id &&
+        isWithinGroupWindow
+      ) {
+        currentGroup.messages.push(message)
+        return groups
+      }
+
+      groups.push({
+        key: `${message.sender_id}-${message.id}`,
+        senderId: message.sender_id,
+        senderNickname: message.sender_nickname,
+        meta: senderMetaById?.[message.sender_id],
+        isMine: message.sender_id === currentUserId,
+        messages: [message],
+      })
+
+      return groups
+    }, [])
+  }, [currentUserId, messages, senderMetaById])
 
   // 새 메시지가 추가되면 스크롤을 최신 메시지 위치로 이동
   useEffect(() => {
@@ -78,32 +152,80 @@ export default function RoomChat({
           ref={messagesContainerRef}
           className="ui-scrollbar min-h-0 flex-1 space-y-3 overflow-x-hidden overflow-y-auto bg-ui-surface px-3 py-3"
         >
-          {messages.map((message) => {
-            const isMine = message.sender_id === currentUserId
+          {messageGroups.map((group) => {
+            const accentColor = group.meta?.accentColor
+            const displayName = group.meta?.displayName ?? group.senderNickname
+            const badgeBackgroundColor = withAlpha(accentColor, '1F')
 
             return (
               <div
-                key={message.id}
+                key={group.key}
                 className={cn(
-                  'flex min-w-0 w-full flex-col',
-                  isMine ? 'items-end' : 'items-start'
+                  'flex min-w-0 w-full',
+                  group.isMine ? 'justify-end' : 'justify-start'
                 )}
               >
-                <div className="mb-0.5 max-w-[85%] px-0.5">
-                  <span className="block truncate text-[11px] font-medium text-ui-text-subtle">
-                    {message.sender_nickname}
-                  </span>
-                </div>
-
                 <div
                   className={cn(
-                    'min-w-0 w-fit max-w-[85%] whitespace-pre-wrap break-words [overflow-wrap:anywhere] px-3 py-2 text-sm leading-snug font-medium shadow-sm',
-                    isMine
-                      ? 'rounded-[16px_0_16px_16px] bg-ui-brand text-white'
-                      : 'rounded-[0_16px_16px_16px] border border-ui-border bg-ui-surface-soft text-ui-text-primary'
+                    'flex min-w-0',
+                    group.isMine
+                      ? 'max-w-[85%] flex-col items-end gap-1'
+                      : 'max-w-[90%] items-start gap-2'
                   )}
                 >
-                  {message.content}
+                  {group.isMine ? null : (
+                    <Avatar
+                      size="xs"
+                      displayName={displayName}
+                      backgroundColor={group.meta?.avatarColor}
+                      colorSeed={group.senderId}
+                      className="mt-0.5 text-white shadow-sm"
+                      textClassName="text-[10px] font-bold"
+                    />
+                  )}
+
+                  <div className="flex min-w-0 flex-1 flex-col gap-1">
+                    {group.isMine ? null : (
+                      <div className="flex min-w-0 items-center gap-2 px-0.5">
+                        <span
+                          className="block truncate text-[12px] font-semibold text-ui-text-primary"
+                          style={
+                            accentColor ? { color: accentColor } : undefined
+                          }
+                        >
+                          {displayName}
+                        </span>
+                        {group.meta?.badgeLabel ? (
+                          <span
+                            className="inline-flex shrink-0 items-center rounded-full border px-2 py-0.5 text-[10px] font-bold tracking-[0.12em]"
+                            style={{
+                              color: accentColor,
+                              borderColor: accentColor,
+                              backgroundColor: badgeBackgroundColor,
+                            }}
+                          >
+                            {group.meta.badgeLabel}
+                          </span>
+                        ) : null}
+                      </div>
+                    )}
+
+                    <div className="flex min-w-0 flex-col gap-1">
+                      {group.messages.map((message) => (
+                        <div
+                          key={message.id}
+                          className={cn(
+                            'min-w-0 w-fit max-w-full whitespace-pre-wrap break-words [overflow-wrap:anywhere] px-3 py-2 text-sm leading-snug font-medium shadow-sm',
+                            group.isMine
+                              ? 'self-end rounded-2xl rounded-tr-md bg-ui-brand text-white'
+                              : 'rounded-2xl rounded-tl-md border border-ui-border bg-ui-surface-soft text-ui-text-primary'
+                          )}
+                        >
+                          {message.content}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
                 </div>
               </div>
             )

--- a/src/pages/GamePage.test.tsx
+++ b/src/pages/GamePage.test.tsx
@@ -1,6 +1,6 @@
 import { forwardRef } from 'react'
 import { Route, Routes } from 'react-router-dom'
-import { act, cleanup, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import GamePage from './GamePage'
@@ -565,6 +565,45 @@ describe('GamePage chat flow', () => {
       message: expectedMessage,
     })
     expect(await screen.findByText(expectedMessage)).toBeInTheDocument()
+  })
+
+  it('게임 채팅에서 현재 턴 플레이어 메시지에 TURN badge를 표시한다', () => {
+    resetAndSetTestGameState({
+      roomId: 'room-1',
+      gameId: 'game-1',
+      currentTurn: 'user-2',
+      players: [
+        createPlayer(),
+        createPlayer({
+          id: 'user-2',
+          nickname: '유저2',
+          color: '#0000ff',
+        }),
+      ],
+      tiles: [],
+      messages: [
+        {
+          id: 'chat-turn',
+          sender_id: 'user-2',
+          sender_nickname: '유저2',
+          content: '내 차례입니다.',
+          timestamp: '2026-03-25T10:00:00.000Z',
+          type: 'talk',
+        },
+      ],
+    })
+
+    renderGamePage()
+
+    const chatSection = screen.getByText('실시간 채팅').closest('section')
+
+    expect(chatSection).not.toBeNull()
+    expect(
+      within(chatSection as HTMLElement).getByText('TURN')
+    ).toBeInTheDocument()
+    expect(
+      within(chatSection as HTMLElement).getByText('내 차례입니다.')
+    ).toBeInTheDocument()
   })
 
   it('게임 나가기 성공 시 leave API 호출 후 로비로 이동하고 game store를 초기화한다', async () => {

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -12,7 +12,9 @@ import { IS_SOCKET_MOCK_ENABLED } from '../config/env'
 import { useAuthStore } from '../features/auth/session/store'
 import { requestOnlineUsersSnapshotSync } from '../features/presence/online-users/onlineUsersSocket'
 import { DevRoomChatControlPanel } from '../features/room-chat/DevRoomChatControlPanel'
-import RoomChat from '../features/room-chat/RoomChat'
+import RoomChat, {
+  type RoomChatSenderMeta,
+} from '../features/room-chat/RoomChat'
 import { useDiceRoll } from '../hooks/game/useDiceRoll'
 import { useGameState } from '../hooks/game/useGameState'
 import { useTurn } from '../hooks/game/useTurn'
@@ -504,6 +506,22 @@ const GamePage: React.FC = () => {
     roomChatSenderOptions.find(
       (senderOption) => senderOption.id !== currentUserIdForChat
     )?.id ?? roomChatSenderOptions[0]?.id
+  const roomChatSenderMetaById = useMemo<Record<string, RoomChatSenderMeta>>(
+    () =>
+      Object.fromEntries(
+        panelPlayers.map((player) => [
+          player.id,
+          {
+            avatarColor: player.color,
+            accentColor: player.color,
+            badgeLabel:
+              player.isActive && !player.isBankrupt ? 'TURN' : undefined,
+            displayName: player.nickname,
+          },
+        ])
+      ),
+    [panelPlayers]
+  )
   const handlePromptChoice = (
     choice: string,
     payload?: Record<string, unknown>
@@ -747,6 +765,7 @@ const GamePage: React.FC = () => {
             messages={messages}
             onSendMessage={handleSendMessage}
             currentUserId={currentUserId ?? DEFAULT_GUEST_ID}
+            senderMetaById={roomChatSenderMetaById}
             notice={
               (round ?? 1) > 1 ? undefined : '게임 시작! 순서를 정했습니다.'
             }

--- a/src/pages/waiting-room/components/WaitingRoomChatBox.tsx
+++ b/src/pages/waiting-room/components/WaitingRoomChatBox.tsx
@@ -1,11 +1,13 @@
 import { useMemo } from 'react'
 import RoomChat from '../../../features/room-chat/RoomChat'
 import type { ChatMessage } from '../../../types/domain'
-import type { WaitingRoomChatMessage } from '../api/types'
+import { getAvatarBackgroundColor } from '../../../components/avatar/avatarModel'
+import type { WaitingRoomChatMessage, WaitingRoomPlayer } from '../api/types'
 
 // 대기방 채팅 박스 렌더링 입력값 타입
 interface WaitingRoomChatBoxProps {
   messages: WaitingRoomChatMessage[]
+  roomPlayers: WaitingRoomPlayer[]
   currentUserId: string
   onSendMessage: (content: string) => void
 }
@@ -13,6 +15,7 @@ interface WaitingRoomChatBoxProps {
 // 대기방 채팅 메시지를 RoomChat 공통 포맷으로 변환해 렌더링
 export function WaitingRoomChatBox({
   messages,
+  roomPlayers,
   currentUserId,
   onSendMessage,
 }: WaitingRoomChatBoxProps) {
@@ -28,6 +31,24 @@ export function WaitingRoomChatBox({
     }))
   }, [messages])
 
+  const senderMetaById = useMemo(() => {
+    return Object.fromEntries(
+      roomPlayers.map((player) => {
+        const accentColor = getAvatarBackgroundColor(player.id)
+
+        return [
+          player.id,
+          {
+            avatarColor: accentColor,
+            accentColor,
+            badgeLabel: player.isHost ? 'HOST' : undefined,
+            displayName: player.nickname,
+          },
+        ]
+      })
+    )
+  }, [roomPlayers])
+
   return (
     <RoomChat
       className="min-h-0 flex-1 w-full"
@@ -36,6 +57,7 @@ export function WaitingRoomChatBox({
       inputPlaceholder="메시지 입력..."
       messages={chatMessages}
       onSendMessage={onSendMessage}
+      senderMetaById={senderMetaById}
     />
   )
 }

--- a/src/pages/waiting-room/components/WaitingRoomSidePanel.tsx
+++ b/src/pages/waiting-room/components/WaitingRoomSidePanel.tsx
@@ -1,10 +1,11 @@
 import { WaitingRoomActionPanel } from './WaitingRoomActionPanel'
 import { WaitingRoomChatBox } from './WaitingRoomChatBox'
-import type { WaitingRoomChatMessage } from '../api/types'
+import type { WaitingRoomChatMessage, WaitingRoomPlayer } from '../api/types'
 
 // 우측 사이드 패널 렌더링 입력값 타입
 interface WaitingRoomSidePanelProps {
   messages: WaitingRoomChatMessage[]
+  roomPlayers: WaitingRoomPlayer[]
   currentUserId: string
   isHost: boolean
   canStartGame: boolean
@@ -20,6 +21,7 @@ interface WaitingRoomSidePanelProps {
 // 채팅 박스와 액션 패널을 결합한 대기방 우측 패널 렌더링
 export function WaitingRoomSidePanel({
   messages,
+  roomPlayers,
   currentUserId,
   isHost,
   canStartGame,
@@ -35,6 +37,7 @@ export function WaitingRoomSidePanel({
     <aside className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden rounded-3xl border border-ui-border bg-ui-surface p-3">
       <WaitingRoomChatBox
         messages={messages}
+        roomPlayers={roomPlayers}
         currentUserId={currentUserId}
         onSendMessage={onSendMessage}
       />

--- a/src/pages/waiting-room/page/WaitingRoomPage.test.tsx
+++ b/src/pages/waiting-room/page/WaitingRoomPage.test.tsx
@@ -213,6 +213,43 @@ describe('WaitingRoomPage interaction', () => {
     expect(screen.getByRole('button', { name: '시작' })).toBeDisabled()
   })
 
+  it('대기방 채팅에서 host 메시지에 HOST badge를 표시한다', () => {
+    useAuthStore.setState({
+      session: createAuthSessionFixture({
+        userId: 'user-2',
+        nickname: '상대방',
+      }),
+    })
+
+    waitingRoomControllerStateRef.current = createWaitingRoomControllerState({
+      isHost: false,
+      isReady: true,
+      canToggleReady: true,
+      chatMessages: [
+        {
+          id: 'chat-host',
+          senderId: 'user-1',
+          senderNickname: '테스터',
+          content: '방장이 안내합니다.',
+          timestamp: '2026-03-25T10:00:00.000Z',
+          type: 'talk',
+        },
+      ],
+    })
+
+    renderWaitingRoomPage()
+
+    const chatSection = screen.getByText('실시간 채팅').closest('section')
+
+    expect(chatSection).not.toBeNull()
+    expect(
+      within(chatSection as HTMLElement).getByText('HOST')
+    ).toBeInTheDocument()
+    expect(
+      within(chatSection as HTMLElement).getByText('방장이 안내합니다.')
+    ).toBeInTheDocument()
+  })
+
   it('2명 이상 + non-host 전원 준비 완료 상태면 host 시작 버튼이 활성화된다', () => {
     waitingRoomControllerStateRef.current = createWaitingRoomControllerState({
       isHost: true,

--- a/src/pages/waiting-room/page/WaitingRoomPage.tsx
+++ b/src/pages/waiting-room/page/WaitingRoomPage.tsx
@@ -366,6 +366,7 @@ function WaitingRoomPage() {
           <div className="min-h-0 xl:h-full xl:w-85 xl:shrink-0">
             <WaitingRoomSidePanel
               messages={chatMessages}
+              roomPlayers={room?.players ?? []}
               currentUserId={session.userId}
               isHost={isHost}
               canStartGame={canStartGame}


### PR DESCRIPTION
## 📌 관련 이슈

> closes #644

---

## 📝 작업 내용

- `RoomChat`에 sender metadata와 5분 기준 message grouping을 추가해, 상대 메시지를 아바타 + 닉네임 + 역할 badge 기반으로 읽기 쉽게 정리했습니다.
- 대기방 채팅은 room player 정보를 바탕으로 `HOST` badge와 avatar/accent color를 주입하도록 연결했습니다.
- 게임 채팅은 `panelPlayers`의 player color와 현재 턴 상태를 재사용해 `TURN` badge를 노출하도록 연결했습니다.
- 기존 채팅의 긴 메시지 줄바꿈, 300자 제한, optimistic echo dedupe 동작은 그대로 유지되도록 테스트를 함께 보강했습니다.

---

## 🧠 Task 문서 (큰 작업이면 필수)

- plan: docs/ai/tasks/group-chat-sender-grouping-ui/plan.md
- context: docs/ai/tasks/group-chat-sender-grouping-ui/context.md
- checklist: docs/ai/tasks/group-chat-sender-grouping-ui/checklist.md

---

## 📋 TODO.md 연결

- task slug: group-chat-sender-grouping-ui
- TODO status: Done
- TODO entry 확인: TODO.md와 docs/ai/tasks/group-chat-sender-grouping-ui/가 1:1로 연결됨

---

## 📚 참고한 기준 문서

- `AGENTS.md`
- `docs/ai/manuals/common.md`
- `docs/rules.md`
- `docs/testing.md`
- `docs/ai/manuals/lobby.md`
- `docs/ai/manuals/waiting-room.md`
- `docs/ai/manuals/game-runtime.md`

---

## 🧪 실행한 검증

- `npx vitest run src/features/room-chat/RoomChat.test.tsx src/pages/waiting-room/page/WaitingRoomPage.test.tsx src/pages/GamePage.test.tsx`
- `npm run ai:check:lobby`
- `npm run ai:check:waiting-room`
- `npm run ai:check:game`
- `npm run lint`
- `npm run build`
- `npm run ai:self-review -- --files TODO.md docs/ai/tasks/group-chat-sender-grouping-ui/plan.md docs/ai/tasks/group-chat-sender-grouping-ui/context.md docs/ai/tasks/group-chat-sender-grouping-ui/checklist.md src/features/room-chat/RoomChat.tsx src/features/room-chat/RoomChat.test.tsx src/pages/waiting-room/components/WaitingRoomChatBox.tsx src/pages/waiting-room/components/WaitingRoomSidePanel.tsx src/pages/waiting-room/page/WaitingRoomPage.tsx src/pages/waiting-room/page/WaitingRoomPage.test.tsx src/pages/GamePage.tsx src/pages/GamePage.test.tsx`
- `npm run ai:session:brief -- group-chat-sender-grouping-ui`

---

## ⚠️ 남은 리스크

- `TURN` badge는 현재 active player 기준이라, 같은 플레이어의 과거 메시지 그룹에도 함께 보일 수 있습니다.
- 그룹화 기준이 5분 heuristic이라 서버 timestamp가 비정상적이면 그룹 경계가 어색할 수 있습니다.
- UI 스크린샷은 아직 첨부하지 않았습니다.

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료
- [x] 큰 작업이면 task 문서 링크를 남겼다
- [x] 큰 작업이면 `TODO.md` / task slug 연결을 PR 본문에 남겼다
- [x] 참고한 기준 문서를 PR 본문에 남겼다
- [x] 실행한 검증과 남은 리스크를 PR 본문에 적었다

---

## 📸 스크린샷 (선택)

> 필요 시 대기방 채팅 / 게임 채팅 각각 1장씩 추가 예정
