### PR TITLE
fix(game): mock 파산 오탐 제거 + totalAssets 서버권위 표시 정합성 보강

### DIFF
--- a/docs/ai/tasks/board-sot-sync/checklist.md
+++ b/docs/ai/tasks/board-sot-sync/checklist.md
@@ -12,8 +12,8 @@
 ## Testing
 
 - [x] Ran targeted Vitest suites.
-- [ ] Run `npm run lint` if required by change scope.
-- [ ] Run `npm run build` if required by change scope.
+- [x] Ran `npm run lint` for this high-risk runtime change.
+- [x] Ran `npm run build` for this high-risk runtime change.
 - [ ] Run Playwright scenario when user flow risk is high.
 
 ## Review
@@ -21,12 +21,12 @@
 - [x] Self-reviewed with `docs/rules.md` guidance.
 - [x] Checked boundary cases (redirect, cleanup, duplicate subscribe, errors).
 - [x] Synced TODO task status with current work.
+- [x] Reported changed files, validations, and remaining risks.
 - [ ] Updated session handoff notes.
 - [ ] Verified `npm run ai:session:brief -- board-sot-sync` output.
-- [x] Reported changed files, validations, and remaining risks.
 
-## 2026-03-30 Gate Recovery
+## 2026-04-01 Gate Evidence Checklist
 
-- [x] Updated task triplet files in this PR cycle.
-- [x] PR body uses exact heading `## 🧠 Task 문서 (큰 작업이면 필수)`.
-- [ ] Re-run workflow-gate after PR body update and confirm green.
+- [x] Updated task triplet files in current high-risk runtime branch.
+- [x] Confirmed TODO slug linkage for `board-sot-sync`.
+- [ ] Re-run workflow-gate after pushing this doc update.

--- a/docs/ai/tasks/board-sot-sync/context.md
+++ b/docs/ai/tasks/board-sot-sync/context.md
@@ -52,3 +52,13 @@
 - Workflow-gate for high-risk PR requires explicit task-document evidence.
 - This context file is updated to keep plan/context/checklist in sync with TODO `board-sot-sync`.
 - Immediate scope remains runtime parity in mock mode without changing backend contracts.
+
+## 2026-04-01 Context Update
+
+- High-risk runtime files in this PR:
+  - src/pages/GamePage.tsx
+  - src/components/board/GameBoard.tsx
+  - src/mocks/handlers/game.handler.ts
+- Validation focus in this cycle:
+  - remove zero-balance bankrupt false positives
+  - preserve server-authoritative totalAssets rendering path

--- a/docs/ai/tasks/board-sot-sync/plan.md
+++ b/docs/ai/tasks/board-sot-sync/plan.md
@@ -68,3 +68,9 @@
 - This task document triplet is actively maintained for workflow-gate evidence.
 - Current cycle focus: mock parity with server-authoritative game runtime.
 - Follow-up PR sequence: board SoT sync -> chance direction animation -> island/modal polish.
+
+## 2026-04-01 Gate Evidence Update
+
+- This plan file is intentionally updated in the same branch as high-risk runtime changes.
+- Workflow-gate evidence target: docs/ai/tasks/board-sot-sync/{plan,context,checklist}.md
+- Current PR scope: bankrupt guard alignment + totalAssets authoritative display stabilization.

--- a/src/components/board/GameBoard.test.tsx
+++ b/src/components/board/GameBoard.test.tsx
@@ -411,6 +411,48 @@ describe('GameBoard modal reveal timing', () => {
     expect(screen.getByText(/구매 모달/)).toBeInTheDocument()
   })
 
+  it('keeps buy prompt modal hidden when prompt arrives before movement event', async () => {
+    renderGameBoard({
+      activePrompt: {
+        id: 'buy-pre-move',
+        type: 'BUY_OR_SKIP',
+        playerId: '1',
+        payload: {
+          tileId: 1,
+        },
+        choices: [
+          { id: 'buy', label: '구매하기', value: 'BUY' },
+          { id: 'skip', label: '건너뛰기', value: 'SKIP' },
+        ],
+      },
+    })
+
+    expect(screen.queryByText(/구매 모달/)).not.toBeInTheDocument()
+
+    await act(async () => {
+      useGameStore.getState().enqueueEvents([
+        {
+          type: 'PLAYER_MOVED',
+          playerId: 1,
+          tileIndex: 1,
+          payload: {
+            fromIndex: 0,
+          },
+        } as ServerEvent,
+      ])
+    })
+
+    await consumeQueuedBoardEvent()
+
+    expect(screen.queryByText(/구매 모달/)).not.toBeInTheDocument()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500)
+    })
+
+    expect(screen.queryByText(/구매 모달/)).not.toBeInTheDocument()
+  })
+
   it('reveals go-to-island modal only after movement finishes and next frame passes', async () => {
     useGameStore.getState().enqueueEvents([
       {

--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -1381,10 +1381,25 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
         'toTileId',
         'to_tile_id',
       ])
-      const promptPlayerPosition =
+      const promptPlayerAnimatedPosition =
+        promptPlayerId != null ? animatedPositions[promptPlayerId] : undefined
+      const promptPlayerPendingPosition =
+        promptPlayerId != null && pendingMovePlayerIdSet.has(promptPlayerId)
+          ? lastMovePositionRef.current[promptPlayerId]
+          : undefined
+      const promptPlayerSettledPosition =
         promptPlayerId != null
           ? players.find((player) => String(player.id) === promptPlayerId)?.pos
           : players[curPlayer]?.pos
+      const promptPlayerRecentMovePosition =
+        promptPlayerId != null
+          ? lastMovePositionRef.current[promptPlayerId]
+          : undefined
+      const promptPlayerPosition =
+        promptPlayerAnimatedPosition ??
+        promptPlayerPendingPosition ??
+        promptPlayerRecentMovePosition ??
+        promptPlayerSettledPosition
       if (
         travelPromptTileId != null &&
         promptPlayerPosition != null &&
@@ -1912,32 +1927,62 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       animatedPositions,
       isMoving: boardActionAnimationBlocking,
     })
+    const promptPlayerAnimatedPosition =
+      activePromptPlayerId != null
+        ? animatedPositions[activePromptPlayerId]
+        : undefined
+    const promptPlayerPendingPosition =
+      activePromptPlayerId != null &&
+      pendingMovePlayerIdSet.has(activePromptPlayerId)
+        ? lastMovePositionRef.current[activePromptPlayerId]
+        : undefined
+    const promptPlayerSettledPosition =
+      activePromptPlayerId != null
+        ? players.find((player) => String(player.id) === activePromptPlayerId)
+            ?.pos
+        : undefined
+    const promptPlayerRecentMovePosition =
+      activePromptPlayerId != null
+        ? lastMovePositionRef.current[activePromptPlayerId]
+        : undefined
+    const promptPlayerRenderedPosition =
+      promptPlayerAnimatedPosition ??
+      promptPlayerPendingPosition ??
+      promptPlayerRecentMovePosition ??
+      promptPlayerSettledPosition
+    const hasPromptTilePositionMismatch =
+      activePromptPlayerId != null &&
+      promptTileId != null &&
+      promptPlayerRenderedPosition != null &&
+      promptPlayerRenderedPosition !== promptTileId
+    const canRevealPostMovePromptSurface =
+      canRevealPostMoveSurface && !hasPromptTilePositionMismatch
     const cardModalVisible = canRevealPreMoveSurface && cardModal.open
     const travelModalVisible = canRevealPreMoveSurface && travelModal.open
     const goToIslandModalVisible =
-      (canRevealPostMoveSurface && isGoToIslandPromptOpen) ||
+      (canRevealPostMovePromptSurface && isGoToIslandPromptOpen) ||
       (canRevealPreMoveSurface && goToIslandModal.open)
     const islandModalVisible =
-      canRevealPostMoveSurface && (isIslandPromptOpen || islandModal.open)
+      canRevealPostMovePromptSurface && (isIslandPromptOpen || islandModal.open)
 
     const buyModalVisible =
-      canRevealPostMoveSurface &&
+      canRevealPostMovePromptSurface &&
       buyModalOpen &&
       !isBuyPromptDismissed &&
       !insufficientFundsModal.open
     const buildModalVisible =
-      canRevealPostMoveSurface &&
+      canRevealPostMovePromptSurface &&
       buildModalOpen &&
       !isBuildPromptDismissed &&
       !insufficientFundsModal.open
-    const tollModalVisible = canRevealPostMoveSurface && tollModalOpen
+    const tollModalVisible = canRevealPostMovePromptSurface && tollModalOpen
     const acquisitionModalOpen =
-      canRevealPostMoveSurface &&
+      canRevealPostMovePromptSurface &&
       acquisitionModalOpenRaw &&
       !tollModalOpen &&
       !insufficientFundsModal.open
     const sellModalVisible =
-      canRevealPostMoveSurface && (citySellModal.open || isSellPromptOpen)
+      canRevealPostMovePromptSurface && (citySellModal.open || isSellPromptOpen)
 
     const doubleDiceModalVisible = canShowModal && doubleDiceModal.open
 
@@ -2310,7 +2355,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
 
             {/* ─── 플레이어 토큰 레이어 (절대 좌표 대신 Grid 활용 정점 방식) ──────────────── */}
             {players
-              .filter((p) => p.state !== 'bankrupt' && p.money > 0)
+              .filter((p) => p.state !== 'bankrupt')
               .map((p) => {
                 const playerKey = String(p.id)
                 const animatedPos = animatedPositions[playerKey]
@@ -2320,7 +2365,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
                 const pos = animatedPos ?? pendingPos ?? p.pos
                 const { row, col } = getTileGridPos(pos)
                 const tokensAtThisPos = players.filter((pl) => {
-                  if (pl.state === 'bankrupt' || pl.money <= 0) {
+                  if (pl.state === 'bankrupt') {
                     return false
                   }
                   const key = String(pl.id)

--- a/src/mocks/handlers/game.handler.test.ts
+++ b/src/mocks/handlers/game.handler.test.ts
@@ -587,4 +587,61 @@ describe('mock game socket handlers contract', () => {
 
     teardown()
   })
+
+  it('does not mark player bankrupt when toll payment consumes balance down to exactly zero', async () => {
+    const { acks, patches, teardown } = captureGameSocketEvents()
+    const gameId = 'game-pay-toll-zero-balance'
+
+    mockEmitGameSync({
+      gameId,
+      knownRevision: -1,
+    })
+    await flushMockTimers()
+
+    const baselinePatch = patches[patches.length - 1]
+    const currentPlayerId = String(baselinePatch?.snapshot?.currentTurn ?? '1')
+    const currentPlayer = baselinePatch?.snapshot?.players.find(
+      (player) => String(player.id) === currentPlayerId
+    )
+    expect(currentPlayer).toBeDefined()
+
+    const prompt: GamePrompt = {
+      id: 'prompt-pay-toll-zero-balance',
+      type: 'PAY_TOLL',
+      playerId: currentPlayerId,
+      timeoutSec: 30,
+      payload: {
+        tileId: 1,
+        amount: currentPlayer?.balance ?? 0,
+      },
+    }
+    mockDevSetPromptForTest(prompt)
+    patches.length = 0
+
+    mockEmitPromptResponse({
+      gameId,
+      promptId: prompt.id,
+      choice: 'PAY_TOLL',
+    })
+    await flushMockTimers()
+
+    const promptAck = acks.find(
+      (ack) => ack.type === 'PROMPT_RESPONSE' && ack.promptId === prompt.id
+    )
+    expect(promptAck?.ok).toBe(true)
+
+    const promptPatch = patches.find(
+      (patch) => patch.revision === promptAck?.revision
+    )
+    expect(promptPatch).toBeDefined()
+
+    const settledPlayer = promptPatch?.snapshot?.players.find(
+      (player) => String(player.id) === currentPlayerId
+    )
+    expect(settledPlayer?.balance).toBe(0)
+    expect(settledPlayer?.is_bankrupt).toBe(false)
+    expect(settledPlayer?.state).not.toBe('bankrupt')
+
+    teardown()
+  })
 })

--- a/src/mocks/handlers/game.handler.test.ts
+++ b/src/mocks/handlers/game.handler.test.ts
@@ -472,4 +472,119 @@ describe('mock game socket handlers contract', () => {
 
     teardown()
   })
+
+  it('does not auto-emit TURN_ENDED on ROLL_DICE', async () => {
+    const { acks, patches, teardown } = captureGameSocketEvents()
+    const gameId = 'game-roll-no-auto-end'
+
+    mockEmitGameSync({
+      gameId,
+      knownRevision: -1,
+    })
+    await flushMockTimers()
+    patches.length = 0
+
+    mockEmitGameAction({
+      actionId: 'action-roll-no-auto-end',
+      type: 'ROLL_DICE',
+      gameId,
+    })
+    await flushMockTimers()
+
+    const rollAck = acks.find(
+      (ack) => ack.actionId === 'action-roll-no-auto-end'
+    )
+    expect(rollAck?.ok).toBe(true)
+
+    const rollPatch = patches.find(
+      (patch) => patch.revision === rollAck?.revision
+    )
+    expect(rollPatch).toBeDefined()
+    expect(
+      rollPatch?.events?.some((event) => event.type === 'TURN_ENDED')
+    ).toBe(false)
+    expect(['prompt', 'resolving']).toContain(rollPatch?.snapshot?.phase)
+
+    teardown()
+  })
+
+  it('keeps turn on END_TURN when player has double-roll bonus turn', async () => {
+    const { acks, patches, teardown } = captureGameSocketEvents()
+    const gameId = 'game-end-turn-double-bonus'
+
+    mockEmitGameSync({
+      gameId,
+      knownRevision: -1,
+    })
+    await flushMockTimers()
+    patches.length = 0
+
+    const randomSpy = vi
+      .spyOn(Math, 'random')
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(0)
+
+    mockEmitGameAction({
+      actionId: 'action-roll-double',
+      type: 'ROLL_DICE',
+      gameId,
+    })
+    await flushMockTimers()
+
+    randomSpy.mockRestore()
+
+    const rollAck = acks.find((ack) => ack.actionId === 'action-roll-double')
+    const rollPatch = patches.find(
+      (patch) => patch.revision === rollAck?.revision
+    )
+    expect(rollPatch?.snapshot?.prompt).toBeTruthy()
+
+    const activePrompt = rollPatch?.snapshot?.prompt
+    expect(activePrompt?.id).toBeTruthy()
+
+    mockEmitPromptResponse({
+      gameId,
+      promptId: activePrompt?.id ?? '',
+      choice: 'SKIP',
+    })
+    await flushMockTimers()
+
+    const promptAck = acks.find(
+      (ack) =>
+        ack.type === 'PROMPT_RESPONSE' && ack.promptId === activePrompt?.id
+    )
+    expect(promptAck?.ok).toBe(true)
+
+    const resolvingPatch = patches.find(
+      (patch) => patch.revision === promptAck?.revision
+    )
+    const currentTurnBeforeEndTurn = resolvingPatch?.snapshot?.currentTurn
+    expect(currentTurnBeforeEndTurn).toBeDefined()
+
+    mockEmitGameAction({
+      actionId: 'action-end-turn-double',
+      type: 'END_TURN',
+      gameId,
+    })
+    await flushMockTimers()
+
+    const endTurnAck = acks.find(
+      (ack) => ack.actionId === 'action-end-turn-double'
+    )
+    expect(endTurnAck?.ok).toBe(true)
+
+    const endTurnPatch = patches.find(
+      (patch) => patch.revision === endTurnAck?.revision
+    )
+    const turnEndedEvent = endTurnPatch?.events?.find(
+      (event) => event.type === 'TURN_ENDED'
+    )
+
+    expect(turnEndedEvent).toBeDefined()
+    expect(turnEndedEvent?.payload?.bonusTurn).toBe(true)
+    expect(turnEndedEvent?.nextPlayerId).toBe(currentTurnBeforeEndTurn)
+    expect(endTurnPatch?.snapshot?.currentTurn).toBe(currentTurnBeforeEndTurn)
+
+    teardown()
+  })
 })

--- a/src/mocks/handlers/game.handler.ts
+++ b/src/mocks/handlers/game.handler.ts
@@ -824,12 +824,12 @@ const syncPlayerStatus = (player: Player) => {
     player.stateDuration ?? player.jail_turn_count ?? 0,
     0
   )
+  player.balance = Math.max(0, player.balance)
   player.stateDuration = stateDuration
   player.jail_turn_count = stateDuration
   player.is_in_jail = stateDuration > 0 || player.state === 'locked'
 
-  if (player.is_bankrupt || player.balance <= 0) {
-    player.balance = Math.max(0, player.balance)
+  if (player.is_bankrupt) {
     player.is_bankrupt = true
     player.state = 'bankrupt'
     player.is_in_jail = false
@@ -1024,8 +1024,9 @@ const resolveLanding = ({
     }
 
     if (chanceEffect.type === 'LOSE_MONEY') {
+      const hadEnoughBalance = player.balance >= chanceEffect.power
       player.balance = Math.max(0, player.balance - chanceEffect.power)
-      if (player.balance <= 0) {
+      if (!hadEnoughBalance) {
         player.is_bankrupt = true
       }
       return { events, prompt: null, phase: 'resolving' }
@@ -2132,7 +2133,7 @@ export const mockEmitPromptResponse = ({
         owner.balance += paidAmount
       }
 
-      if (paidAmount < promptAmount || respondingPlayer.balance <= 0) {
+      if (paidAmount < promptAmount) {
         respondingPlayer.is_bankrupt = true
         respondingPlayer.state = 'bankrupt'
         respondingPlayer.stateDuration = 0

--- a/src/mocks/handlers/game.handler.ts
+++ b/src/mocks/handlers/game.handler.ts
@@ -14,7 +14,6 @@ import type {
   PlayerId,
   Tile,
   GlobalEffectState,
-  GlobalEffectType,
 } from '../../types/domain'
 import { mockMessages, mockPlayers, mockTiles } from '../gameMockData'
 
@@ -22,6 +21,8 @@ const MOCK_PLAYER_ID = 'mock-player-1'
 const ROOM_ID_FROM_GAME_ID_PATTERN = /^game-(room-\d+)-/
 const MOCK_PASS_GO_SALARY = 100_000
 const MOCK_TURN_TIMEOUT_SEC = 30
+const MOCK_MAX_ROUNDS = 20
+const MOCK_ISLAND_LOCK_TURNS = 3
 const SYNC_SNAPSHOT_GAP_THRESHOLD = 200
 const PROMPT_RESPONSE_ACK_TYPE = 'PROMPT_RESPONSE'
 const PROMPT_RESPONSE_ACTION_PREFIX = 'prompt-response'
@@ -33,8 +34,56 @@ const PROMPT_CHOICE_CANONICAL_MAP: Record<string, readonly string[]> = {
   BUILD_OR_SKIP: ['BUILD', 'SKIP'],
   CONFIRM_ONLY: ['CONFIRM'],
   PAY_TOLL: ['PAY_TOLL'],
+  ACQUISITION_OR_SKIP: ['ACQUIRE', 'SKIP'],
   TRAVEL_SELECT: ['CONFIRM', 'SKIP'],
 }
+
+type MockChanceType =
+  | 'GAIN_MONEY'
+  | 'LOSE_MONEY'
+  | 'MOVE_FORWARD'
+  | 'MOVE_BACKWARD'
+  | 'MOVE_TO_ISLAND'
+
+type MockChanceEffect = {
+  type: MockChanceType
+  power: number
+  effect: 'GOOD' | 'BAD' | 'MOVE'
+  description: string
+}
+
+const MOCK_CHANCE_EFFECTS: readonly MockChanceEffect[] = [
+  {
+    type: 'GAIN_MONEY',
+    power: 10_000,
+    effect: 'GOOD',
+    description: '지원금 수령! 1억원을 획득합니다.',
+  },
+  {
+    type: 'LOSE_MONEY',
+    power: 10_000,
+    effect: 'BAD',
+    description: '벌금 납부! 1억원을 지불합니다.',
+  },
+  {
+    type: 'MOVE_FORWARD',
+    power: 5,
+    effect: 'MOVE',
+    description: '앞으로 5칸 이동합니다.',
+  },
+  {
+    type: 'MOVE_BACKWARD',
+    power: 3,
+    effect: 'MOVE',
+    description: '뒤로 3칸 이동합니다.',
+  },
+  {
+    type: 'MOVE_TO_ISLAND',
+    power: 0,
+    effect: 'MOVE',
+    description: '무인도로 이동합니다.',
+  },
+]
 
 type TierRuleMan = {
   tolls: [number, number, number, number]
@@ -88,7 +137,14 @@ type GameStateResponse = {
   prompt: GamePrompt | null
   promptIssuedAtMs: number | null
   activeGlobalEffect: GlobalEffectState | null
+  gameResult: GameSnapshot['gameResult'] | null
+  isGameOver: boolean
+  winnerId: PlayerId | null
+  pendingBonusTurnPlayerId: PlayerId | null
 }
+
+type GameEvents = NonNullable<GamePatchEnvelope['events']>
+type GameEvent = GameEvents[number]
 
 type MockGameRuntimeContext = {
   gameId: string | null
@@ -211,10 +267,11 @@ const createInitialGameState = (
   roomId: string | null = null
 ): GameStateResponse => {
   const players = roomId ? createPlayersFromWaitingRoom(roomId) : clonePlayers()
+  const initialTiles = cloneTiles()
 
-  return {
+  const initialState: GameStateResponse = {
     players,
-    tiles: cloneTiles(),
+    tiles: initialTiles,
     messages: createMessagesFromPlayers(players),
     currentTurn: players[0]?.id ?? MOCK_PLAYER_ID,
     round: 1,
@@ -223,7 +280,19 @@ const createInitialGameState = (
     prompt: null,
     promptIssuedAtMs: null,
     activeGlobalEffect: null,
+    gameResult: null,
+    isGameOver: false,
+    winnerId: null,
+    pendingBonusTurnPlayerId: null,
   }
+
+  initialState.players.forEach((player) => {
+    player.state = player.is_bankrupt ? 'bankrupt' : 'normal'
+    player.stateDuration = player.is_in_jail ? player.jail_turn_count : 0
+    player.totalAssets = Math.max(0, player.balance)
+  })
+
+  return initialState
 }
 
 const mockGameState: GameStateResponse = createInitialGameState()
@@ -244,8 +313,16 @@ const resetMockGameState = (options?: {
   mockGameState.prompt = initialState.prompt
   mockGameState.promptIssuedAtMs = initialState.promptIssuedAtMs
   mockGameState.activeGlobalEffect = initialState.activeGlobalEffect
+  mockGameState.gameResult = initialState.gameResult
+  mockGameState.isGameOver = initialState.isGameOver
+  mockGameState.winnerId = initialState.winnerId
+  mockGameState.pendingBonusTurnPlayerId = initialState.pendingBonusTurnPlayerId
   mockGameContext.gameId = options?.gameId ?? null
   mockGameContext.roomId = roomId
+
+  mockGameState.players.forEach((player) => {
+    player.totalAssets = Math.max(0, player.balance)
+  })
 }
 
 const buildStateResponse = () => ({
@@ -270,9 +347,9 @@ const buildSnapshot = (gameId: string): GameSnapshot => ({
   round: mockGameState.round,
   turnTimeoutSec: MOCK_TURN_TIMEOUT_SEC,
   prompt: mockGameState.prompt,
-  gameResult: null,
-  isGameOver: false,
-  winnerId: null,
+  gameResult: structuredClone(mockGameState.gameResult),
+  isGameOver: mockGameState.isGameOver,
+  winnerId: mockGameState.winnerId,
   activeGlobalEffect: structuredClone(mockGameState.activeGlobalEffect),
 })
 
@@ -369,9 +446,13 @@ const buildStatePatch = (gameId: string): GamePatchEnvelope['patch'] => [
   { op: 'set', path: 'round', value: mockGameState.round },
   { op: 'set', path: 'turnTimeoutSec', value: MOCK_TURN_TIMEOUT_SEC },
   { op: 'set', path: 'prompt', value: structuredClone(mockGameState.prompt) },
-  { op: 'set', path: 'gameResult', value: null },
-  { op: 'set', path: 'isGameOver', value: false },
-  { op: 'set', path: 'winnerId', value: null },
+  {
+    op: 'set',
+    path: 'gameResult',
+    value: structuredClone(mockGameState.gameResult),
+  },
+  { op: 'set', path: 'isGameOver', value: mockGameState.isGameOver },
+  { op: 'set', path: 'winnerId', value: mockGameState.winnerId },
   {
     op: 'set',
     path: 'activeGlobalEffect',
@@ -455,12 +536,6 @@ const removeOwnedTile = (player: Player, tileIndex: number) => {
   )
 }
 
-const isModalLandingTile = (tile: Tile | undefined) =>
-  !!tile &&
-  ['chance', 'event', 'travel', 'ai', 'island', 'go_to_island'].includes(
-    tile.type
-  )
-
 const getSellRefund = (tile: Tile, requestedLevel?: number) => {
   const sellLevel = requestedLevel ?? tile.building
   const buildCost = getTileBuildCost(tile)
@@ -532,10 +607,7 @@ const nextRevision = () => {
 const buildErrorResponse = (message: string, status: number) =>
   HttpResponse.json({ message }, { status })
 
-const emitSnapshotPatch = (
-  gameId: string,
-  events?: GamePatchEnvelope['events']
-) => {
+const emitSnapshotPatch = (gameId: string, events?: GameEvents) => {
   emitGamePatch({
     revision: mockGameState.revision,
     patch: [],
@@ -626,7 +698,7 @@ const resolvePromptAmount = (prompt: GamePrompt | null) => {
 const buildBuyPrompt = (_player: Player, tile: Tile): GamePrompt => ({
   id: createPromptId('prompt-buy'),
   type: 'BUY_OR_SKIP',
-  playerId: null,
+  playerId: _player.id,
   title: '토지를 구매하시겠습니까?',
   message: `${tile.name} 칸을 구매할까요?`,
   timeoutSec: MOCK_TURN_TIMEOUT_SEC,
@@ -644,7 +716,7 @@ const buildBuyPrompt = (_player: Player, tile: Tile): GamePrompt => ({
 const buildBuildPrompt = (_player: Player, tile: Tile): GamePrompt => ({
   id: createPromptId('prompt-build'),
   type: 'BUILD_OR_SKIP',
-  playerId: null,
+  playerId: _player.id,
   title: `${tile.name} 건설`,
   message: `${tile.name}에 건설하시겠습니까?`,
   timeoutSec: MOCK_TURN_TIMEOUT_SEC,
@@ -668,7 +740,7 @@ const buildTollPrompt = (
 ): GamePrompt => ({
   id: createPromptId('prompt-toll'),
   type: 'PAY_TOLL',
-  playerId: null,
+  playerId: _player.id,
   title: '통행료 지불',
   message: `${owner.nickname}님의 ${tile.name} 칸에 도착했습니다.`,
   timeoutSec: MOCK_TURN_TIMEOUT_SEC,
@@ -682,6 +754,460 @@ const buildTollPrompt = (
     tollAmount: amount,
   },
 })
+
+const buildTravelPrompt = (player: Player, tile: Tile): GamePrompt => ({
+  id: createPromptId('prompt-travel'),
+  type: 'TRAVEL_SELECT',
+  playerId: player.id,
+  title: `${tile.name} 선택`,
+  message: `${tile.name} 효과로 이동할 칸을 선택하세요.`,
+  timeoutSec: MOCK_TURN_TIMEOUT_SEC,
+  choices: [
+    { id: 'confirm', label: '선택 이동', value: 'CONFIRM' },
+    { id: 'skip', label: '건너뛰기', value: 'SKIP' },
+  ],
+  payload: {
+    tileId: tile.index,
+    tileName: tile.name,
+  },
+})
+
+const buildAcquisitionPrompt = (
+  player: Player,
+  owner: Player,
+  tile: Tile
+): GamePrompt => ({
+  id: createPromptId('prompt-acquisition'),
+  type: 'ACQUISITION_OR_SKIP',
+  playerId: player.id,
+  title: `${tile.name} 인수`,
+  message: `${owner.nickname}의 ${tile.name}을(를) ${tile.price ?? 0}에 인수하시겠습니까?`,
+  timeoutSec: MOCK_TURN_TIMEOUT_SEC,
+  choices: [
+    { id: 'acquire', label: '인수하기', value: 'ACQUIRE' },
+    { id: 'skip', label: '건너뛰기', value: 'SKIP' },
+  ],
+  payload: {
+    tileId: tile.index,
+    tileName: tile.name,
+    ownerId: owner.id,
+    ownerName: owner.nickname,
+    amount: tile.price ?? 0,
+  },
+})
+
+const getIslandTileIndex = () =>
+  mockGameState.tiles.find(
+    (tile) => tile.type === 'island' || tile.transportType === 'ISLAND'
+  )?.index ?? 8
+
+const getAccumulatedBuildCost = (tile: Tile): number => {
+  if (!isOwnableTile(tile) || tile.building <= 0) {
+    return 0
+  }
+
+  const tierRule = getTierRuleByTile(tile)
+  if (!tierRule) {
+    return 0
+  }
+
+  const level = Math.max(0, Math.min(tile.building, 3))
+  let total = 0
+  for (let index = 0; index < level; index += 1) {
+    total += tierRule.buildCosts[index] ?? 0
+  }
+  return total
+}
+
+const syncPlayerStatus = (player: Player) => {
+  const stateDuration = Math.max(
+    player.stateDuration ?? player.jail_turn_count ?? 0,
+    0
+  )
+  player.stateDuration = stateDuration
+  player.jail_turn_count = stateDuration
+  player.is_in_jail = stateDuration > 0 || player.state === 'locked'
+
+  if (player.is_bankrupt || player.balance <= 0) {
+    player.balance = Math.max(0, player.balance)
+    player.is_bankrupt = true
+    player.state = 'bankrupt'
+    player.is_in_jail = false
+    player.stateDuration = 0
+    player.jail_turn_count = 0
+    return
+  }
+
+  if (player.state === 'locked' || player.state === 'island') {
+    player.state = 'locked'
+    player.is_in_jail = true
+    return
+  }
+
+  player.state = 'normal'
+  player.is_in_jail = false
+}
+
+const calculatePlayerTotalAssets = (player: Player): number => {
+  const ownedInvested = player.owned_tiles.reduce((sum, tileIndex) => {
+    const tile = getTileByIndex(tileIndex)
+    if (!tile || !isOwnableTile(tile)) {
+      return sum
+    }
+
+    const landPrice = tile.price ?? 0
+    return sum + landPrice + getAccumulatedBuildCost(tile)
+  }, 0)
+
+  return Math.max(0, player.balance) + ownedInvested
+}
+
+const recalculatePlayerAssets = () => {
+  mockGameState.players.forEach((player) => {
+    syncPlayerStatus(player)
+    player.totalAssets = calculatePlayerTotalAssets(player)
+  })
+}
+
+const createPlayerMovedEvent = ({
+  playerId,
+  fromTileId,
+  toTileId,
+  trigger,
+  passGo,
+  amount,
+}: {
+  playerId: PlayerId
+  fromTileId: number
+  toTileId: number
+  trigger: string
+  passGo?: boolean
+  amount?: number
+}): GameEvent => ({
+  type: 'PLAYER_MOVED',
+  playerId,
+  tileIndex: toTileId,
+  amount,
+  payload: {
+    fromIndex: fromTileId,
+    fromTileId,
+    toIndex: toTileId,
+    toTileId,
+    passGo: Boolean(passGo),
+    trigger,
+  },
+})
+
+const createLandedEvent = (
+  playerId: PlayerId,
+  tileIndex: number
+): GameEvent => {
+  const tile = getTileByIndex(tileIndex)
+
+  return {
+    type: 'LANDED',
+    playerId,
+    tileIndex,
+    payload: {
+      tileId: tileIndex,
+      tile: tile
+        ? {
+            tileId: tile.index,
+            name: tile.name,
+            tileType: tile.transportType ?? tile.type,
+            price: tile.price ?? 0,
+          }
+        : undefined,
+    },
+  }
+}
+
+const pickMockChanceEffect = (): MockChanceEffect => {
+  const randomIndex = Math.floor(Math.random() * MOCK_CHANCE_EFFECTS.length)
+  return MOCK_CHANCE_EFFECTS[randomIndex] ?? MOCK_CHANCE_EFFECTS[0]
+}
+
+type LandingResolution = {
+  events: GameEvents
+  prompt: GamePrompt | null
+  phase: Extract<GameSnapshot['phase'], 'prompt' | 'resolving'>
+}
+
+const resolveLanding = ({
+  player,
+  tileIndex,
+  allowCardEffect = true,
+}: {
+  player: Player
+  tileIndex: number
+  allowCardEffect?: boolean
+}): LandingResolution => {
+  const tile = getTileByIndex(tileIndex)
+  const events: GameEvents = [createLandedEvent(player.id, tileIndex)]
+
+  if (!tile) {
+    return { events, prompt: null, phase: 'resolving' }
+  }
+
+  if (tile.type === 'go_to_island' || tile.transportType === 'MOVE_TO_ISLAND') {
+    const islandTileIndex = getIslandTileIndex()
+    const fromTileId = tileIndex
+    player.position = islandTileIndex
+    player.state = 'locked'
+    player.stateDuration = MOCK_ISLAND_LOCK_TURNS
+    player.jail_turn_count = MOCK_ISLAND_LOCK_TURNS
+    player.is_in_jail = true
+
+    events.push(
+      createPlayerMovedEvent({
+        playerId: player.id,
+        fromTileId,
+        toTileId: islandTileIndex,
+        trigger: 'move_to_island',
+      }),
+      createLandedEvent(player.id, islandTileIndex),
+      {
+        type: 'PLAYER_STATE_CHANGED',
+        playerId: player.id,
+        payload: {
+          playerState: 'locked',
+          stateDuration: MOCK_ISLAND_LOCK_TURNS,
+          reason: 'move_to_island',
+        },
+      }
+    )
+
+    return { events, prompt: null, phase: 'resolving' }
+  }
+
+  if (tile.type === 'island' || tile.transportType === 'ISLAND') {
+    player.state = 'locked'
+    player.stateDuration = MOCK_ISLAND_LOCK_TURNS
+    player.jail_turn_count = MOCK_ISLAND_LOCK_TURNS
+    player.is_in_jail = true
+    events.push({
+      type: 'PLAYER_STATE_CHANGED',
+      playerId: player.id,
+      payload: {
+        playerState: 'locked',
+        stateDuration: MOCK_ISLAND_LOCK_TURNS,
+        reason: 'island_arrival',
+      },
+    })
+    return { events, prompt: null, phase: 'resolving' }
+  }
+
+  if (tile.type === 'travel') {
+    return {
+      events,
+      prompt: buildTravelPrompt(player, tile),
+      phase: 'prompt',
+    }
+  }
+
+  if ((tile.type === 'chance' || tile.type === 'event') && allowCardEffect) {
+    const chanceEffect = pickMockChanceEffect()
+    events.push({
+      type: 'CHANCE_RESOLVED',
+      playerId: player.id,
+      tileIndex: tile.index,
+      payload: {
+        tileId: tile.index,
+        tileType: tile.type.toUpperCase(),
+        chance: chanceEffect,
+      },
+    })
+
+    if (chanceEffect.type === 'GAIN_MONEY') {
+      player.balance += chanceEffect.power
+      return { events, prompt: null, phase: 'resolving' }
+    }
+
+    if (chanceEffect.type === 'LOSE_MONEY') {
+      player.balance = Math.max(0, player.balance - chanceEffect.power)
+      if (player.balance <= 0) {
+        player.is_bankrupt = true
+      }
+      return { events, prompt: null, phase: 'resolving' }
+    }
+
+    if (
+      chanceEffect.type === 'MOVE_FORWARD' ||
+      chanceEffect.type === 'MOVE_BACKWARD'
+    ) {
+      const totalTiles = mockGameState.tiles.length
+      const fromTileId = player.position
+      const rawTargetIndex =
+        chanceEffect.type === 'MOVE_BACKWARD'
+          ? fromTileId - chanceEffect.power
+          : fromTileId + chanceEffect.power
+      const toTileId = ((rawTargetIndex % totalTiles) + totalTiles) % totalTiles
+      player.position = toTileId
+
+      events.push(
+        createPlayerMovedEvent({
+          playerId: player.id,
+          fromTileId,
+          toTileId,
+          trigger: 'chance',
+        })
+      )
+
+      const chained = resolveLanding({
+        player,
+        tileIndex: toTileId,
+        allowCardEffect: false,
+      })
+      events.push(...chained.events)
+      return chained.prompt
+        ? { events, prompt: chained.prompt, phase: chained.phase }
+        : { events, prompt: null, phase: 'resolving' }
+    }
+
+    if (chanceEffect.type === 'MOVE_TO_ISLAND') {
+      const islandTileIndex = getIslandTileIndex()
+      const fromTileId = player.position
+      player.position = islandTileIndex
+
+      events.push(
+        createPlayerMovedEvent({
+          playerId: player.id,
+          fromTileId,
+          toTileId: islandTileIndex,
+          trigger: 'chance',
+        })
+      )
+
+      const chained = resolveLanding({
+        player,
+        tileIndex: islandTileIndex,
+        allowCardEffect: false,
+      })
+      events.push(...chained.events)
+      return { events, prompt: null, phase: chained.phase }
+    }
+  }
+
+  if (!isOwnableTile(tile)) {
+    return { events, prompt: null, phase: 'resolving' }
+  }
+
+  const tileOwner =
+    tile.owner_id == null
+      ? null
+      : (mockGameState.players.find(
+          (candidate) => String(candidate.id) === String(tile.owner_id)
+        ) ?? null)
+
+  if (!tileOwner) {
+    return {
+      events,
+      prompt: buildBuyPrompt(player, tile),
+      phase: 'prompt',
+    }
+  }
+
+  if (String(tileOwner.id) === String(player.id) && (tile.building ?? 0) < 3) {
+    return {
+      events,
+      prompt: buildBuildPrompt(player, tile),
+      phase: 'prompt',
+    }
+  }
+
+  if (String(tileOwner.id) !== String(player.id)) {
+    return {
+      events,
+      prompt: buildTollPrompt(player, tileOwner, tile, getTileTollAmount(tile)),
+      phase: 'prompt',
+    }
+  }
+
+  return { events, prompt: null, phase: 'resolving' }
+}
+
+const getActivePlayersByAssets = () => {
+  const alivePlayers = mockGameState.players.filter(
+    (player) => !player.is_bankrupt
+  )
+  return [...alivePlayers].sort((left, right) => {
+    const leftAssets = left.totalAssets ?? 0
+    const rightAssets = right.totalAssets ?? 0
+    if (leftAssets !== rightAssets) {
+      return rightAssets - leftAssets
+    }
+    return right.balance - left.balance
+  })
+}
+
+const buildGameResultPayload = (
+  reason: GameSnapshot['gameResult'] extends infer T
+    ? T extends { reason: infer R }
+      ? R
+      : never
+    : never
+) => {
+  const sortedPlayers = getActivePlayersByAssets()
+  const rankings = sortedPlayers.map((player, index) => ({
+    rank: index + 1,
+    player_id: player.id,
+    nickname: player.nickname,
+    final_assets: player.totalAssets ?? player.balance,
+    is_winner: index === 0,
+  }))
+  const winner = sortedPlayers[0]
+
+  return {
+    reason,
+    rankings,
+    winner: winner
+      ? {
+          playerId: winner.id,
+          nickname: winner.nickname,
+          balance: winner.balance,
+          assets: winner.totalAssets ?? winner.balance,
+        }
+      : null,
+  } as NonNullable<GameSnapshot['gameResult']>
+}
+
+const markGameOver = (
+  reason: NonNullable<GameSnapshot['gameResult']>['reason']
+) => {
+  const gameResult = buildGameResultPayload(reason)
+  mockGameState.gameResult = gameResult
+  mockGameState.isGameOver = true
+  mockGameState.winnerId = gameResult.winner?.playerId ?? null
+  mockGameState.phase = 'finished'
+  mockGameState.prompt = null
+  mockGameState.promptIssuedAtMs = null
+  mockGameState.pendingBonusTurnPlayerId = null
+  return gameResult
+}
+
+const createGameOverEvent = (
+  gameResult: NonNullable<GameSnapshot['gameResult']>
+): GameEvent => ({
+  type: 'GAME_OVER',
+  reason: gameResult.reason,
+  payload: {
+    reason: gameResult.reason,
+    winner: gameResult.winner,
+    rankings: gameResult.rankings,
+  },
+})
+
+const maybeMarkGameOverByStanding = () => {
+  const activePlayers = mockGameState.players.filter(
+    (player) => !player.is_bankrupt
+  )
+
+  if (activePlayers.length <= 1) {
+    return markGameOver('last_player_standing')
+  }
+
+  return null
+}
 
 const emitPromptResponseRejected = ({
   actionId,
@@ -773,12 +1299,27 @@ const handleRollDiceAction = (action: MockResolvedGameAction) => {
   const dice2 = Math.floor(Math.random() * 6) + 1
   const isDouble = dice1 === dice2
   const total = dice1 + dice2
-  const isLockedState =
+  const nextEvents: GameEvents = [
+    {
+      type: 'DICE_ROLLED',
+      playerId: currentPlayer.id,
+      payload: {
+        dice: [dice1, dice2],
+        total,
+        isDouble,
+        is_double: isDouble,
+        doubleCount: isDouble ? 1 : 0,
+        double_count: isDouble ? 1 : 0,
+      },
+    },
+  ]
+
+  const isLockedPlayer =
     currentPlayer.is_in_jail ||
     currentPlayer.state === 'locked' ||
     currentPlayer.state === 'island'
 
-  if (isLockedState && !isDouble) {
+  if (isLockedPlayer && !isDouble) {
     const currentDuration = Math.max(
       currentPlayer.stateDuration ?? currentPlayer.jail_turn_count ?? 3,
       0
@@ -789,57 +1330,56 @@ const handleRollDiceAction = (action: MockResolvedGameAction) => {
     currentPlayer.is_in_jail = nextDuration > 0
     currentPlayer.state = nextDuration > 0 ? 'locked' : 'normal'
 
-    const previousPlayerId = currentPlayer.id
-    const previousTurn = mockGameState.round
-    advanceMockTurn()
-    mockGameState.phase = 'rolling'
-    const revision = nextRevision()
+    nextEvents.push({
+      type: 'PLAYER_STATE_CHANGED',
+      playerId: currentPlayer.id,
+      payload: {
+        playerState: currentPlayer.state,
+        stateDuration: nextDuration,
+        reason: nextDuration > 0 ? 'island_wait' : 'island_timeout',
+      },
+    })
 
+    clearMockPrompt()
+    mockGameState.phase = 'resolving'
+    mockGameState.pendingBonusTurnPlayerId = null
+    recalculatePlayerAssets()
+
+    const gameResult = maybeMarkGameOverByStanding()
+    if (gameResult) {
+      nextEvents.push(createGameOverEvent(gameResult))
+    }
+
+    const revision = nextRevision()
     emitGameAck({
       actionId: action.actionId,
       type: action.type,
       ok: true,
       revision,
+      payload: {
+        dice: [dice1, dice2],
+        total,
+        isDouble,
+      },
     })
-
-    emitSnapshotPatch(action.gameId, [
-      {
-        type: 'DICE_ROLLED',
-        playerId: currentPlayer.id,
-        payload: {
-          dice: [dice1, dice2],
-          total,
-          is_double: isDouble,
-          double_count: 0,
-        },
-      },
-      {
-        type: 'PLAYER_STATE_CHANGED',
-        playerId: currentPlayer.id,
-        payload: {
-          playerState: currentPlayer.state,
-          stateDuration: nextDuration,
-          reason: nextDuration > 0 ? 'island_wait' : 'island_timeout',
-        },
-      },
-      {
-        type: 'TURN_ENDED',
-        playerId: previousPlayerId,
-        nextPlayerId: mockGameState.currentTurn,
-        turn: previousTurn + 1,
-        round: mockGameState.round,
-        reason: 'island_wait',
-        bonusTurn: false,
-      },
-    ])
+    emitSnapshotPatch(action.gameId, nextEvents)
     return
   }
 
-  if (isLockedState && isDouble) {
+  if (isLockedPlayer && isDouble) {
     currentPlayer.state = 'normal'
     currentPlayer.stateDuration = 0
     currentPlayer.jail_turn_count = 0
     currentPlayer.is_in_jail = false
+    nextEvents.push({
+      type: 'PLAYER_STATE_CHANGED',
+      playerId: currentPlayer.id,
+      payload: {
+        playerState: 'normal',
+        stateDuration: 0,
+        reason: 'island_double_escape',
+      },
+    })
   }
 
   const fromIndex = currentPlayer.position
@@ -849,105 +1389,6 @@ const handleRollDiceAction = (action: MockResolvedGameAction) => {
   currentPlayer.position = toIndex
   if (passGo) {
     currentPlayer.balance += MOCK_PASS_GO_SALARY
-  }
-
-  const landedTile = getTileByIndex(toIndex)
-  const isMoveToIslandTile =
-    landedTile?.type === 'go_to_island' ||
-    landedTile?.transportType === 'MOVE_TO_ISLAND'
-  const isIslandTile =
-    landedTile?.type === 'island' || landedTile?.transportType === 'ISLAND'
-  const islandTileIndex =
-    mockGameState.tiles.find(
-      (tile) => tile.type === 'island' || tile.transportType === 'ISLAND'
-    )?.index ?? 8
-  let resolvedTileIndex = toIndex
-  let resolvedLandedTile = landedTile
-
-  if (isMoveToIslandTile) {
-    currentPlayer.position = islandTileIndex
-    resolvedTileIndex = islandTileIndex
-    resolvedLandedTile = getTileByIndex(islandTileIndex)
-    currentPlayer.state = 'locked'
-    currentPlayer.stateDuration = 3
-    currentPlayer.jail_turn_count = 3
-    currentPlayer.is_in_jail = true
-  } else if (isIslandTile) {
-    currentPlayer.state = 'locked'
-    currentPlayer.stateDuration = 3
-    currentPlayer.jail_turn_count = 3
-    currentPlayer.is_in_jail = true
-  }
-  const isOwnableLanding =
-    !!resolvedLandedTile && isOwnableTile(resolvedLandedTile)
-  const landingOwner = isOwnableLanding
-    ? mockGameState.players.find(
-        (player) => String(player.id) === String(resolvedLandedTile?.owner_id)
-      )
-    : null
-  const shouldPromptBuy = isOwnableLanding && !resolvedLandedTile?.owner_id
-  const shouldPromptBuild =
-    isOwnableLanding &&
-    Boolean(resolvedLandedTile?.owner_id) &&
-    landingOwner != null &&
-    String(landingOwner.id) === String(currentPlayer.id) &&
-    (resolvedLandedTile?.building ?? 0) < 3
-  const shouldPromptToll =
-    isOwnableLanding &&
-    resolvedLandedTile?.owner_id &&
-    landingOwner &&
-    String(landingOwner.id) !== String(currentPlayer.id)
-
-  const shouldHoldTurnForModal =
-    !shouldPromptBuy &&
-    !shouldPromptBuild &&
-    !shouldPromptToll &&
-    isModalLandingTile(resolvedLandedTile)
-  const nextEvents: GamePatchEnvelope['events'] = [
-    {
-      type: 'DICE_ROLLED',
-      playerId: currentPlayer.id,
-      payload: {
-        dice: [dice1, dice2],
-        total,
-        is_double: isDouble,
-        double_count: isDouble ? 1 : 0,
-      },
-    },
-    {
-      type: 'PLAYER_MOVED',
-      playerId: currentPlayer.id,
-      tileIndex: resolvedTileIndex,
-      amount: passGo ? MOCK_PASS_GO_SALARY : undefined,
-      payload: {
-        fromIndex,
-        fromTileId: fromIndex,
-        toIndex: resolvedTileIndex,
-        toTileId: resolvedTileIndex,
-        passGo,
-        trigger: isMoveToIslandTile ? 'move_to_island' : 'normal',
-      },
-    },
-    {
-      type: 'LANDED',
-      playerId: currentPlayer.id,
-      tileIndex: resolvedTileIndex,
-      payload: {
-        tileId: resolvedTileIndex,
-        tile: resolvedLandedTile
-          ? {
-              tileId: resolvedLandedTile.index,
-              name: resolvedLandedTile.name,
-              tileType:
-                resolvedLandedTile.transportType ?? resolvedLandedTile.type,
-              price: resolvedLandedTile.price ?? 0,
-            }
-          : undefined,
-      },
-    },
-  ]
-
-  if (passGo) {
     nextEvents.push({
       type: 'PASSED_START',
       playerId: currentPlayer.id,
@@ -958,83 +1399,47 @@ const handleRollDiceAction = (action: MockResolvedGameAction) => {
     })
   }
 
-  if (shouldPromptBuy && resolvedLandedTile) {
-    mockGameState.prompt = buildBuyPrompt(currentPlayer, resolvedLandedTile)
-    mockGameState.promptIssuedAtMs = Date.now()
-    mockGameState.phase = 'prompt'
-  } else if (shouldPromptBuild && resolvedLandedTile) {
-    mockGameState.prompt = buildBuildPrompt(currentPlayer, resolvedLandedTile)
-    mockGameState.promptIssuedAtMs = Date.now()
-    mockGameState.phase = 'prompt'
-  } else if (shouldPromptToll && resolvedLandedTile && landingOwner) {
-    const tollAmount = getTileTollAmount(resolvedLandedTile)
-    mockGameState.prompt = buildTollPrompt(
-      currentPlayer,
-      landingOwner,
-      resolvedLandedTile,
-      tollAmount
-    )
-    mockGameState.promptIssuedAtMs = Date.now()
-    mockGameState.phase = 'prompt'
-  } else if (shouldHoldTurnForModal) {
-    mockGameState.phase = 'resolving'
-  } else {
-    const previousPlayerId = currentPlayer.id
-    const previousTurn = mockGameState.round
-
-    if (!isDouble) {
-      advanceMockTurn()
-    }
-    mockGameState.phase = 'rolling'
-
-    // Mock Global Effect logic
-    if (
-      mockGameState.activeGlobalEffect &&
-      mockGameState.activeGlobalEffect.duration > 0
-    ) {
-      mockGameState.activeGlobalEffect.duration -= 1
-      if (mockGameState.activeGlobalEffect.duration <= 0) {
-        mockGameState.activeGlobalEffect = null
-      }
-    } else if (Math.random() < 0.2) {
-      // 20% chance to trigger
-      const effects: GlobalEffectType[] = [
-        'PANDEMIC',
-        'FESTIVAL',
-        'INFLATION',
-        'DEFLATION',
-      ]
-      const randomEffect = effects[Math.floor(Math.random() * effects.length)]
-      const isMultiplier =
-        randomEffect === 'PANDEMIC' || randomEffect === 'FESTIVAL'
-      mockGameState.activeGlobalEffect = {
-        type: isMultiplier ? 'TOLL_MULTIPLIER' : 'PRICE_MULTIPLIER',
-        effect: randomEffect,
-        duration: 3,
-        multiplier:
-          randomEffect === 'PANDEMIC' || randomEffect === 'DEFLATION' ? 0.5 : 2,
-        description: `테스트 글로벌 효과: ${randomEffect}`,
-      }
-    }
-
-    nextEvents.push({
-      type: 'TURN_ENDED',
-      playerId: previousPlayerId,
-      nextPlayerId: mockGameState.currentTurn,
-      turn: previousTurn + 1,
-      round: mockGameState.round,
-      reason: isDouble ? 'double_roll' : 'normal',
-      bonusTurn: isDouble,
-      payload: {
-        playerId: previousPlayerId,
-        nextPlayerId: mockGameState.currentTurn,
-        turn: previousTurn + 1,
-        round: mockGameState.round,
-        reason: isDouble ? 'double_roll' : 'normal',
-        bonusTurn: isDouble,
-      },
+  nextEvents.push(
+    createPlayerMovedEvent({
+      playerId: currentPlayer.id,
+      fromTileId: fromIndex,
+      toTileId: toIndex,
+      trigger: 'normal',
+      passGo,
+      amount: passGo ? MOCK_PASS_GO_SALARY : undefined,
     })
+  )
+
+  const landingResult = resolveLanding({
+    player: currentPlayer,
+    tileIndex: toIndex,
+  })
+  nextEvents.push(...landingResult.events)
+
+  if (landingResult.prompt) {
+    mockGameState.prompt = landingResult.prompt
+    mockGameState.promptIssuedAtMs = Date.now()
+    mockGameState.phase = 'prompt'
+  } else {
+    clearMockPrompt()
+    mockGameState.phase = 'resolving'
   }
+
+  const isStillLocked =
+    currentPlayer.state === 'locked' ||
+    currentPlayer.state === 'island' ||
+    currentPlayer.is_in_jail
+  mockGameState.pendingBonusTurnPlayerId =
+    isDouble && !isStillLocked && !currentPlayer.is_bankrupt
+      ? currentPlayer.id
+      : null
+  recalculatePlayerAssets()
+
+  const gameResult = maybeMarkGameOverByStanding()
+  if (gameResult) {
+    nextEvents.push(createGameOverEvent(gameResult))
+  }
+
   const revision = nextRevision()
 
   emitGameAck({
@@ -1042,6 +1447,11 @@ const handleRollDiceAction = (action: MockResolvedGameAction) => {
     type: action.type,
     ok: true,
     revision,
+    payload: {
+      dice: [dice1, dice2],
+      total,
+      isDouble,
+    },
   })
 
   emitSnapshotPatch(action.gameId, nextEvents)
@@ -1294,9 +1704,54 @@ const handleEndTurnAction = (action: MockResolvedGameAction) => {
   }
 
   const previousPlayerId = mockGameState.currentTurn
-  const previousTurn = mockGameState.round
-  advanceMockTurn()
+  const previousRound = mockGameState.round
+  const hadBonusTurn =
+    mockGameState.pendingBonusTurnPlayerId != null &&
+    String(mockGameState.pendingBonusTurnPlayerId) === String(previousPlayerId)
+
+  if (!hadBonusTurn) {
+    advanceMockTurn()
+  }
+
+  mockGameState.pendingBonusTurnPlayerId = null
+  clearMockPrompt()
   mockGameState.phase = 'rolling'
+
+  recalculatePlayerAssets()
+
+  let gameResult: NonNullable<GameSnapshot['gameResult']> | null = null
+  if (!hadBonusTurn && mockGameState.round > MOCK_MAX_ROUNDS) {
+    gameResult = markGameOver('max_rounds')
+  } else {
+    gameResult = maybeMarkGameOverByStanding()
+  }
+
+  const turnNumber = mockGameState.revision + 1
+  const nextEvents: GameEvents = [
+    {
+      type: 'TURN_ENDED',
+      playerId: previousPlayerId,
+      nextPlayerId: mockGameState.currentTurn,
+      turn: turnNumber,
+      round: mockGameState.round,
+      reason: hadBonusTurn ? 'double_roll' : 'manual_end_turn',
+      bonusTurn: hadBonusTurn,
+      payload: {
+        playerId: previousPlayerId,
+        nextPlayerId: mockGameState.currentTurn,
+        turn: turnNumber,
+        round: mockGameState.round,
+        reason: hadBonusTurn ? 'double_roll' : 'manual_end_turn',
+        bonusTurn: hadBonusTurn,
+        previousRound,
+      },
+    },
+  ]
+
+  if (gameResult) {
+    nextEvents.push(createGameOverEvent(gameResult))
+  }
+
   const revision = nextRevision()
 
   emitGameAck({
@@ -1306,25 +1761,7 @@ const handleEndTurnAction = (action: MockResolvedGameAction) => {
     revision,
   })
 
-  emitSnapshotPatch(action.gameId, [
-    {
-      type: 'TURN_ENDED',
-      playerId: previousPlayerId,
-      nextPlayerId: mockGameState.currentTurn,
-      turn: previousTurn + 1,
-      round: mockGameState.round,
-      reason: 'manual_end_turn',
-      bonusTurn: false,
-      payload: {
-        playerId: previousPlayerId,
-        nextPlayerId: mockGameState.currentTurn,
-        turn: previousTurn + 1,
-        round: mockGameState.round,
-        reason: 'manual_end_turn',
-        bonusTurn: false,
-      },
-    },
-  ])
+  emitSnapshotPatch(action.gameId, nextEvents)
 }
 
 export const mockEmitGameSync = ({
@@ -1573,12 +2010,15 @@ export const mockEmitPromptResponse = ({
       : undefined
   const promptAmount = resolvePromptAmount(activePrompt)
   const responsePayload = payload && typeof payload === 'object' ? payload : {}
-  const nextEvents: GamePatchEnvelope['events'] = [
+  const nextEvents: GameEvents = [
     {
       type: 'PROMPT_RESPONSE',
       payload: { choice: normalizedChoice, promptId, ...responsePayload },
     },
   ]
+  let nextPrompt: GamePrompt | null = null
+  let nextPhase: Extract<GameSnapshot['phase'], 'prompt' | 'resolving'> =
+    'resolving'
 
   if (promptType === 'BUY_OR_SKIP') {
     if (
@@ -1603,6 +2043,23 @@ export const mockEmitPromptResponse = ({
           payload: {
             tileId: targetTile.index,
             amount: price,
+          },
+        })
+
+        const buildCost = getTileBuildCost(targetTile)
+        if (buildCost > 0 && targetTile.building < 3) {
+          nextPrompt = buildBuildPrompt(respondingPlayer, targetTile)
+          nextPhase = 'prompt'
+        }
+      } else {
+        nextEvents.push({
+          type: 'INSUFFICIENT_FUNDS',
+          playerId: respondingPlayer.id,
+          tileIndex: targetTile.index,
+          amount: price,
+          payload: {
+            amount: price,
+            reason: 'buy_property',
           },
         })
       }
@@ -1635,37 +2092,127 @@ export const mockEmitPromptResponse = ({
             buildingLevel: targetTile.building,
           },
         })
+      } else if (buildCost > 0) {
+        nextEvents.push({
+          type: 'INSUFFICIENT_FUNDS',
+          playerId: respondingPlayer.id,
+          tileIndex: targetTile.index,
+          amount: buildCost,
+          payload: {
+            amount: buildCost,
+            reason: 'build_property',
+          },
+        })
       }
     }
   }
 
   if (promptType === 'PAY_TOLL') {
-    if (respondingPlayer && promptAmount > 0) {
-      respondingPlayer.balance -= promptAmount
-      if (respondingPlayer.balance <= 0) {
-        respondingPlayer.balance = 0
-        respondingPlayer.is_bankrupt = true
+    if (
+      respondingPlayer &&
+      promptAmount > 0 &&
+      targetTile &&
+      isOwnableTile(targetTile)
+    ) {
+      const owner =
+        targetTile.owner_id == null
+          ? null
+          : (mockGameState.players.find(
+              (player) => String(player.id) === String(targetTile.owner_id)
+            ) ?? null)
+      const paidAmount = Math.min(
+        promptAmount,
+        Math.max(respondingPlayer.balance, 0)
+      )
+      respondingPlayer.balance = Math.max(
+        0,
+        respondingPlayer.balance - paidAmount
+      )
+      if (owner) {
+        owner.balance += paidAmount
       }
 
-      if (targetTile?.owner_id != null) {
-        const owner = mockGameState.players.find(
-          (player) => String(player.id) === String(targetTile.owner_id)
-        )
-        if (owner) {
-          owner.balance += promptAmount
-        }
+      if (paidAmount < promptAmount || respondingPlayer.balance <= 0) {
+        respondingPlayer.is_bankrupt = true
+        respondingPlayer.state = 'bankrupt'
+        respondingPlayer.stateDuration = 0
+        respondingPlayer.jail_turn_count = 0
+        respondingPlayer.is_in_jail = false
+        nextEvents.push({
+          type: 'PLAYER_STATE_CHANGED',
+          playerId: respondingPlayer.id,
+          payload: {
+            playerState: 'bankrupt',
+            reason: 'toll_bankrupt',
+          },
+        })
+      } else if (owner && String(owner.id) !== String(respondingPlayer.id)) {
+        nextPrompt = buildAcquisitionPrompt(respondingPlayer, owner, targetTile)
+        nextPhase = 'prompt'
+      }
+
+      nextEvents.push({
+        type: 'PAID_TOLL',
+        playerId: respondingPlayer.id,
+        tileIndex: targetTile.index,
+        amount: paidAmount,
+        payload: {
+          amount: paidAmount,
+          expectedAmount: promptAmount,
+          ownerId: owner?.id ?? null,
+        },
+      })
+    }
+  }
+
+  if (promptType === 'ACQUISITION_OR_SKIP') {
+    if (
+      normalizedChoice === 'ACQUIRE' &&
+      respondingPlayer &&
+      targetTile &&
+      isOwnableTile(targetTile) &&
+      targetTile.owner_id != null &&
+      String(targetTile.owner_id) !== String(respondingPlayer.id)
+    ) {
+      const owner = mockGameState.players.find(
+        (player) => String(player.id) === String(targetTile.owner_id)
+      )
+      const acquisitionCost =
+        promptAmount > 0 ? promptAmount : (targetTile.price ?? 0)
+
+      if (owner && respondingPlayer.balance >= acquisitionCost) {
+        respondingPlayer.balance -= acquisitionCost
+        owner.balance += acquisitionCost
+        removeOwnedTile(owner, targetTile.index)
+        targetTile.owner_id = respondingPlayer.id
+        targetTile.ownerId = respondingPlayer.id
+        ensureOwnedTiles(respondingPlayer, targetTile.index)
+
+        nextEvents.push({
+          type: 'ACQUIRED_PROPERTY',
+          playerId: respondingPlayer.id,
+          tileIndex: targetTile.index,
+          amount: acquisitionCost,
+          payload: {
+            tileId: targetTile.index,
+            fromPlayerId: owner.id,
+            toPlayerId: respondingPlayer.id,
+            amount: acquisitionCost,
+          },
+        })
+      } else {
+        nextEvents.push({
+          type: 'INSUFFICIENT_FUNDS',
+          playerId: respondingPlayer.id,
+          tileIndex: targetTile.index,
+          amount: acquisitionCost,
+          payload: {
+            amount: acquisitionCost,
+            reason: 'acquire_property',
+          },
+        })
       }
     }
-
-    nextEvents.push({
-      type: 'PAID_TOLL',
-      playerId: respondingPlayer?.id ?? null,
-      tileIndex: targetTileIndex ?? null,
-      amount: promptAmount,
-      payload: {
-        amount: promptAmount,
-      },
-    })
   }
 
   if (promptType === 'TRAVEL_SELECT') {
@@ -1688,28 +2235,42 @@ export const mockEmitPromptResponse = ({
         respondingPlayer.position = targetTileId
 
         nextEvents.push(
-          {
-            type: 'PLAYER_MOVED',
+          createPlayerMovedEvent({
             playerId: respondingPlayer.id,
-            tileIndex: targetTileId,
-            payload: {
-              fromTileId,
-              toTileId: targetTileId,
-              trigger: 'travel_select',
-            },
-          },
-          {
-            type: 'LANDED',
-            playerId: respondingPlayer.id,
-            tileIndex: targetTileId,
-          }
+            fromTileId,
+            toTileId: targetTileId,
+            trigger: 'travel_select',
+          })
         )
+
+        const travelLanding = resolveLanding({
+          player: respondingPlayer,
+          tileIndex: targetTileId,
+        })
+        nextEvents.push(...travelLanding.events)
+        if (travelLanding.prompt) {
+          nextPrompt = travelLanding.prompt
+          nextPhase = travelLanding.phase
+        }
       }
     }
   }
 
-  mockGameState.phase = 'resolving'
   clearMockPrompt()
+  if (nextPrompt) {
+    mockGameState.prompt = nextPrompt
+    mockGameState.promptIssuedAtMs = Date.now()
+    mockGameState.phase = 'prompt'
+  } else {
+    mockGameState.phase = nextPhase
+  }
+
+  recalculatePlayerAssets()
+  const gameResult = maybeMarkGameOverByStanding()
+  if (gameResult) {
+    nextEvents.push(createGameOverEvent(gameResult))
+  }
+
   const revision = nextRevision()
 
   emitGameAck({

--- a/src/pages/GamePage.test.tsx
+++ b/src/pages/GamePage.test.tsx
@@ -447,6 +447,49 @@ describe('GamePage chat flow', () => {
     expect(getRoundBadge()).not.toHaveTextContent('21')
   })
 
+  it('clears previous prompt submitting state when server replaces prompt id', async () => {
+    const user = userEvent.setup()
+
+    setTestGameState({
+      prompt: {
+        id: 'prompt-1',
+        type: 'BUY_OR_SKIP',
+        playerId: 'user-1',
+        title: 'First prompt',
+        choices: [
+          { id: 'c1', label: 'Choice A', value: 'A' },
+          { id: 'c2', label: 'Choice B', value: 'B' },
+        ],
+      },
+    })
+
+    renderGamePage()
+
+    await user.click(screen.getByRole('button', { name: 'Choice A' }))
+
+    expect(screen.getByText('Sending response...')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Choice A' })).toBeDisabled()
+
+    setTestGameState({
+      prompt: {
+        id: 'prompt-2',
+        type: 'BUILD_OR_SKIP',
+        playerId: 'user-1',
+        title: 'Second prompt',
+        choices: [
+          { id: 'c3', label: 'Choice C', value: 'C' },
+          { id: 'c4', label: 'Choice D', value: 'D' },
+        ],
+      },
+    })
+
+    await waitFor(() => {
+      expect(screen.queryByText('Sending response...')).not.toBeInTheDocument()
+    })
+
+    expect(screen.getByRole('button', { name: 'Choice C' })).toBeEnabled()
+  })
+
   it('우측 패널은 totalAssets를 우선 표시하고 그 기준으로 정렬과 왕관을 표시한다', () => {
     setTestGameState({
       players: [
@@ -1131,5 +1174,34 @@ describe('GamePage chat flow', () => {
       type: 'END_TURN',
       gameId: 'game-1',
     })
+  })
+
+  it('treats zero balance as non-bankrupt unless server marks player bankrupt', () => {
+    useTurnMock.mockReturnValue(true)
+    setTestGameState({
+      currentTurn: 'user-1',
+      phase: 'rolling',
+      prompt: null,
+      pendingAction: null,
+      players: [
+        createPlayer({
+          id: 'user-1',
+          balance: 0,
+          is_bankrupt: false,
+          state: 'normal',
+        }),
+        createPlayer({
+          id: 'user-2',
+          balance: 1000,
+          is_bankrupt: false,
+          state: 'normal',
+        }),
+      ],
+    })
+
+    renderGamePage()
+
+    expect(screen.getByRole('button', { name: /주사위/i })).toBeEnabled()
+    expect(getPlayerPanelById('user-1').dataset.isBankrupt).toBe('false')
   })
 })

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -187,6 +187,9 @@ const GamePage: React.FC = () => {
   const [promptSubmittingChoice, setPromptSubmittingChoice] = useState<
     string | null
   >(null)
+  const [promptSubmittingPromptId, setPromptSubmittingPromptId] = useState<
+    string | null
+  >(null)
   const [isBoardBlockingModalOpen, setIsBoardBlockingModalOpen] =
     useState(false)
   const [isExitModalOpen, setIsExitModalOpen] = useState(false)
@@ -284,14 +287,25 @@ const GamePage: React.FC = () => {
   useEffect(() => {
     if (!prompt) {
       setPromptSubmittingChoice(null)
+      setPromptSubmittingPromptId(null)
+      return
+    }
+
+    if (
+      promptSubmittingPromptId != null &&
+      promptSubmittingPromptId !== prompt.id
+    ) {
+      setPromptSubmittingChoice(null)
+      setPromptSubmittingPromptId(null)
       return
     }
 
     if (lastAck?.promptId === prompt.id) {
       clearPrompt(prompt.id)
       setPromptSubmittingChoice(null)
+      setPromptSubmittingPromptId(null)
     }
-  }, [clearPrompt, lastAck?.promptId, prompt])
+  }, [clearPrompt, lastAck?.promptId, prompt, promptSubmittingPromptId])
 
   useEffect(() => {
     if (!lastError) {
@@ -299,6 +313,7 @@ const GamePage: React.FC = () => {
     }
 
     setPromptSubmittingChoice(null)
+    setPromptSubmittingPromptId(null)
   }, [lastError])
 
   useEffect(() => {
@@ -396,7 +411,7 @@ const GamePage: React.FC = () => {
           isBankrupt:
             Boolean(storePlayer.is_bankrupt) ||
             storePlayer.state === 'bankrupt' ||
-            money <= 0,
+            boardPlayer?.state === 'bankrupt',
           isRichest: false,
         }
       }
@@ -483,8 +498,7 @@ const GamePage: React.FC = () => {
     return applyRichestFlag(sortedPlayers, richestPlayerId)
   }, [activePlayerId, boardPlayers, gameResult, storePlayers])
   const currentPlayerState = boardPlayers[boardCurPlayer]
-  const isCurrentPlayerBankrupt =
-    currentPlayerState?.money <= 0 || currentPlayerState?.state === 'bankrupt'
+  const isCurrentPlayerBankrupt = currentPlayerState?.state === 'bankrupt'
   const isRollPhase = phase === 'rolling'
   const isEndTurnPhase = phase === 'resolving' && !prompt
   const canControlTurn =
@@ -539,6 +553,7 @@ const GamePage: React.FC = () => {
     }
 
     setPromptSubmittingChoice(choice)
+    setPromptSubmittingPromptId(prompt.id)
     emitPromptResponse({
       gameId: activeGameId,
       promptId: prompt.id,


### PR DESCRIPTION
## 📌 관련 이슈

> closes #N/A

- related: board-sot-sync
- related: mock-runtime-server-parity

---

## 📝 작업 내용

- 게임 패널/보드에서 `money <= 0`을 즉시 파산으로 보던 추론 로직을 제거했습니다.
- 파산 판정 기준을 서버 상태(`is_bankrupt`, `state=bankrupt`)로 통일했습니다.
- mock 런타임에서 통행료/찬스 처리 후 잔액이 정확히 0원이 되는 경우를 정상 상태로 유지하도록 보정했습니다.
- totalAssets는 서버 권위값을 우선 표시하도록 경로를 유지/점검했습니다.
- 관련 회귀 테스트를 추가하고 lint/build까지 통과 확인했습니다.

---

## 🧠 Task 문서 (큰 작업이면 필수)

- plan: docs/ai/tasks/board-sot-sync/plan.md
- context: docs/ai/tasks/board-sot-sync/context.md
- checklist: docs/ai/tasks/board-sot-sync/checklist.md

---

## 📋 TODO.md 연결

- task slug: board-sot-sync
- TODO status: [ ] In Progress
- TODO entry 확인: TODO.md의 `board-sot-sync` 항목과 현재 PR 범위 일치 확인

---

## 📚 참고한 기준 문서

- AGENTS.md
- docs/rules.md
- docs/testing.md
- docs/ai/manuals/common.md
- docs/ai/manuals/game-runtime.md

---

## 🧪 실행한 검증

- npx vitest run src/mocks/handlers/game.handler.test.ts
- npx vitest run src/pages/GamePage.test.tsx
- npx vitest run src/components/board/GameBoard.test.tsx
- npm run lint
- npm run build

---

## ⚠️ 남은 리스크

- 이번 PR은 파산 오탐/표시 정합성 중심 보정입니다.
- 특수 이동(무인도/여행/찬스) 체감 애니메이션 완전 정합성은 후속 PR에서 추가 보강이 필요합니다.

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 미추가/정리
- [x] 관련 이슈 연결 완료
- [x] task 문서(plan/context/checklist) 링크 기입
- [x] TODO.md 연결/slug 기입
- [x] 참고한 기준 문서 기입
- [x] 실행한 검증/남은 리스크 기입

---

## 📸 스크린샷 (선택)

- N/A
