### PR TITLE
fix: 내 턴 수동 매각 선택 복구

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -17,6 +17,7 @@
 
 ## Done
 
+- [x] `manual-sell-selection-restore` - Manual Sell Selection Restore (`docs/ai/tasks/manual-sell-selection-restore/`) - 내 턴 자산 액션 구간에서 보유 토지 클릭 수동 매각을 복구하되 서버 sell prompt 경로와 충돌하지 않게 정리
 - [x] `forced-island-fast-move-fix` - Forced Island Fast Move Fix (`docs/ai/tasks/forced-island-fast-move-fix/`) - 무인도 강제 이동만 빠른 애니메이션을 적용하고 일반 무인도 착지/출발은 기본 속도로 유지
 - [x] `group-chat-sender-grouping-ui` - Group Chat Sender Grouping UI (`docs/ai/tasks/group-chat-sender-grouping-ui/`) - 대기방/게임 공용 채팅을 sender grouping, 아바타, 이름 강조, 역할 badge 기반 실무형 그룹 채팅 UI로 정리
 - [x] `chat-message-limit-300` - Chat Message Limit 300 (`docs/ai/tasks/chat-message-limit-300/`) - room chat과 DM에 300자 하드 제한을 입력/송신/contract/mock/test 기준으로 통일

--- a/docs/ai/tasks/manual-sell-selection-restore/checklist.md
+++ b/docs/ai/tasks/manual-sell-selection-restore/checklist.md
@@ -1,0 +1,27 @@
+# Checklist
+
+## Implementation
+
+- [x] 관련 manual과 기존 문서를 읽었다
+- [x] 영향 범위를 정리했다
+- [x] WAT 단계와 역할 분담을 문서에 반영했다
+- [x] `GameBoard` owned-tile click 수동 매각 경로를 복구했다
+- [x] prompt/travel 경계에서는 로컬 sell modal이 열리지 않게 유지했다
+- [x] `SELL_PROPERTY` emit 경로를 기존 계약과 동일하게 유지했다
+
+## Testing
+
+- [x] `npx vitest run src/components/board/GameBoard.test.tsx src/components/board/gameBoardActionHandlers.test.ts`
+- [x] `npm run lint`
+- [x] `npm run ai:check:game`
+- [x] `npm run build`
+
+## Review
+
+- [x] `docs/rules.md` 기준으로 셀프 리뷰했다
+- [x] prompt-driven sell과 local manual sell의 우선순위가 충돌하지 않는지 확인했다
+- [x] `TODO.md` task 한 줄을 최신 상태로 유지했다
+- [x] session handoff notes를 최신 상태로 갱신했다
+- [x] `npm run ai:session:brief -- manual-sell-selection-restore` 출력이 현재 상태와 맞는다
+- [x] `npm run ai:self-review -- --files ...`를 실행했다
+- [x] 변경 파일 / 실행한 검증 / 남은 리스크를 정리했다

--- a/docs/ai/tasks/manual-sell-selection-restore/context.md
+++ b/docs/ai/tasks/manual-sell-selection-restore/context.md
@@ -1,0 +1,45 @@
+# Context
+
+## Current Behavior
+
+- `GameBoard`는 현재 `canManageOwnAssets`를 계산하지만, `isOwnedTileSellClickable`를 항상 `false`로 두고 있다.
+- `handleBoardTileClick`는 travel 선택만 처리하고, 본인 소유 타일 클릭 시 로컬 sell modal을 열지 않는다.
+- `CitySellModal`과 `handleCitySellConfirm` 자체는 남아 있어, 서버 sell prompt 또는 로컬 modal open 상태에서 `SELL_PROPERTY` emit은 여전히 가능하다.
+
+## Related Files
+
+- `src/components/board/GameBoard.tsx`
+- `src/components/board/gameBoardActionHandlers.test.ts`
+- `docs/ai/tasks/sell-modal-server-driven/*`
+
+## Relevant Manuals
+
+- `docs/ai/manuals/common.md`
+- `docs/ai/manuals/game-runtime.md`
+- `docs/rules.md`
+- `docs/testing.md`
+
+## Constraints
+
+- 서버 authoritative prompt/state machine은 유지한다.
+- `SELL_PROPERTY` payload shape와 prompt response shape는 바꾸지 않는다.
+- prompt visible 상태에서는 로컬 sell modal을 열지 않는다.
+- travel selection active 상태에서는 travel destination 선택이 우선한다.
+
+## Decision Notes
+
+- 수동 매각은 `allowAssetActions + isAssetActionPhase` 경계 안에서만 복구한다.
+- 로컬 수동 매각은 보조 UX이고, 강제 매각/파산 흐름은 계속 서버 prompt가 canonical이다.
+- build cancel 후 auto reopen 같은 과거 동작은 복구하지 않는다.
+
+## Session Handoff Notes
+
+- 다음 세션에서 다시 읽을 문서: `docs/ai/tasks/manual-sell-selection-restore/*`, `docs/ai/manuals/game-runtime.md`
+- 바로 이어서 할 1개 단계: 없음
+- pending decision / blocker: 없음
+- 검증 재개 지점: `npx vitest run src/components/board/GameBoard.test.tsx src/components/board/gameBoardActionHandlers.test.ts`, `npm run lint`, `npm run ai:check:game`, `npm run build`, `npm run ai:self-review -- --files ...` 실행 완료
+
+## Open Risks
+
+- 실서버가 특정 phase에서 `SELL_PROPERTY`를 거부하면, 로컬 수동 매각 modal은 열리더라도 ack 에러 UX가 필요할 수 있다.
+- 현재 보드 테스트는 수동 매각 open/confirm, prompt 차단, travel 우선 경로까지 추가했지만, 실서버 ack 에러 표시까지는 다루지 않는다.

--- a/docs/ai/tasks/manual-sell-selection-restore/plan.md
+++ b/docs/ai/tasks/manual-sell-selection-restore/plan.md
@@ -1,0 +1,69 @@
+# Plan
+
+## Task
+
+- 작업 이름: Manual Sell Selection Restore
+- 작업 slug: `manual-sell-selection-restore`
+- 요청 날짜: 2026-03-26
+- 담당 범위: 내 턴 자산 액션 구간에서 보유 토지 클릭 수동 매각을 복구하고 서버 sell prompt 경로와 충돌하지 않게 정리
+
+## Goal
+
+- 내 턴의 자산 액션 가능 구간에서는 본인 소유 타일을 클릭해 수동 매각 모달을 열 수 있다.
+- 서버 `SELL_OR_BANKRUPT` prompt가 떠 있을 때는 기존 prompt-driven sell modal 경로를 그대로 유지한다.
+- build/buy/toll/travel/island prompt와 겹치는 상태에서는 로컬 매각 modal을 열지 않는다.
+
+## WAT Workflow
+
+1. task 문서와 TODO를 만들어 범위 / 완료 기준 / 검증 명령을 고정한다.
+2. `GameBoard`에 owned-tile click 기반 수동 매각 경로를 복구하되 prompt/travel 경계와 충돌하지 않게 제한한다.
+3. UI interaction test와 emit 회귀 테스트를 추가해 수동 매각 open/confirm 경로를 검증한다.
+
+## In Scope
+
+- `src/components/board/GameBoard.tsx`
+- 관련 보드 테스트
+- task 문서와 TODO 상태 정리
+
+## Out Of Scope
+
+- backend contract 변경
+- 새 prompt type 추가
+- build cancel 후 자동 매각 reopen
+- 파산 강제 매각 정책 변경
+
+## Target Files
+
+- `src/components/board/GameBoard.tsx`
+- `src/components/board/GameBoard.test.tsx`
+- `src/components/board/gameBoardActionHandlers.test.ts`
+- `docs/ai/tasks/manual-sell-selection-restore/*`
+- `TODO.md`
+
+## Task Tracking
+
+- TODO line: - [ ] `manual-sell-selection-restore` - Manual Sell Selection Restore (`docs/ai/tasks/manual-sell-selection-restore/`)
+- Session brief: `npm run ai:session:brief -- manual-sell-selection-restore`
+- Reopen docs: `docs/ai/tasks/manual-sell-selection-restore/plan.md`, `context.md`, `checklist.md`, 관련 manuals
+
+## Completion Criteria
+
+- 내 턴 + 자산 액션 허용 상태에서 본인 소유 타일을 클릭하면 `CitySellModal`이 열린다.
+- prompt가 떠 있는 동안에는 로컬 클릭으로 sell modal이 열리지 않는다.
+- `CitySellModal` confirm은 기존처럼 `SELL_PROPERTY`를 emit한다.
+- 다른 사람 땅, 비허용 phase, travel selection 중에는 클릭 매각이 열리지 않는다.
+
+## Role Plan
+
+- Planner: manual sell 허용 범위와 prompt 우선 정책 정리
+- Implementer: `GameBoard` click/open 경로 복구
+- Reviewer: prompt/travel과의 충돌 여부 점검
+- Tester: UI interaction + game 검증 실행
+
+## Test Plan
+
+- `npx vitest run src/components/board/GameBoard.test.tsx src/components/board/gameBoardActionHandlers.test.ts`
+- `npm run lint`
+- `npm run ai:check:game`
+- `npm run build`
+- `npm run ai:self-review -- --files TODO.md docs/ai/tasks/manual-sell-selection-restore/plan.md docs/ai/tasks/manual-sell-selection-restore/context.md docs/ai/tasks/manual-sell-selection-restore/checklist.md src/components/board/GameBoard.tsx src/components/board/GameBoard.test.tsx src/components/board/gameBoardActionHandlers.test.ts`

--- a/src/components/board/GameBoard.test.tsx
+++ b/src/components/board/GameBoard.test.tsx
@@ -1,0 +1,275 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+import GameBoard from './GameBoard'
+import type { PlayerState } from './board.constants'
+import type { GamePrompt } from '../../types/domain'
+import { emitGameAction } from '../../services/socket/game.handler'
+import { useGameStore } from '../../stores/game.store'
+
+vi.mock('./BoardTile', () => ({
+  default: ({ tile }: { tile: { id: number; name?: string } }) => (
+    <div>{tile.name ?? `tile-${tile.id}`}</div>
+  ),
+  PlayerToken: () => null,
+}))
+
+vi.mock('./useBoardEventQueue', () => ({
+  useBoardEventQueue: () => undefined,
+}))
+
+vi.mock('../../lib/bgm', () => ({
+  playLongSfx: vi.fn(),
+  stopLongSfx: vi.fn(),
+}))
+
+vi.mock('../../services/socket/game.handler', () => ({
+  emitGameAction: vi.fn(),
+}))
+
+vi.mock('../game/GlobalEffectOverlay', () => ({
+  default: () => null,
+}))
+
+vi.mock('../game/modals/BuyModal', () => ({
+  default: () => null,
+}))
+
+vi.mock('../game/modals/BuildModal', () => ({
+  default: () => null,
+}))
+
+vi.mock('../game/modals/CardModal', () => ({
+  default: () => null,
+}))
+
+vi.mock('../game/modals/TravelModal', () => ({
+  default: ({ open, onConfirm }: { open: boolean; onConfirm?: () => void }) =>
+    open ? <button onClick={onConfirm}>여행 확인</button> : null,
+}))
+
+vi.mock('../game/modals/CityAcquisitionModals', () => ({
+  default: () => null,
+}))
+
+vi.mock('../game/modals/CitySellModal', () => ({
+  default: ({
+    open,
+    ownerName,
+    onCancel,
+    onSell,
+  }: {
+    open: boolean
+    ownerName?: string
+    onCancel?: () => void
+    onSell?: () => void
+  }) =>
+    open ? (
+      <div>
+        <div>{ownerName} 수동 매각 모달</div>
+        <button onClick={onCancel}>매각 취소</button>
+        <button onClick={onSell}>매각하기</button>
+      </div>
+    ) : null,
+}))
+
+vi.mock('../game/modals/InsufficientFundsModal', () => ({
+  default: () => null,
+}))
+
+vi.mock('../game/modals/TollModal', () => ({
+  default: () => null,
+}))
+
+vi.mock('../game/modals/BankruptModal', () => ({
+  default: () => null,
+}))
+
+vi.mock('../game/modals/DoubleDicePopup', () => ({
+  default: () => null,
+}))
+
+vi.mock('../game/modals/GameResultModal', () => ({
+  default: () => null,
+}))
+
+vi.mock('../game/modals/GoToIslandModal', () => ({
+  default: () => null,
+}))
+
+vi.mock('../game/modals/IslandModal', () => ({
+  default: () => null,
+}))
+
+const players: PlayerState[] = [
+  {
+    id: 1,
+    name: '플레이어1',
+    color: '#ff0000',
+    pos: 0,
+    money: 1000,
+    skipTurns: 0,
+  },
+  {
+    id: 2,
+    name: '플레이어2',
+    color: '#00ff00',
+    pos: 3,
+    money: 1000,
+    skipTurns: 0,
+  },
+]
+
+const tiles = [
+  {
+    index: 1,
+    name: '테스트서울',
+    type: 'PROPERTY',
+    building: 1,
+    level: 1,
+    price: 1000,
+    color: '#ff0000',
+    owner_id: 1,
+  },
+  {
+    index: 2,
+    name: '테스트부산',
+    type: 'PROPERTY',
+    building: 1,
+    level: 1,
+    price: 1200,
+    color: '#00ff00',
+    owner_id: 2,
+  },
+  {
+    index: 16,
+    name: '여행',
+    type: 'TRAVEL',
+    building: 0,
+  },
+] as const
+
+const renderGameBoard = (options?: {
+  activePrompt?: GamePrompt | null
+  onPromptChoice?: (choice: string, payload?: Record<string, unknown>) => void
+  allowAssetActions?: boolean
+  gamePhase?: 'rolling' | 'resolving' | 'waiting'
+}) =>
+  render(
+    <GameBoard
+      gameId="game-1"
+      players={players}
+      curPlayer={0}
+      round={1}
+      gamePhase={options?.gamePhase ?? 'rolling'}
+      allowAssetActions={options?.allowAssetActions ?? true}
+      activePrompt={options?.activePrompt ?? null}
+      onPromptChoice={options?.onPromptChoice}
+      tiles={[...tiles]}
+      localPlayerId={1}
+    />
+  )
+
+beforeAll(() => {
+  class ResizeObserverMock {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+
+  class AudioMock {
+    play() {
+      return Promise.resolve()
+    }
+  }
+
+  vi.stubGlobal('ResizeObserver', ResizeObserverMock)
+  vi.stubGlobal('Audio', AudioMock)
+})
+
+afterAll(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('GameBoard manual sell selection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useGameStore.getState().resetGame()
+  })
+
+  it('opens local sell modal for owned tile and emits SELL_PROPERTY on confirm', async () => {
+    const user = userEvent.setup()
+    renderGameBoard()
+
+    await user.click(screen.getByText('테스트서울'))
+
+    expect(screen.getByText('플레이어1 수동 매각 모달')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: '매각하기' }))
+
+    expect(emitGameAction).toHaveBeenCalledWith({
+      type: 'SELL_PROPERTY',
+      gameId: 'game-1',
+      payload: {
+        tileId: 1,
+        buildingLevel: 1,
+      },
+    })
+  })
+
+  it('does not open local sell modal for another player owned tile', async () => {
+    const user = userEvent.setup()
+    renderGameBoard()
+
+    await user.click(screen.getByText('테스트부산'))
+
+    expect(screen.queryByText(/수동 매각 모달/)).not.toBeInTheDocument()
+    expect(emitGameAction).not.toHaveBeenCalled()
+  })
+
+  it('does not open local sell modal while another prompt is visible', async () => {
+    const user = userEvent.setup()
+    renderGameBoard({
+      activePrompt: {
+        id: 'build-1',
+        type: 'BUILD_OR_SKIP',
+      },
+    })
+
+    await user.click(screen.getByText('테스트서울'))
+
+    expect(screen.queryByText(/수동 매각 모달/)).not.toBeInTheDocument()
+  })
+
+  it('prioritizes travel selection over local sell click', async () => {
+    const user = userEvent.setup()
+    const onPromptChoice = vi.fn()
+    renderGameBoard({
+      activePrompt: {
+        id: 'travel-1',
+        type: 'TRAVEL',
+        choices: [
+          { id: 'confirm', label: '확인', value: 'CONFIRM' },
+          { id: 'cancel', label: '취소', value: 'SKIP' },
+        ],
+      },
+      onPromptChoice,
+    })
+
+    await user.click(screen.getByRole('button', { name: '여행 확인' }))
+    await user.click(screen.getByText('테스트서울'))
+
+    expect(screen.queryByText(/수동 매각 모달/)).not.toBeInTheDocument()
+    expect(onPromptChoice).toHaveBeenCalledWith('CONFIRM', {
+      targetTileId: 1,
+    })
+  })
+})

--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -127,6 +127,7 @@ const BOARD_RENDER_BASE_SIZE =
   BOARD_GRID_BASE_SIZE + BOARD_INNER_PADDING + BOARD_INNER_BORDER
 const MIN_BOARD_SCALE = 0.55
 const MAX_BOARD_SCALE = 2.4
+const OWNED_TILE_SELL_BOX_SHADOW = '0 0 0 3px rgba(245,158,11,0.55)'
 
 const INITIAL_CITY_SELL_MODAL_STATE: CitySellModalState = {
   open: false,
@@ -2125,7 +2126,67 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       isLocalPlayersTurn && allowAssetActions && isAssetActionPhase
     const isTravelSelectableTile = (tileId: number) =>
       travelSelection.active && tileId !== players[curPlayer]?.pos
-    const isOwnedTileSellClickable = () => false
+    const openLocalSellModal = (tileId: number) => {
+      const tile = boardTiles[tileId]
+      const owner = tileOwnersRef.current[tileId]
+      const activePlayer = players[curPlayer]
+
+      if (
+        !tile ||
+        tile.type !== 'PROPERTY' ||
+        !owner ||
+        !activePlayer ||
+        String(owner.ownerId) !== String(activePlayer.id)
+      ) {
+        return
+      }
+
+      const ownerName =
+        players.find((player) => String(player.id) === String(owner.ownerId))
+          ?.name ??
+        activePlayer.name ??
+        ''
+
+      setCitySellModal({
+        open: true,
+        tileId,
+        ownerName,
+        currentLevel: owner.level,
+        sellPrice: getBoardSellFallbackRefund(tile.price ?? 0, owner.level),
+        showBuildOnCancel: false,
+      })
+    }
+    const isOwnedTileSellClickable = (tileId: number) => {
+      if (!canManageOwnAssets || travelSelection.active || activePrompt) {
+        return false
+      }
+
+      const tile = boardTiles[tileId]
+      const owner = tileOwnersRef.current[tileId]
+      if (
+        !tile ||
+        tile.type !== 'PROPERTY' ||
+        !owner ||
+        activePlayerId == null
+      ) {
+        return false
+      }
+
+      return String(owner.ownerId) === String(activePlayerId)
+    }
+    const getTileClickState = (tileId: number) => {
+      const isTravelSelectable = isTravelSelectableTile(tileId)
+      const isOwnedSellClickable = isOwnedTileSellClickable(tileId)
+
+      return {
+        isClickable: isTravelSelectable || isOwnedSellClickable,
+        boxShadow: isTravelSelectable
+          ? '0 0 0 3px rgba(43,127,255,0.9)'
+          : isOwnedSellClickable
+            ? OWNED_TILE_SELL_BOX_SHADOW
+            : undefined,
+      }
+    }
     const handleBoardTileClick = (tileId: number) => {
       if (isGameOver) return
 
@@ -2143,7 +2204,11 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
         return
       }
 
-      // 본인 땅 매각 모달 강제 오픈 로직 제거 (서버 프롬프트 기반으로만 매각 처리)
+      if (!isOwnedTileSellClickable(tileId)) {
+        return
+      }
+
+      openLocalSellModal(tileId)
     }
 
     const handleCityBuildConfirm = (tileId: number) => {
@@ -2212,9 +2277,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
             {TOP_ROW.map((id, ci) =>
               (() => {
                 const isCornerTile = ci === 0 || ci === 8
-                const isTravelSelectable = isTravelSelectableTile(id)
-                const isOwnedSellClickable = isOwnedTileSellClickable()
-                const isClickable = isTravelSelectable || isOwnedSellClickable
+                const { isClickable, boxShadow } = getTileClickState(id)
                 return (
                   <div
                     key={id}
@@ -2226,9 +2289,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
                       gridColumn: ci + 1,
                       cursor: isClickable ? 'pointer' : 'default',
                       borderRadius: isCornerTile ? 18 : 13,
-                      boxShadow: isTravelSelectable
-                        ? '0 0 0 3px rgba(43,127,255,0.9)'
-                        : undefined,
+                      boxShadow,
                       transition: 'box-shadow 0.2s ease',
                     }}
                   >
@@ -2249,9 +2310,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
             {BOTTOM_ROW.map((id, ci) =>
               (() => {
                 const isCornerTile = ci === 0 || ci === 8
-                const isTravelSelectable = isTravelSelectableTile(id)
-                const isOwnedSellClickable = isOwnedTileSellClickable()
-                const isClickable = isTravelSelectable || isOwnedSellClickable
+                const { isClickable, boxShadow } = getTileClickState(id)
                 return (
                   <div
                     key={id}
@@ -2263,9 +2322,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
                       gridColumn: 9 - ci,
                       cursor: isClickable ? 'pointer' : 'default',
                       borderRadius: isCornerTile ? 18 : 13,
-                      boxShadow: isTravelSelectable
-                        ? '0 0 0 3px rgba(43,127,255,0.9)'
-                        : undefined,
+                      boxShadow,
                       transition: 'box-shadow 0.2s ease',
                     }}
                   >
@@ -2285,9 +2342,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
             )}
             {LEFT_COL.map((id, ri) =>
               (() => {
-                const isTravelSelectable = isTravelSelectableTile(id)
-                const isOwnedSellClickable = isOwnedTileSellClickable()
-                const isClickable = isTravelSelectable || isOwnedSellClickable
+                const { isClickable, boxShadow } = getTileClickState(id)
                 return (
                   <div
                     key={id}
@@ -2299,9 +2354,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
                       gridColumn: 1,
                       cursor: isClickable ? 'pointer' : 'default',
                       borderRadius: 13,
-                      boxShadow: isTravelSelectable
-                        ? '0 0 0 3px rgba(43,127,255,0.9)'
-                        : undefined,
+                      boxShadow,
                       transition: 'box-shadow 0.2s ease',
                     }}
                   >
@@ -2321,9 +2374,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
             )}
             {RIGHT_COL.map((id, ri) =>
               (() => {
-                const isTravelSelectable = isTravelSelectableTile(id)
-                const isOwnedSellClickable = isOwnedTileSellClickable()
-                const isClickable = isTravelSelectable || isOwnedSellClickable
+                const { isClickable, boxShadow } = getTileClickState(id)
                 return (
                   <div
                     key={id}
@@ -2335,9 +2386,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
                       gridColumn: 9,
                       cursor: isClickable ? 'pointer' : 'default',
                       borderRadius: 13,
-                      boxShadow: isTravelSelectable
-                        ? '0 0 0 3px rgba(43,127,255,0.9)'
-                        : undefined,
+                      boxShadow,
                       transition: 'box-shadow 0.2s ease',
                     }}
                   >

--- a/src/components/board/gameBoardActionHandlers.test.ts
+++ b/src/components/board/gameBoardActionHandlers.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { emitGameAction } from '../../services/socket/game.handler'
 import { createGameBoardActionHandlers } from './gameBoardActionHandlers'
 import type { BuildModalState } from './gameBoard.types'
+import type { TileOwner } from './board.constants'
 
 vi.mock('../../services/socket/game.handler', () => ({
   emitGameAction: vi.fn(),
@@ -13,11 +14,15 @@ const createDefaultHandlers = (overrides?: {
   gameId?: string | null
   setStatus?: SetState<string>
   setBuildModal?: SetState<BuildModalState>
+  tileOwners?: Record<number, TileOwner>
+  getPlayerIdByIndex?: (playerIdx: number) => number
 }) => {
   const setStatus = overrides?.setStatus ?? vi.fn()
   const setBuildModal = overrides?.setBuildModal ?? vi.fn()
   const gameId: string | null =
     overrides?.gameId === undefined ? 'game-1' : overrides.gameId
+  const tileOwners = overrides?.tileOwners ?? {}
+  const getPlayerIdByIndex = overrides?.getPlayerIdByIndex ?? (() => 0)
 
   return createGameBoardActionHandlers({
     gameId,
@@ -28,8 +33,8 @@ const createDefaultHandlers = (overrides?: {
     setBuildModal: setBuildModal as never,
     setTollModal: vi.fn() as never,
     curPlayerRef: { current: 0 },
-    tileOwnersRef: { current: {} },
-    getPlayerIdByIndex: () => 0,
+    tileOwnersRef: { current: tileOwners },
+    getPlayerIdByIndex,
     getPlayerColorByIndex: () => '#000',
     getPlayerIndexById: () => 0,
     getPurchaseCost: () => 0,
@@ -102,5 +107,29 @@ describe('createGameBoardActionHandlers - non mock build action', () => {
     expect(emitGameAction).not.toHaveBeenCalled()
     expect(setStatus).not.toHaveBeenCalled()
     expect(setBuildModal).not.toHaveBeenCalled()
+  })
+
+  it('sends SELL_PROPERTY action with current owner level', async () => {
+    const handlers = createDefaultHandlers({
+      tileOwners: {
+        7: {
+          ownerId: 11,
+          ownerColor: '#f00',
+          level: 2,
+        },
+      },
+      getPlayerIdByIndex: () => 11,
+    })
+
+    const result = await handlers.sellOwnedTileForPlayer(0, {
+      tileId: 7,
+    })
+
+    expect(result).toBe(true)
+    expect(emitGameAction).toHaveBeenCalledWith({
+      type: 'SELL_PROPERTY',
+      gameId: 'game-1',
+      payload: { tileId: 7, buildingLevel: 2 },
+    })
   })
 })


### PR DESCRIPTION
## 📌 관련 이슈

> closes #649

---

## 📝 작업 내용

- `src/components/board/GameBoard.tsx`
- 관련 보드 테스트
- task 문서와 TODO 상태 정리
- 내 턴의 자산 액션 가능 구간에서는 본인 소유 타일을 클릭해 수동 매각 모달을 열 수 있다.

---

## 🧠 Task 문서 (큰 작업이면 필수)

- plan: docs/ai/tasks/manual-sell-selection-restore/plan.md
- context: docs/ai/tasks/manual-sell-selection-restore/context.md
- checklist: docs/ai/tasks/manual-sell-selection-restore/checklist.md

---

## 📋 TODO.md 연결

- task slug: manual-sell-selection-restore
- TODO status: Done
- TODO entry 확인: TODO.md와 docs/ai/tasks/manual-sell-selection-restore/가 1:1로 연결됨

---

## 📚 참고한 기준 문서

- `AGENTS.md`
- `docs/ai/manuals/common.md`
- `docs/rules.md`
- `docs/testing.md`
- `docs/ai/manuals/game-runtime.md`

---

## 🧪 실행한 검증

- `npm run lint`
- `npm run ai:check:game`
- `npm run ai:check:build`
- `npx vitest run src/components/board/GameBoard.test.tsx src/components/board/gameBoardActionHandlers.test.ts`
- `npm run ai:self-review -- --files TODO.md docs/ai/tasks/manual-sell-selection-restore/checklist.md docs/ai/tasks/manual-sell-selection-restore/context.md docs/ai/tasks/manual-sell-selection-restore/plan.md src/components/board/GameBoard.test.tsx src/components/board/GameBoard.tsx src/components/board/gameBoardActionHandlers.test.ts`
- `npm run ai:pr-gate -- --files TODO.md docs/ai/tasks/manual-sell-selection-restore/checklist.md docs/ai/tasks/manual-sell-selection-restore/context.md docs/ai/tasks/manual-sell-selection-restore/plan.md src/components/board/GameBoard.test.tsx src/components/board/GameBoard.tsx src/components/board/gameBoardActionHandlers.test.ts --pr-body-file /tmp/ai-git-flow-pr-body.md`

---

## ⚠️ 남은 리스크

- 현재 확인된 추가 리스크는 없습니다.

---

## ✅ 체크리스트

- [ ] 로컬에서 정상 동작 확인
- [ ] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료
- [x] 큰 작업이면 task 문서 링크를 남겼다
- [x] 큰 작업이면 `TODO.md` / task slug 연결을 PR 본문에 남겼다
- [x] 참고한 기준 문서를 PR 본문에 남겼다
- [x] 실행한 검증과 남은 리스크를 PR 본문에 적었다

---

## 📸 스크린샷 (선택)

> UI 변경이 있을 경우 첨부해주세요.