### PR TITLE
fix: 게임 인수 프롬프트 canonical 계약 정렬

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -17,6 +17,7 @@
 
 ## Done
 
+- [x] `game-acquisition-prompt-contract-alignment` - Game Acquisition Prompt Contract Alignment (`docs/ai/tasks/game-acquisition-prompt-contract-alignment/`) - acquisition prompt 분류를 `ACQUISITION_OR_SKIP` canonical 계약으로 축소하고 malformed choice fallback 전송을 방어
 - [x] `end-turn-after-board-settle` - End Turn After Board Settle (`docs/ai/tasks/end-turn-after-board-settle/`) - 말 이동과 보드 로컬 액션이 모두 해소된 뒤에만 턴 종료 버튼이 보이고 눌리도록 `GamePage`를 `GameBoard` blocking 상태와 다시 연결
 - [x] `game-board-modal-reveal-timing` - Game Board Modal Reveal Timing (`docs/ai/tasks/game-board-modal-reveal-timing/`) - PLAYER_MOVED 직후 보드 액션 모달이 말 이동 전에 한 프레임 보이는 경로를 barrier와 공통 reveal gate로 정리
 - [x] `manual-sell-selection-restore` - Manual Sell Selection Restore (`docs/ai/tasks/manual-sell-selection-restore/`) - 내 턴 자산 액션 구간에서 보유 토지 클릭 수동 매각을 복구하되 서버 sell prompt 경로와 충돌하지 않게 정리

--- a/docs/ai/tasks/game-acquisition-prompt-contract-alignment/checklist.md
+++ b/docs/ai/tasks/game-acquisition-prompt-contract-alignment/checklist.md
@@ -1,0 +1,26 @@
+# Checklist
+
+## Implementation
+
+- [x] 관련 manual과 기존 문서를 읽었다
+- [x] backend canonical acquisition 계약을 범위 문서에 반영했다
+- [x] `promptModalMapping` acquisition 분류를 exact type 기준으로 축소했다
+- [x] acquisition confirm/cancel fallback choice 전송을 막았다
+- [x] `GameBoard` 회귀 테스트로 acquisition modal 경계를 검증했다
+
+## Testing
+
+- [x] `npx vitest run src/components/game/modals/promptModalMapping.test.ts src/components/board/GameBoard.test.tsx`
+- [x] `npm run lint`
+- [x] `npm run ai:check:game`
+- [x] `npm run build`
+
+## Review
+
+- [x] `docs/rules.md` 기준으로 셀프 리뷰했다
+- [x] prompt canonical contract가 UI heuristic보다 우선하는지 확인했다
+- [x] `TODO.md` task 한 줄을 최신 상태로 유지했다
+- [x] session handoff notes를 최신 상태로 갱신했다
+- [x] `npm run ai:session:brief -- game-acquisition-prompt-contract-alignment` 출력이 현재 상태와 맞는다
+- [x] `npm run ai:self-review -- --files ...`를 실행했다
+- [x] 변경 파일 / 실행한 검증 / 남은 리스크를 정리했다

--- a/docs/ai/tasks/game-acquisition-prompt-contract-alignment/context.md
+++ b/docs/ai/tasks/game-acquisition-prompt-contract-alignment/context.md
@@ -1,0 +1,52 @@
+# Context
+
+## Current Behavior
+
+- `promptModalMapping`은 acquisition prompt를 substring token과 choice 조합으로 넓게 추론한다.
+- 이 경로 때문에 서버 canonical type이 아닌 prompt도 acquisition으로 분류될 수 있다.
+- acquisition confirm/cancel choice는 현재 fallback index를 사용해 canonical choice가 없어도 첫 번째/두 번째 choice를 반환할 수 있다.
+
+## Backend Contract Notes
+
+- 랜드마크(`buildingLevel = 3`)는 backend에서 인수 불가다.
+- 랜드마크에서는 `ACQUISITION_OR_SKIP` prompt가 아예 발송되지 않는다.
+- frontend가 신뢰해야 할 canonical 기준은 `prompt.type === 'ACQUISITION_OR_SKIP'` 여부다.
+- `choices`는 acquisition 가능 prompt에서 항상 `ACQUIRE` / `SKIP`로 고정이다.
+- `payload.buildingLevel`은 UI 표시용 참고 데이터이며 acquisition 가능 여부의 판단 기준이 아니다.
+
+## Related Files
+
+- `src/components/game/modals/promptModalMapping.ts`
+- `src/components/board/GameBoard.tsx`
+- `src/components/board/GameBoard.test.tsx`
+
+## Relevant Manuals
+
+- `docs/ai/manuals/common.md`
+- `docs/ai/manuals/game-runtime.md`
+- `docs/rules.md`
+- `docs/testing.md`
+
+## Constraints
+
+- 서버 authoritative prompt 계약을 프론트에서 다시 계산하지 않는다.
+- `GameBoard`는 raw transport 예외를 직접 해석하지 않고 normalized prompt를 렌더링한다.
+- malformed acquisition prompt가 와도 프론트가 임의 fallback choice를 전송하지 않는다.
+
+## Decision Notes
+
+- acquisition modal 분류는 exact type match로 고정한다.
+- acquisition confirm/cancel choice는 fallback index와 first-choice fallback을 모두 제거한다.
+- malformed acquisition prompt는 자동 dismiss하지 않는다. 현재 null guard로 잘못된 submit만 막는다.
+
+## Session Handoff Notes
+
+- 다음 세션에서 다시 읽을 문서: `docs/ai/tasks/game-acquisition-prompt-contract-alignment/*`, `docs/ai/manuals/game-runtime.md`
+- 바로 이어서 할 1개 단계: 없음
+- pending decision / blocker: 없음
+- 검증 재개 지점: `npx vitest run src/components/game/modals/promptModalMapping.test.ts src/components/board/GameBoard.test.tsx`, `npm run lint`, `npm run ai:check:game`, `npm run build`, `npm run ai:self-review -- --files ...` 실행 완료
+
+## Open Risks
+
+- 실서버 malformed acquisition prompt는 정상 경로가 아니므로, 이번 작업은 fallback submit 차단까지만 방어한다.
+- mock runtime에는 acquisition prompt 생성 경로가 없어, 회귀는 unit/UI 테스트 중심으로 확인한다.

--- a/docs/ai/tasks/game-acquisition-prompt-contract-alignment/plan.md
+++ b/docs/ai/tasks/game-acquisition-prompt-contract-alignment/plan.md
@@ -1,0 +1,70 @@
+# Plan
+
+## Task
+
+- 작업 이름: Game Acquisition Prompt Contract Alignment
+- 작업 slug: `game-acquisition-prompt-contract-alignment`
+- 요청 날짜: 2026-03-26
+- 담당 범위: 게임 acquisition prompt 분류를 백엔드 canonical 계약에 맞추고 malformed prompt fallback을 방어
+
+## Goal
+
+- 프론트는 `ACQUISITION_OR_SKIP` prompt가 왔을 때만 acquisition UI를 연다.
+- 랜드마크 여부를 `buildingLevel`로 추론하지 않는다.
+- acquisition prompt choice가 비정상이더라도 잘못된 fallback choice를 전송하지 않는다.
+
+## WAT Workflow
+
+1. task 문서와 TODO를 만들어 범위 / 완료 기준 / 검증 명령을 고정한다.
+2. `promptModalMapping`에서 acquisition modal 분류와 choice fallback을 canonical 계약으로 축소한다.
+3. `GameBoard` 회귀 테스트와 mapping unit test를 추가해 non-canonical prompt 오분류를 막는다.
+
+## In Scope
+
+- `src/components/game/modals/promptModalMapping.ts`
+- `src/components/game/modals/promptModalMapping.test.ts`
+- `src/components/board/GameBoard.test.tsx`
+- task 문서와 TODO 상태 정리
+
+## Out Of Scope
+
+- backend contract 변경
+- mock runtime acquisition prompt 신규 추가
+- `gameContractAdapters` prompt 정규화 규칙 변경
+- 랜드마크 인수 불가를 `buildingLevel === 3` 프론트 가드로 중복 구현
+
+## Target Files
+
+- `src/components/game/modals/promptModalMapping.ts`
+- `src/components/game/modals/promptModalMapping.test.ts`
+- `src/components/board/GameBoard.test.tsx`
+- `docs/ai/tasks/game-acquisition-prompt-contract-alignment/*`
+- `TODO.md`
+
+## Task Tracking
+
+- TODO line: - [ ] `game-acquisition-prompt-contract-alignment` - Game Acquisition Prompt Contract Alignment (`docs/ai/tasks/game-acquisition-prompt-contract-alignment/`)
+- Session brief: `npm run ai:session:brief -- game-acquisition-prompt-contract-alignment`
+- Reopen docs: `docs/ai/tasks/game-acquisition-prompt-contract-alignment/plan.md`, `context.md`, `checklist.md`, 관련 manuals
+
+## Completion Criteria
+
+- `ACQUISITION_OR_SKIP`만 acquisition modal로 분류된다.
+- `CITY_ACQUISITION`과 choice heuristic만 있는 prompt는 acquisition으로 분류되지 않는다.
+- acquisition confirm/cancel choice는 각각 `ACQUIRE` / `SKIP`일 때만 반환된다.
+- malformed acquisition prompt에서 confirm 버튼 클릭이 잘못된 fallback choice를 보내지 않는다.
+
+## Role Plan
+
+- Planner: 백엔드 canonical acquisition 계약을 프론트 구현 기준으로 정리
+- Implementer: mapping과 tests를 canonical prompt 기준으로 축소
+- Reviewer: malformed prompt fallback과 board-handled 경계 점검
+- Tester: mapping unit + board UI 회귀 + game/build 검증 실행
+
+## Test Plan
+
+- `npx vitest run src/components/game/modals/promptModalMapping.test.ts src/components/board/GameBoard.test.tsx`
+- `npm run lint`
+- `npm run ai:check:game`
+- `npm run build`
+- `npm run ai:self-review -- --files TODO.md docs/ai/tasks/game-acquisition-prompt-contract-alignment/plan.md docs/ai/tasks/game-acquisition-prompt-contract-alignment/context.md docs/ai/tasks/game-acquisition-prompt-contract-alignment/checklist.md src/components/game/modals/promptModalMapping.ts src/components/game/modals/promptModalMapping.test.ts src/components/board/GameBoard.test.tsx`

--- a/src/components/board/GameBoard.test.tsx
+++ b/src/components/board/GameBoard.test.tsx
@@ -46,13 +46,8 @@ vi.mock('../game/GlobalEffectOverlay', () => ({
 }))
 
 vi.mock('../game/modals/BuyModal', () => ({
-  default: ({
-    open,
-    cityName,
-  }: {
-    open: boolean
-    cityName?: string
-  }) => (open ? <div>{cityName || '도시'} 구매 모달</div> : null),
+  default: ({ open, cityName }: { open: boolean; cityName?: string }) =>
+    open ? <div>{cityName || '도시'} 구매 모달</div> : null,
 }))
 
 vi.mock('../game/modals/BuildModal', () => ({
@@ -69,7 +64,24 @@ vi.mock('../game/modals/TravelModal', () => ({
 }))
 
 vi.mock('../game/modals/CityAcquisitionModals', () => ({
-  default: () => null,
+  default: ({
+    open,
+    ownerName,
+    onCancel,
+    onAcquire,
+  }: {
+    open: boolean
+    ownerName?: string
+    onCancel?: () => void
+    onAcquire?: () => void
+  }) =>
+    open ? (
+      <div>
+        <div>{ownerName} 인수 모달</div>
+        <button onClick={onCancel}>인수 취소</button>
+        <button onClick={onAcquire}>인수하기</button>
+      </div>
+    ) : null,
 }))
 
 vi.mock('../game/modals/CitySellModal', () => ({
@@ -243,15 +255,13 @@ beforeAll(() => {
 
   vi.stubGlobal('ResizeObserver', ResizeObserverMock)
   vi.stubGlobal('Audio', AudioMock)
-  vi.stubGlobal(
-    'requestAnimationFrame',
-    ((callback: FrameRequestCallback) =>
-      window.setTimeout(() => callback(performance.now()), 16)) as typeof requestAnimationFrame
-  )
-  vi.stubGlobal(
-    'cancelAnimationFrame',
-    ((handle: number) => window.clearTimeout(handle)) as typeof cancelAnimationFrame
-  )
+  vi.stubGlobal('requestAnimationFrame', ((callback: FrameRequestCallback) =>
+    window.setTimeout(
+      () => callback(performance.now()),
+      16
+    )) as typeof requestAnimationFrame)
+  vi.stubGlobal('cancelAnimationFrame', ((handle: number) =>
+    window.clearTimeout(handle)) as typeof cancelAnimationFrame)
 })
 
 afterAll(() => {
@@ -420,5 +430,81 @@ describe('GameBoard modal reveal timing', () => {
     })
 
     expect(screen.getByText('무인도 이동 모달')).toBeInTheDocument()
+  })
+})
+
+describe('GameBoard acquisition prompt handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useGameStore.getState().resetGame()
+  })
+
+  it('opens acquisition modal only for canonical acquisition prompt type', () => {
+    renderGameBoard({
+      activePrompt: {
+        id: 'acquire-1',
+        type: 'ACQUISITION_OR_SKIP',
+        payload: {
+          tileId: 2,
+          ownerName: '플레이어2',
+          buildingLevel: 2,
+          acquisitionCost: 1800,
+        },
+        choices: [
+          { id: 'acquire', label: '인수하기', value: 'ACQUIRE' },
+          { id: 'skip', label: '넘기기', value: 'SKIP' },
+        ],
+      },
+    })
+
+    expect(screen.getByText('플레이어2 인수 모달')).toBeInTheDocument()
+  })
+
+  it('does not open acquisition modal for non-acquisition prompt with acquisition-like payload', () => {
+    renderGameBoard({
+      activePrompt: {
+        id: 'build-1',
+        type: 'BUILD_OR_SKIP',
+        payload: {
+          tileId: 2,
+          ownerName: '플레이어2',
+          buildingLevel: 2,
+          acquisitionCost: 1800,
+        },
+        choices: [
+          { id: 'build', label: '건설', value: 'BUILD' },
+          { id: 'skip', label: '건너뛰기', value: 'SKIP' },
+        ],
+      },
+    })
+
+    expect(screen.queryByText(/인수 모달/)).not.toBeInTheDocument()
+  })
+
+  it('does not send a fallback acquisition choice when canonical confirm choice is missing', async () => {
+    const user = userEvent.setup()
+    const onPromptChoice = vi.fn()
+
+    renderGameBoard({
+      activePrompt: {
+        id: 'acquire-2',
+        type: 'ACQUISITION_OR_SKIP',
+        payload: {
+          tileId: 2,
+          ownerName: '플레이어2',
+          buildingLevel: 2,
+          acquisitionCost: 1800,
+        },
+        choices: [
+          { id: 'skip', label: '넘기기', value: 'SKIP' },
+          { id: 'wait', label: '대기', value: 'WAIT' },
+        ],
+      },
+      onPromptChoice,
+    })
+
+    await user.click(screen.getByRole('button', { name: '인수하기' }))
+
+    expect(onPromptChoice).not.toHaveBeenCalled()
   })
 })

--- a/src/components/game/modals/promptModalMapping.test.ts
+++ b/src/components/game/modals/promptModalMapping.test.ts
@@ -34,7 +34,7 @@ describe('promptModalMapping', () => {
 
   it('resolves acquisition modal by prompt type token', () => {
     const prompt = createPrompt({
-      type: 'CITY_ACQUISITION',
+      type: 'ACQUISITION_OR_SKIP',
       choices: [
         { id: 'skip', label: '건너뛰기', value: 'SKIP' },
         { id: 'acquire', label: '인수하기', value: 'ACQUIRE' },
@@ -42,6 +42,30 @@ describe('promptModalMapping', () => {
     })
 
     expect(resolvePromptModalKind(prompt)).toBe('acquisition')
+  })
+
+  it('does not resolve acquisition modal for legacy acquisition alias', () => {
+    const prompt = createPrompt({
+      type: 'CITY_ACQUISITION',
+      choices: [
+        { id: 'skip', label: '건너뛰기', value: 'SKIP' },
+        { id: 'acquire', label: '인수하기', value: 'ACQUIRE' },
+      ],
+    })
+
+    expect(resolvePromptModalKind(prompt)).toBe('unknown')
+  })
+
+  it('does not resolve acquisition modal from choice tokens alone', () => {
+    const prompt = createPrompt({
+      type: 'SERVER_PROMPT',
+      choices: [
+        { id: 'skip', label: '건너뛰기', value: 'SKIP' },
+        { id: 'acquire', label: '인수하기', value: 'ACQUIRE' },
+      ],
+    })
+
+    expect(resolvePromptModalKind(prompt)).toBe('unknown')
   })
 
   it('resolves sell modal by prompt type token', () => {
@@ -82,7 +106,7 @@ describe('promptModalMapping', () => {
 
   it('resolves acquisition confirm/cancel choices', () => {
     const prompt = createPrompt({
-      type: 'CITY_ACQUISITION',
+      type: 'ACQUISITION_OR_SKIP',
       choices: [
         { id: 'skip', label: '건너뛰기', value: 'SKIP' },
         { id: 'acquire', label: '인수하기', value: 'ACQUIRE' },
@@ -93,6 +117,31 @@ describe('promptModalMapping', () => {
       'ACQUIRE'
     )
     expect(resolvePromptChoiceValue(prompt, 'acquisitionCancel')).toBe('SKIP')
+  })
+
+  it('returns null when acquisition confirm choice is missing', () => {
+    const prompt = createPrompt({
+      type: 'ACQUISITION_OR_SKIP',
+      choices: [
+        { id: 'skip', label: '건너뛰기', value: 'SKIP' },
+        { id: 'wait', label: '대기', value: 'WAIT' },
+      ],
+    })
+
+    expect(resolvePromptChoiceValue(prompt, 'acquisitionConfirm')).toBeNull()
+    expect(resolvePromptChoiceValue(prompt, 'acquisitionCancel')).toBe('SKIP')
+  })
+
+  it('returns null when acquisition cancel choice is missing', () => {
+    const prompt = createPrompt({
+      type: 'ACQUISITION_OR_SKIP',
+      choices: [{ id: 'acquire', label: '인수하기', value: 'ACQUIRE' }],
+    })
+
+    expect(resolvePromptChoiceValue(prompt, 'acquisitionConfirm')).toBe(
+      'ACQUIRE'
+    )
+    expect(resolvePromptChoiceValue(prompt, 'acquisitionCancel')).toBeNull()
   })
 
   it('resolves sell confirm/cancel choices', () => {

--- a/src/components/game/modals/promptModalMapping.ts
+++ b/src/components/game/modals/promptModalMapping.ts
@@ -29,22 +29,13 @@ export type PromptChoiceRuleKey =
 const BUY_TYPE_TOKENS = ['BUY_OR_SKIP', 'BUY_PROPERTY', 'BUY_PROMPT']
 const BUILD_TYPE_TOKENS = ['BUILD_OR_SKIP', 'UPGRADE_OR_SKIP', 'BUILD_PROMPT']
 const TOLL_TYPE_TOKENS = ['PAY_TOLL', 'TOLL_CONFIRM', 'PAY_TOLL_CONFIRM']
+const ACQUISITION_PROMPT_TYPE = 'ACQUISITION_OR_SKIP'
 const SELL_TYPE_TOKENS = [
   'SELL_PROPERTY',
   'SELL_OR_SKIP',
   'SELL_PROMPT',
   'CITY_SELL',
   'FORCED_SELL',
-]
-const ACQUISITION_TYPE_TOKENS = [
-  'CITY_ACQUISITION',
-  'CITY_ACQUIRE',
-  'ACQUISITION',
-  'TAKEOVER',
-  'BUYOUT',
-  'ACQUIRE_CITY',
-  'PURCHASE_CITY',
-  'TAKEOVER_CITY',
 ]
 const TRAVEL_TYPE_TOKENS = [
   'TRAVEL',
@@ -70,6 +61,7 @@ const PROMPT_CHOICE_RULES: Record<
   {
     preferredTokens: string[]
     fallbackIndex?: number
+    allowFirstChoiceFallback?: boolean
   }
 > = {
   buyConfirm: {
@@ -101,12 +93,12 @@ const PROMPT_CHOICE_RULES: Record<
     fallbackIndex: 1,
   },
   acquisitionConfirm: {
-    preferredTokens: ['ACQUIRE', 'ACQUISITION', 'TAKEOVER', 'BUYOUT', 'BUY'],
-    fallbackIndex: 0,
+    preferredTokens: ['ACQUIRE'],
+    allowFirstChoiceFallback: false,
   },
   acquisitionCancel: {
-    preferredTokens: ['SKIP', 'PASS', 'CANCEL', 'NO'],
-    fallbackIndex: 1,
+    preferredTokens: ['SKIP'],
+    allowFirstChoiceFallback: false,
   },
   travelConfirm: {
     preferredTokens: ['TRAVEL', 'DESTINATION', 'SELECT', 'CONFIRM', 'YES'],
@@ -137,6 +129,9 @@ const hasTypeToken = (prompt: GamePrompt, tokens: string[]) => {
   const promptType = normalize(prompt.type)
   return tokens.some((token) => promptType.includes(token))
 }
+
+const hasExactType = (prompt: GamePrompt, expectedType: string) =>
+  normalize(prompt.type) === normalize(expectedType)
 
 const getPromptChoices = (prompt: GamePrompt) => prompt.choices ?? []
 
@@ -199,11 +194,7 @@ export const resolvePromptModalKind = (
     return 'sell'
   }
 
-  if (
-    hasTypeToken(prompt, ACQUISITION_TYPE_TOKENS) ||
-    (hasChoiceToken(prompt, ['ACQUIRE', 'TAKEOVER', 'BUYOUT']) &&
-      hasChoiceToken(prompt, ['SKIP', 'PASS', 'CANCEL']))
-  ) {
+  if (hasExactType(prompt, ACQUISITION_PROMPT_TYPE)) {
     return 'acquisition'
   }
 
@@ -240,7 +231,10 @@ export const isPromptHandledByBoardModal = (
 export const findPromptChoiceValue = (
   prompt: GamePrompt | null | undefined,
   preferredTokens: string[],
-  fallbackIndex?: number
+  options?: {
+    fallbackIndex?: number
+    allowFirstChoiceFallback?: boolean
+  }
 ): string | null => {
   if (!prompt) {
     return null
@@ -250,6 +244,9 @@ export const findPromptChoiceValue = (
   if (choices.length === 0) {
     return null
   }
+
+  const fallbackIndex = options?.fallbackIndex
+  const allowFirstChoiceFallback = options?.allowFirstChoiceFallback ?? true
 
   for (const token of preferredTokens) {
     const matchedChoiceByToken = choices.find((choice) =>
@@ -268,7 +265,11 @@ export const findPromptChoiceValue = (
     return choices[fallbackIndex].value
   }
 
-  return choices[0].value
+  if (allowFirstChoiceFallback) {
+    return choices[0].value
+  }
+
+  return null
 }
 
 export const resolvePromptChoiceValue = (
@@ -277,7 +278,10 @@ export const resolvePromptChoiceValue = (
 ): string | null => {
   const rule = PROMPT_CHOICE_RULES[ruleKey]
 
-  return findPromptChoiceValue(prompt, rule.preferredTokens, rule.fallbackIndex)
+  return findPromptChoiceValue(prompt, rule.preferredTokens, {
+    fallbackIndex: rule.fallbackIndex,
+    allowFirstChoiceFallback: rule.allowFirstChoiceFallback,
+  })
 }
 
 export const getPromptChoiceLabel = (


### PR DESCRIPTION
## 관련 이슈

> closes #655 

## 작업 내용

- acquisition prompt 분류를 substring/choice heuristic 기반에서 `ACQUISITION_OR_SKIP` exact match 기준으로 축소했습니다.
- acquisition confirm/cancel choice 해석에서 fallback 전송을 제거해 canonical choice(`ACQUIRE`, `SKIP`)가 없으면 잘못된 응답을 보내지 않도록 정리했습니다.
- `GameBoard` 회귀 테스트와 prompt mapping unit test를 추가해 non-canonical prompt 오분류와 malformed choice fallback을 방지했습니다.

## 🧠 Task 문서 (큰 작업이면 필수)

- `docs/ai/tasks/game-acquisition-prompt-contract-alignment/plan.md`
- `docs/ai/tasks/game-acquisition-prompt-contract-alignment/context.md`
- `docs/ai/tasks/game-acquisition-prompt-contract-alignment/checklist.md`

## 📋 TODO.md 연결

- task slug: game-acquisition-prompt-contract-alignment
- TODO status: Done
- TODO entry 확인: TODO.md

## 📚 참고한 기준 문서

- `AGENTS.md`
- `docs/ai/manuals/common.md`
- `docs/ai/manuals/game-runtime.md`
- `docs/rules.md`
- `docs/testing.md`

## 변경 파일

- `src/components/game/modals/promptModalMapping.ts`
- `src/components/game/modals/promptModalMapping.test.ts`
- `src/components/board/GameBoard.test.tsx`
- `docs/ai/tasks/game-acquisition-prompt-contract-alignment/*`
- `TODO.md`

## 🧪 실행한 검증

- `npx vitest run src/components/game/modals/promptModalMapping.test.ts src/components/board/GameBoard.test.tsx`
- `npm run lint`
- `npm run ai:check:game`
- `npm run build`
- `npm run ai:session:brief -- game-acquisition-prompt-contract-alignment`
- `npm run ai:self-review -- --files TODO.md docs/ai/tasks/game-acquisition-prompt-contract-alignment/plan.md docs/ai/tasks/game-acquisition-prompt-contract-alignment/context.md docs/ai/tasks/game-acquisition-prompt-contract-alignment/checklist.md src/components/game/modals/promptModalMapping.ts src/components/game/modals/promptModalMapping.test.ts src/components/board/GameBoard.test.tsx`

## ⚠️ 남은 리스크

- 실서버 malformed acquisition prompt는 정상 경로가 아니므로, 이번 PR은 잘못된 fallback choice 전송 차단까지만 방어합니다.
- mock runtime에는 acquisition prompt 생성 경로가 없어, 회귀는 unit/UI 테스트 중심으로 확인했습니다.

## 체크리스트

- [x] 관련 task 문서와 TODO를 업데이트했다
- [x] 최소 범위 테스트를 추가/수정했다
- [x] `lint`, `ai:check:game`, `build`를 실행했다
- [x] 관련 이슈 번호를 연결했다
