### PR TITLE
fix: 누락된 SoT 타일명 반영

### DIFF
--- a/docs/ai/tasks/board-sot-sync/checklist.md
+++ b/docs/ai/tasks/board-sot-sync/checklist.md
@@ -22,11 +22,17 @@
 - [x] Checked boundary cases (redirect, cleanup, duplicate subscribe, errors).
 - [x] Synced TODO task status with current work.
 - [x] Reported changed files, validations, and remaining risks.
-- [ ] Updated session handoff notes.
-- [ ] Verified `npm run ai:session:brief -- board-sot-sync` output.
+- [x] Updated session handoff notes.
+- [x] Verified `npm run ai:session:brief -- board-sot-sync` output.
 
 ## 2026-04-01 Gate Evidence Checklist
 
 - [x] Updated task triplet files in current high-risk runtime branch.
 - [x] Confirmed TODO slug linkage for `board-sot-sync`.
 - [ ] Re-run workflow-gate after pushing this doc update.
+
+## 2026-04-03 Parity Checklist
+
+- [x] Backend ruleset board-name diff check (tile 24) and fallback/mock rename synced.
+- [x] Adapter normalization preserves `transportType` for `TRAVEL`/`EVENT`.
+- [x] Added adapter regression test for travel/event `tile_type` transport metadata.

--- a/docs/ai/tasks/board-sot-sync/context.md
+++ b/docs/ai/tasks/board-sot-sync/context.md
@@ -62,3 +62,10 @@
 - Validation focus in this cycle:
   - remove zero-balance bankrupt false positives
   - preserve server-authoritative totalAssets rendering path
+
+## 2026-04-03 Context Update
+
+- Backend SoT diff check against `default.v1.json` confirmed a single board-name drift:
+  - tile 24 expected `무인도로 이동`, frontend fallback/mock still had `섬으로 이동`.
+- Tile metadata normalization gap:
+  - adapter did not preserve `transportType` for `TRAVEL`, causing mock/real payload semantics to be weaker than server payload.

--- a/docs/ai/tasks/board-sot-sync/plan.md
+++ b/docs/ai/tasks/board-sot-sync/plan.md
@@ -74,3 +74,10 @@
 - This plan file is intentionally updated in the same branch as high-risk runtime changes.
 - Workflow-gate evidence target: docs/ai/tasks/board-sot-sync/{plan,context,checklist}.md
 - Current PR scope: bankrupt guard alignment + totalAssets authoritative display stabilization.
+
+## 2026-04-03 Parity Follow-up
+
+- Backend ruleset(`default.v1.json`) board name parity audit found one remaining mismatch:
+  - tile 24 name `섬으로 이동` -> `무인도로 이동` (frontend fallback/mock)
+- Snapshot tile metadata parity follow-up:
+  - preserve `transportType: TRAVEL/EVENT` in adapter normalization so mock/real runtime keep tile meta semantics.

--- a/src/components/board/GameBoard.test.tsx
+++ b/src/components/board/GameBoard.test.tsx
@@ -200,7 +200,7 @@ const tiles = [
   },
   {
     index: 24,
-    name: '섬으로 이동',
+    name: '무인도로 이동',
     type: 'MOVE_TO_ISLAND',
     building: 0,
   },

--- a/src/components/board/board.constants.ts
+++ b/src/components/board/board.constants.ts
@@ -214,7 +214,7 @@ export const TILES: TileData[] = [
     color: '#FF7043',
     price: 500_000_000,
   },
-  { id: 24, name: '섬으로 이동', type: 'MOVE_TO_ISLAND', emoji: '🚓' },
+  { id: 24, name: '무인도로 이동', type: 'MOVE_TO_ISLAND', emoji: '🚓' },
   {
     id: 25,
     name: '청주',

--- a/src/mocks/gameMockData.ts
+++ b/src/mocks/gameMockData.ts
@@ -146,7 +146,7 @@ export const mockTiles: Tile[] = [
   },
   {
     index: 24,
-    name: '\uC12C\uC73C\uB85C \uC774\uB3D9',
+    name: '\uBB34\uC778\uB3C4\uB85C \uC774\uB3D9',
     type: 'go_to_island',
     building: 0,
   },

--- a/src/services/socket/gameContractAdapters.test.ts
+++ b/src/services/socket/gameContractAdapters.test.ts
@@ -249,6 +249,48 @@ describe('gameContractAdapters', () => {
     expect(normalized?.phase).toBe('rolling')
   })
 
+  it('preserves transportType for travel and event tiles from tile_type', () => {
+    const normalized = normalizeSnapshotPayload(
+      {
+        gameId: 'game-travel-transport',
+        revision: 5,
+        phase: 'ROLLING',
+        players: [],
+        tiles: [
+          {
+            tile_id: 16,
+            name: '여행',
+            tile_type: 'TRAVEL',
+          },
+          {
+            tile_id: 20,
+            name: '이벤트',
+            tile_type: 'EVENT',
+          },
+        ],
+      },
+      {
+        envelopeRevision: 5,
+      }
+    )
+
+    expect(normalized).not.toBeNull()
+    expect(normalized?.tiles).toEqual([
+      expect.objectContaining({
+        index: 16,
+        name: '여행',
+        type: 'travel',
+        transportType: 'TRAVEL',
+      }),
+      expect.objectContaining({
+        index: 20,
+        name: '이벤트',
+        type: 'event',
+        transportType: 'EVENT',
+      }),
+    ])
+  })
+
   it('normalizes active global effect from snapshot aliases', () => {
     const normalized = normalizeSnapshotPayload(
       {

--- a/src/services/socket/gameContractAdapters.ts
+++ b/src/services/socket/gameContractAdapters.ts
@@ -79,6 +79,7 @@ const TILE_TYPE_TO_INTERNAL_MAP: Record<string, Tile['type']> = {
   PROPERTY: 'property',
   EVENT: 'event',
   CHANCE: 'chance',
+  TRAVEL: 'travel',
   MOVE_TO_ISLAND: 'go_to_island',
   ISLAND: 'island',
 }

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -26,6 +26,8 @@ export type TransportTileType =
   | 'START'
   | 'PROPERTY'
   | 'CHANCE'
+  | 'EVENT'
+  | 'TRAVEL'
   | 'MOVE_TO_ISLAND'
   | 'ISLAND'
 


### PR DESCRIPTION
## 🧠 Task 문서 (큰 작업이면 필수)
- plan: docs/ai/tasks/board-sot-sync/plan.md
- context: docs/ai/tasks/board-sot-sync/context.md
- checklist: docs/ai/tasks/board-sot-sync/checklist.md

## 📋 TODO.md 연결
- task slug: board-sot-sync
- TODO status: In Progress
- TODO entry 확인: TODO.md 11번 라인의 board-sot-sync

## 📚 참고한 기준 문서
- docs/ai/manuals/game-runtime.md
- docs/socket-mock-server.md

## 🧪 실행한 검증
- `npm run lint`
- `npm run ai:check:game`
- `npm run ai:check:build`

## ⚠️ 남은 리스크
- 없음
