### PR TITLE
fix: 무인도 강제 이동 fast animation 정렬

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -17,6 +17,7 @@
 
 ## Done
 
+- [x] `forced-island-fast-move-fix` - Forced Island Fast Move Fix (`docs/ai/tasks/forced-island-fast-move-fix/`) - 무인도 강제 이동만 빠른 애니메이션을 적용하고 일반 무인도 착지/출발은 기본 속도로 유지
 - [x] `group-chat-sender-grouping-ui` - Group Chat Sender Grouping UI (`docs/ai/tasks/group-chat-sender-grouping-ui/`) - 대기방/게임 공용 채팅을 sender grouping, 아바타, 이름 강조, 역할 badge 기반 실무형 그룹 채팅 UI로 정리
 - [x] `chat-message-limit-300` - Chat Message Limit 300 (`docs/ai/tasks/chat-message-limit-300/`) - room chat과 DM에 300자 하드 제한을 입력/송신/contract/mock/test 기준으로 통일
 - [x] `chat-bubble-overflow-fix` - Chat Bubble Overflow Fix (`docs/ai/tasks/chat-bubble-overflow-fix/`) - 긴 메시지가 말풍선을 뚫고 가로 스크롤을 만드는 문제를 RoomChat/DM 공통 스타일로 정리

--- a/docs/ai/tasks/forced-island-fast-move-fix/checklist.md
+++ b/docs/ai/tasks/forced-island-fast-move-fix/checklist.md
@@ -1,0 +1,27 @@
+# Checklist
+
+## Implementation
+
+- [x] 관련 manual과 기존 문서를 읽었다
+- [x] 영향 범위를 정리했다
+- [x] WAT 단계와 역할 분담을 문서에 반영했다
+- [x] `shouldApplyTravelMoveAnimation` fast 판정을 강제 무인도 이동 기준으로 수정했다
+- [x] `GameBoard` 카드 무인도 이동 연출에 fast timing을 적용했다
+- [x] 일반 무인도 착지/출발 동작을 건드리지 않았다
+
+## Testing
+
+- [x] `npx vitest run src/components/board/gameBoardEventQueueUtils.test.ts`
+- [x] `npm run lint`
+- [x] `npm run ai:check:game`
+- [x] `npm run build`
+
+## Review
+
+- [x] `docs/rules.md` 기준으로 셀프 리뷰했다
+- [x] `MOVE_TO_ISLAND -> ISLAND`만 fast인지 회귀 여부를 확인했다
+- [x] `TODO.md` task 한 줄을 최신 상태로 유지했다
+- [x] session handoff notes를 최신 상태로 갱신했다
+- [x] `npm run ai:session:brief -- forced-island-fast-move-fix` 출력이 현재 상태와 맞는다
+- [x] `npm run ai:self-review -- --files ...`를 실행했다
+- [x] 변경 파일 / 실행한 검증 / 남은 리스크를 정리했다

--- a/docs/ai/tasks/forced-island-fast-move-fix/context.md
+++ b/docs/ai/tasks/forced-island-fast-move-fix/context.md
@@ -1,0 +1,47 @@
+# Context
+
+## Current Behavior
+
+- `shouldApplyTravelMoveAnimation`은 `trigger === 'travel'` 또는 출발 타일이 `TRAVEL` / `ISLAND`일 때 fast animation을 적용한다.
+- 이 때문에 일반 주사위로 무인도에서 출발하는 이동이 fast로 분류되고, 반대로 `섬으로 이동` 칸에서 무인도로 강제 이동하는 경로는 일반 속도로 보일 수 있다.
+- 카드/이벤트로 무인도로 이동하는 mock 연출은 `handleCardConfirm()`에서 직접 `movePlayerSequentially()`를 호출하지만, 현재는 fast timing을 재사용하지 않는다.
+
+## Related Files
+
+- `src/components/board/gameBoardEventQueueUtils.ts`
+- `src/components/board/gameBoardEventQueueUtils.test.ts`
+- `src/components/board/GameBoard.tsx`
+- `docs/ai/tasks/island-speed-and-exit-modal-style/*`
+- `docs/ai/tasks/game-board-result-and-travel-fix/*`
+
+## Relevant Manuals
+
+- `docs/ai/manuals/common.md`
+- `docs/ai/manuals/game-runtime.md`
+- `docs/rules.md`
+- `docs/testing.md`
+
+## Constraints
+
+- 서버 authoritative state나 socket event shape는 바꾸지 않는다.
+- fast 판정은 UI animation 로직에만 한정한다.
+- 카드 무인도 이동은 mock 경로 연출이므로 기존 skipTurns/state 갱신 로직은 유지한다.
+- 일반 무인도 착지/출발과 travel tile 동작은 회귀시키면 안 된다.
+
+## Decision Notes
+
+- fast 이동의 정의는 `travel` 또는 `MOVE_TO_ISLAND -> ISLAND` 강제 이동으로 제한한다.
+- `ISLAND` 출발만으로 fast 처리하는 규칙은 제거한다.
+- 카드/이벤트 무인도 이동도 사용자 기대상 “강제 이동”에 포함하므로 같은 fast timing 상수를 재사용한다.
+
+## Session Handoff Notes
+
+- 다음 세션에서 다시 읽을 문서: `docs/ai/tasks/forced-island-fast-move-fix/*`, `docs/ai/manuals/game-runtime.md`
+- 바로 이어서 할 1개 단계: 없음
+- pending decision / blocker: 없음
+- 검증 재개 지점: `npx vitest run src/components/board/gameBoardEventQueueUtils.test.ts`, `npm run lint`, `npm run ai:check:game`, `npm run build`, `npm run ai:self-review -- --files ...` 실행 완료
+
+## Open Risks
+
+- 실서버가 별도 `go_to_island` trigger를 보내지 않아도 `from=MOVE_TO_ISLAND`, `to=ISLAND` fallback 판정이 필요하다.
+- 카드 무인도 이동은 mock 전용 로컬 연출이라 실서버 경로와 다르지만, 현재 UX 기준상 같은 fast 속도로 맞추는 것이 자연스럽다.

--- a/docs/ai/tasks/forced-island-fast-move-fix/plan.md
+++ b/docs/ai/tasks/forced-island-fast-move-fix/plan.md
@@ -1,0 +1,70 @@
+# Plan
+
+## Task
+
+- 작업 이름: Forced Island Fast Move Fix
+- 작업 slug: `forced-island-fast-move-fix`
+- 요청 날짜: 2026-03-25
+- 담당 범위: 무인도 강제 이동 fast animation을 `MOVE_TO_ISLAND`/카드 강제 이동에만 제한
+
+## Goal
+
+- `섬으로 이동` 칸에서 무인도로 강제 이동할 때만 빠른 이동 애니메이션을 적용한다.
+- 카드/이벤트로 무인도로 강제 이동하는 mock 연출도 같은 fast timing으로 맞춘다.
+- 일반 주사위로 무인도에 도착하거나 무인도에서 출발하는 이동은 기존 일반 속도를 유지한다.
+
+## WAT Workflow
+
+1. task 문서와 TODO를 만들어 범위 / 완료 기준 / 검증 명령을 고정한다.
+2. 보드 이동 helper에서 fast 판정 기준을 `travel` 또는 `MOVE_TO_ISLAND -> ISLAND` 강제 이동으로 좁힌다.
+3. `GameBoard`의 카드 기반 무인도 강제 이동 연출도 같은 fast 옵션을 사용하도록 정리하고 관련 테스트로 마감한다.
+
+## In Scope
+
+- `src/components/board/gameBoardEventQueueUtils.ts`
+- `src/components/board/gameBoardEventQueueUtils.test.ts`
+- `src/components/board/GameBoard.tsx`
+- task 문서와 TODO 상태 정리
+
+## Out Of Scope
+
+- 게임 종료 모달 스타일
+- 일반 travel 이동 UX
+- 무인도 탈출 규칙 / skipTurns / 서버 authoritative state
+- socket contract / store shape 변경
+
+## Target Files
+
+- `src/components/board/gameBoardEventQueueUtils.ts`
+- `src/components/board/gameBoardEventQueueUtils.test.ts`
+- `src/components/board/GameBoard.tsx`
+- `docs/ai/tasks/forced-island-fast-move-fix/*`
+- `TODO.md`
+
+## Task Tracking
+
+- TODO line: - [ ] `forced-island-fast-move-fix` - Forced Island Fast Move Fix (`docs/ai/tasks/forced-island-fast-move-fix/`)
+- Session brief: `npm run ai:session:brief -- forced-island-fast-move-fix`
+- Reopen docs: `docs/ai/tasks/forced-island-fast-move-fix/plan.md`, `context.md`, `checklist.md`, 관련 manuals
+
+## Completion Criteria
+
+- `trigger === 'travel'` 이동은 기존처럼 fast다.
+- `MOVE_TO_ISLAND -> ISLAND` 강제 이동은 fast다.
+- `ISLAND` 출발 일반 이동은 fast가 아니다.
+- 카드/이벤트 무인도 강제 이동 연출은 `stepDelayMs: 80`, `initialDelayMs: 200`, `endDelayMs: 100`을 사용한다.
+
+## Role Plan
+
+- Planner: 강제 무인도 이동과 일반 무인도 이동의 UX 기준 정리
+- Implementer: helper 판정과 카드 무인도 이동 연출 정렬
+- Reviewer: 일반 무인도 착지/출발이 fast로 회귀하지 않는지 점검
+- Tester: 관련 Vitest와 game/build 검증 실행
+
+## Test Plan
+
+- `npx vitest run src/components/board/gameBoardEventQueueUtils.test.ts`
+- `npm run lint`
+- `npm run ai:check:game`
+- `npm run build`
+- `npm run ai:self-review -- --files TODO.md docs/ai/tasks/forced-island-fast-move-fix/plan.md docs/ai/tasks/forced-island-fast-move-fix/context.md docs/ai/tasks/forced-island-fast-move-fix/checklist.md src/components/board/GameBoard.tsx src/components/board/gameBoardEventQueueUtils.ts src/components/board/gameBoardEventQueueUtils.test.ts`

--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -52,6 +52,7 @@ import { getBoardSellFallbackRefund } from './gameBoardActionUtils'
 import { syncMockStorePlayers } from './gameBoardStoreBridge'
 import { useBoardEventQueue } from './useBoardEventQueue'
 import {
+  FAST_MOVE_ANIMATION_OPTIONS,
   getPendingMovePlayerIdsFromEvents,
   getBoardEventAnimationHoldMs,
   resolveBoardCardModalContentFromEvent,
@@ -872,6 +873,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
           const isTravelMove = shouldApplyTravelMoveAnimation({
             normalizedTrigger,
             fromIndex,
+            toIndex: tileIndex,
             tiles: boardTiles,
           })
           if (isTravelMove && event.playerId != null) {
@@ -884,9 +886,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
             tileIndex,
             {
               direction: moveDirection,
-              stepDelayMs: isTravelMove ? 80 : undefined,
-              initialDelayMs: isTravelMove ? 200 : undefined,
-              endDelayMs: isTravelMove ? 100 : undefined,
+              ...(isTravelMove ? FAST_MOVE_ANIMATION_OPTIONS : {}),
             }
           )
 
@@ -1547,11 +1547,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
           player.id,
           player.pos === islandTile.id ? 24 : player.pos,
           islandTile.id,
-          {
-            stepDelayMs: 80,
-            initialDelayMs: 200,
-            endDelayMs: 100,
-          }
+          FAST_MOVE_ANIMATION_OPTIONS
         )
 
         const updatedPlayers = [...playersRef.current]
@@ -1693,9 +1689,12 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
         const islandTile = boardTiles.find((t) => t.type === 'ISLAND')
 
         if (player && islandTile) {
-          await movePlayerSequentially(player.id, player.pos, islandTile.id, {
-            initialDelayMs: 0,
-          })
+          await movePlayerSequentially(
+            player.id,
+            player.pos,
+            islandTile.id,
+            FAST_MOVE_ANIMATION_OPTIONS
+          )
 
           const updatedPlayers = [...playersRef.current]
           updatedPlayers[playerIdx] = {

--- a/src/components/board/gameBoardEventQueueUtils.test.ts
+++ b/src/components/board/gameBoardEventQueueUtils.test.ts
@@ -4,6 +4,7 @@ import type { PlayerState, TileData } from './board.constants'
 import {
   createBoardStatusFromEvent,
   extractEventDice,
+  FAST_MOVE_ANIMATION_OPTIONS,
   getBoardEventAnimationHoldMs,
   getBoardEventConsumeDelayMs,
   getPendingMovePlayerIdsFromEvents,
@@ -397,12 +398,62 @@ describe('gameBoardEventQueueUtils', () => {
       shouldApplyTravelMoveAnimation({
         normalizedTrigger: 'travel',
         fromIndex: 4,
+        toIndex: 1,
         tiles,
       })
     ).toBe(true)
   })
 
-  it('applies fast travel animation when departing from travel or island tile', () => {
+  it('applies fast travel animation when trigger is go_to_island', () => {
+    expect(
+      shouldApplyTravelMoveAnimation({
+        normalizedTrigger: 'go_to_island',
+        fromIndex: 4,
+        toIndex: 1,
+        tiles,
+      })
+    ).toBe(true)
+  })
+
+  it('applies fast travel animation when departing from travel tile', () => {
+    const movementTiles: TileData[] = [
+      { id: 0, name: 'Start', type: 'START' },
+      { id: 1, name: 'Island', type: 'ISLAND' },
+      { id: 2, name: 'Travel', type: 'TRAVEL' },
+      { id: 3, name: 'Go To Island', type: 'MOVE_TO_ISLAND' },
+      { id: 4, name: 'Event', type: 'EVENT' },
+    ]
+
+    expect(
+      shouldApplyTravelMoveAnimation({
+        normalizedTrigger: '',
+        fromIndex: 2,
+        toIndex: 4,
+        tiles: movementTiles,
+      })
+    ).toBe(true)
+  })
+
+  it('applies fast travel animation when moving from go to island tile to island', () => {
+    const movementTiles: TileData[] = [
+      { id: 0, name: 'Start', type: 'START' },
+      { id: 1, name: 'Island', type: 'ISLAND' },
+      { id: 2, name: 'Travel', type: 'TRAVEL' },
+      { id: 3, name: 'Go To Island', type: 'MOVE_TO_ISLAND' },
+      { id: 4, name: 'Event', type: 'EVENT' },
+    ]
+
+    expect(
+      shouldApplyTravelMoveAnimation({
+        normalizedTrigger: '',
+        fromIndex: 3,
+        toIndex: 1,
+        tiles: movementTiles,
+      })
+    ).toBe(true)
+  })
+
+  it('does not apply fast travel animation when departing from island tile', () => {
     const movementTiles: TileData[] = [
       { id: 0, name: 'Start', type: 'START' },
       { id: 1, name: 'Island', type: 'ISLAND' },
@@ -414,30 +465,31 @@ describe('gameBoardEventQueueUtils', () => {
       shouldApplyTravelMoveAnimation({
         normalizedTrigger: '',
         fromIndex: 1,
+        toIndex: 3,
         tiles: movementTiles,
       })
-    ).toBe(true)
-
-    expect(
-      shouldApplyTravelMoveAnimation({
-        normalizedTrigger: '',
-        fromIndex: 2,
-        tiles: movementTiles,
-      })
-    ).toBe(true)
+    ).toBe(false)
   })
 
-  it('does not apply fast travel animation when departing from event tile', () => {
+  it('does not apply fast travel animation when arriving at island by dice move', () => {
     const movementTiles: TileData[] = [
-      { id: 19, name: '광주', type: 'PROPERTY', color: '#66BB6A', price: 1000 },
-      { id: 20, name: '이벤트', type: 'EVENT' },
-      { id: 21, name: '춘천', type: 'PROPERTY', color: '#7E57C2', price: 1000 },
+      { id: 0, name: 'Start', type: 'START' },
+      { id: 1, name: 'Island', type: 'ISLAND' },
+      {
+        id: 2,
+        name: 'Property',
+        type: 'PROPERTY',
+        color: '#66BB6A',
+        price: 1000,
+      },
+      { id: 3, name: 'Event', type: 'EVENT' },
     ]
 
     expect(
       shouldApplyTravelMoveAnimation({
         normalizedTrigger: '',
-        fromIndex: 1,
+        fromIndex: 2,
+        toIndex: 1,
         tiles: movementTiles,
       })
     ).toBe(false)
@@ -448,8 +500,17 @@ describe('gameBoardEventQueueUtils', () => {
       shouldApplyTravelMoveAnimation({
         normalizedTrigger: '',
         fromIndex: 99,
+        toIndex: 1,
         tiles,
       })
     ).toBe(false)
+  })
+
+  it('keeps fast move animation timing constants aligned', () => {
+    expect(FAST_MOVE_ANIMATION_OPTIONS).toEqual({
+      initialDelayMs: 200,
+      stepDelayMs: 80,
+      endDelayMs: 100,
+    })
   })
 })

--- a/src/components/board/gameBoardEventQueueUtils.ts
+++ b/src/components/board/gameBoardEventQueueUtils.ts
@@ -26,21 +26,39 @@ export type ChanceMoveAnimationHint = {
   steps: number
 }
 
+export const FAST_MOVE_ANIMATION_OPTIONS = {
+  initialDelayMs: 200,
+  stepDelayMs: 80,
+  endDelayMs: 100,
+} as const
+
 export const shouldApplyTravelMoveAnimation = ({
   normalizedTrigger,
   fromIndex,
+  toIndex,
   tiles,
 }: {
   normalizedTrigger: string
   fromIndex: number
+  toIndex: number
   tiles: TileData[]
 }) => {
-  if (normalizedTrigger === 'travel') {
+  if (
+    normalizedTrigger === 'travel' ||
+    normalizedTrigger === 'go_to_island' ||
+    normalizedTrigger === 'move_to_island'
+  ) {
     return true
   }
 
   const fromTileType = tiles[fromIndex]?.type
-  return fromTileType === 'TRAVEL' || fromTileType === 'ISLAND'
+  const toTileType = tiles[toIndex]?.type
+
+  if (fromTileType === 'TRAVEL') {
+    return true
+  }
+
+  return fromTileType === 'MOVE_TO_ISLAND' && toTileType === 'ISLAND'
 }
 
 const normalizeEventType = (type: unknown) =>


### PR DESCRIPTION
## 📌 관련 이슈

> closes #646

---

## 📝 작업 내용

- `shouldApplyTravelMoveAnimation` fast 판정을 `travel` 또는 `MOVE_TO_ISLAND -> ISLAND` 강제 이동 기준으로 좁혔습니다.
- `ISLAND` 출발만으로 fast 처리되던 규칙을 제거해, 일반 무인도 착지/출발은 기본 속도를 유지하도록 정리했습니다.
- `GameBoard`의 카드/이벤트 기반 무인도 강제 이동 연출도 공통 fast timing 상수를 재사용하도록 맞췄습니다.
- task 문서와 `TODO.md`를 `forced-island-fast-move-fix` 기준으로 정리했습니다.

---

## 🧠 Task 문서 (큰 작업이면 필수)

- plan: `docs/ai/tasks/forced-island-fast-move-fix/plan.md`
- context: `docs/ai/tasks/forced-island-fast-move-fix/context.md`
- checklist: `docs/ai/tasks/forced-island-fast-move-fix/checklist.md`

---

## 📋 TODO.md 연결

- task slug: `forced-island-fast-move-fix`
- TODO status: `Done`
- TODO entry 확인: `TODO.md` Done 섹션 반영 완료

---

## 📚 참고한 기준 문서

- `AGENTS.md`
- `docs/ai/manuals/common.md`
- `docs/rules.md`
- `docs/testing.md`
- 추가 manual / 문서 경로:
  - `docs/ai/manuals/game-runtime.md`

---

## 🧪 실행한 검증

- `npx vitest run src/components/board/gameBoardEventQueueUtils.test.ts`
- `npm run lint`
- `npm run ai:check:game`
- `npm run build`
- `npm run ai:self-review -- --files TODO.md docs/ai/tasks/forced-island-fast-move-fix/plan.md docs/ai/tasks/forced-island-fast-move-fix/context.md docs/ai/tasks/forced-island-fast-move-fix/checklist.md src/components/board/GameBoard.tsx src/components/board/gameBoardEventQueueUtils.ts src/components/board/gameBoardEventQueueUtils.test.ts`
- `npm run ai:session:brief -- forced-island-fast-move-fix`

---

## ⚠️ 남은 리스크

- 카드/이벤트 무인도 강제 이동은 mock 로컬 연출 경로에서 fast timing으로 맞췄고, 실서버 경로는 `PLAYER_MOVED`의 trigger 또는 `MOVE_TO_ISLAND -> ISLAND` fallback 판정에 의존합니다.
- 이번 검증은 helper unit test 중심이며, 카드 모달 클릭까지 포함한 `GameBoard` integration test는 아직 없습니다.

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료
- [x] 큰 작업이면 task 문서 링크를 남겼다
- [x] 큰 작업이면 `TODO.md` / task slug 연결을 PR 본문에 남겼다
- [x] 참고한 기준 문서를 PR 본문에 남겼다
- [x] 실행한 검증과 남은 리스크를 PR 본문에 적었다

---

## 📸 스크린샷 (선택)

- 게임 보드에서 `섬으로 이동` 강제 이동 애니메이션 전/후 비교 캡처 추가 가능
