### PR TITLE
feat: mock 보드 SoT 동기화 및 턴/이벤트 런타임 정합성 보강

### DIFF
--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -51,11 +51,13 @@ import {
 import { getBoardSellFallbackRefund } from './gameBoardActionUtils'
 import { useBoardEventQueue } from './useBoardEventQueue'
 import {
+  FAST_MOVE_ANIMATION_OPTIONS,
   getPendingMovePlayerIdsFromEvents,
   getBoardEventAnimationHoldMs,
   resolveBoardCardModalContentFromEvent,
   resolveBoardEventTileIndex,
   resolveChanceMoveAnimationHint,
+  shouldApplyTravelMoveAnimation,
   shouldRevealPostMoveSurface,
   shouldRevealPreMoveSurface,
   type BoardEventAnimationKind,
@@ -889,6 +891,12 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
             'move_to_island',
             'go_to_island',
           ].includes(normalizedTrigger)
+          const shouldUseFastMoveAnimation = shouldApplyTravelMoveAnimation({
+            normalizedTrigger,
+            fromIndex,
+            toIndex: tileIndex,
+            tiles: boardTiles,
+          })
           lockBoardActionModals()
           if (isTravelMove && event.playerId != null) {
             startTravelTokenFx(event.playerId, 1600)
@@ -898,9 +906,9 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
             event.playerId!,
             fromIndex,
             tileIndex,
-            {
-              direction: moveDirection,
-            }
+            shouldUseFastMoveAnimation
+              ? { ...FAST_MOVE_ANIMATION_OPTIONS, direction: moveDirection }
+              : { direction: moveDirection }
           )
 
           // 애니메이션 시작 (비동기로 실행하여 이벤트 큐의 지연과 맞춤)
@@ -1075,7 +1083,8 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
     const promptOwnerName =
       promptOwnerNameFromPayload ??
       (promptOwnerId != null
-        ? players.find((player) => Number(player.id) === promptOwnerId)?.name
+        ? players.find((player) => String(player.id) === String(promptOwnerId))
+            ?.name
         : null) ??
       DEFAULT_OPPONENT_NAME
     const promptSellerName =

--- a/src/components/board/board.constants.ts
+++ b/src/components/board/board.constants.ts
@@ -33,7 +33,7 @@ export const LEVEL_MODAL_ICONS: Record<number, string> = {
 }
 
 export interface TileOwner {
-  ownerId: number
+  ownerId: string | number
   ownerColor: string
   level: BuildingLevel
 }
@@ -49,7 +49,7 @@ export interface TileData {
 }
 
 export interface PlayerState {
-  id: number
+  id: string | number
   name: string
   color: string
   pos: number
@@ -66,24 +66,24 @@ type TierRuleWon = {
 
 const PROPERTY_TIER_BY_PRICE_WON: Record<number, TierRuleWon> = {
   300_000_000: {
-    tolls: [100_000_000, 150_000_000, 300_000_000, 800_000_000],
-    buildCosts: [200_000_000, 300_000_000, 400_000_000],
+    tolls: [50_000_000, 100_000_000, 300_000_000, 650_000_000],
+    buildCosts: [400_000_000, 850_000_000, 1_400_000_000],
   },
   500_000_000: {
-    tolls: [150_000_000, 250_000_000, 650_000_000, 1_200_000_000],
-    buildCosts: [250_000_000, 500_000_000, 700_000_000],
+    tolls: [100_000_000, 200_000_000, 900_000_000, 1_550_000_000],
+    buildCosts: [600_000_000, 1_550_000_000, 1_800_000_000],
   },
   700_000_000: {
-    tolls: [200_000_000, 400_000_000, 900_000_000, 1_800_000_000],
-    buildCosts: [500_000_000, 900_000_000, 1_400_000_000],
+    tolls: [150_000_000, 300_000_000, 950_000_000, 1_750_000_000],
+    buildCosts: [800_000_000, 1_900_000_000, 2_500_000_000],
   },
   1_100_000_000: {
-    tolls: [350_000_000, 700_000_000, 1_300_000_000, 2_500_000_000],
-    buildCosts: [800_000_000, 1_700_000_000, 3_000_000_000],
+    tolls: [180_000_000, 350_000_000, 950_000_000, 1_550_000_000],
+    buildCosts: [1_600_000_000, 3_400_000_000, 3_900_000_000],
   },
-  1_500_000_000: {
-    tolls: [450_000_000, 900_000_000, 1_800_000_000, 3_200_000_000],
-    buildCosts: [1_000_000_000, 1_800_000_000, 3_200_000_000],
+  1_700_000_000: {
+    tolls: [200_000_000, 400_000_000, 900_000_000, 1_300_000_000],
+    buildCosts: [2_800_000_000, 5_300_000_000, 5_600_000_000],
   },
 }
 
@@ -113,14 +113,14 @@ export const TILES: TileData[] = [
   },
   {
     id: 5,
-    name: '태백',
+    name: '평택',
     type: 'PROPERTY',
     color: '#42A5F5',
     price: 300_000_000,
   },
   {
     id: 6,
-    name: '울산',
+    name: '익산',
     type: 'PROPERTY',
     color: '#42A5F5',
     price: 300_000_000,
@@ -151,14 +151,14 @@ export const TILES: TileData[] = [
   },
   {
     id: 13,
-    name: '창원',
+    name: '청원',
     type: 'PROPERTY',
     color: '#7E57C2',
     price: 500_000_000,
   },
   {
     id: 14,
-    name: '익산',
+    name: '울산',
     type: 'PROPERTY',
     color: '#EF5350',
     price: 700_000_000,
@@ -168,7 +168,7 @@ export const TILES: TileData[] = [
     name: '부산',
     type: 'PROPERTY',
     color: '#EF5350',
-    price: 1_500_000_000,
+    price: 1_700_000_000,
   },
   { id: 16, name: '여행', type: 'TRAVEL', emoji: '✈️' },
   {
@@ -176,7 +176,7 @@ export const TILES: TileData[] = [
     name: '제주',
     type: 'PROPERTY',
     color: '#42A5F5',
-    price: 1_500_000_000,
+    price: 1_700_000_000,
   },
   {
     id: 18,
@@ -209,12 +209,12 @@ export const TILES: TileData[] = [
   },
   {
     id: 23,
-    name: '전주',
+    name: '원주',
     type: 'PROPERTY',
     color: '#FF7043',
     price: 500_000_000,
   },
-  { id: 24, name: '무인도로 이동', type: 'MOVE_TO_ISLAND', emoji: '🚓' },
+  { id: 24, name: '섬으로 이동', type: 'MOVE_TO_ISLAND', emoji: '🚓' },
   {
     id: 25,
     name: '청주',
@@ -250,7 +250,7 @@ export const TILES: TileData[] = [
     name: '서울',
     type: 'PROPERTY',
     color: '#FF7043',
-    price: 1_500_000_000,
+    price: 1_700_000_000,
   },
 ]
 

--- a/src/components/board/gameBoardActionHandlers.ts
+++ b/src/components/board/gameBoardActionHandlers.ts
@@ -22,7 +22,7 @@ type UpdateTileOwners = (
 
 interface TollResolvedPayload {
   tileId: number
-  ownerId: number
+  ownerId: string | number
   ownerLevel: BuildingLevel
   ownerName: string
   onDoneCallback?: () => void
@@ -40,7 +40,7 @@ interface CreateGameBoardActionHandlersParams {
   tileOwnersRef: MutableRefObject<Record<number, TileOwner>>
   getPlayerIdByIndex: (playerIdx: number) => number
   getPlayerColorByIndex: (playerIdx: number) => string
-  getPlayerIndexById: (playerId: number) => number
+  getPlayerIndexById: (playerId: string | number) => number
   getPurchaseCost: (tileId: number) => number
   getUpgradeCost: (price: number, currentLevel: BuildingLevel) => number
   calcToll: (price: number, level: BuildingLevel) => number

--- a/src/mocks/gameMockData.ts
+++ b/src/mocks/gameMockData.ts
@@ -29,7 +29,7 @@ export const mockTiles: Tile[] = [
   },
   {
     index: 5,
-    name: '\uD0DC\uBC31',
+    name: '\uD3C9\uD0DD',
     type: 'property',
     building: 0,
     price: 30000,
@@ -37,7 +37,7 @@ export const mockTiles: Tile[] = [
   },
   {
     index: 6,
-    name: '\uC6B8\uC0B0',
+    name: '\uC775\uC0B0',
     type: 'property',
     building: 0,
     price: 30000,
@@ -72,7 +72,7 @@ export const mockTiles: Tile[] = [
   },
   {
     index: 13,
-    name: '\uCC3D\uC6D0',
+    name: '\uCCAD\uC6D0',
     type: 'property',
     building: 0,
     price: 50000,
@@ -80,7 +80,7 @@ export const mockTiles: Tile[] = [
   },
   {
     index: 14,
-    name: '\uC775\uC0B0',
+    name: '\uC6B8\uC0B0',
     type: 'property',
     building: 0,
     price: 70000,
@@ -91,7 +91,7 @@ export const mockTiles: Tile[] = [
     name: '\uBD80\uC0B0',
     type: 'property',
     building: 0,
-    price: 150000,
+    price: 170000,
     color: '#EF5350',
   },
   { index: 16, name: '\uC5EC\uD589', type: 'travel', building: 0 },
@@ -100,7 +100,7 @@ export const mockTiles: Tile[] = [
     name: '\uC81C\uC8FC',
     type: 'property',
     building: 0,
-    price: 150000,
+    price: 170000,
     color: '#42A5F5',
   },
   {
@@ -138,7 +138,7 @@ export const mockTiles: Tile[] = [
   },
   {
     index: 23,
-    name: '\uC804\uC8FC',
+    name: '\uC6D0\uC8FC',
     type: 'property',
     building: 0,
     price: 50000,
@@ -146,7 +146,7 @@ export const mockTiles: Tile[] = [
   },
   {
     index: 24,
-    name: '\uBB34\uC778\uB3C4\uB85C \uC774\uB3D9',
+    name: '\uC12C\uC73C\uB85C \uC774\uB3D9',
     type: 'go_to_island',
     building: 0,
   },
@@ -189,7 +189,7 @@ export const mockTiles: Tile[] = [
     name: '\uC11C\uC6B8',
     type: 'property',
     building: 0,
-    price: 150000,
+    price: 170000,
     color: '#FF7043',
   },
 ]

--- a/src/mocks/handlers/game.handler.ts
+++ b/src/mocks/handlers/game.handler.ts
@@ -20,20 +20,48 @@ import { mockMessages, mockPlayers, mockTiles } from '../gameMockData'
 
 const MOCK_PLAYER_ID = 'mock-player-1'
 const ROOM_ID_FROM_GAME_ID_PATTERN = /^game-(room-\d+)-/
-const MOCK_BUILD_COST = 30
-const MOCK_PASS_GO_SALARY = 200
+const MOCK_PASS_GO_SALARY = 100_000
 const MOCK_TURN_TIMEOUT_SEC = 30
 const SYNC_SNAPSHOT_GAP_THRESHOLD = 200
 const PROMPT_RESPONSE_ACK_TYPE = 'PROMPT_RESPONSE'
 const PROMPT_RESPONSE_ACTION_PREFIX = 'prompt-response'
-const MOCK_PLAYER_START_BALANCE = 5000000000
+const MOCK_PLAYER_START_BALANCE = 1_000_000
 const DEFAULT_MOCK_CHAT_MESSAGES = ['즐겜해요~', '모두의 마블 한판!'] as const
 
 const PROMPT_CHOICE_CANONICAL_MAP: Record<string, readonly string[]> = {
   BUY_OR_SKIP: ['BUY', 'SKIP'],
+  BUILD_OR_SKIP: ['BUILD', 'SKIP'],
   CONFIRM_ONLY: ['CONFIRM'],
   PAY_TOLL: ['PAY_TOLL'],
   TRAVEL_SELECT: ['CONFIRM', 'SKIP'],
+}
+
+type TierRuleMan = {
+  tolls: [number, number, number, number]
+  buildCosts: [number, number, number]
+}
+
+const PROPERTY_TIER_BY_PRICE_MAN: Record<number, TierRuleMan> = {
+  30_000: {
+    tolls: [5_000, 10_000, 30_000, 65_000],
+    buildCosts: [40_000, 85_000, 140_000],
+  },
+  50_000: {
+    tolls: [10_000, 20_000, 90_000, 155_000],
+    buildCosts: [60_000, 155_000, 180_000],
+  },
+  70_000: {
+    tolls: [15_000, 30_000, 95_000, 175_000],
+    buildCosts: [80_000, 190_000, 250_000],
+  },
+  110_000: {
+    tolls: [18_000, 35_000, 95_000, 155_000],
+    buildCosts: [160_000, 340_000, 390_000],
+  },
+  170_000: {
+    tolls: [20_000, 40_000, 90_000, 130_000],
+    buildCosts: [280_000, 530_000, 560_000],
+  },
 }
 
 type DiceRequestBody = {
@@ -372,6 +400,49 @@ const getTileByIndex = (tileIndex: number) =>
 const isOwnableTile = (tile: Tile | undefined): tile is Tile =>
   !!tile && (tile.type === 'city' || tile.type === 'property')
 
+const getTierRuleByTile = (tile: Tile | undefined): TierRuleMan | null => {
+  if (!tile) {
+    return null
+  }
+  const price = typeof tile.price === 'number' ? Math.trunc(tile.price) : 0
+  if (price <= 0) {
+    return null
+  }
+  return PROPERTY_TIER_BY_PRICE_MAN[price] ?? null
+}
+
+const getTileBuildCost = (tile: Tile | undefined): number => {
+  if (!tile || !isOwnableTile(tile)) {
+    return 0
+  }
+
+  const currentLevel = Math.max(0, Math.min(tile.building ?? 0, 3))
+  if (currentLevel >= 3) {
+    return 0
+  }
+
+  const tierRule = getTierRuleByTile(tile)
+  if (!tierRule) {
+    return 0
+  }
+
+  return tierRule.buildCosts[currentLevel] ?? 0
+}
+
+const getTileTollAmount = (tile: Tile | undefined): number => {
+  if (!tile || !isOwnableTile(tile)) {
+    return 0
+  }
+
+  const tierRule = getTierRuleByTile(tile)
+  if (!tierRule) {
+    return tile.price ?? 0
+  }
+
+  const level = Math.max(0, Math.min(tile.building ?? 0, 3))
+  return tierRule.tolls[level] ?? tile.price ?? 0
+}
+
 const ensureOwnedTiles = (player: Player, tileIndex: number) => {
   if (!player.owned_tiles.includes(tileIndex)) {
     player.owned_tiles.push(tileIndex)
@@ -392,10 +463,11 @@ const isModalLandingTile = (tile: Tile | undefined) =>
 
 const getSellRefund = (tile: Tile, requestedLevel?: number) => {
   const sellLevel = requestedLevel ?? tile.building
+  const buildCost = getTileBuildCost(tile)
 
   if (sellLevel > 0) {
     return {
-      refund: MOCK_BUILD_COST,
+      refund: buildCost > 0 ? buildCost : 0,
       nextBuilding: Math.max(0, sellLevel - 1) as BuildingLevel,
       releaseOwnership: false,
     }
@@ -432,7 +504,24 @@ const getNextActivePlayerId = (currentPlayerId: PlayerId) => {
 }
 
 const advanceMockTurn = () => {
-  mockGameState.currentTurn = getNextActivePlayerId(mockGameState.currentTurn)
+  const currentIndex = mockGameState.players.findIndex(
+    (player) => String(player.id) === String(mockGameState.currentTurn)
+  )
+  const nextPlayerId = getNextActivePlayerId(mockGameState.currentTurn)
+  const nextIndex = mockGameState.players.findIndex(
+    (player) => String(player.id) === String(nextPlayerId)
+  )
+
+  if (
+    currentIndex >= 0 &&
+    nextIndex >= 0 &&
+    nextPlayerId !== mockGameState.currentTurn &&
+    nextIndex <= currentIndex
+  ) {
+    mockGameState.round += 1
+  }
+
+  mockGameState.currentTurn = nextPlayerId
 }
 
 const nextRevision = () => {
@@ -552,6 +641,25 @@ const buildBuyPrompt = (_player: Player, tile: Tile): GamePrompt => ({
   },
 })
 
+const buildBuildPrompt = (_player: Player, tile: Tile): GamePrompt => ({
+  id: createPromptId('prompt-build'),
+  type: 'BUILD_OR_SKIP',
+  playerId: null,
+  title: `${tile.name} 건설`,
+  message: `${tile.name}에 건설하시겠습니까?`,
+  timeoutSec: MOCK_TURN_TIMEOUT_SEC,
+  choices: [
+    { id: 'build', label: '건설하기', value: 'BUILD' },
+    { id: 'skip', label: '건너뛰기', value: 'SKIP' },
+  ],
+  payload: {
+    tileId: tile.index,
+    tileName: tile.name,
+    buildCost: getTileBuildCost(tile),
+    buildingLevel: tile.building ?? 0,
+  },
+})
+
 const buildTollPrompt = (
   _player: Player,
   owner: Player,
@@ -633,6 +741,19 @@ export const mockDevSetRevisionForTest = (revision: number) => {
 }
 
 const handleRollDiceAction = (action: MockResolvedGameAction) => {
+  if (mockGameState.phase !== 'rolling') {
+    emitGameAck({
+      actionId: action.actionId,
+      type: action.type,
+      ok: false,
+      error: {
+        code: 'INVALID_PHASE',
+        message: '주사위는 턴 시작 phase에서만 굴릴 수 있습니다.',
+      },
+    })
+    return
+  }
+
   const currentPlayer = getCurrentPlayer()
 
   if (!currentPlayer) {
@@ -652,6 +773,75 @@ const handleRollDiceAction = (action: MockResolvedGameAction) => {
   const dice2 = Math.floor(Math.random() * 6) + 1
   const isDouble = dice1 === dice2
   const total = dice1 + dice2
+  const isLockedState =
+    currentPlayer.is_in_jail ||
+    currentPlayer.state === 'locked' ||
+    currentPlayer.state === 'island'
+
+  if (isLockedState && !isDouble) {
+    const currentDuration = Math.max(
+      currentPlayer.stateDuration ?? currentPlayer.jail_turn_count ?? 3,
+      0
+    )
+    const nextDuration = Math.max(currentDuration - 1, 0)
+    currentPlayer.stateDuration = nextDuration
+    currentPlayer.jail_turn_count = nextDuration
+    currentPlayer.is_in_jail = nextDuration > 0
+    currentPlayer.state = nextDuration > 0 ? 'locked' : 'normal'
+
+    const previousPlayerId = currentPlayer.id
+    const previousTurn = mockGameState.round
+    advanceMockTurn()
+    mockGameState.phase = 'rolling'
+    const revision = nextRevision()
+
+    emitGameAck({
+      actionId: action.actionId,
+      type: action.type,
+      ok: true,
+      revision,
+    })
+
+    emitSnapshotPatch(action.gameId, [
+      {
+        type: 'DICE_ROLLED',
+        playerId: currentPlayer.id,
+        payload: {
+          dice: [dice1, dice2],
+          total,
+          is_double: isDouble,
+          double_count: 0,
+        },
+      },
+      {
+        type: 'PLAYER_STATE_CHANGED',
+        playerId: currentPlayer.id,
+        payload: {
+          playerState: currentPlayer.state,
+          stateDuration: nextDuration,
+          reason: nextDuration > 0 ? 'island_wait' : 'island_timeout',
+        },
+      },
+      {
+        type: 'TURN_ENDED',
+        playerId: previousPlayerId,
+        nextPlayerId: mockGameState.currentTurn,
+        turn: previousTurn + 1,
+        round: mockGameState.round,
+        reason: 'island_wait',
+        bonusTurn: false,
+      },
+    ])
+    return
+  }
+
+  if (isLockedState && isDouble) {
+    currentPlayer.state = 'normal'
+    currentPlayer.stateDuration = 0
+    currentPlayer.jail_turn_count = 0
+    currentPlayer.is_in_jail = false
+  }
+
   const fromIndex = currentPlayer.position
   const toIndex = (fromIndex + total) % mockGameState.tiles.length
   const passGo = fromIndex + total >= mockGameState.tiles.length
@@ -662,32 +852,126 @@ const handleRollDiceAction = (action: MockResolvedGameAction) => {
   }
 
   const landedTile = getTileByIndex(toIndex)
-  const isOwnableLanding = !!landedTile && isOwnableTile(landedTile)
+  const isMoveToIslandTile =
+    landedTile?.type === 'go_to_island' ||
+    landedTile?.transportType === 'MOVE_TO_ISLAND'
+  const isIslandTile =
+    landedTile?.type === 'island' || landedTile?.transportType === 'ISLAND'
+  const islandTileIndex =
+    mockGameState.tiles.find(
+      (tile) => tile.type === 'island' || tile.transportType === 'ISLAND'
+    )?.index ?? 8
+  let resolvedTileIndex = toIndex
+  let resolvedLandedTile = landedTile
+
+  if (isMoveToIslandTile) {
+    currentPlayer.position = islandTileIndex
+    resolvedTileIndex = islandTileIndex
+    resolvedLandedTile = getTileByIndex(islandTileIndex)
+    currentPlayer.state = 'locked'
+    currentPlayer.stateDuration = 3
+    currentPlayer.jail_turn_count = 3
+    currentPlayer.is_in_jail = true
+  } else if (isIslandTile) {
+    currentPlayer.state = 'locked'
+    currentPlayer.stateDuration = 3
+    currentPlayer.jail_turn_count = 3
+    currentPlayer.is_in_jail = true
+  }
+  const isOwnableLanding =
+    !!resolvedLandedTile && isOwnableTile(resolvedLandedTile)
   const landingOwner = isOwnableLanding
     ? mockGameState.players.find(
-        (player) => String(player.id) === String(landedTile?.owner_id)
+        (player) => String(player.id) === String(resolvedLandedTile?.owner_id)
       )
     : null
-  const shouldPromptBuy = isOwnableLanding && !landedTile?.owner_id
+  const shouldPromptBuy = isOwnableLanding && !resolvedLandedTile?.owner_id
+  const shouldPromptBuild =
+    isOwnableLanding &&
+    Boolean(resolvedLandedTile?.owner_id) &&
+    landingOwner != null &&
+    String(landingOwner.id) === String(currentPlayer.id) &&
+    (resolvedLandedTile?.building ?? 0) < 3
   const shouldPromptToll =
     isOwnableLanding &&
-    landedTile?.owner_id &&
+    resolvedLandedTile?.owner_id &&
     landingOwner &&
     String(landingOwner.id) !== String(currentPlayer.id)
 
   const shouldHoldTurnForModal =
-    !shouldPromptBuy && !shouldPromptToll && isModalLandingTile(landedTile)
+    !shouldPromptBuy &&
+    !shouldPromptBuild &&
+    !shouldPromptToll &&
+    isModalLandingTile(resolvedLandedTile)
+  const nextEvents: GamePatchEnvelope['events'] = [
+    {
+      type: 'DICE_ROLLED',
+      playerId: currentPlayer.id,
+      payload: {
+        dice: [dice1, dice2],
+        total,
+        is_double: isDouble,
+        double_count: isDouble ? 1 : 0,
+      },
+    },
+    {
+      type: 'PLAYER_MOVED',
+      playerId: currentPlayer.id,
+      tileIndex: resolvedTileIndex,
+      amount: passGo ? MOCK_PASS_GO_SALARY : undefined,
+      payload: {
+        fromIndex,
+        fromTileId: fromIndex,
+        toIndex: resolvedTileIndex,
+        toTileId: resolvedTileIndex,
+        passGo,
+        trigger: isMoveToIslandTile ? 'move_to_island' : 'normal',
+      },
+    },
+    {
+      type: 'LANDED',
+      playerId: currentPlayer.id,
+      tileIndex: resolvedTileIndex,
+      payload: {
+        tileId: resolvedTileIndex,
+        tile: resolvedLandedTile
+          ? {
+              tileId: resolvedLandedTile.index,
+              name: resolvedLandedTile.name,
+              tileType:
+                resolvedLandedTile.transportType ?? resolvedLandedTile.type,
+              price: resolvedLandedTile.price ?? 0,
+            }
+          : undefined,
+      },
+    },
+  ]
 
-  if (shouldPromptBuy && landedTile) {
-    mockGameState.prompt = buildBuyPrompt(currentPlayer, landedTile)
+  if (passGo) {
+    nextEvents.push({
+      type: 'PASSED_START',
+      playerId: currentPlayer.id,
+      amount: MOCK_PASS_GO_SALARY,
+      payload: {
+        salary: MOCK_PASS_GO_SALARY,
+      },
+    })
+  }
+
+  if (shouldPromptBuy && resolvedLandedTile) {
+    mockGameState.prompt = buildBuyPrompt(currentPlayer, resolvedLandedTile)
     mockGameState.promptIssuedAtMs = Date.now()
     mockGameState.phase = 'prompt'
-  } else if (shouldPromptToll && landedTile && landingOwner) {
-    const tollAmount = landedTile.price ?? 0
+  } else if (shouldPromptBuild && resolvedLandedTile) {
+    mockGameState.prompt = buildBuildPrompt(currentPlayer, resolvedLandedTile)
+    mockGameState.promptIssuedAtMs = Date.now()
+    mockGameState.phase = 'prompt'
+  } else if (shouldPromptToll && resolvedLandedTile && landingOwner) {
+    const tollAmount = getTileTollAmount(resolvedLandedTile)
     mockGameState.prompt = buildTollPrompt(
       currentPlayer,
       landingOwner,
-      landedTile,
+      resolvedLandedTile,
       tollAmount
     )
     mockGameState.promptIssuedAtMs = Date.now()
@@ -695,7 +979,12 @@ const handleRollDiceAction = (action: MockResolvedGameAction) => {
   } else if (shouldHoldTurnForModal) {
     mockGameState.phase = 'resolving'
   } else {
-    advanceMockTurn()
+    const previousPlayerId = currentPlayer.id
+    const previousTurn = mockGameState.round
+
+    if (!isDouble) {
+      advanceMockTurn()
+    }
     mockGameState.phase = 'rolling'
 
     // Mock Global Effect logic
@@ -727,6 +1016,24 @@ const handleRollDiceAction = (action: MockResolvedGameAction) => {
         description: `테스트 글로벌 효과: ${randomEffect}`,
       }
     }
+
+    nextEvents.push({
+      type: 'TURN_ENDED',
+      playerId: previousPlayerId,
+      nextPlayerId: mockGameState.currentTurn,
+      turn: previousTurn + 1,
+      round: mockGameState.round,
+      reason: isDouble ? 'double_roll' : 'normal',
+      bonusTurn: isDouble,
+      payload: {
+        playerId: previousPlayerId,
+        nextPlayerId: mockGameState.currentTurn,
+        turn: previousTurn + 1,
+        round: mockGameState.round,
+        reason: isDouble ? 'double_roll' : 'normal',
+        bonusTurn: isDouble,
+      },
+    })
   }
   const revision = nextRevision()
 
@@ -737,29 +1044,7 @@ const handleRollDiceAction = (action: MockResolvedGameAction) => {
     revision,
   })
 
-  emitSnapshotPatch(action.gameId, [
-    {
-      type: 'DICE_ROLLED',
-      playerId: currentPlayer.id,
-      payload: {
-        dice: [dice1, dice2],
-        total,
-        is_double: isDouble,
-        double_count: isDouble ? 1 : 0,
-      },
-    },
-    {
-      type: 'PLAYER_MOVED',
-      playerId: currentPlayer.id,
-      tileIndex: toIndex,
-      amount: passGo ? MOCK_PASS_GO_SALARY : undefined,
-      payload: {
-        fromIndex,
-        toIndex,
-        passGo,
-      },
-    },
-  ])
+  emitSnapshotPatch(action.gameId, nextEvents)
 }
 
 const handleBuyPropertyAction = (action: MockResolvedGameAction) => {
@@ -930,7 +1215,7 @@ const handleBuildPropertyAction = (action: MockResolvedGameAction) => {
     return
   }
 
-  if (tile.building >= 7) {
+  if (tile.building >= 3) {
     emitGameAck({
       actionId: action.actionId,
       type: action.type,
@@ -943,7 +1228,21 @@ const handleBuildPropertyAction = (action: MockResolvedGameAction) => {
     return
   }
 
-  if (player.balance < MOCK_BUILD_COST) {
+  const buildCost = getTileBuildCost(tile)
+  if (buildCost <= 0) {
+    emitGameAck({
+      actionId: action.actionId,
+      type: action.type,
+      ok: false,
+      error: {
+        code: 'INVALID_BUILD_LEVEL',
+        message: '더 이상 건설할 수 없는 단계입니다.',
+      },
+    })
+    return
+  }
+
+  if (player.balance < buildCost) {
     emitGameAck({
       actionId: action.actionId,
       type: action.type,
@@ -956,7 +1255,7 @@ const handleBuildPropertyAction = (action: MockResolvedGameAction) => {
     return
   }
 
-  player.balance -= MOCK_BUILD_COST
+  player.balance -= buildCost
   tile.building = (tile.building + 1) as BuildingLevel
   const revision = nextRevision()
 
@@ -972,7 +1271,7 @@ const handleBuildPropertyAction = (action: MockResolvedGameAction) => {
       type: 'BOUGHT_BUILDING', // 또는 UPGRADED_PROPERTY
       playerId: player.id,
       tileIndex,
-      amount: MOCK_BUILD_COST,
+      amount: buildCost,
       payload: {
         buildingLevel: tile.building,
       },
@@ -981,6 +1280,21 @@ const handleBuildPropertyAction = (action: MockResolvedGameAction) => {
 }
 
 const handleEndTurnAction = (action: MockResolvedGameAction) => {
+  if (mockGameState.phase !== 'resolving') {
+    emitGameAck({
+      actionId: action.actionId,
+      type: action.type,
+      ok: false,
+      error: {
+        code: 'INVALID_PHASE',
+        message: '턴 종료가 가능한 phase가 아닙니다.',
+      },
+    })
+    return
+  }
+
+  const previousPlayerId = mockGameState.currentTurn
+  const previousTurn = mockGameState.round
   advanceMockTurn()
   mockGameState.phase = 'rolling'
   const revision = nextRevision()
@@ -995,7 +1309,20 @@ const handleEndTurnAction = (action: MockResolvedGameAction) => {
   emitSnapshotPatch(action.gameId, [
     {
       type: 'TURN_ENDED',
-      playerId: mockGameState.currentTurn,
+      playerId: previousPlayerId,
+      nextPlayerId: mockGameState.currentTurn,
+      turn: previousTurn + 1,
+      round: mockGameState.round,
+      reason: 'manual_end_turn',
+      bonusTurn: false,
+      payload: {
+        playerId: previousPlayerId,
+        nextPlayerId: mockGameState.currentTurn,
+        turn: previousTurn + 1,
+        round: mockGameState.round,
+        reason: 'manual_end_turn',
+        bonusTurn: false,
+      },
     },
   ])
 }
@@ -1014,8 +1341,10 @@ export const mockEmitGameSync = ({
     typeof knownRevision === 'number' && Number.isFinite(knownRevision)
       ? Math.trunc(knownRevision)
       : null
+  const shouldForceFullSnapshot =
+    normalizedKnownRevision == null || normalizedKnownRevision < 0
   const shouldResetForGame =
-    mockGameContext.gameId !== resolvedGameId || normalizedKnownRevision === 0
+    mockGameContext.gameId !== resolvedGameId || shouldForceFullSnapshot
 
   if (shouldResetForGame) {
     resetMockGameState({
@@ -1027,7 +1356,7 @@ export const mockEmitGameSync = ({
   setTimeout(() => {
     const serverRevision = mockGameState.revision
 
-    if (normalizedKnownRevision == null || normalizedKnownRevision <= 0) {
+    if (shouldForceFullSnapshot) {
       emitSnapshotPatch(resolvedGameId)
       return
     }
@@ -1266,9 +1595,48 @@ export const mockEmitPromptResponse = ({
         targetTile.ownerId = respondingPlayer.id
         targetTile.building = 0
         ensureOwnedTiles(respondingPlayer, targetTile.index)
+        nextEvents.push({
+          type: 'BOUGHT_PROPERTY',
+          playerId: respondingPlayer.id,
+          tileIndex: targetTile.index,
+          amount: price,
+          payload: {
+            tileId: targetTile.index,
+            amount: price,
+          },
+        })
       }
     }
-    advanceMockTurn()
+  }
+
+  if (promptType === 'BUILD_OR_SKIP') {
+    if (
+      normalizedChoice === 'BUILD' &&
+      respondingPlayer &&
+      targetTile &&
+      isOwnableTile(targetTile) &&
+      String(targetTile.owner_id) === String(respondingPlayer.id)
+    ) {
+      const buildCost = getTileBuildCost(targetTile)
+      if (buildCost > 0 && respondingPlayer.balance >= buildCost) {
+        respondingPlayer.balance -= buildCost
+        targetTile.building = Math.min(
+          (targetTile.building ?? 0) + 1,
+          3
+        ) as BuildingLevel
+        nextEvents.push({
+          type: 'BOUGHT_BUILDING',
+          playerId: respondingPlayer.id,
+          tileIndex: targetTile.index,
+          amount: buildCost,
+          payload: {
+            tileId: targetTile.index,
+            buildCost,
+            buildingLevel: targetTile.building,
+          },
+        })
+      }
+    }
   }
 
   if (promptType === 'PAY_TOLL') {
@@ -1298,7 +1666,6 @@ export const mockEmitPromptResponse = ({
         amount: promptAmount,
       },
     })
-    advanceMockTurn()
   }
 
   if (promptType === 'TRAVEL_SELECT') {
@@ -1328,7 +1695,7 @@ export const mockEmitPromptResponse = ({
             payload: {
               fromTileId,
               toTileId: targetTileId,
-              trigger: 'travel',
+              trigger: 'travel_select',
             },
           },
           {
@@ -1339,11 +1706,9 @@ export const mockEmitPromptResponse = ({
         )
       }
     }
-
-    advanceMockTurn()
   }
 
-  mockGameState.phase = 'rolling'
+  mockGameState.phase = 'resolving'
   clearMockPrompt()
   const revision = nextRevision()
 
@@ -1490,21 +1855,22 @@ export const gameHandlers = [
       )
     }
 
-    if (tile.building >= 7) {
+    if (tile.building >= 3) {
       return buildErrorResponse(
         '\uCD5C\uB300 \uB2E8\uACC4\uAE4C\uC9C0 \uAC74\uC124\uD588\uC2B5\uB2C8\uB2E4.',
         409
       )
     }
 
-    if (player.balance < MOCK_BUILD_COST) {
+    const buildCost = getTileBuildCost(tile)
+    if (buildCost <= 0 || player.balance < buildCost) {
       return buildErrorResponse(
         '\uAC74\uC124 \uBE44\uC6A9\uC774 \uBD80\uC871\uD569\uB2C8\uB2E4.',
         409
       )
     }
 
-    player.balance -= MOCK_BUILD_COST
+    player.balance -= buildCost
     tile.building = (tile.building + 1) as BuildingLevel
     advanceMockTurn()
 

--- a/src/pages/game/gameViewModel.test.ts
+++ b/src/pages/game/gameViewModel.test.ts
@@ -25,7 +25,7 @@ describe('game view model mapper', () => {
     ])
 
     expect(boardPlayers[0]).toMatchObject({
-      id: 0,
+      id: 'player-1',
       name: 'Player 1',
       pos: 4,
       money: 900,

--- a/src/pages/game/gameViewModel.ts
+++ b/src/pages/game/gameViewModel.ts
@@ -7,15 +7,6 @@ import {
 } from '../../components/board/board.constants'
 import type { Player, PlayerId, Tile } from '../../types/domain'
 
-const toBoardPlayerId = (playerId: PlayerId, fallbackIndex: number) => {
-  if (typeof playerId === 'number') {
-    return playerId
-  }
-
-  const parsedPlayerId = Number.parseInt(String(playerId), 10)
-  return Number.isNaN(parsedPlayerId) ? fallbackIndex : parsedPlayerId
-}
-
 export const mapStorePlayersToBoardPlayers = (storePlayers: Player[]) =>
   (storePlayers.length > 0 ? storePlayers : INIT_PLAYERS).map(
     (storePlayerOrFallback, index) => {
@@ -29,7 +20,7 @@ export const mapStorePlayersToBoardPlayers = (storePlayers: Player[]) =>
 
       return {
         ...initialPlayer,
-        id: toBoardPlayerId(storePlayer.id, initialPlayer.id),
+        id: storePlayer.id ?? initialPlayer.id,
         name: storePlayer.nickname || initialPlayer.name,
         color: storePlayer.color || initialPlayer.color,
         pos: storePlayer.position,

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -182,8 +182,16 @@ export interface ServerEvent {
   id?: string
   type: string
   playerId?: PlayerId | null
+  nextPlayerId?: PlayerId | null
   tileIndex?: number | null
+  fromTileId?: number | null
+  toTileId?: number | null
+  trigger?: string
   amount?: Money
+  turn?: number
+  round?: number
+  reason?: string
+  bonusTurn?: boolean
   payload?: Record<string, unknown>
 }
 


### PR DESCRIPTION
## 📌 관련 이슈

> closes #이슈번호

---

## ✅ 작업 내용

- mock 게임 런타임에서 보드 SoT/턴 처리/이벤트 체인을 실서버 계약 기준으로 정렬했습니다.
- 보드 상수/목 데이터/런타임 처리에서 이름·가격·타입 정합성을 맞췄습니다.
- 이동/모달/턴 종료 흐름의 계약 기반 동작을 보강했습니다.

---

## 🧠 Task 문서 (큰 작업이면 필수)

- plan: docs/ai/tasks/board-sot-sync/plan.md
- context: docs/ai/tasks/board-sot-sync/context.md
- checklist: docs/ai/tasks/board-sot-sync/checklist.md

---

## 📋 TODO.md 연결

- task slug: board-sot-sync
- TODO status: In Progress
- TODO entry 확인: TODO.md의 In Progress 섹션에 `board-sot-sync`가 1:1로 연결되어 있습니다.

---

## 📚 참고한 기준 문서

- `AGENTS.md`
- `docs/ai/manuals/common.md`
- `docs/ai/manuals/game-runtime.md`
- `docs/socket-mock-server.md`
- `docs/rules.md`
- `docs/testing.md`

---

## 🧪 실행한 검증

- `npm run lint`
- `npm run build`
- `npm run test -- src/mocks/handlers/game.handler.test.ts`
- `npm run test -- src/services/socket/gameContractAdapters.test.ts`
- `npm run test -- src/components/board/useBoardEventQueue.test.tsx`
- `npm run test -- src/components/board/GameBoard.test.tsx`
- `npm run test -- src/components/board/gameBoardEventQueueUtils.test.ts`

---

## ⚠️ 남은 리스크

- mock 턴 엔진의 실서버 100% 동등성은 Travel/Chance 복합 체인(연속 prompt + bonus turn)에서 추가 E2E 검증이 필요합니다.
- pre-push 전체 `npm run test`는 저장소 기존 이슈(비변경 영역 테스트 실패)로 아직 red일 수 있어, 이번 PR 변경 영역과 분리 추적이 필요합니다.
- mock-socket-server와 프론트 mock handler를 동시에 변경할 때 계약 누락 회귀 가능성이 있어 다음 사이클에서 계약 체크 테스트를 추가할 예정입니다.

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결
- [x] Task 문서/TODO/manual/검증/리스크 섹션 작성
