### PR TITLE
fix: 게임 보드 이동 후 모달 노출 및 턴 종료 타이밍 정리

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -17,6 +17,8 @@
 
 ## Done
 
+- [x] `end-turn-after-board-settle` - End Turn After Board Settle (`docs/ai/tasks/end-turn-after-board-settle/`) - 말 이동과 보드 로컬 액션이 모두 해소된 뒤에만 턴 종료 버튼이 보이고 눌리도록 `GamePage`를 `GameBoard` blocking 상태와 다시 연결
+- [x] `game-board-modal-reveal-timing` - Game Board Modal Reveal Timing (`docs/ai/tasks/game-board-modal-reveal-timing/`) - PLAYER_MOVED 직후 보드 액션 모달이 말 이동 전에 한 프레임 보이는 경로를 barrier와 공통 reveal gate로 정리
 - [x] `manual-sell-selection-restore` - Manual Sell Selection Restore (`docs/ai/tasks/manual-sell-selection-restore/`) - 내 턴 자산 액션 구간에서 보유 토지 클릭 수동 매각을 복구하되 서버 sell prompt 경로와 충돌하지 않게 정리
 - [x] `forced-island-fast-move-fix` - Forced Island Fast Move Fix (`docs/ai/tasks/forced-island-fast-move-fix/`) - 무인도 강제 이동만 빠른 애니메이션을 적용하고 일반 무인도 착지/출발은 기본 속도로 유지
 - [x] `group-chat-sender-grouping-ui` - Group Chat Sender Grouping UI (`docs/ai/tasks/group-chat-sender-grouping-ui/`) - 대기방/게임 공용 채팅을 sender grouping, 아바타, 이름 강조, 역할 badge 기반 실무형 그룹 채팅 UI로 정리

--- a/docs/ai/tasks/end-turn-after-board-settle/checklist.md
+++ b/docs/ai/tasks/end-turn-after-board-settle/checklist.md
@@ -1,0 +1,26 @@
+# Checklist
+
+## Implementation
+
+- [x] 관련 manual과 기존 문서를 읽었다
+- [x] 영향 범위를 정리했다
+- [x] `GamePage`가 `BoardGame.onBlockingModalChange`를 사용하도록 다시 연결했다
+- [x] 턴 제어 / 버튼 모드 / 자산 액션 허용 조건에 board blocking 상태를 반영했다
+- [x] `START`/일반 `PROPERTY`처럼 모달이 없는 도착 경로도 같은 기준을 따르도록 유지했다
+
+## Testing
+
+- [x] `npx vitest run src/pages/GamePage.test.tsx`
+- [x] `npm run lint`
+- [x] `npm run ai:check:game`
+- [x] `npm run build`
+
+## Review
+
+- [x] `docs/rules.md` 기준으로 셀프 리뷰했다
+- [x] blocked 상태에서 `END_TURN` emit이 되지 않는지 확인했다
+- [x] unblocked 상태에서만 `턴 종료` 모드로 바뀌는지 확인했다
+- [x] `TODO.md` task 한 줄을 최신 상태로 유지했다
+- [x] session handoff notes를 최신 상태로 갱신했다
+- [x] `npm run ai:self-review -- --files ...`를 실행했다
+- [x] 변경 파일 / 실행한 검증 / 남은 리스크를 정리했다

--- a/docs/ai/tasks/end-turn-after-board-settle/context.md
+++ b/docs/ai/tasks/end-turn-after-board-settle/context.md
@@ -1,0 +1,45 @@
+# Context
+
+## Current Behavior
+
+- `GamePage`는 현재 `phase === 'resolving' && !prompt`만 보면 즉시 `end_turn` 모드로 전환한다.
+- `GameBoard`는 이미 `onBlockingModalChange`로 `isEventQueuePaused`를 부모에 올릴 수 있지만, `GamePage`는 이 신호를 사용하지 않는다.
+- 그래서 말 이동 중이거나 `Chance/Event/Travel/Island` 같은 보드 액션이 남아 있어도 부모 기준에서는 턴 종료가 가능해 보일 수 있다.
+
+## Related Files
+
+- `src/pages/GamePage.tsx`
+- `src/pages/GamePage.test.tsx`
+- `src/components/board/GameBoard.tsx`
+- `docs/ai/tasks/game-board-modal-reveal-timing/*`
+
+## Relevant Manuals
+
+- `docs/ai/manuals/common.md`
+- `docs/ai/manuals/game-runtime.md`
+- `docs/rules.md`
+- `docs/testing.md`
+
+## Constraints
+
+- `GameBoard`의 blocking 의미와 barrier/reveal timing 로직은 유지한다.
+- public socket contract와 store shape는 바꾸지 않는다.
+- 버튼 UX는 숨김이 아니라 `roll` 모드 disabled 유지 -> `end_turn` 전환으로 맞춘다.
+
+## Decision Notes
+
+- 턴 종료 허용 기준과 버튼 모드 전환 시점을 같은 `isBoardBlockingModalOpen` 상태에 묶는다.
+- `START`/일반 `PROPERTY`처럼 모달이 없는 도착 칸도 `GameBoard`의 blocked 신호로 막는다.
+- `canManageAssetsThisTurn`도 같은 기준을 써서 보드가 아직 정리되지 않았을 때 자산 액션이 열리지 않게 한다.
+
+## Session Handoff Notes
+
+- 다음 세션에서 다시 읽을 문서: `docs/ai/tasks/end-turn-after-board-settle/*`, `docs/ai/manuals/game-runtime.md`
+- 바로 이어서 할 1개 단계: 필요 시 실제 게임에서 modal 있는 경로 / 없는 경로 수동 확인
+- pending decision / blocker: 없음
+- 검증 재개 지점: `npx vitest run src/pages/GamePage.test.tsx`, `npm run lint`, `npm run ai:check:game`, `npm run build`, `npm run ai:self-review -- --files ...`
+
+## Open Risks
+
+- `GameBoard`가 올리는 blocked 상태가 보수적으로 잡혀 있으면 턴 종료가 의도보다 조금 늦게 풀릴 수 있다.
+- 이번 테스트는 `GamePage` 부모-자식 연결 회귀를 검증한 것이고, 실제 이동 타이밍의 세부 연출은 여전히 `GameBoard` 쪽 barrier 로직에 의존한다.

--- a/docs/ai/tasks/end-turn-after-board-settle/plan.md
+++ b/docs/ai/tasks/end-turn-after-board-settle/plan.md
@@ -1,0 +1,68 @@
+# Plan
+
+## Task
+
+- 작업 이름: End Turn After Board Settle
+- 작업 slug: `end-turn-after-board-settle`
+- 요청 날짜: 2026-03-26
+- 담당 범위: `GameBoard`가 올리는 blocking 상태를 `GamePage`의 턴 제어와 다시 연결해 말 도착 후 보드 정리가 끝난 뒤에만 턴 종료를 허용
+
+## Goal
+
+- 말 이동 중이거나 보드 로컬 액션이 남아 있으면 `턴 종료`가 보이거나 눌리지 않는다.
+- `GameBoard`가 `blocked=false`를 올린 뒤에만 `RollButton`이 `end_turn` 모드로 바뀐다.
+- `START`나 일반 `PROPERTY`처럼 모달이 없는 도착 칸도 이동 완료 전에는 턴 종료가 노출되지 않는다.
+
+## WAT Workflow
+
+1. task 문서와 TODO를 정리해 범위 / 완료 기준 / 검증 명령을 고정한다.
+2. `GamePage`에 board blocking 상태를 연결하고 턴 제어/버튼 모드/자산 액션 허용 조건을 모두 같은 기준으로 묶는다.
+3. `GamePage.test.tsx`의 `GameBoard`/`RollButton` mock을 실사용 형태로 올리고 blocked/unblocked 회귀 테스트를 추가한다.
+
+## In Scope
+
+- `src/pages/GamePage.tsx`
+- `src/pages/GamePage.test.tsx`
+- `docs/ai/tasks/end-turn-after-board-settle/*`
+- `TODO.md`
+
+## Out Of Scope
+
+- `GameBoard`의 barrier/reveal timing 로직 변경
+- 게임 소켓 contract / store shape 변경
+- 자동 턴 종료 UX
+
+## Target Files
+
+- `src/pages/GamePage.tsx`
+- `src/pages/GamePage.test.tsx`
+- `docs/ai/tasks/end-turn-after-board-settle/*`
+- `TODO.md`
+
+## Task Tracking
+
+- TODO line: - [x] `end-turn-after-board-settle` - End Turn After Board Settle (`docs/ai/tasks/end-turn-after-board-settle/`)
+- Session brief: `npm run ai:session:brief -- end-turn-after-board-settle`
+- Reopen docs: `docs/ai/tasks/end-turn-after-board-settle/plan.md`, `context.md`, `checklist.md`, 관련 manuals
+
+## Completion Criteria
+
+- `GamePage`가 `BoardGame`의 `onBlockingModalChange`를 사용한다.
+- blocked 상태에서는 `RollButton`이 `turn end` 모드로 바뀌지 않고 `END_TURN` emit이 발생하지 않는다.
+- unblocked 상태가 된 뒤에만 `턴 종료`가 보이고 클릭 시 `END_TURN` emit이 된다.
+- 관련 Vitest / lint / game check / build가 통과한다.
+
+## Role Plan
+
+- Planner: blocked 신호를 부모 턴 제어 정책에 어떻게 연결할지 정리
+- Implementer: `GamePage` 조건과 버튼 모드 계산 복구
+- Reviewer: 말 도착 전 턴 종료 선노출과 asset-action 경계 회귀 점검
+- Tester: blocked/unblocked end-turn 회귀 테스트와 game 검증 실행
+
+## Test Plan
+
+- `npx vitest run src/pages/GamePage.test.tsx`
+- `npm run lint`
+- `npm run ai:check:game`
+- `npm run build`
+- `npm run ai:self-review -- --files TODO.md docs/ai/tasks/end-turn-after-board-settle/plan.md docs/ai/tasks/end-turn-after-board-settle/context.md docs/ai/tasks/end-turn-after-board-settle/checklist.md src/pages/GamePage.tsx src/pages/GamePage.test.tsx`

--- a/docs/ai/tasks/game-board-modal-reveal-timing/checklist.md
+++ b/docs/ai/tasks/game-board-modal-reveal-timing/checklist.md
@@ -1,0 +1,7 @@
+# Checklist
+
+- [x] `PLAYER_MOVED` 시작 직전에 board modal barrier를 올린다
+- [x] 이동 완료 후 `handleArrival()` 다음 프레임에 barrier를 내린다
+- [x] 보드 액션 modal visibility가 공통 reveal gate를 따른다
+- [x] `GameBoard.test.tsx`에 prompt-driven / local arrival 회귀 테스트를 추가했다
+- [x] lint, game check, build를 실행했다

--- a/docs/ai/tasks/game-board-modal-reveal-timing/context.md
+++ b/docs/ai/tasks/game-board-modal-reveal-timing/context.md
@@ -1,0 +1,19 @@
+# Context
+
+## Why
+
+- 현재 `shouldDelayPromptModalByMovement()`는 `pendingMovePlayerIdSet`와 `isMoving`만 본다.
+- `PLAYER_MOVED`를 consume하는 순간 queue에서는 이동 이벤트가 빠지지만 `isMoving`은 다음 렌더에 반영되어, modal reveal이 먼저 되는 짧은 틈이 생긴다.
+- `GamePage`의 턴 종료 버튼보다 더 근본적인 원인은 `GameBoard` 자체의 modal reveal 타이밍 경계가 빠진 상태다.
+
+## Scope
+
+- `GameBoard` modal reveal timing
+- `GameBoard.test.tsx` 회귀 테스트
+- 기존 slug 문서 복구
+
+## Non-Goals
+
+- prompt contract 변경
+- `GamePage`의 턴 종료 버튼 모드 정책 변경
+- 무인도 이동 UX 단계 축소

--- a/docs/ai/tasks/game-board-modal-reveal-timing/plan.md
+++ b/docs/ai/tasks/game-board-modal-reveal-timing/plan.md
@@ -1,0 +1,21 @@
+# Game Board Modal Reveal Timing
+
+## Summary
+
+- `PLAYER_MOVED` consume 직후 prompt/local board modal이 말 이동 전에 한 프레임 보이는 문제를 막는다.
+- `GameBoard`에 보드 액션 modal 전용 barrier를 두고, 이동 시작 전부터 이동 완료 후 다음 프레임까지 modal reveal을 지연한다.
+
+## Implementation
+
+1. `GameBoard`에 `boardActionModalBarrier`와 `requestAnimationFrame` 기반 release 로직을 추가한다.
+2. `PLAYER_MOVED` 처리에서 이동 시작 직전에 barrier를 올리고, `movePlayerSequentially()` 완료 후 `handleArrival()` 호출 다음 프레임에 barrier를 내린다.
+3. `buy/build/toll/acquisition/sell/card/travel/go_to_island/island` modal visibility를 공통 reveal gate로 통일한다.
+4. `isEventQueuePaused`와 `onBlockingModalChange`도 같은 barrier를 반영해 부모와 queue pause 의미를 맞춘다.
+5. `GameBoard.test.tsx`에 prompt-driven modal과 local arrival modal 대표 경로 회귀 테스트를 추가한다.
+
+## Validation
+
+- `npx vitest run src/components/board/GameBoard.test.tsx`
+- `npm run lint`
+- `npm run ai:check:game`
+- `npm run build`

--- a/src/components/board/GameBoard.test.tsx
+++ b/src/components/board/GameBoard.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen } from '@testing-library/react'
+import { act, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import {
   afterAll,
+  afterEach,
   beforeAll,
   beforeEach,
   describe,
@@ -11,7 +12,7 @@ import {
 } from 'vitest'
 import GameBoard from './GameBoard'
 import type { PlayerState } from './board.constants'
-import type { GamePrompt } from '../../types/domain'
+import type { GamePrompt, ServerEvent } from '../../types/domain'
 import { emitGameAction } from '../../services/socket/game.handler'
 import { useGameStore } from '../../stores/game.store'
 
@@ -22,8 +23,13 @@ vi.mock('./BoardTile', () => ({
   PlayerToken: () => null,
 }))
 
+const useBoardEventQueueMock = vi.fn()
+
 vi.mock('./useBoardEventQueue', () => ({
-  useBoardEventQueue: () => undefined,
+  useBoardEventQueue: (params: unknown) => {
+    useBoardEventQueueMock(params)
+    return undefined
+  },
 }))
 
 vi.mock('../../lib/bgm', () => ({
@@ -40,7 +46,13 @@ vi.mock('../game/GlobalEffectOverlay', () => ({
 }))
 
 vi.mock('../game/modals/BuyModal', () => ({
-  default: () => null,
+  default: ({
+    open,
+    cityName,
+  }: {
+    open: boolean
+    cityName?: string
+  }) => (open ? <div>{cityName || '도시'} 구매 모달</div> : null),
 }))
 
 vi.mock('../game/modals/BuildModal', () => ({
@@ -102,7 +114,8 @@ vi.mock('../game/modals/GameResultModal', () => ({
 }))
 
 vi.mock('../game/modals/GoToIslandModal', () => ({
-  default: () => null,
+  default: ({ open }: { open: boolean }) =>
+    open ? <div>무인도 이동 모달</div> : null,
 }))
 
 vi.mock('../game/modals/IslandModal', () => ({
@@ -155,6 +168,18 @@ const tiles = [
     type: 'TRAVEL',
     building: 0,
   },
+  {
+    index: 8,
+    name: '무인도',
+    type: 'ISLAND',
+    building: 0,
+  },
+  {
+    index: 24,
+    name: '섬으로 이동',
+    type: 'MOVE_TO_ISLAND',
+    building: 0,
+  },
 ] as const
 
 const renderGameBoard = (options?: {
@@ -178,6 +203,31 @@ const renderGameBoard = (options?: {
     />
   )
 
+const getBoardQueueCallbacks = () => {
+  const lastCall = useBoardEventQueueMock.mock.lastCall?.[0] as
+    | {
+        onEventConsumed?: (event: ServerEvent) => void
+      }
+    | undefined
+
+  if (!lastCall?.onEventConsumed) {
+    throw new Error('GameBoard queue callbacks were not captured')
+  }
+
+  return lastCall
+}
+
+const consumeQueuedBoardEvent = async () => {
+  await act(async () => {
+    const nextEvent = useGameStore.getState().consumeNextEvent()
+    if (!nextEvent) {
+      throw new Error('No queued board event to consume')
+    }
+    getBoardQueueCallbacks().onEventConsumed?.(nextEvent)
+    await Promise.resolve()
+  })
+}
+
 beforeAll(() => {
   class ResizeObserverMock {
     observe() {}
@@ -193,6 +243,15 @@ beforeAll(() => {
 
   vi.stubGlobal('ResizeObserver', ResizeObserverMock)
   vi.stubGlobal('Audio', AudioMock)
+  vi.stubGlobal(
+    'requestAnimationFrame',
+    ((callback: FrameRequestCallback) =>
+      window.setTimeout(() => callback(performance.now()), 16)) as typeof requestAnimationFrame
+  )
+  vi.stubGlobal(
+    'cancelAnimationFrame',
+    ((handle: number) => window.clearTimeout(handle)) as typeof cancelAnimationFrame
+  )
 })
 
 afterAll(() => {
@@ -271,5 +330,95 @@ describe('GameBoard manual sell selection', () => {
     expect(onPromptChoice).toHaveBeenCalledWith('CONFIRM', {
       targetTileId: 1,
     })
+  })
+})
+
+describe('GameBoard modal reveal timing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    useGameStore.getState().resetGame()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('keeps buy prompt modal hidden until movement fully finishes', async () => {
+    useGameStore.getState().enqueueEvents([
+      {
+        type: 'PLAYER_MOVED',
+        playerId: 1,
+        tileIndex: 1,
+        payload: {
+          fromIndex: 0,
+        },
+      } as ServerEvent,
+    ])
+
+    renderGameBoard({
+      activePrompt: {
+        id: 'buy-1',
+        type: 'BUY_OR_SKIP',
+        payload: {
+          tileId: 1,
+        },
+        choices: [
+          { id: 'buy', label: '구매하기', value: 'BUY' },
+          { id: 'skip', label: '건너뛰기', value: 'SKIP' },
+        ],
+      },
+    })
+
+    expect(screen.queryByText(/구매 모달/)).not.toBeInTheDocument()
+
+    await consumeQueuedBoardEvent()
+
+    expect(screen.queryByText(/구매 모달/)).not.toBeInTheDocument()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1580)
+    })
+
+    expect(screen.queryByText(/구매 모달/)).not.toBeInTheDocument()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(16)
+    })
+
+    expect(screen.getByText(/구매 모달/)).toBeInTheDocument()
+  })
+
+  it('reveals go-to-island modal only after movement finishes and next frame passes', async () => {
+    useGameStore.getState().enqueueEvents([
+      {
+        type: 'PLAYER_MOVED',
+        playerId: 1,
+        tileIndex: 24,
+        payload: {
+          fromIndex: 23,
+        },
+      } as ServerEvent,
+    ])
+
+    renderGameBoard()
+
+    expect(screen.queryByText('무인도 이동 모달')).not.toBeInTheDocument()
+
+    await consumeQueuedBoardEvent()
+
+    expect(screen.queryByText('무인도 이동 모달')).not.toBeInTheDocument()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1580)
+    })
+
+    expect(screen.queryByText('무인도 이동 모달')).not.toBeInTheDocument()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(16)
+    })
+
+    expect(screen.getByText('무인도 이동 모달')).toBeInTheDocument()
   })
 })

--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -534,10 +534,13 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       Record<string, number>
     >({})
     const [isMoving, setIsMoving] = useState(false)
+    const [boardActionModalBarrier, setBoardActionModalBarrier] =
+      useState(false)
     const [travelingPlayerIds, setTravelingPlayerIds] = useState<
       Record<string, boolean>
     >({})
     const travelFxTimeoutRef = useRef<Record<string, number>>({})
+    const boardActionModalBarrierFrameRef = useRef<number | null>(null)
     const lastMovePositionRef = useRef<Record<string, number>>({})
     const pendingChanceMoveHintRef = useRef<
       Record<string, { direction: BoardMoveDirection; steps: number }>
@@ -572,6 +575,25 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
         return next
       })
     }, [])
+    const clearBoardActionModalBarrierFrame = useCallback(() => {
+      if (boardActionModalBarrierFrameRef.current != null) {
+        window.cancelAnimationFrame(boardActionModalBarrierFrameRef.current)
+        boardActionModalBarrierFrameRef.current = null
+      }
+    }, [])
+    const lockBoardActionModals = useCallback(() => {
+      clearBoardActionModalBarrierFrame()
+      setBoardActionModalBarrier(true)
+    }, [clearBoardActionModalBarrierFrame])
+    const releaseBoardActionModalsNextFrame = useCallback(() => {
+      clearBoardActionModalBarrierFrame()
+      boardActionModalBarrierFrameRef.current = window.requestAnimationFrame(
+        () => {
+          boardActionModalBarrierFrameRef.current = null
+          setBoardActionModalBarrier(false)
+        }
+      )
+    }, [clearBoardActionModalBarrierFrame])
     const startTravelTokenFx = useCallback(
       (playerId: PlayerId, durationMs = 1400) => {
         const playerKey = String(playerId)
@@ -616,6 +638,11 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       }
       setIsDiceRolling(false)
     }, [freezeDiceRollValues])
+    useEffect(() => {
+      return () => {
+        clearBoardActionModalBarrierFrame()
+      }
+    }, [clearBoardActionModalBarrierFrame])
     const flashDiceRollAnimation = useCallback(
       (durationMs = 260) => {
         stopDiceRollAnimation()
@@ -877,6 +904,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
             toIndex: tileIndex,
             tiles: boardTiles,
           })
+          lockBoardActionModals()
           if (isTravelMove && event.playerId != null) {
             startTravelTokenFx(event.playerId, 1600)
           }
@@ -892,23 +920,27 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
           )
 
           // 애니메이션 시작 (비동기로 실행하여 이벤트 큐의 지연과 맞춤)
-          movePromise.then(() => {
-            if (isChanceTriggeredMove && playerKey && playerKey !== 'null') {
-              delete pendingChanceMoveHintRef.current[playerKey]
-            }
-            if (playerKey && playerKey !== 'null') {
-              lastMovePositionRef.current[playerKey] = tileIndex
-            }
-            if (isTravelMove && event.playerId != null) {
-              clearTravelTokenFx(event.playerId)
-            }
-            // 애니메이션 종료 후 도착 처리 (모달 띄우기 등)
-            handleArrivalRef.current(
-              tileIndex,
-              emitMockEndTurn,
-              event.playerId ?? null
-            )
-          })
+          void movePromise
+            .then(() => {
+              if (isChanceTriggeredMove && playerKey && playerKey !== 'null') {
+                delete pendingChanceMoveHintRef.current[playerKey]
+              }
+              if (playerKey && playerKey !== 'null') {
+                lastMovePositionRef.current[playerKey] = tileIndex
+              }
+              if (isTravelMove && event.playerId != null) {
+                clearTravelTokenFx(event.playerId)
+              }
+              // 애니메이션 종료 후 도착 처리 (모달 띄우기 등)
+              handleArrivalRef.current(
+                tileIndex,
+                emitMockEndTurn,
+                event.playerId ?? null
+              )
+            })
+            .finally(() => {
+              releaseBoardActionModalsNextFrame()
+            })
           return
         }
 
@@ -956,8 +988,10 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
         emitMockEndTurn,
         freezeDiceRollValues,
         flashDiceRollAnimation,
+        lockBoardActionModals,
         localPlayerId,
         movePlayerSequentially,
+        releaseBoardActionModalsNextFrame,
         startTravelTokenFx,
       ]
     )
@@ -1345,7 +1379,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
         promptPlayerId,
         pendingMovePlayerIdSet,
         animatedPositions,
-        isMoving: isMoving || rolling,
+        isMoving: isMoving || rolling || boardActionModalBarrier,
       })
       if (shouldDelayTravelModalOpen) {
         return
@@ -1381,6 +1415,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       animatedPositions,
       curPlayer,
       dismissedTravelPromptId,
+      boardActionModalBarrier,
       isTravelPromptOpen,
       isMoving,
       pendingMovePlayerIdSet,
@@ -2003,38 +2038,37 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
 
     const hasAnimationBlocking = isMoving || rolling
     const canShowModal = !hasAnimationBlocking
+    const boardActionAnimationBlocking =
+      hasAnimationBlocking || boardActionModalBarrier
     const activePromptPlayerId =
       activePrompt?.playerId != null ? String(activePrompt.playerId) : null
     const shouldDelayPromptModal = shouldDelayPromptModalByMovement({
       promptPlayerId: activePromptPlayerId,
       pendingMovePlayerIdSet,
       animatedPositions,
-      isMoving,
+      isMoving: boardActionAnimationBlocking,
     })
+    const canRevealBoardActionModal =
+      canShowModal && !shouldDelayPromptModal && !boardActionModalBarrier
 
     const buyModalVisible =
-      canShowModal &&
+      canRevealBoardActionModal &&
       buyModalOpen &&
-      !shouldDelayPromptModal &&
       !isBuyPromptDismissed &&
       !insufficientFundsModal.open
     const buildModalVisible =
-      canShowModal &&
+      canRevealBoardActionModal &&
       buildModalOpen &&
-      !shouldDelayPromptModal &&
       !isBuildPromptDismissed &&
       !insufficientFundsModal.open
-    const tollModalVisible =
-      canShowModal && tollModalOpen && !shouldDelayPromptModal
+    const tollModalVisible = canRevealBoardActionModal && tollModalOpen
     const acquisitionModalOpen =
-      canShowModal &&
+      canRevealBoardActionModal &&
       acquisitionModalOpenRaw &&
-      !shouldDelayPromptModal &&
       !tollModalOpen &&
       !insufficientFundsModal.open
     const sellModalVisible =
-      canShowModal &&
-      (citySellModal.open || (isSellPromptOpen && !shouldDelayPromptModal))
+      canRevealBoardActionModal && (citySellModal.open || isSellPromptOpen)
 
     const doubleDiceModalVisible = canShowModal && doubleDiceModal.open
 
@@ -2082,20 +2116,21 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
     const hasBlockingModalOpen =
       buyModalVisible ||
       buildModalVisible ||
-      cardModal.open ||
-      travelModal.open ||
+      (canRevealBoardActionModal && cardModal.open) ||
+      (canRevealBoardActionModal && travelModal.open) ||
       tollModalVisible ||
       acquisitionModalOpen ||
       sellModalVisible ||
       insufficientFundsModal.open ||
       aiModal.open ||
-      goToIslandModal.open ||
-      islandModal.open ||
+      (canRevealBoardActionModal && goToIslandModal.open) ||
+      (canRevealBoardActionModal && islandModal.open) ||
       doubleDiceModalVisible ||
       bankruptModal.open ||
       gameResultModal.open
     const isEventQueuePaused =
       hasAnimationBlocking ||
+      boardActionModalBarrier ||
       hasBlockingModalOpen ||
       travelSelection.active ||
       promptSubmittingChoice !== null
@@ -2648,7 +2683,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
           }}
         />
         <CardModal
-          open={canShowModal && cardModal.open}
+          open={canRevealBoardActionModal && cardModal.open}
           variant={cardModal.variant}
           title={cardModal.title}
           descriptionLine1={cardModal.descriptionLine1}
@@ -2657,7 +2692,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
           onConfirm={handleCardConfirm}
         />
         <TravelModal
-          open={canShowModal && !shouldDelayPromptModal && travelModal.open}
+          open={canRevealBoardActionModal && travelModal.open}
           onConfirm={handleTravelConfirm}
           onCancel={handleTravelCancel}
           showCancel={false}
@@ -2684,13 +2719,17 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
         />
         <GoToIslandModal
           open={
-            canShowModal && (isGoToIslandPromptOpen || goToIslandModal.open)
+            canRevealBoardActionModal &&
+            (isGoToIslandPromptOpen || goToIslandModal.open)
           }
           onConfirm={handleGoToIslandConfirm}
         />
         {/* 🏝️ 무인도 (직접 도착) 팝업 */}
         <IslandModal
-          open={canShowModal && (isIslandPromptOpen || islandModal.open)}
+          open={
+            canRevealBoardActionModal &&
+            (isIslandPromptOpen || islandModal.open)
+          }
           restTurns={islandRestTurns}
           onConfirm={handleIslandConfirm}
         />

--- a/src/pages/GamePage.test.tsx
+++ b/src/pages/GamePage.test.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from 'react'
+import { forwardRef, useEffect } from 'react'
 import { Route, Routes } from 'react-router-dom'
 import { act, cleanup, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
@@ -21,6 +21,7 @@ vi.mock('../config/env', () => ({
 const {
   sendWaitingRoomChatMock,
   emitChatEvent,
+  emitGameActionMock,
   socketOnMock,
   socketOffMock,
   navigateMock,
@@ -28,11 +29,13 @@ const {
   leaveRoomFromGameMock,
   getGameLeaveErrorMessageMock,
   requestOnlineUsersSnapshotSyncMock,
+  useTurnMock,
 } = vi.hoisted(() => {
   const handlers = new Map<string, Set<(payload: unknown) => void>>()
 
   return {
     sendWaitingRoomChatMock: vi.fn(),
+    emitGameActionMock: vi.fn(),
     socketOnMock: vi.fn(
       (event: string, handler: (payload: unknown) => void) => {
         const nextHandlers = handlers.get(event) ?? new Set()
@@ -53,6 +56,7 @@ const {
     leaveRoomFromGameMock: vi.fn(),
     getGameLeaveErrorMessageMock: vi.fn(),
     requestOnlineUsersSnapshotSyncMock: vi.fn(),
+    useTurnMock: vi.fn(),
   }
 })
 
@@ -98,7 +102,7 @@ vi.mock('../hooks/game/useDiceRoll', () => ({
 }))
 
 vi.mock('../hooks/game/useTurn', () => ({
-  useTurn: () => false,
+  useTurn: () => useTurnMock(),
 }))
 
 vi.mock('../lib/bgm', () => ({
@@ -113,7 +117,7 @@ vi.mock('../pages/game/api', () => ({
 
 vi.mock('../services/socket/game.handler', () => ({
   emitPromptResponse: vi.fn(),
-  emitGameAction: vi.fn(),
+  emitGameAction: emitGameActionMock,
 }))
 
 vi.mock('../components/board/GameBoard', () => ({
@@ -122,6 +126,7 @@ vi.mock('../components/board/GameBoard', () => ({
     {
       gameResult?: object | null
       isGameOver?: boolean
+      onBlockingModalChange?: (blocked: boolean) => void
       onGameResultConfirm?: () => void
     }
   >(function MockBoardGame(props, ref) {
@@ -136,10 +141,27 @@ vi.mock('../components/board/GameBoard', () => ({
       gameResult?.winner ||
       (Array.isArray(gameResult?.rankings) && gameResult.rankings.length > 0)
     )
+    const onBlockingModalChange = props.onBlockingModalChange
+
+    useEffect(() => {
+      onBlockingModalChange?.(false)
+    }, [onBlockingModalChange])
 
     return (
       <div ref={ref} data-testid="mock-board-game">
         게임 보드
+        <button
+          type="button"
+          onClick={() => props.onBlockingModalChange?.(true)}
+        >
+          보드 막기
+        </button>
+        <button
+          type="button"
+          onClick={() => props.onBlockingModalChange?.(false)}
+        >
+          보드 해제
+        </button>
         {hasAuthoritativeGameResult && (
           <button type="button" onClick={props.onGameResultConfirm}>
             대기방으로 돌아가기
@@ -151,7 +173,30 @@ vi.mock('../components/board/GameBoard', () => ({
 }))
 
 vi.mock('../components/game/controls/RollButton', () => ({
-  default: () => <button type="button">주사위</button>,
+  default: ({
+    isMyTurn,
+    mode = 'roll',
+    onRoll,
+    onEndTurn,
+  }: {
+    isMyTurn: boolean
+    mode?: 'roll' | 'end_turn'
+    onRoll?: () => void
+    onEndTurn?: () => void
+  }) => {
+    const isEndTurnMode = mode === 'end_turn'
+    const label = isEndTurnMode ? '턴 종료' : '주사위'
+
+    return (
+      <button
+        type="button"
+        disabled={!isMyTurn}
+        onClick={isEndTurnMode ? onEndTurn : onRoll}
+      >
+        {label}
+      </button>
+    )
+  },
 }))
 
 vi.mock('../components/game/modals/ExitGameModal', () => ({
@@ -335,6 +380,7 @@ const getPlayerPanelById = (playerId: string): HTMLElement => {
 describe('GamePage chat flow', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    useTurnMock.mockReturnValue(false)
 
     setTestAuthSession(
       createAuthSessionFixture({
@@ -979,5 +1025,60 @@ describe('GamePage chat flow', () => {
     expect(screen.getByText('/ 20')).toBeInTheDocument()
     // Label
     expect(screen.getByText('Round')).toBeInTheDocument()
+  })
+
+  it('보드가 아직 blocked면 resolving 상태여도 턴 종료 대신 주사위 버튼이 비활성으로 유지된다', async () => {
+    const user = userEvent.setup()
+
+    useTurnMock.mockReturnValue(true)
+    setTestGameState({
+      currentTurn: 'user-1',
+      phase: 'resolving',
+      prompt: null,
+      pendingAction: null,
+    })
+
+    renderGamePage()
+
+    await user.click(screen.getByRole('button', { name: '보드 막기' }))
+
+    const rollButton = screen.getByRole('button', { name: '주사위' })
+    expect(rollButton).toBeDisabled()
+    expect(
+      screen.queryByRole('button', { name: '턴 종료' })
+    ).not.toBeInTheDocument()
+
+    await user.click(rollButton)
+
+    expect(emitGameActionMock).not.toHaveBeenCalled()
+  })
+
+  it('보드가 해제된 뒤에만 턴 종료 버튼으로 바뀌고 END_TURN을 emit한다', async () => {
+    const user = userEvent.setup()
+
+    useTurnMock.mockReturnValue(true)
+    setTestGameState({
+      currentTurn: 'user-1',
+      phase: 'resolving',
+      prompt: null,
+      pendingAction: null,
+    })
+
+    renderGamePage()
+
+    await user.click(screen.getByRole('button', { name: '보드 막기' }))
+    expect(screen.getByRole('button', { name: '주사위' })).toBeDisabled()
+
+    await user.click(screen.getByRole('button', { name: '보드 해제' }))
+
+    const endTurnButton = screen.getByRole('button', { name: '턴 종료' })
+    expect(endTurnButton).toBeEnabled()
+
+    await user.click(endTurnButton)
+
+    expect(emitGameActionMock).toHaveBeenCalledWith({
+      type: 'END_TURN',
+      gameId: 'game-1',
+    })
   })
 })

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -188,6 +188,8 @@ const GamePage: React.FC = () => {
   const [promptSubmittingChoice, setPromptSubmittingChoice] = useState<
     string | null
   >(null)
+  const [isBoardBlockingModalOpen, setIsBoardBlockingModalOpen] =
+    useState(false)
   const [isExitModalOpen, setIsExitModalOpen] = useState(false)
   const [isLeavePending, setIsLeavePending] = useState(false)
   const [isGlobalEffectModalOpen, setIsGlobalEffectModalOpen] = useState(false)
@@ -479,15 +481,16 @@ const GamePage: React.FC = () => {
   const isEndTurnPhase = phase === 'resolving' && !prompt
   const canControlTurn =
     isMyTurn &&
+    !isBoardBlockingModalOpen &&
     !isActionPending &&
     !isPromptVisible &&
     !isCurrentPlayerBankrupt &&
     (isRollPhase || isEndTurnPhase)
-  const rollButtonMode: 'roll' | 'end_turn' = isEndTurnPhase
-    ? 'end_turn'
-    : 'roll'
+  const rollButtonMode: 'roll' | 'end_turn' =
+    isEndTurnPhase && !isBoardBlockingModalOpen ? 'end_turn' : 'roll'
   const canManageAssetsThisTurn =
     isMyTurn &&
+    !isBoardBlockingModalOpen &&
     !isActionPending &&
     !isPromptVisible &&
     !isCurrentPlayerBankrupt &&
@@ -597,6 +600,7 @@ const GamePage: React.FC = () => {
   const handleRollClick = () => {
     if (
       !isMyTurn ||
+      isBoardBlockingModalOpen ||
       isActionPending ||
       isPromptVisible ||
       isCurrentPlayerBankrupt
@@ -621,6 +625,7 @@ const GamePage: React.FC = () => {
   const handleEndTurnClick = () => {
     if (
       !isMyTurn ||
+      isBoardBlockingModalOpen ||
       isActionPending ||
       isPromptVisible ||
       isCurrentPlayerBankrupt
@@ -794,6 +799,7 @@ const GamePage: React.FC = () => {
               localPlayerId={currentUserId}
               gamePhase={phase}
               allowAssetActions={canManageAssetsThisTurn}
+              onBlockingModalChange={setIsBoardBlockingModalOpen}
               gameResult={gameResult}
               isGameOver={isGameOver}
               winnerId={winnerId}


### PR DESCRIPTION
## 📌 관련 이슈

> closes #651

---

## 📝 작업 내용

- `GameBoard`에 board action modal barrier를 추가해 `PLAYER_MOVED` 직후 보드 액션 modal이 말 이동 전에 한 프레임 먼저 보이는 경로를 막았습니다.
- `buy/build/toll/card/travel/go_to_island/island` modal visibility를 공통 reveal gate로 맞춰, 이동 완료 후 다음 프레임에만 modal이 보이도록 정리했습니다.
- `GamePage`를 `GameBoard.onBlockingModalChange`와 다시 연결해, 말 이동과 보드 로컬 액션이 모두 해소된 뒤에만 `턴 종료` 버튼이 보이고 눌리도록 복구했습니다.
- `START`/일반 `PROPERTY`처럼 modal이 없는 도착 경로도 같은 blocked 기준을 따르도록 `turn end` 모드 전환 시점을 늦췄습니다.
- `GameBoard.test.tsx`, `GamePage.test.tsx`에 modal reveal timing / blocked-unblocked turn end 회귀 테스트를 추가했습니다.

---

## 🧠 Task 문서 (큰 작업이면 필수)

- plan:
  - `docs/ai/tasks/game-board-modal-reveal-timing/plan.md`
  - `docs/ai/tasks/end-turn-after-board-settle/plan.md`
- context:
  - `docs/ai/tasks/game-board-modal-reveal-timing/context.md`
  - `docs/ai/tasks/end-turn-after-board-settle/context.md`
- checklist:
  - `docs/ai/tasks/game-board-modal-reveal-timing/checklist.md`
  - `docs/ai/tasks/end-turn-after-board-settle/checklist.md`

---

## 📋 TODO.md 연결

- task slug: `game-board-modal-reveal-timing`, `end-turn-after-board-settle`
- TODO status: `Done`
- TODO entry 확인: `TODO.md` Done 섹션에 두 task line을 반영했습니다.

---

## 📚 참고한 기준 문서

- `AGENTS.md`
- `docs/ai/manuals/common.md`
- `docs/ai/manuals/game-runtime.md`
- `docs/rules.md`
- `docs/testing.md`

---

## 🧪 실행한 검증

- `npx vitest run src/components/board/GameBoard.test.tsx src/pages/GamePage.test.tsx`
- `npm run lint`
- `npm run ai:check:game`
- `npm run build`
- `npm run ai:self-review -- --files TODO.md docs/ai/tasks/end-turn-after-board-settle/plan.md docs/ai/tasks/end-turn-after-board-settle/context.md docs/ai/tasks/end-turn-after-board-settle/checklist.md docs/ai/tasks/game-board-modal-reveal-timing/plan.md docs/ai/tasks/game-board-modal-reveal-timing/context.md docs/ai/tasks/game-board-modal-reveal-timing/checklist.md src/components/board/GameBoard.tsx src/components/board/GameBoard.test.tsx src/pages/GamePage.tsx src/pages/GamePage.test.tsx`

---

## ⚠️ 남은 리스크

- `turn end` 활성화와 modal reveal은 현재 `GameBoard`가 올리는 blocked 의미를 그대로 재사용합니다. 보드 쪽 blocked가 보수적으로 잡히면 버튼이 약간 늦게 풀릴 수 있습니다.
- `GameBoard.test.tsx`는 대표 경로인 구매 modal, 무인도 이동 modal만 직접 잡고 있습니다. `build/toll/travel/island`도 같은 reveal gate를 타지만, 필요하면 후속 대표 케이스를 더 추가할 수 있습니다.

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료
- [x] 큰 작업이면 task 문서 링크를 남겼다
- [x] 큰 작업이면 `TODO.md` / task slug 연결을 PR 본문에 남겼다
- [x] 참고한 기준 문서를 PR 본문에 남겼다
- [x] 실행한 검증과 남은 리스크를 PR 본문에 적었다

---

## 📸 스크린샷 (선택)

- 게임 보드 이동 후 modal reveal timing과 turn end 노출 타이밍은 필요 시 영상/스크린샷 추가 가능
