### PR TITLE
fix: RoomChat 긴 sent bubble 줄바꿈과 sender badge 정리

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -24,6 +24,8 @@
 - [x] `group-chat-sender-grouping-ui` - Group Chat Sender Grouping UI (`docs/ai/tasks/group-chat-sender-grouping-ui/`) - 대기방/게임 공용 채팅을 sender grouping, 아바타, 이름 강조, 역할 badge 기반 실무형 그룹 채팅 UI로 정리
 - [x] `chat-message-limit-300` - Chat Message Limit 300 (`docs/ai/tasks/chat-message-limit-300/`) - room chat과 DM에 300자 하드 제한을 입력/송신/contract/mock/test 기준으로 통일
 - [x] `chat-bubble-overflow-fix` - Chat Bubble Overflow Fix (`docs/ai/tasks/chat-bubble-overflow-fix/`) - 긴 메시지가 말풍선을 뚫고 가로 스크롤을 만드는 문제를 RoomChat/DM 공통 스타일로 정리
+- [x] `room-chat-sent-bubble-wrap-fix` - Room Chat Sent Bubble Wrap Fix (`docs/ai/tasks/room-chat-sent-bubble-wrap-fix/`) - 대기방/게임 공용 `RoomChat`에서 내가 보낸 긴 메시지 말풍선이 한 줄로 늘어나는 레이아웃을 sent path 폭 제약으로 정리
+- [x] `chat-nickname-neutralization` - Chat Nickname Neutralization (`docs/ai/tasks/chat-nickname-neutralization/`) - 공용 RoomChat 닉네임 색을 기본 검은색 계열로 통일하고 대기방 HOST / 게임 TURN badge를 제거
 
 - [x] `waiting-room-authoritative-resume-refresh` - Waiting Room Authoritative Resume Refresh (`docs/ai/tasks/waiting-room-authoritative-resume-refresh/`) - game 종료 후 waiting-room 복귀를 background join revalidation으로 교정하고 room create/join presence 반영을 follow-up refresh로 보강
 - [x] `waiting-room-resume-bootstrap-presence-resync` - Waiting Room Resume Bootstrap Presence Resync (`docs/ai/tasks/waiting-room-resume-bootstrap-presence-resync/`) - 게임 종료 후 대기방 복귀 무한 로딩을 bootstrap snapshot으로 해소하고 waiting-room에서도 lobby_updated 기반 presence 재동기화를 수행

--- a/docs/ai/tasks/chat-nickname-neutralization/checklist.md
+++ b/docs/ai/tasks/chat-nickname-neutralization/checklist.md
@@ -1,0 +1,30 @@
+# Checklist
+
+## Implementation
+
+- [x] 관련 manual과 기존 문서를 읽었다
+- [x] 영향 범위를 정리했다
+- [x] WAT 단계와 역할 분담을 문서에 반영했다
+- [x] `RoomChat` 닉네임 색을 기본 어두운 텍스트로 통일했다
+- [x] waiting-room `HOST` badge metadata를 제거했다
+- [x] 게임 `TURN` badge metadata를 제거했다
+- [x] 공용 `RoomChat` sender badge 렌더링 경로를 제거했다
+
+## Testing
+
+- [x] `npx vitest run src/features/room-chat/RoomChat.test.tsx src/pages/waiting-room/page/WaitingRoomPage.test.tsx src/pages/GamePage.test.tsx`
+- [x] `npm run ai:check:lobby`
+- [x] `npm run ai:check:waiting-room`
+- [x] `npm run ai:check:game`
+- [x] `npm run lint`
+- [x] `npm run build`
+
+## Review
+
+- [x] `docs/rules.md` 기준으로 셀프 리뷰했다
+- [x] 닉네임 색 통일 / HOST 제거 / TURN 제거 회귀를 확인했다
+- [x] `TODO.md` task 한 줄을 최신 상태로 유지했다
+- [x] session handoff notes를 최신 상태로 갱신했다
+- [x] `npm run ai:session:brief -- chat-nickname-neutralization` 출력이 현재 상태와 맞는다
+- [x] `npm run ai:self-review -- --files ...`를 실행했다
+- [x] 변경 파일 / 실행한 검증 / 남은 리스크를 정리했다

--- a/docs/ai/tasks/chat-nickname-neutralization/context.md
+++ b/docs/ai/tasks/chat-nickname-neutralization/context.md
@@ -1,0 +1,48 @@
+# Context
+
+## Current Behavior
+
+- `RoomChat`은 non-mine sender 닉네임을 `text-ui-text-strong`으로 고정해 inline 색상 없이 렌더링한다.
+- 대기방/게임 sender header는 닉네임만 렌더링하고, `HOST`/`TURN` badge는 더 이상 표시하지 않는다.
+- avatarColor는 sender 식별을 위한 아바타 배경색으로만 유지된다.
+
+## Related Files
+
+- `src/features/room-chat/RoomChat.tsx`
+- `src/features/room-chat/RoomChat.test.tsx`
+- `src/pages/GamePage.tsx`
+- `src/pages/waiting-room/components/WaitingRoomChatBox.tsx`
+- `src/pages/waiting-room/page/WaitingRoomPage.test.tsx`
+- `src/pages/GamePage.test.tsx`
+
+## Relevant Manuals
+
+- `docs/ai/manuals/common.md`
+- `docs/ai/manuals/lobby.md`
+- `docs/ai/manuals/waiting-room.md`
+- `docs/rules.md`
+- `docs/testing.md`
+
+## Constraints
+
+- `RoomChatProps`, socket payload, controller 반환 shape는 유지한다.
+- 대기방 `HOST`, 게임 `TURN` badge를 모두 제거한다.
+- avatarColor는 sender 식별 수단으로 유지하고, DM 패널은 건드리지 않는다.
+
+## Decision Notes
+
+- 닉네임은 `text-ui-text-strong`으로 고정해 밝은 avatar 팔레트에도 가독성을 보장한다.
+- badge는 현재 sender 식별에 필수 정보가 아니므로 `RoomChat` 공용 렌더링에서 제거한다.
+- waiting-room / game sender metadata에서는 badge 관련 필드를 제거해 sender header가 닉네임만 렌더링되게 한다.
+
+## Session Handoff Notes
+
+- 다음 세션에서 다시 읽을 문서: `docs/ai/tasks/chat-nickname-neutralization/*`, `docs/ai/manuals/lobby.md`, `docs/ai/manuals/waiting-room.md`, `docs/testing.md`
+- 바로 이어서 할 1개 단계: 없음
+- pending decision / blocker: 없음
+- 검증 재개 지점: `npx vitest run src/features/room-chat/RoomChat.test.tsx src/pages/waiting-room/page/WaitingRoomPage.test.tsx src/pages/GamePage.test.tsx`, `npm run ai:check:lobby`, `npm run ai:check:waiting-room`, `npm run ai:check:game`, `npm run lint`, `npm run build`, `npm run ai:self-review -- --files ...` 실행 완료
+
+## Open Risks
+
+- 공용 `RoomChat` 닉네임 색 / badge 제거 변경이므로 게임 채팅 visual tone도 같이 바뀐다.
+- `text-ui-text-strong`이 의도보다 무겁게 느껴지면 후속으로 `text-ui-text-primary` 재검토 가능성이 있다.

--- a/docs/ai/tasks/chat-nickname-neutralization/plan.md
+++ b/docs/ai/tasks/chat-nickname-neutralization/plan.md
@@ -1,0 +1,77 @@
+# Plan
+
+## Task
+
+- 작업 이름: Chat Nickname Neutralization
+- 작업 slug: chat-nickname-neutralization
+- 요청 날짜: 2026-03-26
+- 담당 범위: 공용 RoomChat 닉네임 색 통일과 채팅 sender badge 제거
+
+## Goal
+
+- 대기방/게임 채팅 닉네임 색을 아바타색 연동 대신 기본 검은색 계열로 통일한다.
+- 대기방 `HOST`, 게임 `TURN` badge를 모두 제거한다.
+- socket/controller/message type 변경 없이 `RoomChat` sender metadata와 렌더링만 정리한다.
+
+## WAT Workflow
+
+1. task 문서와 TODO를 만들어 범위 / 완료 기준 / 검증 명령을 고정한다.
+2. `RoomChat` 닉네임 스타일과 sender metadata/badge 렌더링을 최소 범위로 수정한다.
+3. RoomChat / WaitingRoomPage / GamePage 회귀 테스트와 repo 검증으로 마감한다.
+
+## In Scope
+
+- `src/features/room-chat/RoomChat.tsx`
+- `src/pages/waiting-room/components/WaitingRoomChatBox.tsx`
+- 관련 Vitest
+- `docs/ai/tasks/chat-nickname-neutralization/*`
+- `TODO.md`
+
+## Out Of Scope
+
+- DM 패널 변경
+- 메시지 버블 색상 변경
+- avatar fallback 색상 변경
+- socket payload, optimistic chat, unread, mock gateway 변경
+
+## Target Files
+
+- `src/features/room-chat/RoomChat.tsx`
+- `src/features/room-chat/RoomChat.test.tsx`
+- `src/pages/GamePage.tsx`
+- `src/pages/waiting-room/components/WaitingRoomChatBox.tsx`
+- `src/pages/waiting-room/page/WaitingRoomPage.test.tsx`
+- `src/pages/GamePage.test.tsx`
+- `docs/ai/tasks/chat-nickname-neutralization/plan.md`
+- `docs/ai/tasks/chat-nickname-neutralization/context.md`
+- `docs/ai/tasks/chat-nickname-neutralization/checklist.md`
+- `TODO.md`
+
+## Task Tracking
+
+- TODO line: - [ ] `chat-nickname-neutralization` - Chat Nickname Neutralization (`docs/ai/tasks/chat-nickname-neutralization/`)
+- Session brief: `npm run ai:session:brief -- chat-nickname-neutralization`
+- Reopen docs: `docs/ai/tasks/chat-nickname-neutralization/plan.md`, `context.md`, `checklist.md`, 관련 manuals
+
+## Completion Criteria
+
+- non-mine sender 닉네임이 대기방/게임 공용 `RoomChat`에서 기본 어두운 텍스트 색으로 렌더링된다.
+- 대기방/게임 채팅 header에서 sender badge가 더 이상 보이지 않는다.
+- 관련 Vitest, `ai:check:lobby`, `ai:check:waiting-room`, `ai:check:game`, `lint`, `build`, `ai:self-review`가 통과한다.
+
+## Role Plan
+
+- Planner: 범위 / badge 유지 정책 / 검증 기준 확정
+- Implementer: `RoomChat` 닉네임 스타일과 waiting-room / game metadata 정리
+- Reviewer: 대기방/게임 공용 경계와 badge 제거 회귀 여부 점검
+- Tester: 관련 Vitest와 repo 검증 실행
+
+## Test Plan
+
+- `npx vitest run src/features/room-chat/RoomChat.test.tsx src/pages/waiting-room/page/WaitingRoomPage.test.tsx src/pages/GamePage.test.tsx`
+- `npm run ai:check:lobby`
+- `npm run ai:check:waiting-room`
+- `npm run ai:check:game`
+- `npm run lint`
+- `npm run build`
+- `npm run ai:self-review -- --files TODO.md docs/ai/tasks/chat-nickname-neutralization/plan.md docs/ai/tasks/chat-nickname-neutralization/context.md docs/ai/tasks/chat-nickname-neutralization/checklist.md src/features/room-chat/RoomChat.tsx src/features/room-chat/RoomChat.test.tsx src/pages/waiting-room/components/WaitingRoomChatBox.tsx src/pages/waiting-room/page/WaitingRoomPage.test.tsx src/pages/GamePage.tsx src/pages/GamePage.test.tsx`

--- a/docs/ai/tasks/room-chat-sent-bubble-wrap-fix/checklist.md
+++ b/docs/ai/tasks/room-chat-sent-bubble-wrap-fix/checklist.md
@@ -1,0 +1,28 @@
+# Checklist
+
+## Implementation
+
+- [x] 관련 manual과 기존 문서를 읽었다
+- [x] 영향 범위를 정리했다
+- [x] WAT 단계와 역할 분담을 문서에 반영했다
+- [x] `RoomChat` sent bubble 폭 제약을 수정했다
+- [x] received bubble / badge / grouping / input / socket 범위를 유지했다
+
+## Testing
+
+- [x] `npx vitest run src/features/room-chat/RoomChat.test.tsx src/pages/waiting-room/page/WaitingRoomPage.test.tsx src/pages/GamePage.test.tsx`
+- [x] `npm run ai:check:lobby`
+- [x] `npm run ai:check:waiting-room`
+- [x] `npm run ai:check:chat-e2e`
+- [x] `npm run lint`
+- [x] `npm run build`
+
+## Review
+
+- [x] `docs/rules.md` 기준으로 셀프 리뷰했다
+- [x] sent bubble 긴 메시지 회귀와 received bubble 유지 여부를 확인했다
+- [x] `TODO.md` task 한 줄을 최신 상태로 유지했다
+- [x] session handoff notes를 최신 상태로 갱신했다
+- [x] `npm run ai:session:brief -- room-chat-sent-bubble-wrap-fix` 출력이 현재 상태와 맞는다
+- [x] `npm run ai:self-review -- --files ...`를 실행했다
+- [x] 변경 파일 / 실행한 검증 / 남은 리스크를 정리했다

--- a/docs/ai/tasks/room-chat-sent-bubble-wrap-fix/context.md
+++ b/docs/ai/tasks/room-chat-sent-bubble-wrap-fix/context.md
@@ -1,0 +1,47 @@
+# Context
+
+## Current Behavior
+
+- `RoomChat`은 received bubble은 정상적으로 줄바꿈되지만, sent bubble은 부모 폭이 shrink-wrap처럼 계산돼 긴 메시지가 한 줄로 길게 보일 수 있다.
+- 문제는 입력창이 아니라 공용 `RoomChat`의 `group.isMine` 경로 레이아웃 제약이다.
+- 같은 공용 컴포넌트를 대기방과 게임이 함께 쓰므로 한 번 수정하면 두 화면에 같이 반영된다.
+
+## Related Files
+
+- `src/features/room-chat/RoomChat.tsx`
+- `src/features/room-chat/RoomChat.test.tsx`
+- `src/pages/waiting-room/page/WaitingRoomPage.test.tsx`
+- `src/pages/GamePage.test.tsx`
+- `e2e/chat-flow-waiting-room.spec.ts`
+
+## Relevant Manuals
+
+- `docs/ai/manuals/common.md`
+- `docs/ai/manuals/lobby.md`
+- `docs/ai/manuals/waiting-room.md`
+- `docs/rules.md`
+- `docs/testing.md`
+
+## Constraints
+
+- `RoomChatProps`, message type, socket payload, controller 반환 shape를 바꾸지 않는다.
+- input/composer, DM 패널, optimistic chat, unread, mock/real socket 경로는 건드리지 않는다.
+- 기존 wrap 클래스 `whitespace-pre-wrap`, `break-words`, `[overflow-wrap:anywhere]`는 유지한다.
+
+## Decision Notes
+
+- sent path에 `w-full max-w-[85%]` 같은 명시적 폭 제약을 주고, 내부 content/message column도 `w-full items-end`로 정렬해 bubble이 실제 너비 기준을 갖게 한다.
+- received path는 현재 avatar + metadata 레이아웃을 유지한다.
+- unit test는 sent bubble 래퍼 class 존재를 확인하고, 브라우저 레이아웃 회귀는 waiting-room chat E2E에서 긴 메시지 bounding box로 확인한다.
+
+## Session Handoff Notes
+
+- 다음 세션에서 다시 읽을 문서: `docs/ai/tasks/room-chat-sent-bubble-wrap-fix/*`, `docs/ai/manuals/lobby.md`, `docs/ai/manuals/waiting-room.md`, `docs/testing.md`
+- 바로 이어서 할 1개 단계: 없음
+- pending decision / blocker: 없음
+- 검증 재개 지점: `npx vitest run src/features/room-chat/RoomChat.test.tsx src/pages/waiting-room/page/WaitingRoomPage.test.tsx src/pages/GamePage.test.tsx`, `npm run ai:check:lobby`, `npm run ai:check:waiting-room`, `npm run ai:check:chat-e2e`, `npm run lint`, `npm run build`, `npm run ai:self-review -- --files ...` 실행 완료
+
+## Open Risks
+
+- jsdom에서는 실제 레이아웃 폭 계산을 완전히 재현하지 못하므로 DOM class 검증과 Playwright bounding-box 검증을 함께 써야 한다.
+- sent bubble 폭을 고정에 가깝게 두면 짧은 메시지 모양이 과도하게 넓어질 수 있으므로 bubble 자체는 `w-fit`을 유지해야 한다.

--- a/docs/ai/tasks/room-chat-sent-bubble-wrap-fix/plan.md
+++ b/docs/ai/tasks/room-chat-sent-bubble-wrap-fix/plan.md
@@ -1,0 +1,75 @@
+# Plan
+
+## Task
+
+- 작업 이름: Room Chat Sent Bubble Wrap Fix
+- 작업 slug: room-chat-sent-bubble-wrap-fix
+- 요청 날짜: 2026-03-26
+- 담당 범위: 대기방/게임 공용 `RoomChat` sent bubble 폭 제약 수정과 회귀 테스트
+
+## Goal
+
+- 내가 보낸 긴 메시지도 대기방/게임 채팅창 안에서 여러 줄로 감기게 만든다.
+- received bubble, sender grouping, badge, input/composer, socket 흐름은 유지한다.
+- 브라우저 기준 레이아웃 문제를 unit test + waiting-room chat E2E로 재현/회귀 방지한다.
+
+## WAT Workflow
+
+1. task 문서와 TODO를 만들어 범위 / 완료 기준 / 검증 명령을 고정한다.
+2. `RoomChat` sent path에 실제 계산 가능한 폭 제약을 주고 기존 줄바꿈 클래스를 유지한다.
+3. 긴 내 메시지 회귀 테스트와 채팅 관련 검증을 실행하고 문서를 완료 상태로 맞춘다.
+
+## In Scope
+
+- `src/features/room-chat/RoomChat.tsx`
+- `src/features/room-chat/RoomChat.test.tsx`
+- `e2e/chat-flow-waiting-room.spec.ts`
+- `docs/ai/tasks/room-chat-sent-bubble-wrap-fix/*`
+- `TODO.md`
+
+## Out Of Scope
+
+- DM 패널 레이아웃 수정
+- 채팅 입력창 textarea 전환
+- socket payload, optimistic chat, unread, mock gateway 변경
+- DEV 제어 패널 수정
+
+## Target Files
+
+- `src/features/room-chat/RoomChat.tsx`
+- `src/features/room-chat/RoomChat.test.tsx`
+- `e2e/chat-flow-waiting-room.spec.ts`
+- `docs/ai/tasks/room-chat-sent-bubble-wrap-fix/plan.md`
+- `docs/ai/tasks/room-chat-sent-bubble-wrap-fix/context.md`
+- `docs/ai/tasks/room-chat-sent-bubble-wrap-fix/checklist.md`
+- `TODO.md`
+
+## Task Tracking
+
+- TODO line: - [ ] `room-chat-sent-bubble-wrap-fix` - Room Chat Sent Bubble Wrap Fix (`docs/ai/tasks/room-chat-sent-bubble-wrap-fix/`)
+- Session brief: `npm run ai:session:brief -- room-chat-sent-bubble-wrap-fix`
+- Reopen docs: `docs/ai/tasks/room-chat-sent-bubble-wrap-fix/plan.md`, `context.md`, `checklist.md`, 관련 manuals
+
+## Completion Criteria
+
+- `RoomChat` sent bubble이 실제 폭 제약 안에서 `w-fit` / `max-w-full` / wrap 규칙을 평가받는다.
+- 긴 내 메시지가 대기방/게임 채팅창 안에서 한 줄 overflow 없이 감긴다.
+- received bubble, badge, grouping, input, socket 동작은 유지된다.
+- 관련 Vitest, waiting-room/lobby 검증, chat E2E, lint/build, self-review가 통과한다.
+
+## Role Plan
+
+- Planner: sent path 원인과 제외 범위 고정
+- Implementer: `RoomChat` sent bubble 레이아웃과 회귀 테스트 구현
+- Reviewer: shared chat 경로와 대기방 E2E 안정성 점검
+- Tester: Vitest / lobby / waiting-room / chat E2E / lint / build 실행
+
+## Test Plan
+
+- `npx vitest run src/features/room-chat/RoomChat.test.tsx src/pages/waiting-room/page/WaitingRoomPage.test.tsx src/pages/GamePage.test.tsx`
+- `npm run ai:check:lobby`
+- `npm run ai:check:waiting-room`
+- `npm run ai:check:chat-e2e`
+- `npm run lint`
+- `npm run build`
+- `npm run ai:self-review -- --files TODO.md docs/ai/tasks/room-chat-sent-bubble-wrap-fix/plan.md docs/ai/tasks/room-chat-sent-bubble-wrap-fix/context.md docs/ai/tasks/room-chat-sent-bubble-wrap-fix/checklist.md src/features/room-chat/RoomChat.tsx src/features/room-chat/RoomChat.test.tsx e2e/chat-flow-waiting-room.spec.ts src/pages/waiting-room/page/WaitingRoomPage.test.tsx src/pages/GamePage.test.tsx`

--- a/e2e/chat-flow-waiting-room.spec.ts
+++ b/e2e/chat-flow-waiting-room.spec.ts
@@ -20,4 +20,37 @@ test.describe('대기방 채팅 플로우', () => {
 
     await expect(page.getByText('대기방 채팅 e2e')).toBeVisible()
   })
+
+  test('긴 내 메시지도 대기방 채팅 패널 안에서 줄바꿈 폭을 유지한다', async ({
+    page,
+  }) => {
+    const longMessage = `my-waiting-room-chat-${'1'.repeat(160)}`
+
+    await resetSessionAndOpenHome(page)
+    await loginAsGuest(page)
+
+    await page.getByRole('button', { name: '방 만들기' }).click()
+    await page.getByLabel('방 제목').fill('E2E 긴 채팅 방')
+    await page.getByRole('button', { name: '방 만들기 완료' }).click()
+
+    await expect(page).toHaveURL(/\/rooms\/room-\d+$/)
+
+    const chatSection = page
+      .locator('section')
+      .filter({ has: page.getByText('실시간 채팅') })
+    const sentBubble = page.getByText(longMessage)
+
+    await page.getByPlaceholder('메시지 입력...').fill(longMessage)
+    await page.getByPlaceholder('메시지 입력...').press('Enter')
+
+    await expect(sentBubble).toBeVisible()
+
+    const chatSectionBox = await chatSection.boundingBox()
+    const sentBubbleBox = await sentBubble.boundingBox()
+
+    expect(chatSectionBox).not.toBeNull()
+    expect(sentBubbleBox).not.toBeNull()
+
+    expect(sentBubbleBox!.width).toBeLessThan(chatSectionBox!.width * 0.9)
+  })
 })

--- a/src/features/room-chat/RoomChat.test.tsx
+++ b/src/features/room-chat/RoomChat.test.tsx
@@ -119,6 +119,35 @@ describe('RoomChat', () => {
     ).toBeInTheDocument()
   })
 
+  it('상대 닉네임은 기본 텍스트 색으로 렌더링한다', () => {
+    renderWithProviders(
+      <RoomChat
+        currentUserId="me"
+        onSendMessage={vi.fn()}
+        senderMetaById={{
+          'user-2': {
+            displayName: '상대',
+          },
+        }}
+        messages={[
+          {
+            id: 'm-accent',
+            sender_id: 'user-2',
+            sender_nickname: '상대',
+            content: '색상 테스트',
+            timestamp: '2026-03-03T10:02:00.000Z',
+            type: 'talk',
+          },
+        ]}
+      />
+    )
+
+    const senderName = screen.getByText('상대') as HTMLSpanElement
+
+    expect(senderName.className).toContain('text-ui-text-strong')
+    expect(senderName.style.color).toBe('')
+  })
+
   it('긴 공백 없는 메시지도 말풍선 줄바꿈 클래스로 렌더링한다', () => {
     const longMessage =
       'https://example.com/' + 'verylongsegment'.repeat(16) + '/chat-overflow'
@@ -146,6 +175,38 @@ describe('RoomChat', () => {
     expect(messageBubble.className).toContain('[overflow-wrap:anywhere]')
   })
 
+  it('내가 보낸 긴 메시지는 폭 제약 래퍼 안에서 줄바꿈되도록 렌더링한다', () => {
+    const longMessage =
+      'https://example.com/' + 'myownsegment'.repeat(20) + '/sent-overflow'
+
+    renderWithProviders(
+      <RoomChat
+        currentUserId="me"
+        onSendMessage={vi.fn()}
+        messages={[
+          {
+            id: 'm-mine-long',
+            sender_id: 'me',
+            sender_nickname: '나',
+            content: longMessage,
+            timestamp: '2026-03-03T10:02:00.000Z',
+            type: 'talk',
+          },
+        ]}
+      />
+    )
+
+    const messageBubble = screen.getByText(longMessage)
+    const messageGroupColumn = messageBubble.parentElement
+    const contentColumn = messageGroupColumn?.parentElement
+
+    expect(messageBubble.className).toContain('max-w-full')
+    expect(messageGroupColumn?.className).toContain('w-full')
+    expect(messageGroupColumn?.className).toContain('items-end')
+    expect(contentColumn?.className).toContain('w-full')
+    expect(contentColumn?.className).toContain('items-end')
+  })
+
   it('같은 sender의 연속 메시지는 하나의 sender header로 그룹화한다', () => {
     renderWithProviders(
       <RoomChat
@@ -153,7 +214,6 @@ describe('RoomChat', () => {
         onSendMessage={vi.fn()}
         senderMetaById={{
           'user-2': {
-            badgeLabel: 'HOST',
             displayName: '상대',
           },
         }}
@@ -179,7 +239,6 @@ describe('RoomChat', () => {
     )
 
     expect(screen.getAllByText('상대')).toHaveLength(1)
-    expect(screen.getAllByText('HOST')).toHaveLength(1)
     expect(screen.getByText('첫 번째 메시지')).toBeInTheDocument()
     expect(screen.getByText('두 번째 메시지')).toBeInTheDocument()
   })

--- a/src/features/room-chat/RoomChat.tsx
+++ b/src/features/room-chat/RoomChat.tsx
@@ -10,8 +10,6 @@ import {
 
 export interface RoomChatSenderMeta {
   avatarColor?: string
-  accentColor?: string
-  badgeLabel?: string
   displayName?: string
 }
 
@@ -42,18 +40,6 @@ function getMessageTimestampMs(timestamp: string) {
   const parsedTimestamp = Date.parse(timestamp)
 
   return Number.isNaN(parsedTimestamp) ? null : parsedTimestamp
-}
-
-function withAlpha(color: string | undefined, alphaHex: string) {
-  if (!color) {
-    return undefined
-  }
-
-  if (/^#[0-9a-fA-F]{6}$/.test(color)) {
-    return `${color}${alphaHex}`
-  }
-
-  return undefined
 }
 
 // 대기방/게임 공용 채팅 UI 렌더링
@@ -153,9 +139,7 @@ export default function RoomChat({
           className="ui-scrollbar min-h-0 flex-1 space-y-3 overflow-x-hidden overflow-y-auto bg-ui-surface px-3 py-3"
         >
           {messageGroups.map((group) => {
-            const accentColor = group.meta?.accentColor
             const displayName = group.meta?.displayName ?? group.senderNickname
-            const badgeBackgroundColor = withAlpha(accentColor, '1F')
 
             return (
               <div
@@ -169,7 +153,7 @@ export default function RoomChat({
                   className={cn(
                     'flex min-w-0',
                     group.isMine
-                      ? 'max-w-[85%] flex-col items-end gap-1'
+                      ? 'w-full max-w-[85%] flex-col items-end gap-1'
                       : 'max-w-[90%] items-start gap-2'
                   )}
                 >
@@ -184,33 +168,26 @@ export default function RoomChat({
                     />
                   )}
 
-                  <div className="flex min-w-0 flex-1 flex-col gap-1">
+                  <div
+                    className={cn(
+                      'flex min-w-0 flex-col gap-1',
+                      group.isMine ? 'w-full items-end' : 'flex-1'
+                    )}
+                  >
                     {group.isMine ? null : (
-                      <div className="flex min-w-0 items-center gap-2 px-0.5">
-                        <span
-                          className="block truncate text-[12px] font-semibold text-ui-text-primary"
-                          style={
-                            accentColor ? { color: accentColor } : undefined
-                          }
-                        >
+                      <div className="flex min-w-0 items-center px-0.5">
+                        <span className="block truncate text-[12px] font-semibold text-ui-text-strong">
                           {displayName}
                         </span>
-                        {group.meta?.badgeLabel ? (
-                          <span
-                            className="inline-flex shrink-0 items-center rounded-full border px-2 py-0.5 text-[10px] font-bold tracking-[0.12em]"
-                            style={{
-                              color: accentColor,
-                              borderColor: accentColor,
-                              backgroundColor: badgeBackgroundColor,
-                            }}
-                          >
-                            {group.meta.badgeLabel}
-                          </span>
-                        ) : null}
                       </div>
                     )}
 
-                    <div className="flex min-w-0 flex-col gap-1">
+                    <div
+                      className={cn(
+                        'flex min-w-0 flex-col gap-1',
+                        group.isMine ? 'w-full items-end' : undefined
+                      )}
+                    >
                       {group.messages.map((message) => (
                         <div
                           key={message.id}

--- a/src/pages/GamePage.test.tsx
+++ b/src/pages/GamePage.test.tsx
@@ -613,7 +613,7 @@ describe('GamePage chat flow', () => {
     expect(await screen.findByText(expectedMessage)).toBeInTheDocument()
   })
 
-  it('게임 채팅에서 현재 턴 플레이어 메시지에 TURN badge를 표시한다', () => {
+  it('게임 채팅에서도 sender 닉네임은 badge 없이 기본 텍스트 색으로 렌더링한다', () => {
     resetAndSetTestGameState({
       roomId: 'room-1',
       gameId: 'game-1',
@@ -642,11 +642,12 @@ describe('GamePage chat flow', () => {
     renderGamePage()
 
     const chatSection = screen.getByText('실시간 채팅').closest('section')
+    const senderName = within(chatSection as HTMLElement).getByText('유저2')
 
     expect(chatSection).not.toBeNull()
-    expect(
-      within(chatSection as HTMLElement).getByText('TURN')
-    ).toBeInTheDocument()
+    expect(senderName.className).toContain('text-ui-text-strong')
+    expect((senderName as HTMLSpanElement).style.color).toBe('')
+    expect(within(chatSection as HTMLElement).queryByText('TURN')).toBeNull()
     expect(
       within(chatSection as HTMLElement).getByText('내 차례입니다.')
     ).toBeInTheDocument()

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -516,9 +516,6 @@ const GamePage: React.FC = () => {
           player.id,
           {
             avatarColor: player.color,
-            accentColor: player.color,
-            badgeLabel:
-              player.isActive && !player.isBankrupt ? 'TURN' : undefined,
             displayName: player.nickname,
           },
         ])

--- a/src/pages/waiting-room/components/WaitingRoomChatBox.tsx
+++ b/src/pages/waiting-room/components/WaitingRoomChatBox.tsx
@@ -34,14 +34,12 @@ export function WaitingRoomChatBox({
   const senderMetaById = useMemo(() => {
     return Object.fromEntries(
       roomPlayers.map((player) => {
-        const accentColor = getAvatarBackgroundColor(player.id)
+        const avatarColor = getAvatarBackgroundColor(player.id)
 
         return [
           player.id,
           {
-            avatarColor: accentColor,
-            accentColor,
-            badgeLabel: player.isHost ? 'HOST' : undefined,
+            avatarColor,
             displayName: player.nickname,
           },
         ]

--- a/src/pages/waiting-room/page/WaitingRoomPage.test.tsx
+++ b/src/pages/waiting-room/page/WaitingRoomPage.test.tsx
@@ -213,7 +213,7 @@ describe('WaitingRoomPage interaction', () => {
     expect(screen.getByRole('button', { name: '시작' })).toBeDisabled()
   })
 
-  it('대기방 채팅에서 host 메시지에 HOST badge를 표시한다', () => {
+  it('대기방 채팅에서 host 메시지 닉네임은 보이지만 HOST badge는 표시하지 않는다', () => {
     useAuthStore.setState({
       session: createAuthSessionFixture({
         userId: 'user-2',
@@ -243,8 +243,11 @@ describe('WaitingRoomPage interaction', () => {
 
     expect(chatSection).not.toBeNull()
     expect(
-      within(chatSection as HTMLElement).getByText('HOST')
+      within(chatSection as HTMLElement).getByText('테스터')
     ).toBeInTheDocument()
+    expect(
+      within(chatSection as HTMLElement).queryByText('HOST')
+    ).not.toBeInTheDocument()
     expect(
       within(chatSection as HTMLElement).getByText('방장이 안내합니다.')
     ).toBeInTheDocument()


### PR DESCRIPTION
## 📌 관련 이슈

- #654 

---

## 📝 작업 내용

- 대기방/게임 공용 `RoomChat`에서 내가 보낸 긴 메시지 말풍선이 한 줄로 늘어나는 문제를 sent path 폭 제약으로 수정했습니다.
- 공용 `RoomChat` sender header에서 닉네임을 기본 어두운 텍스트로 통일하고 `HOST`/`TURN` badge 렌더링 경로를 제거했습니다.
- 대기방/게임 채팅 회귀를 Vitest와 chat E2E로 함께 확인했습니다.

---

## 🧠 Task 문서 (큰 작업이면 필수)

- plan: docs/ai/tasks/room-chat-sent-bubble-wrap-fix/plan.md, docs/ai/tasks/chat-nickname-neutralization/plan.md
- context: docs/ai/tasks/room-chat-sent-bubble-wrap-fix/context.md, docs/ai/tasks/chat-nickname-neutralization/context.md
- checklist: docs/ai/tasks/room-chat-sent-bubble-wrap-fix/checklist.md, docs/ai/tasks/chat-nickname-neutralization/checklist.md

---

## 📋 TODO.md 연결

- task slug: room-chat-sent-bubble-wrap-fix, chat-nickname-neutralization
- TODO status: Done
- TODO entry 확인: TODO.md Done 섹션에 `room-chat-sent-bubble-wrap-fix`, `chat-nickname-neutralization` 항목 반영 완료

---

## 📚 참고한 기준 문서

- `AGENTS.md`
- `docs/rules.md`
- `docs/testing.md`
- `docs/ai/manuals/common.md`
- `docs/ai/manuals/lobby.md`
- `docs/ai/manuals/waiting-room.md`
- `docs/ai/manuals/game-runtime.md`

---

## 🧪 실행한 검증

- `npx vitest run src/features/room-chat/RoomChat.test.tsx src/pages/waiting-room/page/WaitingRoomPage.test.tsx src/pages/GamePage.test.tsx`
- `npm run ai:check:lobby`
- `npm run ai:check:waiting-room`
- `npm run ai:check:game`
- `npm run ai:check:chat-e2e`
- `npm run lint`
- `npm run build`
- `npm run ai:self-review -- --files TODO.md docs/ai/tasks/room-chat-sent-bubble-wrap-fix/plan.md docs/ai/tasks/room-chat-sent-bubble-wrap-fix/context.md docs/ai/tasks/room-chat-sent-bubble-wrap-fix/checklist.md docs/ai/tasks/chat-nickname-neutralization/plan.md docs/ai/tasks/chat-nickname-neutralization/context.md docs/ai/tasks/chat-nickname-neutralization/checklist.md e2e/chat-flow-waiting-room.spec.ts src/features/room-chat/RoomChat.tsx src/features/room-chat/RoomChat.test.tsx src/pages/GamePage.tsx src/pages/GamePage.test.tsx src/pages/waiting-room/components/WaitingRoomChatBox.tsx src/pages/waiting-room/page/WaitingRoomPage.test.tsx`
- `git push -u origin fix/room-chat-bubble-and-badges` (pre-push hook: `lint`, `test`, `test:coverage`, `e2e:ci`, `build`)

---

## ⚠️ 남은 리스크

- sender 역할 구분은 이제 아바타와 말풍선 정렬만 남습니다. 시각적 구분이 더 필요하면 후속 cue가 필요할 수 있습니다.
- 이번 PR은 `room-chat-sent-bubble-wrap-fix`와 `chat-nickname-neutralization` 두 task slug를 함께 포함합니다. `ai:self-review`에서 one-feature-per-session 관련 경고가 있었으므로 workflow gate 정책에 따라 추후 분리 PR이 필요할 수 있습니다.

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료 또는 없음 명시
- [x] 큰 작업이면 task 문서 링크를 남겼다
- [x] 큰 작업이면 `TODO.md` / task slug 연결을 PR 본문에 남겼다
- [x] 참고한 기준 문서를 PR 본문에 남겼다
- [x] 실행한 검증과 남은 리스크를 PR 본문에 적었다

---

## 📸 스크린샷 (선택)

- 없음
