### PR TITLE
fix: 게임 디버그 오버레이 배포 숨김

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -17,6 +17,7 @@
 
 ## Done
 
+- [x] `game-debug-overlay-production-hide` - Game Debug Overlay 배포 숨김 (`docs/ai/tasks/game-debug-overlay-production-hide/`) - `GamePage` 오른쪽 상단 debug/status overlay를 production에서 숨기고 dev에서만 유지
 - [x] `game-board-modal-reveal-policy-split` - Game Board Modal Reveal Policy Split (`docs/ai/tasks/game-board-modal-reveal-policy-split/`) - pre-move / post-move reveal policy를 분리해 travel, go-to-island, chance chain move modal ordering을 정리
 - [x] `game-acquisition-prompt-contract-alignment` - Game Acquisition Prompt Contract Alignment (`docs/ai/tasks/game-acquisition-prompt-contract-alignment/`) - acquisition prompt 분류를 `ACQUISITION_OR_SKIP` canonical 계약으로 축소하고 malformed choice fallback 전송을 방어
 - [x] `end-turn-after-board-settle` - End Turn After Board Settle (`docs/ai/tasks/end-turn-after-board-settle/`) - 말 이동과 보드 로컬 액션이 모두 해소된 뒤에만 턴 종료 버튼이 보이고 눌리도록 `GamePage`를 `GameBoard` blocking 상태와 다시 연결

--- a/docs/ai/tasks/game-debug-overlay-production-hide/checklist.md
+++ b/docs/ai/tasks/game-debug-overlay-production-hide/checklist.md
@@ -1,0 +1,21 @@
+# Checklist
+
+## Implementation
+
+- [x] 관련 manual과 기존 문서를 읽었다
+- [x] `env.ts`에 game debug overlay 플래그를 추가했다
+- [x] `GamePage`에서 overlay를 production-hide 조건으로 감쌌다
+- [x] fatal fallback과 게임 진행 로직을 그대로 유지했다
+
+## Testing
+
+- [x] `npx vitest run src/pages/GamePage.test.tsx`
+- [x] `npm run lint`
+- [x] `npm run ai:check:game`
+- [x] `npm run build`
+
+## Review
+
+- [x] `npm run ai:self-review -- --files ...`를 실행했다
+- [x] `TODO.md` task 한 줄을 최신 상태로 유지했다
+- [x] 변경 파일 / 실행한 검증 / 남은 리스크를 정리했다

--- a/docs/ai/tasks/game-debug-overlay-production-hide/context.md
+++ b/docs/ai/tasks/game-debug-overlay-production-hide/context.md
@@ -1,0 +1,25 @@
+# Context
+
+## Current Behavior
+
+- `GamePage`는 오른쪽 상단 absolute 영역에 `Pending action`, `Action acknowledged`, `lastError` 상태 박스를 항상 렌더링한다.
+- 이 overlay는 개발 디버깅에는 유용하지만 최종 배포 화면에는 노출할 필요가 없다.
+- fatal route error는 같은 `lastError` store를 사용하지만, 실제 fallback 렌더링은 overlay와 별도 분기다.
+
+## Relevant Manuals
+
+- `docs/ai/manuals/common.md`
+- `docs/ai/manuals/game-runtime.md`
+- `docs/rules.md`
+- `docs/testing.md`
+
+## Decision Notes
+
+- overlay는 완전히 제거하지 않고 dev에서만 유지한다.
+- env 플래그는 `src/config/env.ts`에서 export해 `GamePage.test.tsx`에서 mock 가능하게 둔다.
+- `lastError` store 구독과 fatal fallback 로직은 그대로 유지한다.
+
+## Open Risks
+
+- non-fatal error는 production에서 화면상으로 보이지 않으므로, 운영 중 즉시 가시성은 낮아진다.
+- overlay 숨김은 UI 정책 변경일 뿐이라 socket/store 상태 자체는 계속 갱신된다.

--- a/docs/ai/tasks/game-debug-overlay-production-hide/plan.md
+++ b/docs/ai/tasks/game-debug-overlay-production-hide/plan.md
@@ -1,0 +1,41 @@
+# Plan
+
+## Task
+
+- 작업 이름: Game Debug Overlay 배포 숨김
+- 작업 slug: `game-debug-overlay-production-hide`
+- 요청 날짜: 2026-03-26
+- 담당 범위: `GamePage` 오른쪽 상단 디버그 오버레이를 production에서 숨기고 dev에서는 유지
+
+## Goal
+
+- 최종 배포에서는 `Pending action / Action acknowledged / lastError` 박스가 보이지 않는다.
+- 개발 환경에서는 기존 디버그 오버레이를 그대로 유지한다.
+- fatal fallback, 게임 진행, prompt 처리, store 계약은 바꾸지 않는다.
+
+## In Scope
+
+- `src/config/env.ts`
+- `src/pages/GamePage.tsx`
+- `src/pages/GamePage.test.tsx`
+- task 문서와 TODO 상태 정리
+
+## Out Of Scope
+
+- 게임 socket/store 계약 변경
+- `DevRoomChatControlPanel` 등 다른 개발용 UI 제거
+- 브라우저 console 출력 정리
+
+## Completion Criteria
+
+- production 기준 `GamePage`에서 오른쪽 상단 디버그 오버레이가 렌더링되지 않는다.
+- dev 기준에서는 기존 overlay가 그대로 보인다.
+- fatal route fallback은 overlay 플래그와 무관하게 기존처럼 동작한다.
+
+## Test Plan
+
+- `npx vitest run src/pages/GamePage.test.tsx`
+- `npm run lint`
+- `npm run ai:check:game`
+- `npm run build`
+- `npm run ai:self-review -- --files TODO.md docs/ai/tasks/game-debug-overlay-production-hide/plan.md docs/ai/tasks/game-debug-overlay-production-hide/context.md docs/ai/tasks/game-debug-overlay-production-hide/checklist.md src/config/env.ts src/pages/GamePage.tsx src/pages/GamePage.test.tsx`

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -13,5 +13,8 @@ export const IS_SOCKET_MOCK_ENABLED =
   (import.meta.env.DEV && import.meta.env.VITE_USE_SOCKET_MOCK !== 'false') ||
   IS_DEMO_MOCK_ENABLED
 
+// 게임 화면 우측 상단 디버그 오버레이는 개발 환경에서만 노출
+export const SHOW_GAME_DEBUG_OVERLAY = import.meta.env.DEV
+
 // MSW는 실제로 목 데이터를 사용할 때만 활성화
 export const SHOULD_ENABLE_MSW = IS_SOCKET_MOCK_ENABLED

--- a/src/pages/GamePage.test.tsx
+++ b/src/pages/GamePage.test.tsx
@@ -12,9 +12,16 @@ import { renderWithProviders } from '../test/renderWithProviders'
 import type { Player } from '../types/domain'
 import type { WaitingRoomSnapshot } from './waiting-room/api/types'
 
+const envFlags = vi.hoisted(() => ({
+  showGameDebugOverlay: false,
+}))
+
 vi.mock('../config/env', () => ({
   IS_DEMO_MOCK_ENABLED: false,
   IS_SOCKET_MOCK_ENABLED: false,
+  get SHOW_GAME_DEBUG_OVERLAY() {
+    return envFlags.showGameDebugOverlay
+  },
   SHOULD_ENABLE_MSW: true,
 }))
 
@@ -328,6 +335,10 @@ const resetAndSetTestGameState = (state: GameStatePatch) => {
   setTestGameState(state)
 }
 
+const setTestGameDebugOverlayVisible = (visible: boolean) => {
+  envFlags.showGameDebugOverlay = visible
+}
+
 function renderGamePage(options?: {
   initialEntries?: Array<{
     pathname: string
@@ -381,6 +392,7 @@ describe('GamePage chat flow', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     useTurnMock.mockReturnValue(false)
+    setTestGameDebugOverlayVisible(false)
 
     setTestAuthSession(
       createAuthSessionFixture({
@@ -1026,6 +1038,72 @@ describe('GamePage chat flow', () => {
     expect(screen.getByText('/ 20')).toBeInTheDocument()
     // Label
     expect(screen.getByText('Round')).toBeInTheDocument()
+  })
+
+  it('디버그 오버레이 플래그가 켜져 있으면 pending/ack/error 상태 박스를 렌더한다', () => {
+    setTestGameDebugOverlayVisible(true)
+    setTestGameState({
+      pendingAction: {
+        actionId: 'action-1',
+        type: 'END_TURN',
+        requestedAt: Date.now(),
+      },
+      lastAck: {
+        actionId: 'action-1',
+        type: 'END_TURN',
+        ok: true,
+      },
+      lastError: {
+        code: 'RETRY_LATER',
+        message: '잠시 후 다시 시도해주세요.',
+      },
+    })
+
+    renderGamePage()
+
+    expect(screen.getByText('Pending action: END_TURN')).toBeInTheDocument()
+    expect(
+      screen.getByText('Action acknowledged (END_TURN)')
+    ).toBeInTheDocument()
+    expect(screen.getByText('RETRY_LATER')).toBeInTheDocument()
+    expect(screen.getByText('잠시 후 다시 시도해주세요.')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Dismiss' })).toBeInTheDocument()
+  })
+
+  it('디버그 오버레이 플래그가 꺼져 있으면 pending/ack/error 상태 박스를 숨긴다', () => {
+    setTestGameDebugOverlayVisible(false)
+    setTestGameState({
+      pendingAction: {
+        actionId: 'action-1',
+        type: 'END_TURN',
+        requestedAt: Date.now(),
+      },
+      lastAck: {
+        actionId: 'action-1',
+        type: 'END_TURN',
+        ok: true,
+      },
+      lastError: {
+        code: 'RETRY_LATER',
+        message: '잠시 후 다시 시도해주세요.',
+      },
+    })
+
+    renderGamePage()
+
+    expect(
+      screen.queryByText('Pending action: END_TURN')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText('Action acknowledged (END_TURN)')
+    ).not.toBeInTheDocument()
+    expect(screen.queryByText('RETRY_LATER')).not.toBeInTheDocument()
+    expect(
+      screen.queryByText('잠시 후 다시 시도해주세요.')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Dismiss' })
+    ).not.toBeInTheDocument()
   })
 
   it('보드가 아직 blocked면 resolving 상태여도 턴 종료 대신 주사위 버튼이 비활성으로 유지된다', async () => {

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -8,7 +8,7 @@ import ExitGameModal from '../components/game/modals/ExitGameModal'
 import { isPromptHandledByBoardModal } from '../components/game/modals/promptModalMapping'
 import PlayerPanel from '../components/game/panels/PlayerPanel'
 import GlobalEffectModal from '../components/game/GlobalEffectModal'
-import { IS_SOCKET_MOCK_ENABLED } from '../config/env'
+import { IS_SOCKET_MOCK_ENABLED, SHOW_GAME_DEBUG_OVERLAY } from '../config/env'
 import { useAuthStore } from '../features/auth/session/store'
 import { requestOnlineUsersSnapshotSync } from '../features/presence/online-users/onlineUsersSocket'
 import { DevRoomChatControlPanel } from '../features/room-chat/DevRoomChatControlPanel'
@@ -684,6 +684,8 @@ const GamePage: React.FC = () => {
     !isFatalGameRouteError &&
     !isRecoveringFromFatalGameRoute &&
     storePlayers.length === 0
+  const shouldShowGameDebugOverlay =
+    SHOW_GAME_DEBUG_OVERLAY && (isActionPending || lastAck || lastError)
 
   if (
     (isFatalGameRouteError || isRecoveringFromFatalGameRoute) &&
@@ -727,38 +729,40 @@ const GamePage: React.FC = () => {
           <ArrowLeft size={20} />
         </button>
       </div>
-      <div className="absolute right-6 top-6 z-20 flex w-85 flex-col gap-2">
-        {isActionPending && (
-          <div className="rounded-xl border border-[#BFDBFE] bg-[#EFF6FF] px-3 py-2 text-xs font-semibold text-[#1D4ED8]">
-            Pending action: {pendingAction.type}
-          </div>
-        )}
-        {lastAck && (
-          <div
-            className={`rounded-xl border px-3 py-2 text-xs font-semibold ${
-              lastAck.ok
-                ? 'border-[#BBF7D0] bg-[#F0FDF4] text-[#166534]'
-                : 'border-[#FECACA] bg-[#FEF2F2] text-[#B91C1C]'
-            }`}
-          >
-            {lastAck.ok ? 'Action acknowledged' : 'Action rejected'} (
-            {lastAck.type ?? 'UNKNOWN'})
-          </div>
-        )}
-        {lastError && (
-          <div className="rounded-xl border border-[#FECACA] bg-[#FEF2F2] px-3 py-2 text-xs text-[#991B1B]">
-            <div className="font-semibold">{lastError.code}</div>
-            <div className="mt-1">{lastError.message}</div>
-            <button
-              type="button"
-              onClick={dismissLastError}
-              className="mt-2 rounded-lg border border-[#FCA5A5] bg-white px-2 py-1 text-[11px] font-semibold text-[#B91C1C] transition-colors hover:bg-[#FEE2E2]"
+      {shouldShowGameDebugOverlay ? (
+        <div className="absolute right-6 top-6 z-20 flex w-85 flex-col gap-2">
+          {isActionPending && (
+            <div className="rounded-xl border border-[#BFDBFE] bg-[#EFF6FF] px-3 py-2 text-xs font-semibold text-[#1D4ED8]">
+              Pending action: {pendingAction.type}
+            </div>
+          )}
+          {lastAck && (
+            <div
+              className={`rounded-xl border px-3 py-2 text-xs font-semibold ${
+                lastAck.ok
+                  ? 'border-[#BBF7D0] bg-[#F0FDF4] text-[#166534]'
+                  : 'border-[#FECACA] bg-[#FEF2F2] text-[#B91C1C]'
+              }`}
             >
-              Dismiss
-            </button>
-          </div>
-        )}
-      </div>
+              {lastAck.ok ? 'Action acknowledged' : 'Action rejected'} (
+              {lastAck.type ?? 'UNKNOWN'})
+            </div>
+          )}
+          {lastError && (
+            <div className="rounded-xl border border-[#FECACA] bg-[#FEF2F2] px-3 py-2 text-xs text-[#991B1B]">
+              <div className="font-semibold">{lastError.code}</div>
+              <div className="mt-1">{lastError.message}</div>
+              <button
+                type="button"
+                onClick={dismissLastError}
+                className="mt-2 rounded-lg border border-[#FCA5A5] bg-white px-2 py-1 text-[11px] font-semibold text-[#B91C1C] transition-colors hover:bg-[#FEE2E2]"
+              >
+                Dismiss
+              </button>
+            </div>
+          )}
+        </div>
+      ) : null}
 
       <div className="relative z-10 mx-auto flex h-full w-full items-center justify-between gap-8 pb-12 pt-4">
         <div className="flex h-[80%] min-h-0 w-[320px] shrink-0 flex-col">


### PR DESCRIPTION
## 📌 관련 이슈

> closes #659

---

## 📝 작업 내용

- `src/config/env.ts`
- `src/pages/GamePage.tsx`
- `src/pages/GamePage.test.tsx`
- task 문서와 TODO 상태 정리

---

## 🧠 Task 문서 (큰 작업이면 필수)

- plan: docs/ai/tasks/game-debug-overlay-production-hide/plan.md
- context: docs/ai/tasks/game-debug-overlay-production-hide/context.md
- checklist: docs/ai/tasks/game-debug-overlay-production-hide/checklist.md

---

## 📋 TODO.md 연결

- task slug: game-debug-overlay-production-hide
- TODO status: Done
- TODO entry 확인: TODO.md와 docs/ai/tasks/game-debug-overlay-production-hide/가 1:1로 연결됨

---

## 📚 참고한 기준 문서

- `AGENTS.md`
- `docs/ai/manuals/common.md`
- `docs/rules.md`
- `docs/testing.md`
- `docs/ai/manuals/game-runtime.md`

---

## 🧪 실행한 검증

- `npm run lint`
- `npm run ai:check:game`
- `npm run ai:check:build`
- `npx vitest run src/pages/GamePage.test.tsx`
- `npm run ai:self-review -- --files TODO.md docs/ai/tasks/game-debug-overlay-production-hide/checklist.md docs/ai/tasks/game-debug-overlay-production-hide/context.md docs/ai/tasks/game-debug-overlay-production-hide/plan.md src/config/env.ts src/pages/GamePage.test.tsx src/pages/GamePage.tsx`
- `npm run ai:pr-gate -- --files TODO.md docs/ai/tasks/game-debug-overlay-production-hide/checklist.md docs/ai/tasks/game-debug-overlay-production-hide/context.md docs/ai/tasks/game-debug-overlay-production-hide/plan.md src/config/env.ts src/pages/GamePage.test.tsx src/pages/GamePage.tsx --pr-body-file /tmp/ai-git-flow-pr-body.md`

---

## ⚠️ 남은 리스크

- non-fatal lastError는 production에서 더 이상 화면에 보이지 않으므로, 운영 중 즉시 가시성은 낮아집니다.

---

## ✅ 체크리스트

- [ ] 로컬에서 정상 동작 확인
- [ ] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료
- [x] 큰 작업이면 task 문서 링크를 남겼다
- [x] 큰 작업이면 `TODO.md` / task slug 연결을 PR 본문에 남겼다
- [x] 참고한 기준 문서를 PR 본문에 남겼다
- [x] 실행한 검증과 남은 리스크를 PR 본문에 적었다

---

## 📸 스크린샷 (선택)

> UI 변경이 있을 경우 첨부해주세요.