### PR TITLE
fix: 게임 런타임 prompt 깜빡임 보정 및 @game 스모크 안정화

### DIFF
--- a/docs/ai/tasks/game-board-result-and-travel-fix/checklist.md
+++ b/docs/ai/tasks/game-board-result-and-travel-fix/checklist.md
@@ -8,6 +8,7 @@
 - [x] 이벤트칸/무인도/여행칸/trigger 기반 travel 판정 테스트 추가
 - [x] `npx vitest run src/components/board/gameBoardResultUtils.test.ts`
 - [x] `npx vitest run src/components/board/gameBoardEventQueueUtils.test.ts`
+- [x] `GameBoard`에서 보유금 부족 확인 직후 `BUILD_OR_SKIP` 모달이 재노출되는 깜빡임 방지 (dismissed prompt id 해제 시점 보정)
 - [x] `npm run lint`
 - [x] `npm run ai:check:game`
 - [x] `npm run ai:check:build`

--- a/e2e/game-runtime-roll-smoke.spec.ts
+++ b/e2e/game-runtime-roll-smoke.spec.ts
@@ -46,11 +46,21 @@ test.describe('@game 게임 런타임 롤 스모크', () => {
     await expect(rollButton).toBeVisible()
 
     const consumePromptIfVisible = async () => {
+      const modalActionButtons = page.locator(
+        'div.fixed.inset-0.z-50 button:enabled'
+      )
+
+      if ((await modalActionButtons.count()) > 0) {
+        await modalActionButtons.first().click()
+        await page.waitForTimeout(350)
+        return true
+      }
+
       for (const promptPattern of PROMPT_BUTTONS) {
         const button = page.getByRole('button', { name: promptPattern }).first()
         if ((await button.count()) > 0 && (await button.isVisible())) {
           await button.click()
-          await page.waitForTimeout(400)
+          await page.waitForTimeout(350)
           return true
         }
       }
@@ -63,6 +73,17 @@ test.describe('@game 게임 런타임 롤 스모크', () => {
       for (let consumeTry = 0; consumeTry < 3; consumeTry += 1) {
         const consumed = await consumePromptIfVisible()
         if (!consumed) break
+      }
+
+      for (let retry = 0; retry < 20; retry += 1) {
+        if (await rollButton.isEnabled()) {
+          break
+        }
+
+        const consumed = await consumePromptIfVisible()
+        if (!consumed) {
+          await page.waitForTimeout(200)
+        }
       }
 
       await expect(rollButton).toBeEnabled()

--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -1451,14 +1451,20 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       string | null
     >(null)
     useEffect(() => {
+      if (!activePrompt?.id) {
+        if (dismissedBuildPromptId != null) {
+          setDismissedBuildPromptId(null)
+        }
+        return
+      }
+
       if (
-        promptSubmittingChoice === null &&
         dismissedBuildPromptId != null &&
-        activePrompt?.id === dismissedBuildPromptId
+        activePrompt.id !== dismissedBuildPromptId
       ) {
         setDismissedBuildPromptId(null)
       }
-    }, [activePrompt?.id, dismissedBuildPromptId, promptSubmittingChoice])
+    }, [activePrompt?.id, dismissedBuildPromptId])
 
     const [aiModal, setAiModal] = useState<AIPenaltyModalState>({
       open: false,


### PR DESCRIPTION
## 🔗 관련 이슈
- related: game-board-result-and-travel-fix
- related: mock runtime parity follow-up

## 📝 작업 내용
- `src/components/board/GameBoard.tsx`
  - 보유금 부족 확인 직후 동일 `BUILD_OR_SKIP` prompt가 다시 잠깐 노출되는 깜빡임을 보정했습니다.
  - `dismissedBuildPromptId` 초기화 시점을 `prompt === null` 또는 `prompt.id 변경`으로 제한해 동일 prompt 재노출을 차단했습니다.
- `e2e/game-runtime-roll-smoke.spec.ts`
  - prompt 소비를 모달 레이어 활성 버튼 우선 방식으로 보강했습니다.
  - roll 버튼 enable 대기 루프를 보강해 prompt/애니메이션 타이밍 경합에서 flaky를 줄였습니다.
- `docs/ai/tasks/game-board-result-and-travel-fix/checklist.md`
  - 이번 flicker 보정 내용을 task 체크리스트에 반영했습니다.

## 🧠 Task 문서 (큰 작업이면 필수)
- plan: `docs/ai/tasks/game-board-result-and-travel-fix/plan.md`
- context: `docs/ai/tasks/game-board-result-and-travel-fix/context.md`
- checklist: `docs/ai/tasks/game-board-result-and-travel-fix/checklist.md`

## 📋 TODO.md 연결
- task slug: `game-board-result-and-travel-fix`
- TODO status: `In Progress`
- TODO entry 확인: TODO.md `In Progress` 섹션의 `game-board-result-and-travel-fix` 항목과 일치

## 📚 참고한 기준 문서
- `AGENTS.md`
- `docs/ai/manuals/common.md`
- `docs/ai/manuals/game-runtime.md`
- `docs/rules.md`
- `docs/testing.md`
- `docs/socket-mock-server.md`
- backend reference: `https://github.com/modoo-marble-team/modoo-marble-backend`

## 🧪 실행한 검증
- `npm run lint`
- `npm run ai:check:game`
- `npm run e2e:game` (2 passed)
- `npm run ai:check:build`

## ⚠️ 남은 리스크
- 이번 PR은 flicker/스모크 안정화 중심 보정이므로, 카드/무인도/여행 복합 체인 장시간 QA는 후속 점검이 필요합니다.
- `@game` E2E는 현재 스모크 2개 기준이며, 케이스 확장은 후속 PR에서 진행합니다.

## 🚧 후속 작업
1. `chance-move-direction-animation` 최종 회귀 확인 (역방향 이동 연출)
2. `island-speed-and-exit-modal-style` 잔여 폴리시/시각 일관성 점검
3. mock 단독 배포 기준 장시간 플레이 QA 시나리오 확장
