### PR TITLE
fix: align mock parity and stabilize board/e2e timing

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,10 +6,7 @@
 
 ## In Progress
 
-- [ ] `game-board-result-and-travel-fix` - Game Board Result And Travel Fix (`docs/ai/tasks/game-board-result-and-travel-fix/`) - 결과 모달 보유도시 수를 종료 시점 타일 소유 정보로 복구하고 이벤트칸 오인 travel 애니메이션을 수정
-- [ ] `island-speed-and-exit-modal-style` - Island Speed and Exit Modal Style (`docs/ai/tasks/island-speed-and-exit-modal-style/`) - 무인도 이동 속도 개선 및 게임 종료 모달 스타일 통일
 - [ ] `board-sot-sync` - Board SoT sync + initial full sync (`docs/ai/tasks/board-sot-sync/`) - 보드판 SoT를 백엔드 기준으로 전환하고 최초 sync knownRevision=-1 요청 반영
-- [ ] `chance-move-direction-animation` - Chance Move Direction Animation (`docs/ai/tasks/chance-move-direction-animation/`) - chance 이동 방향 힌트 기반 순차 애니메이션 보정 및 검증
 - [ ] `mypage-nickname-change` - MyPage Nickname Change (`docs/ai/tasks/mypage-nickname-change/`) - 게스트 제한은 유지하고 카카오 사용자는 마이페이지에서 닉네임을 반복 변경할 수 있게 정리
 - [ ] `git-flow-template-source-of-truth` - Git Flow Template Source Of Truth (`docs/ai/tasks/git-flow-template-source-of-truth/`) - ai:git-flow가 .github 템플릿을 직접 읽어 issue/PR 제목, labels, 본문을 생성하도록 정렬
 
@@ -17,6 +14,9 @@
 
 ## Done
 
+- [x] `game-board-result-and-travel-fix` - Game Board Result And Travel Fix (`docs/ai/tasks/game-board-result-and-travel-fix/`) - 결과 모달 보유도시 수를 종료 시점 타일 소유 정보로 복구하고 이벤트칸 오인 travel 애니메이션을 수정
+- [x] `island-speed-and-exit-modal-style` - Island Speed and Exit Modal Style (`docs/ai/tasks/island-speed-and-exit-modal-style/`) - 무인도 이동 속도 개선 및 게임 종료 모달 스타일 통일
+- [x] `chance-move-direction-animation` - Chance Move Direction Animation (`docs/ai/tasks/chance-move-direction-animation/`) - chance 이동 방향 힌트 기반 순차 애니메이션 보정 및 검증
 - [x] `game-chat-panel-solo-play-toggle` - Game Chat Panel Solo Play Toggle (`docs/ai/tasks/game-chat-panel-solo-play-toggle/`) - 게임방 채팅 테스트 패널 문구를 정리하고 mock 혼자 플레이 토글로 상대 턴 주사위/턴 종료/prompt 응답을 가능하게 정리
 - [x] `game-debug-overlay-production-hide` - Game Debug Overlay 배포 숨김 (`docs/ai/tasks/game-debug-overlay-production-hide/`) - `GamePage` 오른쪽 상단 debug/status overlay를 production에서 숨기고 dev에서만 유지
 - [x] `game-board-modal-reveal-policy-split` - Game Board Modal Reveal Policy Split (`docs/ai/tasks/game-board-modal-reveal-policy-split/`) - pre-move / post-move reveal policy를 분리해 travel, go-to-island, chance chain move modal ordering을 정리

--- a/docs/ai/tasks/board-sot-sync/checklist.md
+++ b/docs/ai/tasks/board-sot-sync/checklist.md
@@ -14,7 +14,7 @@
 - [x] Ran targeted Vitest suites.
 - [x] Ran `npm run lint` for this high-risk runtime change.
 - [x] Ran `npm run build` for this high-risk runtime change.
-- [ ] Run Playwright scenario when user flow risk is high.
+- [x] Run Playwright scenario when user flow risk is high.
 
 ## Review
 

--- a/docs/ai/tasks/board-sot-sync/context.md
+++ b/docs/ai/tasks/board-sot-sync/context.md
@@ -69,3 +69,18 @@
   - tile 24 expected `무인도로 이동`, frontend fallback/mock still had `섬으로 이동`.
 - Tile metadata normalization gap:
   - adapter did not preserve `transportType` for `TRAVEL`, causing mock/real payload semantics to be weaker than server payload.
+
+## 2026-04-03 Runtime Parity Recheck
+
+- `src/mocks/handlers/game.handler.ts` parity updates:
+  - event/chance card pool separation (`EVENT` uses event pool)
+  - strict spend rules (`balance > cost`) for buy/build/acquire
+  - toll settlement parity (`balance <= toll` -> bankrupt) with ownership cleanup
+  - travel prompt response move trigger aligned to `travel`
+  - chance forward move now applies pass-go salary semantics
+  - island lock duration aligned to 3 turns
+  - global effect / extra-turn effect state now affects turn progression
+- TODO sync:
+  - `chance-move-direction-animation`, `game-board-result-and-travel-fix`,
+    `island-speed-and-exit-modal-style` moved to `Done`
+  - `board-sot-sync` remains `In Progress` until workflow-gate follow-up item closes

--- a/e2e/game-runtime-roll-smoke.spec.ts
+++ b/e2e/game-runtime-roll-smoke.spec.ts
@@ -46,20 +46,34 @@ test.describe('@game 게임 런타임 롤 스모크', () => {
     await expect(rollButton).toBeVisible()
 
     const consumePromptIfVisible = async () => {
-      const modalActionButtons = page.locator(
-        'div.fixed.inset-0.z-50 button:enabled'
-      )
+      const topModalOverlay = page
+        .locator('div.fixed.inset-0:has(button:enabled)')
+        .last()
 
-      if ((await modalActionButtons.count()) > 0) {
-        await modalActionButtons.first().click()
-        await page.waitForTimeout(350)
-        return true
+      if ((await topModalOverlay.count()) > 0) {
+        const modalActionButtons = topModalOverlay.locator('button:enabled')
+        const buttonCount = await modalActionButtons.count()
+
+        for (let index = buttonCount - 1; index >= 0; index -= 1) {
+          const button = modalActionButtons.nth(index)
+          if (!(await button.isVisible()) || !(await button.isEnabled())) {
+            continue
+          }
+
+          try {
+            await button.click({ timeout: 1200 })
+            await page.waitForTimeout(350)
+            return true
+          } catch {
+            await page.waitForTimeout(80)
+          }
+        }
       }
 
       for (const promptPattern of PROMPT_BUTTONS) {
         const button = page.getByRole('button', { name: promptPattern }).first()
         if ((await button.count()) > 0 && (await button.isVisible())) {
-          await button.click()
+          await button.click({ timeout: 1200 })
           await page.waitForTimeout(350)
           return true
         }

--- a/src/components/board/BoardTile.tsx
+++ b/src/components/board/BoardTile.tsx
@@ -18,6 +18,7 @@ interface TokenProps {
   style?: React.CSSProperties
   isTraveling?: boolean
   travelIconSrc?: string
+  hideStateBadge?: boolean
 }
 
 export const PlayerToken = React.memo<TokenProps>(
@@ -28,9 +29,12 @@ export const PlayerToken = React.memo<TokenProps>(
     style,
     isTraveling = false,
     travelIconSrc = '/Travel- airplane.svg',
+    hideStateBadge = false,
   }) => {
     const { x, y } = offset
-    const isIsland = player.state === 'island' || (player.skipTurns ?? 0) > 0
+    const isIsland =
+      !hideStateBadge &&
+      (player.state === 'island' || (player.skipTurns ?? 0) > 0)
 
     return (
       <motion.div
@@ -87,7 +91,7 @@ export const PlayerToken = React.memo<TokenProps>(
           />
         )}
         {isIsland && !isTraveling && <span style={{ fontSize: 10 }}>🏝️</span>}
-        {(player.skipTurns ?? 0) > 0 && (
+        {!hideStateBadge && (player.skipTurns ?? 0) > 0 && (
           <div
             style={{
               position: 'absolute',
@@ -119,6 +123,7 @@ export const PlayerToken = React.memo<TokenProps>(
       prev.offset?.y === next.offset?.y &&
       prev.stripOffset === next.stripOffset &&
       prev.isTraveling === next.isTraveling &&
+      prev.hideStateBadge === next.hideStateBadge &&
       prev.travelIconSrc === next.travelIconSrc &&
       prev.style?.gridRow === next.style?.gridRow &&
       prev.style?.gridColumn === next.style?.gridColumn

--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -53,14 +53,17 @@ import { useBoardEventQueue } from './useBoardEventQueue'
 import {
   FAST_MOVE_ANIMATION_OPTIONS,
   getPendingMovePlayerIdsFromEvents,
+  getPendingMoveStartIndexByPlayerIdFromEvents,
   getBoardEventAnimationHoldMs,
   resolveBoardCardModalContentFromEvent,
   resolveBoardEventTileIndex,
+  resolveChanceMoneyEffectFromEvent,
   resolveChanceMoveAnimationHint,
   shouldApplyTravelMoveAnimation,
   shouldRevealPostMoveSurface,
   shouldRevealPreMoveSurface,
   type BoardEventAnimationKind,
+  type ChanceMoneyEffect,
   type BoardMoveDirection,
 } from './gameBoardEventQueueUtils'
 import { buildGameResultModalRows } from './gameBoardResultUtils'
@@ -372,6 +375,7 @@ interface GameBoardProps {
   winnerId?: PlayerId | null
   onGameResultConfirm?: () => void
   onBlockingModalChange?: (blocked: boolean) => void
+  onChanceMoneyEffect?: (effect: ChanceMoneyEffect) => void
   activeGlobalEffect?: GlobalEffectState | null
 }
 
@@ -514,6 +518,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       winnerId = null,
       onGameResultConfirm,
       onBlockingModalChange,
+      onChanceMoneyEffect,
       activeGlobalEffect = null,
     },
     ref
@@ -551,6 +556,10 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
     const eventQueue = useGameStore((state) => state.eventQueue)
     const pendingMovePlayerIds = useMemo(
       () => getPendingMovePlayerIdsFromEvents(eventQueue),
+      [eventQueue]
+    )
+    const pendingMoveStartIndexByPlayerId = useMemo(
+      () => getPendingMoveStartIndexByPlayerIdFromEvents(eventQueue),
       [eventQueue]
     )
     const pendingMovePlayerIdSet = useMemo(
@@ -822,6 +831,10 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
             playerKey && playerKey !== 'null'
               ? pendingChanceMoveHintRef.current[playerKey]
               : undefined
+          const pendingFromIndexForPlayer =
+            playerKey && playerKey !== 'null'
+              ? pendingMoveStartIndexByPlayerId[playerKey]
+              : undefined
           const lastKnownFrom =
             playerKey && playerKey !== 'null'
               ? lastMovePositionRef.current[playerKey]
@@ -830,6 +843,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
             (Number.isFinite(parsedFromIndex ?? Number.NaN)
               ? Number(parsedFromIndex)
               : null) ??
+            pendingFromIndexForPlayer ??
             lastKnownFrom ??
             playersRef.current.find(
               (p) => String(p.id) === String(event.playerId)
@@ -938,6 +952,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
 
         if (normalizedType === 'CHANCE_RESOLVED') {
           const chanceMoveHint = resolveChanceMoveAnimationHint(event)
+          const chanceMoneyEffect = resolveChanceMoneyEffectFromEvent(event)
           if (chanceMoveHint) {
             pendingChanceMoveHintRef.current[chanceMoveHint.playerId] = {
               direction: chanceMoveHint.direction,
@@ -947,6 +962,10 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
 
           if (!isLocalPlayerEvent) {
             return
+          }
+
+          if (chanceMoneyEffect) {
+            onChanceMoneyEffect?.(chanceMoneyEffect)
           }
 
           const cardModalContent = resolveBoardCardModalContentFromEvent(
@@ -982,6 +1001,8 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
         lockBoardActionModals,
         localPlayerId,
         movePlayerSequentially,
+        onChanceMoneyEffect,
+        pendingMoveStartIndexByPlayerId,
         releaseBoardActionModalsNextFrame,
         startTravelTokenFx,
       ]
@@ -2365,9 +2386,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
               .map((p) => {
                 const playerKey = String(p.id)
                 const animatedPos = animatedPositions[playerKey]
-                const pendingPos = pendingMovePlayerIdSet.has(playerKey)
-                  ? lastMovePositionRef.current[playerKey]
-                  : undefined
+                const pendingPos = pendingMoveStartIndexByPlayerId[playerKey]
                 const pos = animatedPos ?? pendingPos ?? p.pos
                 const { row, col } = getTileGridPos(pos)
                 const tokensAtThisPos = players.filter((pl) => {
@@ -2376,9 +2395,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
                   }
                   const key = String(pl.id)
                   const plAnimatedPos = animatedPositions[key]
-                  const plPendingPos = pendingMovePlayerIdSet.has(key)
-                    ? lastMovePositionRef.current[key]
-                    : undefined
+                  const plPendingPos = pendingMoveStartIndexByPlayerId[key]
                   const renderPos = plAnimatedPos ?? plPendingPos ?? pl.pos
                   return renderPos === pos
                 })
@@ -2400,6 +2417,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
                     stripOffset={hasStrip ? 7 : 0}
                     offset={offset}
                     isTraveling={Boolean(travelingPlayerIds[playerKey])}
+                    hideStateBadge={animatedPos != null || pendingPos != null}
                     travelIconSrc="/Travel- airplane.svg"
                     // Grid 직접 컨트롤 (움찔거림 방지 핵심)
                     style={{

--- a/src/components/board/gameBoardEventQueueUtils.test.ts
+++ b/src/components/board/gameBoardEventQueueUtils.test.ts
@@ -8,6 +8,8 @@ import {
   getBoardEventAnimationHoldMs,
   getBoardEventConsumeDelayMs,
   getPendingMovePlayerIdsFromEvents,
+  getPendingMoveStartIndexByPlayerIdFromEvents,
+  resolveChanceMoneyEffectFromEvent,
   resolveChanceMoveAnimationHint,
   resolveBoardCardModalContentFromEvent,
   resolveBoardEventAnimationKind,
@@ -87,6 +89,66 @@ describe('gameBoardEventQueueUtils', () => {
       'guest-2',
       '3',
     ])
+  })
+
+  it('collects pending move start index by player id from move events', () => {
+    const events: ServerEvent[] = [
+      {
+        type: 'PLAYER_MOVED',
+        playerId: 1,
+        payload: {
+          fromIndex: 7,
+          toIndex: 9,
+        },
+      },
+      {
+        type: 'PLAYER_MOVE',
+        playerId: 'guest-2',
+        fromTileId: 4,
+        toTileId: 6,
+      } as ServerEvent,
+      {
+        type: 'PLAYER_MOVED',
+        playerId: 1,
+        payload: {
+          fromIndex: 9,
+          toIndex: 12,
+        },
+      },
+      {
+        type: 'TURN_ENDED',
+        playerId: 3,
+      },
+    ]
+
+    expect(getPendingMoveStartIndexByPlayerIdFromEvents(events)).toEqual({
+      '1': 7,
+      'guest-2': 4,
+    })
+  })
+
+  it('collects pending move start index from snake_case and fallback aliases', () => {
+    const events = [
+      {
+        type: 'PLAYER_MOVED',
+        playerId: 1,
+        payload: {
+          from_index: 10,
+          to_index: 12,
+        },
+      },
+      {
+        type: 'PLAYER_MOVED',
+        playerId: 'guest-3',
+        from_tile: '6',
+        to_tile: '4',
+      },
+    ] as ServerEvent[]
+
+    expect(getPendingMoveStartIndexByPlayerIdFromEvents(events)).toEqual({
+      '1': 10,
+      'guest-3': 6,
+    })
   })
 
   it('extracts dice values from alias payload keys', () => {
@@ -435,6 +497,59 @@ describe('gameBoardEventQueueUtils', () => {
     }
 
     expect(resolveChanceMoveAnimationHint(event)).toBeNull()
+  })
+
+  it('extracts chance money effect for gain card', () => {
+    const event = {
+      type: 'CHANCE_RESOLVED',
+      playerId: 1,
+      chance: {
+        type: 'GAIN_MONEY',
+        power: 20000,
+      },
+    } as ServerEvent & {
+      chance: { type: string; power: number }
+    }
+
+    expect(resolveChanceMoneyEffectFromEvent(event)).toEqual({
+      playerId: '1',
+      chanceType: 'GAIN_MONEY',
+      amount: 20000,
+    })
+  })
+
+  it('extracts chance money effect for lose card from payload aliases', () => {
+    const event = {
+      type: 'CHANCE_RESOLVED',
+      playerId: 'guest-2',
+      payload: {
+        chance: {
+          type: 'LOSE_MONEY',
+          amount: '15000',
+        },
+      },
+    } as ServerEvent
+
+    expect(resolveChanceMoneyEffectFromEvent(event)).toEqual({
+      playerId: 'guest-2',
+      chanceType: 'LOSE_MONEY',
+      amount: 15000,
+    })
+  })
+
+  it('returns null chance money effect for non-money card', () => {
+    const event = {
+      type: 'CHANCE_RESOLVED',
+      playerId: 1,
+      chance: {
+        type: 'MOVE_FORWARD',
+        power: 3,
+      },
+    } as ServerEvent & {
+      chance: { type: string; power: number }
+    }
+
+    expect(resolveChanceMoneyEffectFromEvent(event)).toBeNull()
   })
 
   it('applies fast travel animation when trigger is travel', () => {

--- a/src/components/board/gameBoardEventQueueUtils.ts
+++ b/src/components/board/gameBoardEventQueueUtils.ts
@@ -26,6 +26,12 @@ export type ChanceMoveAnimationHint = {
   steps: number
 }
 
+export type ChanceMoneyEffect = {
+  playerId: string
+  chanceType: 'GAIN_MONEY' | 'LOSE_MONEY'
+  amount: number
+}
+
 export const FAST_MOVE_ANIMATION_OPTIONS = {
   initialDelayMs: 200,
   stepDelayMs: 80,
@@ -105,6 +111,66 @@ export const getPendingMovePlayerIdsFromEvents = (events: ServerEvent[]) =>
         event.playerId != null
     )
     .map((event) => String(event.playerId))
+
+const toFiniteIntOrNull = (value: unknown) => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.trunc(value)
+  }
+
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number.parseInt(value, 10)
+    if (Number.isFinite(parsed)) {
+      return parsed
+    }
+  }
+
+  return null
+}
+
+export const getPendingMoveStartIndexByPlayerIdFromEvents = (
+  events: ServerEvent[]
+) => {
+  const pendingStartIndexByPlayerId: Record<string, number> = {}
+
+  for (const event of events) {
+    if (toCanonicalEventType(event.type) !== 'PLAYER_MOVED') {
+      continue
+    }
+    if (event.playerId == null) {
+      continue
+    }
+
+    const playerId = String(event.playerId)
+    if (pendingStartIndexByPlayerId[playerId] != null) {
+      continue
+    }
+
+    const eventRecord = getEventRecord(event)
+    const payloadRecord =
+      event.payload && typeof event.payload === 'object' ? event.payload : null
+    const fromIndex =
+      toFiniteIntOrNull(eventRecord.fromIndex) ??
+      toFiniteIntOrNull(eventRecord.from_index) ??
+      toFiniteIntOrNull(eventRecord.fromTileId) ??
+      toFiniteIntOrNull(eventRecord.from_tile_id) ??
+      toFiniteIntOrNull(eventRecord.fromTile) ??
+      toFiniteIntOrNull(eventRecord.from_tile) ??
+      toFiniteIntOrNull(payloadRecord?.fromIndex) ??
+      toFiniteIntOrNull(payloadRecord?.from_index) ??
+      toFiniteIntOrNull(payloadRecord?.fromTileId) ??
+      toFiniteIntOrNull(payloadRecord?.from_tile_id) ??
+      toFiniteIntOrNull(payloadRecord?.fromTile) ??
+      toFiniteIntOrNull(payloadRecord?.from_tile)
+
+    if (fromIndex == null) {
+      continue
+    }
+
+    pendingStartIndexByPlayerId[playerId] = fromIndex
+  }
+
+  return pendingStartIndexByPlayerId
+}
 
 export const shouldDelayPromptModalByMovement = ({
   promptPlayerId,
@@ -344,6 +410,20 @@ export const resolveBoardEventTileIndex = (event: ServerEvent) => {
   return getPayloadNumber(payload, ['toIndex', 'tileIndex', 'toTileId'])
 }
 
+const resolveChanceRecord = (event: ServerEvent) => {
+  const eventRecord = getEventRecord(event)
+  return (
+    (typeof eventRecord.chance === 'object' && eventRecord.chance !== null
+      ? (eventRecord.chance as Record<string, unknown>)
+      : null) ??
+    (event.payload?.chance &&
+    typeof event.payload.chance === 'object' &&
+    event.payload.chance !== null
+      ? (event.payload.chance as Record<string, unknown>)
+      : null)
+  )
+}
+
 export const resolveChanceMoveAnimationHint = (
   event: ServerEvent
 ): ChanceMoveAnimationHint | null => {
@@ -355,16 +435,7 @@ export const resolveChanceMoveAnimationHint = (
     return null
   }
 
-  const eventRecord = getEventRecord(event)
-  const chanceRecord =
-    (typeof eventRecord.chance === 'object' && eventRecord.chance !== null
-      ? (eventRecord.chance as Record<string, unknown>)
-      : undefined) ??
-    (event.payload?.chance &&
-    typeof event.payload.chance === 'object' &&
-    event.payload.chance !== null
-      ? (event.payload.chance as Record<string, unknown>)
-      : undefined)
+  const chanceRecord = resolveChanceRecord(event)
 
   const chanceType = getRecordString(chanceRecord, ['type'])
     ?.trim()
@@ -390,6 +461,42 @@ export const resolveChanceMoveAnimationHint = (
   }
 }
 
+export const resolveChanceMoneyEffectFromEvent = (
+  event: ServerEvent
+): ChanceMoneyEffect | null => {
+  if (toCanonicalEventType(event.type) !== 'CHANCE_RESOLVED') {
+    return null
+  }
+
+  if (event.playerId == null) {
+    return null
+  }
+
+  const chanceRecord = resolveChanceRecord(event)
+  const chanceType = getRecordString(chanceRecord, ['type'])
+    ?.trim()
+    .toUpperCase()
+
+  if (chanceType !== 'GAIN_MONEY' && chanceType !== 'LOSE_MONEY') {
+    return null
+  }
+
+  const rawAmount =
+    getRecordNumber(chanceRecord, ['power', 'amount']) ??
+    getPayloadNumber(event.payload, ['power', 'amount'])
+  const amount = Math.trunc(Math.abs(rawAmount ?? 0))
+
+  if (!Number.isFinite(amount) || amount <= 0) {
+    return null
+  }
+
+  return {
+    playerId: String(event.playerId),
+    chanceType,
+    amount,
+  }
+}
+
 const resolveEventTileName = (event: ServerEvent, tiles: TileData[]) => {
   const eventRecord = getEventRecord(event)
   const eventTile = getEventTileRecord(event)
@@ -405,16 +512,7 @@ const resolveEventTileName = (event: ServerEvent, tiles: TileData[]) => {
 }
 
 const resolveChanceDescription = (event: ServerEvent) => {
-  const eventRecord = getEventRecord(event)
-  const chanceRecord =
-    (typeof eventRecord.chance === 'object' && eventRecord.chance !== null
-      ? (eventRecord.chance as Record<string, unknown>)
-      : null) ??
-    (event.payload?.chance &&
-    typeof event.payload.chance === 'object' &&
-    event.payload.chance !== null
-      ? (event.payload.chance as Record<string, unknown>)
-      : null)
+  const chanceRecord = resolveChanceRecord(event)
 
   return (
     getRecordString(chanceRecord, ['description']) ??

--- a/src/components/board/useBoardEventQueue.test.tsx
+++ b/src/components/board/useBoardEventQueue.test.tsx
@@ -33,9 +33,11 @@ const tiles: TileData[] = [
 const setupHook = ({
   enabled = true,
   paused = false,
+  onEventConsumed,
 }: {
   enabled?: boolean
   paused?: boolean
+  onEventConsumed?: (event: { type: string }) => void
 } = {}) => {
   const setStatus = vi.fn()
   const setDice1 = vi.fn()
@@ -53,6 +55,7 @@ const setupHook = ({
         setDice1,
         setDice2,
         onEventAnimation,
+        onEventConsumed,
       }),
     {
       initialProps: {
@@ -199,6 +202,30 @@ describe('useBoardEventQueue', () => {
 
     expect(setStatus).toHaveBeenCalledTimes(1)
     expect(onEventAnimation).toHaveBeenCalledWith('move')
+    expect(useGameStore.getState().eventQueue).toHaveLength(0)
+  })
+
+  it('keeps queue head available while onEventConsumed callback runs', () => {
+    useGameStore.getState().enqueueEvents([
+      {
+        type: 'PLAYER_MOVED',
+        playerId: 1,
+        tileIndex: 1,
+        payload: {
+          fromIndex: 0,
+          toIndex: 1,
+        },
+      },
+    ])
+
+    const onEventConsumed = vi.fn(() => {
+      expect(useGameStore.getState().eventQueue).toHaveLength(1)
+      expect(useGameStore.getState().eventQueue[0]?.type).toBe('PLAYER_MOVED')
+    })
+
+    setupHook({ onEventConsumed })
+
+    expect(onEventConsumed).toHaveBeenCalledTimes(1)
     expect(useGameStore.getState().eventQueue).toHaveLength(0)
   })
 })

--- a/src/components/board/useBoardEventQueue.ts
+++ b/src/components/board/useBoardEventQueue.ts
@@ -65,7 +65,7 @@ export function useBoardEventQueue({
       }
 
       consumingRef.current = true
-      const nextEvent = storeState.consumeNextEvent()
+      const nextEvent = storeState.eventQueue[0]
 
       if (!nextEvent) {
         releaseLock()
@@ -73,6 +73,10 @@ export function useBoardEventQueue({
       }
 
       onEventConsumed?.(nextEvent)
+
+      // Keep the event visible to render logic during consume callback execution.
+      // This avoids a frame where pending move data disappears before animation starts.
+      useGameStore.getState().consumeNextEvent()
 
       if (import.meta.env.DEV) {
         console.debug('[eventQueue] consumed', nextEvent.type, nextEvent)

--- a/src/mocks/handlers/game.handler.test.ts
+++ b/src/mocks/handlers/game.handler.test.ts
@@ -588,7 +588,7 @@ describe('mock game socket handlers contract', () => {
     teardown()
   })
 
-  it('does not mark player bankrupt when toll payment consumes balance down to exactly zero', async () => {
+  it('marks player bankrupt when toll payment consumes balance down to exactly zero', async () => {
     const { acks, patches, teardown } = captureGameSocketEvents()
     const gameId = 'game-pay-toll-zero-balance'
 
@@ -639,8 +639,245 @@ describe('mock game socket handlers contract', () => {
       (player) => String(player.id) === currentPlayerId
     )
     expect(settledPlayer?.balance).toBe(0)
-    expect(settledPlayer?.is_bankrupt).toBe(false)
-    expect(settledPlayer?.state).not.toBe('bankrupt')
+    expect(settledPlayer?.is_bankrupt).toBe(true)
+    expect(settledPlayer?.state).toBe('bankrupt')
+
+    teardown()
+  })
+
+  it('uses travel trigger for TRAVEL_SELECT confirm', async () => {
+    const { acks, patches, teardown } = captureGameSocketEvents()
+    const gameId = 'game-travel-trigger'
+
+    mockEmitGameSync({
+      gameId,
+      knownRevision: -1,
+    })
+    await flushMockTimers()
+
+    const baselinePatch = patches[patches.length - 1]
+    const currentPlayerId = String(baselinePatch?.snapshot?.currentTurn ?? '1')
+    const prompt: GamePrompt = {
+      id: 'prompt-travel-trigger',
+      type: 'TRAVEL_SELECT',
+      playerId: currentPlayerId,
+      timeoutSec: 30,
+      payload: {
+        tileId: 16,
+      },
+    }
+    mockDevSetPromptForTest(prompt)
+    patches.length = 0
+
+    mockEmitPromptResponse({
+      gameId,
+      promptId: prompt.id,
+      choice: 'CONFIRM',
+      payload: {
+        targetTileId: 7,
+      },
+    })
+    await flushMockTimers()
+
+    const promptAck = acks.find(
+      (ack) => ack.type === 'PROMPT_RESPONSE' && ack.promptId === prompt.id
+    )
+    expect(promptAck?.ok).toBe(true)
+
+    const promptPatch = patches.find(
+      (patch) => patch.revision === promptAck?.revision
+    )
+    const movedEvent = promptPatch?.events?.find(
+      (event) => event.type === 'PLAYER_MOVED'
+    )
+
+    expect(movedEvent?.payload?.trigger).toBe('travel')
+
+    teardown()
+  })
+
+  it('rejects BUY when prompt price equals player balance', async () => {
+    const { acks, patches, teardown } = captureGameSocketEvents()
+    const gameId = 'game-buy-strict-balance'
+
+    mockEmitGameSync({
+      gameId,
+      knownRevision: -1,
+    })
+    await flushMockTimers()
+
+    const baselinePatch = patches[patches.length - 1]
+    const currentPlayerId = String(baselinePatch?.snapshot?.currentTurn ?? '1')
+    const currentPlayer = baselinePatch?.snapshot?.players.find(
+      (player) => String(player.id) === currentPlayerId
+    )
+    expect(currentPlayer).toBeDefined()
+
+    const prompt: GamePrompt = {
+      id: 'prompt-buy-strict-balance',
+      type: 'BUY_OR_SKIP',
+      playerId: currentPlayerId,
+      timeoutSec: 30,
+      payload: {
+        tileId: 1,
+        price: currentPlayer?.balance ?? 0,
+      },
+    }
+    mockDevSetPromptForTest(prompt)
+    patches.length = 0
+
+    mockEmitPromptResponse({
+      gameId,
+      promptId: prompt.id,
+      choice: 'BUY',
+    })
+    await flushMockTimers()
+
+    const promptAck = acks.find(
+      (ack) => ack.type === 'PROMPT_RESPONSE' && ack.promptId === prompt.id
+    )
+    expect(promptAck?.ok).toBe(true)
+
+    const promptPatch = patches.find(
+      (patch) => patch.revision === promptAck?.revision
+    )
+    const insufficientEvent = promptPatch?.events?.find(
+      (event) => event.type === 'INSUFFICIENT_FUNDS'
+    )
+    const settledPlayer = promptPatch?.snapshot?.players.find(
+      (player) => String(player.id) === currentPlayerId
+    )
+
+    expect(insufficientEvent).toBeDefined()
+    expect(settledPlayer?.balance).toBe(currentPlayer?.balance ?? 0)
+
+    teardown()
+  })
+
+  it('applies chance GAIN_MONEY amount to player balance after landing on chance tile', async () => {
+    const { acks, patches, teardown } = captureGameSocketEvents()
+    const gameId = 'game-chance-gain-money'
+    const actionId = 'action-roll-chance-gain-money'
+
+    mockEmitGameSync({
+      gameId,
+      knownRevision: -1,
+    })
+    await flushMockTimers()
+
+    const baselinePatch = patches[patches.length - 1]
+    const currentPlayerId = String(baselinePatch?.snapshot?.currentTurn ?? '')
+    const currentPlayerBeforeRoll = baselinePatch?.snapshot?.players.find(
+      (player) => String(player.id) === currentPlayerId
+    )
+    expect(currentPlayerBeforeRoll).toBeDefined()
+
+    patches.length = 0
+
+    const randomSpy = vi
+      .spyOn(Math, 'random')
+      .mockReturnValueOnce(0) // dice1 => 1
+      .mockReturnValueOnce(0.2) // dice2 => 2 (total 3, lands on chance tile)
+      .mockReturnValueOnce(0) // chance effect index 0 => GAIN_MONEY (3억원)
+
+    mockEmitGameAction({
+      actionId,
+      type: 'ROLL_DICE',
+      gameId,
+    })
+    await flushMockTimers()
+    randomSpy.mockRestore()
+
+    const rollAck = acks.find((ack) => ack.actionId === actionId)
+    expect(rollAck?.ok).toBe(true)
+
+    const rollPatch = patches.find(
+      (patch) => patch.revision === rollAck?.revision
+    )
+    expect(rollPatch).toBeDefined()
+
+    const chanceResolvedEvent = rollPatch?.events?.find(
+      (event) => event.type === 'CHANCE_RESOLVED'
+    )
+    expect(chanceResolvedEvent).toBeDefined()
+
+    const chancePayloadRecord = chanceResolvedEvent?.payload as
+      | Record<string, unknown>
+      | undefined
+    const chanceRecord = chancePayloadRecord?.chance as
+      | Record<string, unknown>
+      | undefined
+    const chanceType =
+      typeof chanceRecord?.type === 'string' ? chanceRecord.type : null
+    const chancePower =
+      typeof chanceRecord?.power === 'number' ? chanceRecord.power : null
+    expect(chanceType).toBe('GAIN_MONEY')
+    expect(chancePower).toBeGreaterThan(0)
+
+    const currentPlayerAfterRoll = rollPatch?.snapshot?.players.find(
+      (player) => String(player.id) === currentPlayerId
+    )
+    expect(currentPlayerAfterRoll).toBeDefined()
+    expect(currentPlayerAfterRoll?.position).toBe(3)
+    expect(currentPlayerAfterRoll?.balance).toBe(
+      (currentPlayerBeforeRoll?.balance ?? 0) + (chancePower ?? 0)
+    )
+
+    teardown()
+  })
+
+  it('locks player on island for exactly 3 turns when landing on island tile', async () => {
+    const { acks, patches, teardown } = captureGameSocketEvents()
+    const gameId = 'game-island-lock-3-turns'
+    const actionId = 'action-roll-island-lock'
+
+    mockEmitGameSync({
+      gameId,
+      knownRevision: -1,
+    })
+    await flushMockTimers()
+    patches.length = 0
+
+    const randomSpy = vi
+      .spyOn(Math, 'random')
+      .mockReturnValueOnce(0.34) // dice1 => 3
+      .mockReturnValueOnce(0.67) // dice2 => 5 (total 8, lands on island tile)
+
+    mockEmitGameAction({
+      actionId,
+      type: 'ROLL_DICE',
+      gameId,
+    })
+    await flushMockTimers()
+    randomSpy.mockRestore()
+
+    const rollAck = acks.find((ack) => ack.actionId === actionId)
+    expect(rollAck?.ok).toBe(true)
+
+    const rollPatch = patches.find(
+      (patch) => patch.revision === rollAck?.revision
+    )
+    expect(rollPatch).toBeDefined()
+
+    const currentPlayerId = String(rollPatch?.snapshot?.currentTurn ?? '')
+    const settledPlayer = rollPatch?.snapshot?.players.find(
+      (player) => String(player.id) === currentPlayerId
+    )
+    expect(settledPlayer).toBeDefined()
+    expect(settledPlayer?.position).toBe(8)
+    expect(settledPlayer?.state).toBe('locked')
+    expect(settledPlayer?.stateDuration).toBe(3)
+    expect(settledPlayer?.jail_turn_count).toBe(3)
+
+    const stateChangedEvent = rollPatch?.events?.find(
+      (event) =>
+        event.type === 'PLAYER_STATE_CHANGED' &&
+        String(event.playerId) === currentPlayerId
+    )
+    const statePayload = stateChangedEvent?.payload as
+      | Record<string, unknown>
+      | undefined
+    expect(statePayload?.stateDuration).toBe(3)
 
     teardown()
   })

--- a/src/mocks/handlers/game.handler.ts
+++ b/src/mocks/handlers/game.handler.ts
@@ -27,6 +27,8 @@ const SYNC_SNAPSHOT_GAP_THRESHOLD = 200
 const PROMPT_RESPONSE_ACK_TYPE = 'PROMPT_RESPONSE'
 const PROMPT_RESPONSE_ACTION_PREFIX = 'prompt-response'
 const MOCK_PLAYER_START_BALANCE = 1_000_000
+const SELL_PURCHASE_PRICE_REFUND_RATIO = 0.9
+const SELL_BUILD_COST_REFUND_RATIO = 0.75
 const DEFAULT_MOCK_CHAT_MESSAGES = ['즐겜해요~', '모두의 마블 한판!'] as const
 
 const PROMPT_CHOICE_CANONICAL_MAP: Record<string, readonly string[]> = {
@@ -43,16 +45,35 @@ type MockChanceType =
   | 'LOSE_MONEY'
   | 'MOVE_FORWARD'
   | 'MOVE_BACKWARD'
-  | 'MOVE_TO_ISLAND'
+  | 'STEAL_PROPERTY'
+  | 'GIVE_PROPERTY'
+  | 'TOLL_MULTIPLIER'
+  | 'PRICE_MULTIPLIER'
+  | 'EXTRA_TURN'
 
 type MockChanceEffect = {
   type: MockChanceType
   power: number
-  effect: 'GOOD' | 'BAD' | 'MOVE'
+  effect: string
   description: string
+  failedDescription?: string
+  duration?: number
+  multiplier?: number
 }
 
 const MOCK_CHANCE_EFFECTS: readonly MockChanceEffect[] = [
+  {
+    type: 'GAIN_MONEY',
+    power: 30_000,
+    effect: 'GOOD',
+    description: '복권 당첨! 3억원을 획득합니다.',
+  },
+  {
+    type: 'GAIN_MONEY',
+    power: 20_000,
+    effect: 'GOOD',
+    description: '주식 상승! 2억원을 획득합니다.',
+  },
   {
     type: 'GAIN_MONEY',
     power: 10_000,
@@ -61,27 +82,132 @@ const MOCK_CHANCE_EFFECTS: readonly MockChanceEffect[] = [
   },
   {
     type: 'LOSE_MONEY',
-    power: 10_000,
+    power: 15_000,
     effect: 'BAD',
-    description: '벌금 납부! 1억원을 지불합니다.',
+    description: '병원비 지출! 1억 5천만원을 지불합니다.',
+  },
+  {
+    type: 'LOSE_MONEY',
+    power: 20_000,
+    effect: 'BAD',
+    description: '벌금 지출! 2억원을 지불합니다.',
+  },
+  {
+    type: 'LOSE_MONEY',
+    power: 30_000,
+    effect: 'BAD',
+    description: '세금 지출! 3억원을 지불합니다.',
+  },
+  {
+    type: 'MOVE_FORWARD',
+    power: 3,
+    effect: 'COMMON',
+    description: '앞으로 3칸 이동합니다.',
   },
   {
     type: 'MOVE_FORWARD',
     power: 5,
-    effect: 'MOVE',
+    effect: 'COMMON',
     description: '앞으로 5칸 이동합니다.',
   },
   {
     type: 'MOVE_BACKWARD',
+    power: 2,
+    effect: 'COMMON',
+    description: '뒤로 2칸 이동합니다.',
+  },
+  {
+    type: 'MOVE_BACKWARD',
     power: 3,
-    effect: 'MOVE',
+    effect: 'COMMON',
     description: '뒤로 3칸 이동합니다.',
   },
   {
-    type: 'MOVE_TO_ISLAND',
+    type: 'STEAL_PROPERTY',
     power: 0,
-    effect: 'MOVE',
-    description: '무인도로 이동합니다.',
+    effect: 'GOOD',
+    description: '$player$의 $property$$suffix$ 점유했습니다.',
+    failedDescription: '땅 훔치기! 훔칠 땅이 없어서 실패했습니다...',
+  },
+  {
+    type: 'GIVE_PROPERTY',
+    power: 0,
+    effect: 'BAD',
+    description: '$player$ 에게 $property$$suffix$ 넘겨줬습니다.',
+    failedDescription: '땅 넘기기! 넘겨줄 땅이 없어서 실패했습니다...',
+  },
+  {
+    type: 'TOLL_MULTIPLIER',
+    power: 0,
+    effect: 'FESTIVAL',
+    duration: 3,
+    multiplier: 2,
+    description: '올림픽 개최! 3턴 동안 모든 통행료가 2배가 됩니다.',
+  },
+  {
+    type: 'TOLL_MULTIPLIER',
+    power: 0,
+    effect: 'PANDEMIC',
+    duration: 3,
+    multiplier: 0.5,
+    description: '전염병 확산! 3턴 동안 모든 통행료가 절반이 됩니다.',
+  },
+  {
+    type: 'PRICE_MULTIPLIER',
+    power: 0,
+    effect: 'INFLATION',
+    duration: 3,
+    multiplier: 1.5,
+    description: '인플레이션 발생! 3턴 동안 토지/건설 비용이 50% 증가 됩니다.',
+  },
+  {
+    type: 'PRICE_MULTIPLIER',
+    power: 0,
+    effect: 'DEFLATION',
+    duration: 3,
+    multiplier: 0.7,
+    description: '디플레이션 발생! 3턴 동안 토지/건설 비용이 30% 감소 됩니다.',
+  },
+  {
+    type: 'EXTRA_TURN',
+    power: 0,
+    effect: 'TRANSIT_CARD',
+    duration: 2,
+    description: '교통카드 획득! 추가턴 2회를 획득합니다.',
+  },
+  {
+    type: 'EXTRA_TURN',
+    power: 0,
+    effect: 'CAR',
+    duration: 3,
+    description: '자동차를 얻었습니다. 추가턴 3회를 획득합니다.',
+  },
+]
+
+const MOCK_EVENT_EFFECTS: readonly MockChanceEffect[] = [
+  {
+    type: 'GAIN_MONEY',
+    power: 30_000,
+    effect: 'GOOD',
+    description: '복권에 당첨되어 3억원을 획득합니다.',
+  },
+  {
+    type: 'GAIN_MONEY',
+    power: 20_000,
+    effect: 'GOOD',
+    description: '보유 주식이 올라 2억원을 획득합니다.',
+  },
+  {
+    type: 'GAIN_MONEY',
+    power: 10_000,
+    effect: 'GOOD',
+    description: '지원금 1억원을 획득합니다.',
+  },
+  {
+    type: 'LOSE_MONEY',
+    power: 15_000,
+    effect: 'BAD',
+    description: '병원비로 1억 5천만원을 지불합니다.',
   },
 ]
 
@@ -141,6 +267,8 @@ type GameStateResponse = {
   isGameOver: boolean
   winnerId: PlayerId | null
   pendingBonusTurnPlayerId: PlayerId | null
+  extraTurnEffectTurnsRemainingByPlayer: Record<string, number>
+  extraTurnEffectActiveByPlayer: Record<string, boolean>
 }
 
 type GameEvents = NonNullable<GamePatchEnvelope['events']>
@@ -284,6 +412,8 @@ const createInitialGameState = (
     isGameOver: false,
     winnerId: null,
     pendingBonusTurnPlayerId: null,
+    extraTurnEffectTurnsRemainingByPlayer: {},
+    extraTurnEffectActiveByPlayer: {},
   }
 
   initialState.players.forEach((player) => {
@@ -317,6 +447,10 @@ const resetMockGameState = (options?: {
   mockGameState.isGameOver = initialState.isGameOver
   mockGameState.winnerId = initialState.winnerId
   mockGameState.pendingBonusTurnPlayerId = initialState.pendingBonusTurnPlayerId
+  mockGameState.extraTurnEffectTurnsRemainingByPlayer =
+    initialState.extraTurnEffectTurnsRemainingByPlayer
+  mockGameState.extraTurnEffectActiveByPlayer =
+    initialState.extraTurnEffectActiveByPlayer
   mockGameContext.gameId = options?.gameId ?? null
   mockGameContext.roomId = roomId
 
@@ -492,7 +626,32 @@ const getTierRuleByTile = (tile: Tile | undefined): TierRuleMan | null => {
   return PROPERTY_TIER_BY_PRICE_MAN[price] ?? null
 }
 
-const getTileBuildCost = (tile: Tile | undefined): number => {
+const roundHalfUp = (value: number) => Math.round(value)
+
+const applyMultiplier = (amount: number, multiplier: number) =>
+  roundHalfUp(amount * multiplier)
+
+const getActivePriceMultiplier = () =>
+  mockGameState.activeGlobalEffect?.type === 'PRICE_MULTIPLIER' &&
+  typeof mockGameState.activeGlobalEffect.multiplier === 'number'
+    ? mockGameState.activeGlobalEffect.multiplier
+    : 1
+
+const getActiveTollMultiplier = () =>
+  mockGameState.activeGlobalEffect?.type === 'TOLL_MULTIPLIER' &&
+  typeof mockGameState.activeGlobalEffect.multiplier === 'number'
+    ? mockGameState.activeGlobalEffect.multiplier
+    : 1
+
+const getTilePurchaseCost = (tile: Tile | undefined): number => {
+  if (!tile || !isOwnableTile(tile)) {
+    return 0
+  }
+  const basePrice = tile.price ?? 0
+  return applyMultiplier(basePrice, getActivePriceMultiplier())
+}
+
+const getBaseTileBuildCost = (tile: Tile | undefined): number => {
   if (!tile || !isOwnableTile(tile)) {
     return 0
   }
@@ -510,6 +669,14 @@ const getTileBuildCost = (tile: Tile | undefined): number => {
   return tierRule.buildCosts[currentLevel] ?? 0
 }
 
+const getTileBuildCost = (tile: Tile | undefined): number => {
+  const baseBuildCost = getBaseTileBuildCost(tile)
+  if (baseBuildCost <= 0) {
+    return 0
+  }
+  return applyMultiplier(baseBuildCost, getActivePriceMultiplier())
+}
+
 const getTileTollAmount = (tile: Tile | undefined): number => {
   if (!tile || !isOwnableTile(tile)) {
     return 0
@@ -517,11 +684,12 @@ const getTileTollAmount = (tile: Tile | undefined): number => {
 
   const tierRule = getTierRuleByTile(tile)
   if (!tierRule) {
-    return tile.price ?? 0
+    return applyMultiplier(tile.price ?? 0, getActiveTollMultiplier())
   }
 
   const level = Math.max(0, Math.min(tile.building ?? 0, 3))
-  return tierRule.tolls[level] ?? tile.price ?? 0
+  const baseToll = tierRule.tolls[level] ?? tile.price ?? 0
+  return applyMultiplier(baseToll, getActiveTollMultiplier())
 }
 
 const ensureOwnedTiles = (player: Player, tileIndex: number) => {
@@ -537,21 +705,28 @@ const removeOwnedTile = (player: Player, tileIndex: number) => {
 }
 
 const getSellRefund = (tile: Tile, requestedLevel?: number) => {
-  const sellLevel = requestedLevel ?? tile.building
-  const buildCost = getTileBuildCost(tile)
+  const normalizedSellLevel = Math.max(
+    0,
+    Math.min(requestedLevel ?? tile.building, tile.building ?? 0)
+  )
+  const basePrice = tile.price ?? 0
 
-  if (sellLevel > 0) {
-    return {
-      refund: buildCost > 0 ? buildCost : 0,
-      nextBuilding: Math.max(0, sellLevel - 1) as BuildingLevel,
-      releaseOwnership: false,
+  let refund = Math.trunc(basePrice * SELL_PURCHASE_PRICE_REFUND_RATIO)
+  const tierRule = getTierRuleByTile(tile)
+
+  if (tierRule) {
+    for (let level = 1; level <= normalizedSellLevel; level += 1) {
+      refund += Math.trunc(
+        (tierRule.buildCosts[level - 1] ?? 0) * SELL_BUILD_COST_REFUND_RATIO
+      )
     }
   }
 
+  const nextBuilding = Math.max(0, normalizedSellLevel - 1) as BuildingLevel
   return {
-    refund: tile.price ?? 0,
-    nextBuilding: 0 as BuildingLevel,
-    releaseOwnership: true,
+    refund: Math.max(0, refund),
+    nextBuilding,
+    releaseOwnership: nextBuilding <= 0,
   }
 }
 
@@ -709,7 +884,7 @@ const buildBuyPrompt = (_player: Player, tile: Tile): GamePrompt => ({
   payload: {
     tileId: tile.index,
     tileName: tile.name,
-    price: tile.price ?? 0,
+    price: getTilePurchaseCost(tile),
   },
 })
 
@@ -781,7 +956,7 @@ const buildAcquisitionPrompt = (
   type: 'ACQUISITION_OR_SKIP',
   playerId: player.id,
   title: `${tile.name} 인수`,
-  message: `${owner.nickname}의 ${tile.name}을(를) ${tile.price ?? 0}에 인수하시겠습니까?`,
+  message: `${owner.nickname}의 ${tile.name}을(를) ${getTileAcquisitionCost(tile)}에 인수하시겠습니까?`,
   timeoutSec: MOCK_TURN_TIMEOUT_SEC,
   choices: [
     { id: 'acquire', label: '인수하기', value: 'ACQUIRE' },
@@ -792,7 +967,8 @@ const buildAcquisitionPrompt = (
     tileName: tile.name,
     ownerId: owner.id,
     ownerName: owner.nickname,
-    amount: tile.price ?? 0,
+    amount: getTileAcquisitionCost(tile),
+    acquisitionCost: getTileAcquisitionCost(tile),
   },
 })
 
@@ -817,6 +993,13 @@ const getAccumulatedBuildCost = (tile: Tile): number => {
     total += tierRule.buildCosts[index] ?? 0
   }
   return total
+}
+
+const getTileAssetValue = (tile: Tile): number =>
+  Math.max(0, tile.price ?? 0) + getAccumulatedBuildCost(tile)
+
+const getTileAcquisitionCost = (tile: Tile): number => {
+  return applyMultiplier(getTileAssetValue(tile), 1.5)
 }
 
 const syncPlayerStatus = (player: Player) => {
@@ -922,10 +1105,197 @@ const createLandedEvent = (
   }
 }
 
-const pickMockChanceEffect = (): MockChanceEffect => {
-  const randomIndex = Math.floor(Math.random() * MOCK_CHANCE_EFFECTS.length)
-  return MOCK_CHANCE_EFFECTS[randomIndex] ?? MOCK_CHANCE_EFFECTS[0]
+const getRandomItem = <T>(items: readonly T[]): T | null => {
+  if (items.length === 0) {
+    return null
+  }
+  const randomIndex = Math.floor(Math.random() * items.length)
+  return items[randomIndex] ?? null
 }
+
+const getObjectParticle = (word: string) => {
+  if (!word) {
+    return '를'
+  }
+
+  const lastChar = word[word.length - 1] ?? ''
+  const code = lastChar.codePointAt(0) ?? 0
+  if (code >= 0xac00 && code <= 0xd7a3) {
+    const hasBatchim = (code - 0xac00) % 28 !== 0
+    return hasBatchim ? '을' : '를'
+  }
+
+  return '를'
+}
+
+const replaceCardDescriptionVariables = (
+  template: string,
+  variables: Record<string, string>
+) => {
+  let result = template
+  for (const [key, value] of Object.entries(variables)) {
+    result = result.split(`$${key}$`).join(value)
+  }
+  return result
+}
+
+const isGlobalEffectType = (
+  effect: string
+): effect is GlobalEffectState['effect'] =>
+  effect === 'PANDEMIC' ||
+  effect === 'FESTIVAL' ||
+  effect === 'INFLATION' ||
+  effect === 'DEFLATION'
+
+const releasePlayerProperties = (player: Player) => {
+  for (const tileIndex of [...player.owned_tiles]) {
+    const ownedTile = getTileByIndex(tileIndex)
+    if (!ownedTile || !isOwnableTile(ownedTile)) {
+      continue
+    }
+    ownedTile.owner_id = null
+    ownedTile.ownerId = null
+    ownedTile.building = 0
+  }
+  player.owned_tiles = []
+}
+
+const markPlayerBankrupt = ({
+  player,
+  reason = 'insufficient_funds',
+  events,
+}: {
+  player: Player
+  reason?: string
+  events: GameEvents
+}) => {
+  player.balance = 0
+  player.is_bankrupt = true
+  player.state = 'bankrupt'
+  player.stateDuration = 0
+  player.jail_turn_count = 0
+  player.is_in_jail = false
+  const effectKey = String(player.id)
+  mockGameState.extraTurnEffectTurnsRemainingByPlayer[effectKey] = 0
+  mockGameState.extraTurnEffectActiveByPlayer[effectKey] = false
+  if (
+    mockGameState.pendingBonusTurnPlayerId != null &&
+    String(mockGameState.pendingBonusTurnPlayerId) === String(player.id)
+  ) {
+    mockGameState.pendingBonusTurnPlayerId = null
+  }
+  releasePlayerProperties(player)
+  events.push({
+    type: 'PLAYER_STATE_CHANGED',
+    playerId: player.id,
+    payload: {
+      playerState: 'bankrupt',
+      reason,
+    },
+  })
+}
+
+const getPlayerEffectKey = (playerId: PlayerId) => String(playerId)
+
+const getExtraTurnEffectTurnsRemaining = (playerId: PlayerId) => {
+  const key = getPlayerEffectKey(playerId)
+  return mockGameState.extraTurnEffectTurnsRemainingByPlayer[key] ?? 0
+}
+
+const setExtraTurnEffectTurnsRemaining = (
+  playerId: PlayerId,
+  value: number
+) => {
+  const key = getPlayerEffectKey(playerId)
+  mockGameState.extraTurnEffectTurnsRemainingByPlayer[key] = Math.max(
+    0,
+    Math.trunc(value)
+  )
+}
+
+const isExtraTurnEffectActive = (playerId: PlayerId) => {
+  const key = getPlayerEffectKey(playerId)
+  return Boolean(mockGameState.extraTurnEffectActiveByPlayer[key])
+}
+
+const setExtraTurnEffectActive = (playerId: PlayerId, active: boolean) => {
+  const key = getPlayerEffectKey(playerId)
+  mockGameState.extraTurnEffectActiveByPlayer[key] = active
+}
+
+const applyGlobalEffectCard = (card: MockChanceEffect) => {
+  if (
+    (card.type !== 'TOLL_MULTIPLIER' && card.type !== 'PRICE_MULTIPLIER') ||
+    !isGlobalEffectType(card.effect) ||
+    typeof card.multiplier !== 'number'
+  ) {
+    return
+  }
+
+  const duration =
+    typeof card.duration === 'number' && Number.isFinite(card.duration)
+      ? Math.max(0, Math.trunc(card.duration))
+      : 0
+
+  mockGameState.activeGlobalEffect = {
+    type: card.type,
+    effect: card.effect,
+    duration,
+    multiplier: card.multiplier,
+    description: card.description,
+  }
+}
+
+const tickGlobalEffectDuration = () => {
+  const activeEffect = mockGameState.activeGlobalEffect
+  if (!activeEffect) {
+    return
+  }
+
+  if (activeEffect.duration <= 1) {
+    mockGameState.activeGlobalEffect = null
+    return
+  }
+
+  mockGameState.activeGlobalEffect = {
+    ...activeEffect,
+    duration: activeEffect.duration - 1,
+  }
+}
+
+const collectTransferableTiles = (owner: Player) =>
+  owner.owned_tiles.filter((tileIndex) => {
+    const tile = getTileByIndex(tileIndex)
+    return (
+      tile != null &&
+      isOwnableTile(tile) &&
+      String(tile.owner_id) === String(owner.id) &&
+      (tile.building ?? 0) < 3
+    )
+  })
+
+const transferPropertyOwnership = ({
+  fromPlayer,
+  toPlayer,
+  tile,
+}: {
+  fromPlayer: Player
+  toPlayer: Player
+  tile: Tile
+}) => {
+  removeOwnedTile(fromPlayer, tile.index)
+  tile.owner_id = toPlayer.id
+  tile.ownerId = toPlayer.id
+  tile.building = 0
+  ensureOwnedTiles(toPlayer, tile.index)
+}
+
+const pickMockChanceEffect = (): MockChanceEffect => {
+  return getRandomItem(MOCK_CHANCE_EFFECTS) ?? MOCK_CHANCE_EFFECTS[0]
+}
+
+const pickMockEventEffect = (): MockChanceEffect =>
+  getRandomItem(MOCK_EVENT_EFFECTS) ?? MOCK_EVENT_EFFECTS[0]
 
 type LandingResolution = {
   events: GameEvents
@@ -1006,7 +1376,21 @@ const resolveLanding = ({
   }
 
   if ((tile.type === 'chance' || tile.type === 'event') && allowCardEffect) {
-    const chanceEffect = pickMockChanceEffect()
+    const chanceEffect =
+      tile.type === 'event' ? pickMockEventEffect() : pickMockChanceEffect()
+    const chancePayload: Record<string, unknown> = {
+      type: chanceEffect.type,
+      power: chanceEffect.power,
+      description: chanceEffect.description,
+      effect: chanceEffect.effect,
+    }
+    if (typeof chanceEffect.duration === 'number') {
+      chancePayload.duration = chanceEffect.duration
+    }
+    if (typeof chanceEffect.multiplier === 'number') {
+      chancePayload.multiplier = chanceEffect.multiplier
+    }
+
     events.push({
       type: 'CHANCE_RESOLVED',
       playerId: player.id,
@@ -1014,7 +1398,7 @@ const resolveLanding = ({
       payload: {
         tileId: tile.index,
         tileType: tile.type.toUpperCase(),
-        chance: chanceEffect,
+        chance: chancePayload,
       },
     })
 
@@ -1024,10 +1408,15 @@ const resolveLanding = ({
     }
 
     if (chanceEffect.type === 'LOSE_MONEY') {
-      const hadEnoughBalance = player.balance >= chanceEffect.power
-      player.balance = Math.max(0, player.balance - chanceEffect.power)
-      if (!hadEnoughBalance) {
-        player.is_bankrupt = true
+      const nextBalance = player.balance - chanceEffect.power
+      if (nextBalance > 0) {
+        player.balance = nextBalance
+      } else {
+        markPlayerBankrupt({
+          player,
+          reason: 'insufficient_funds',
+          events,
+        })
       }
       return { events, prompt: null, phase: 'resolving' }
     }
@@ -1043,7 +1432,14 @@ const resolveLanding = ({
           ? fromTileId - chanceEffect.power
           : fromTileId + chanceEffect.power
       const toTileId = ((rawTargetIndex % totalTiles) + totalTiles) % totalTiles
+      const passGo =
+        chanceEffect.type === 'MOVE_FORWARD' &&
+        fromTileId + chanceEffect.power >= totalTiles
+
       player.position = toTileId
+      if (passGo) {
+        player.balance += MOCK_PASS_GO_SALARY
+      }
 
       events.push(
         createPlayerMovedEvent({
@@ -1051,13 +1447,13 @@ const resolveLanding = ({
           fromTileId,
           toTileId,
           trigger: 'chance',
+          passGo,
         })
       )
 
       const chained = resolveLanding({
         player,
         tileIndex: toTileId,
-        allowCardEffect: false,
       })
       events.push(...chained.events)
       return chained.prompt
@@ -1065,27 +1461,106 @@ const resolveLanding = ({
         : { events, prompt: null, phase: 'resolving' }
     }
 
-    if (chanceEffect.type === 'MOVE_TO_ISLAND') {
-      const islandTileIndex = getIslandTileIndex()
-      const fromTileId = player.position
-      player.position = islandTileIndex
+    if (chanceEffect.type === 'STEAL_PROPERTY') {
+      const stealTargets = mockGameState.players
+        .filter(
+          (candidate) =>
+            String(candidate.id) !== String(player.id) && !candidate.is_bankrupt
+        )
+        .flatMap((candidate) =>
+          collectTransferableTiles(candidate).map((tileId) => ({
+            owner: candidate,
+            tile: getTileByIndex(tileId),
+          }))
+        )
+        .filter(
+          (candidate): candidate is { owner: Player; tile: Tile } =>
+            candidate.tile != null
+        )
 
-      events.push(
-        createPlayerMovedEvent({
-          playerId: player.id,
-          fromTileId,
-          toTileId: islandTileIndex,
-          trigger: 'chance',
-        })
-      )
+      const selectedTarget = getRandomItem(stealTargets)
+      if (!selectedTarget) {
+        chancePayload.description =
+          chanceEffect.failedDescription ?? chanceEffect.description
+        return { events, prompt: null, phase: 'resolving' }
+      }
 
-      const chained = resolveLanding({
-        player,
-        tileIndex: islandTileIndex,
-        allowCardEffect: false,
+      transferPropertyOwnership({
+        fromPlayer: selectedTarget.owner,
+        toPlayer: player,
+        tile: selectedTarget.tile,
       })
-      events.push(...chained.events)
-      return { events, prompt: null, phase: chained.phase }
+      chancePayload.description = replaceCardDescriptionVariables(
+        chanceEffect.description,
+        {
+          player: selectedTarget.owner.nickname,
+          property: selectedTarget.tile.name,
+          suffix: getObjectParticle(selectedTarget.tile.name),
+        }
+      )
+      chancePayload.fromPlayerId = selectedTarget.owner.id
+      chancePayload.tileId = selectedTarget.tile.index
+      chancePayload.property = selectedTarget.tile.name
+      return { events, prompt: null, phase: 'resolving' }
+    }
+
+    if (chanceEffect.type === 'GIVE_PROPERTY') {
+      const giveableTiles = collectTransferableTiles(player)
+      const receiverCandidates = mockGameState.players.filter(
+        (candidate) =>
+          String(candidate.id) !== String(player.id) && !candidate.is_bankrupt
+      )
+      const givenTileId = getRandomItem(giveableTiles)
+      const receiver = getRandomItem(receiverCandidates)
+      const givenTile = givenTileId == null ? null : getTileByIndex(givenTileId)
+      if (!receiver || !givenTile) {
+        chancePayload.description =
+          chanceEffect.failedDescription ?? chanceEffect.description
+        return { events, prompt: null, phase: 'resolving' }
+      }
+
+      transferPropertyOwnership({
+        fromPlayer: player,
+        toPlayer: receiver,
+        tile: givenTile,
+      })
+      chancePayload.description = replaceCardDescriptionVariables(
+        chanceEffect.description,
+        {
+          player: receiver.nickname,
+          property: givenTile.name,
+          suffix: getObjectParticle(givenTile.name),
+        }
+      )
+      chancePayload.toPlayerId = receiver.id
+      chancePayload.tileId = givenTile.index
+      chancePayload.property = givenTile.name
+      return { events, prompt: null, phase: 'resolving' }
+    }
+
+    if (
+      chanceEffect.type === 'TOLL_MULTIPLIER' ||
+      chanceEffect.type === 'PRICE_MULTIPLIER'
+    ) {
+      applyGlobalEffectCard(chanceEffect)
+      return { events, prompt: null, phase: 'resolving' }
+    }
+
+    if (chanceEffect.type === 'EXTRA_TURN') {
+      const extraTurnDuration =
+        typeof chanceEffect.duration === 'number'
+          ? Math.max(0, Math.trunc(chanceEffect.duration))
+          : 0
+      if (extraTurnDuration > 0) {
+        setExtraTurnEffectTurnsRemaining(
+          player.id,
+          getExtraTurnEffectTurnsRemaining(player.id) + extraTurnDuration
+        )
+      }
+      if (!isExtraTurnEffectActive(player.id)) {
+        setExtraTurnEffectActive(player.id, false)
+      }
+      return { events, prompt: null, phase: 'resolving' }
     }
   }
 
@@ -1486,8 +1961,8 @@ const handleBuyPropertyAction = (action: MockResolvedGameAction) => {
     return
   }
 
-  const price = tile.price ?? 0
-  if (player.balance < price) {
+  const price = getTilePurchaseCost(tile)
+  if (player.balance <= price) {
     emitGameAck({
       actionId: action.actionId,
       type: action.type,
@@ -1653,7 +2128,7 @@ const handleBuildPropertyAction = (action: MockResolvedGameAction) => {
     return
   }
 
-  if (player.balance < buildCost) {
+  if (player.balance <= buildCost) {
     emitGameAck({
       actionId: action.actionId,
       type: action.type,
@@ -1705,15 +2180,31 @@ const handleEndTurnAction = (action: MockResolvedGameAction) => {
   }
 
   const previousPlayerId = mockGameState.currentTurn
-  const previousRound = mockGameState.round
-  const hadBonusTurn =
+  const hadDoubleBonusTurn =
     mockGameState.pendingBonusTurnPlayerId != null &&
     String(mockGameState.pendingBonusTurnPlayerId) === String(previousPlayerId)
+  const hasExtraTurnBonus =
+    !hadDoubleBonusTurn &&
+    getExtraTurnEffectTurnsRemaining(previousPlayerId) > 0 &&
+    !isExtraTurnEffectActive(previousPlayerId)
+  const shouldKeepTurn = hadDoubleBonusTurn || hasExtraTurnBonus
 
-  if (!hadBonusTurn) {
+  if (shouldKeepTurn) {
+    mockGameState.currentTurn = previousPlayerId
+  } else {
     advanceMockTurn()
+    setExtraTurnEffectActive(previousPlayerId, false)
   }
 
+  if (hasExtraTurnBonus) {
+    setExtraTurnEffectTurnsRemaining(
+      previousPlayerId,
+      getExtraTurnEffectTurnsRemaining(previousPlayerId) - 1
+    )
+    setExtraTurnEffectActive(previousPlayerId, true)
+  }
+
+  tickGlobalEffectDuration()
   mockGameState.pendingBonusTurnPlayerId = null
   clearMockPrompt()
   mockGameState.phase = 'rolling'
@@ -1721,13 +2212,18 @@ const handleEndTurnAction = (action: MockResolvedGameAction) => {
   recalculatePlayerAssets()
 
   let gameResult: NonNullable<GameSnapshot['gameResult']> | null = null
-  if (!hadBonusTurn && mockGameState.round > MOCK_MAX_ROUNDS) {
+  if (!shouldKeepTurn && mockGameState.round > MOCK_MAX_ROUNDS) {
     gameResult = markGameOver('max_rounds')
   } else {
     gameResult = maybeMarkGameOverByStanding()
   }
 
   const turnNumber = mockGameState.revision + 1
+  const turnEndReason = hadDoubleBonusTurn
+    ? 'double_roll'
+    : hasExtraTurnBonus
+      ? 'extra_turn_effect'
+      : null
   const nextEvents: GameEvents = [
     {
       type: 'TURN_ENDED',
@@ -1735,17 +2231,23 @@ const handleEndTurnAction = (action: MockResolvedGameAction) => {
       nextPlayerId: mockGameState.currentTurn,
       turn: turnNumber,
       round: mockGameState.round,
-      reason: hadBonusTurn ? 'double_roll' : 'manual_end_turn',
-      bonusTurn: hadBonusTurn,
-      payload: {
-        playerId: previousPlayerId,
-        nextPlayerId: mockGameState.currentTurn,
-        turn: turnNumber,
-        round: mockGameState.round,
-        reason: hadBonusTurn ? 'double_roll' : 'manual_end_turn',
-        bonusTurn: hadBonusTurn,
-        previousRound,
-      },
+      reason: turnEndReason ?? undefined,
+      bonusTurn: shouldKeepTurn || undefined,
+      payload: turnEndReason
+        ? {
+            playerId: previousPlayerId,
+            nextPlayerId: mockGameState.currentTurn,
+            turn: turnNumber,
+            round: mockGameState.round,
+            reason: turnEndReason,
+            bonusTurn: true,
+          }
+        : {
+            playerId: previousPlayerId,
+            nextPlayerId: mockGameState.currentTurn,
+            turn: turnNumber,
+            round: mockGameState.round,
+          },
     },
   ]
 
@@ -2029,8 +2531,11 @@ export const mockEmitPromptResponse = ({
       isOwnableTile(targetTile) &&
       !targetTile.owner_id
     ) {
-      const price = targetTile.price ?? 0
-      if (respondingPlayer.balance >= price) {
+      const price =
+        promptAmount > 0
+          ? Math.trunc(promptAmount)
+          : getTilePurchaseCost(targetTile)
+      if (respondingPlayer.balance > price) {
         respondingPlayer.balance -= price
         targetTile.owner_id = respondingPlayer.id
         targetTile.ownerId = respondingPlayer.id
@@ -2076,7 +2581,7 @@ export const mockEmitPromptResponse = ({
       String(targetTile.owner_id) === String(respondingPlayer.id)
     ) {
       const buildCost = getTileBuildCost(targetTile)
-      if (buildCost > 0 && respondingPlayer.balance >= buildCost) {
+      if (buildCost > 0 && respondingPlayer.balance > buildCost) {
         respondingPlayer.balance -= buildCost
         targetTile.building = Math.min(
           (targetTile.building ?? 0) + 1,
@@ -2121,33 +2626,28 @@ export const mockEmitPromptResponse = ({
           : (mockGameState.players.find(
               (player) => String(player.id) === String(targetTile.owner_id)
             ) ?? null)
-      const paidAmount = Math.min(
-        promptAmount,
-        Math.max(respondingPlayer.balance, 0)
-      )
-      respondingPlayer.balance = Math.max(
-        0,
-        respondingPlayer.balance - paidAmount
-      )
+      const originalBalance = Math.max(0, respondingPlayer.balance)
+      const paidAmount = Math.min(promptAmount, originalBalance)
+
       if (owner) {
         owner.balance += paidAmount
       }
 
-      if (paidAmount < promptAmount) {
-        respondingPlayer.is_bankrupt = true
-        respondingPlayer.state = 'bankrupt'
-        respondingPlayer.stateDuration = 0
-        respondingPlayer.jail_turn_count = 0
-        respondingPlayer.is_in_jail = false
-        nextEvents.push({
-          type: 'PLAYER_STATE_CHANGED',
-          playerId: respondingPlayer.id,
-          payload: {
-            playerState: 'bankrupt',
-            reason: 'toll_bankrupt',
-          },
+      if (originalBalance > promptAmount) {
+        respondingPlayer.balance = Math.max(0, originalBalance - promptAmount)
+      } else {
+        markPlayerBankrupt({
+          player: respondingPlayer,
+          reason: 'insufficient_funds',
+          events: nextEvents,
         })
-      } else if (owner && String(owner.id) !== String(respondingPlayer.id)) {
+      }
+
+      if (
+        originalBalance >= promptAmount &&
+        owner &&
+        String(owner.id) !== String(respondingPlayer.id)
+      ) {
         nextPrompt = buildAcquisitionPrompt(respondingPlayer, owner, targetTile)
         nextPhase = 'prompt'
       }
@@ -2161,6 +2661,9 @@ export const mockEmitPromptResponse = ({
           amount: paidAmount,
           expectedAmount: promptAmount,
           ownerId: owner?.id ?? null,
+          fromPlayerId: respondingPlayer.id,
+          toPlayerId: owner?.id ?? null,
+          tileId: targetTile.index,
         },
       })
     }
@@ -2179,9 +2682,11 @@ export const mockEmitPromptResponse = ({
         (player) => String(player.id) === String(targetTile.owner_id)
       )
       const acquisitionCost =
-        promptAmount > 0 ? promptAmount : (targetTile.price ?? 0)
+        promptAmount > 0
+          ? Math.trunc(promptAmount)
+          : getTileAcquisitionCost(targetTile)
 
-      if (owner && respondingPlayer.balance >= acquisitionCost) {
+      if (owner && respondingPlayer.balance > acquisitionCost) {
         respondingPlayer.balance -= acquisitionCost
         owner.balance += acquisitionCost
         removeOwnedTile(owner, targetTile.index)
@@ -2240,7 +2745,7 @@ export const mockEmitPromptResponse = ({
             playerId: respondingPlayer.id,
             fromTileId,
             toTileId: targetTileId,
-            trigger: 'travel_select',
+            trigger: 'travel',
           })
         )
 

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { ArrowLeft } from 'lucide-react'
 import toast from 'react-hot-toast'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
@@ -80,6 +80,17 @@ type PlayerPanelViewModel = {
   isActive: boolean
   isBankrupt: boolean
   isRichest: boolean
+}
+
+type DeferredPlayerFinancialSnapshot = {
+  money: number
+  totalAssets: number
+}
+
+type ChanceMoneyEffectPayload = {
+  playerId: string
+  chanceType: 'GAIN_MONEY' | 'LOSE_MONEY'
+  amount: number
 }
 
 const toComparablePlayerId = (playerId: PlayerId | null | undefined) =>
@@ -192,6 +203,8 @@ const GamePage: React.FC = () => {
   >(null)
   const [isBoardBlockingModalOpen, setIsBoardBlockingModalOpen] =
     useState(false)
+  const [deferredPlayerFinancialById, setDeferredPlayerFinancialById] =
+    useState<Record<string, DeferredPlayerFinancialSnapshot>>({})
   const [isExitModalOpen, setIsExitModalOpen] = useState(false)
   const [isLeavePending, setIsLeavePending] = useState(false)
   const [isGlobalEffectModalOpen, setIsGlobalEffectModalOpen] = useState(false)
@@ -392,12 +405,72 @@ const GamePage: React.FC = () => {
 
   const diceRoll = useDiceRoll()
 
+  const handleChanceMoneyEffect = useCallback(
+    (effect: ChanceMoneyEffectPayload) => {
+      const targetPlayer = storePlayers.find(
+        (player) => String(player.id) === String(effect.playerId)
+      )
+      if (!targetPlayer) {
+        return
+      }
+
+      if (targetPlayer.is_bankrupt || targetPlayer.state === 'bankrupt') {
+        return
+      }
+
+      const amount = Math.max(0, Math.trunc(effect.amount))
+      if (!Number.isFinite(amount) || amount <= 0) {
+        return
+      }
+
+      const currentMoney = targetPlayer.balance ?? 0
+      const currentTotalAssets = targetPlayer.totalAssets ?? currentMoney
+      const previousMoney =
+        effect.chanceType === 'GAIN_MONEY'
+          ? currentMoney - amount
+          : currentMoney + amount
+      const previousTotalAssets =
+        effect.chanceType === 'GAIN_MONEY'
+          ? currentTotalAssets - amount
+          : currentTotalAssets + amount
+      const playerId = String(targetPlayer.id)
+
+      setDeferredPlayerFinancialById((previous) => ({
+        ...previous,
+        [playerId]: {
+          money: Math.max(0, previousMoney),
+          totalAssets: Math.max(0, previousTotalAssets),
+        },
+      }))
+    },
+    [storePlayers]
+  )
+
+  useEffect(() => {
+    if (isBoardBlockingModalOpen) {
+      return
+    }
+
+    if (Object.keys(deferredPlayerFinancialById).length === 0) {
+      return
+    }
+
+    setDeferredPlayerFinancialById({})
+  }, [deferredPlayerFinancialById, isBoardBlockingModalOpen])
+
   const panelPlayers = useMemo(() => {
     const basePanelPlayers: PlayerPanelViewModel[] = storePlayers.map(
       (storePlayer, index) => {
         const boardPlayer = boardPlayers[index]
         const playerId = String(storePlayer.id)
-        const money = storePlayer.balance ?? boardPlayer?.money ?? 0
+        const deferredFinancial = deferredPlayerFinancialById[playerId]
+        const money =
+          deferredFinancial?.money ??
+          storePlayer.balance ??
+          boardPlayer?.money ??
+          0
+        const totalAssets =
+          deferredFinancial?.totalAssets ?? storePlayer.totalAssets ?? money
 
         return {
           id: playerId,
@@ -405,7 +478,7 @@ const GamePage: React.FC = () => {
             storePlayer.nickname || boardPlayer?.name || `Player ${index + 1}`,
           color: storePlayer.color || boardPlayer?.color,
           money,
-          totalAssets: storePlayer.totalAssets ?? money,
+          totalAssets,
           originalIndex: index,
           isActive: activePlayerId === playerId,
           isBankrupt:
@@ -496,7 +569,13 @@ const GamePage: React.FC = () => {
       sortedPlayers.find((player) => !player.isBankrupt)?.id ?? null
 
     return applyRichestFlag(sortedPlayers, richestPlayerId)
-  }, [activePlayerId, boardPlayers, gameResult, storePlayers])
+  }, [
+    activePlayerId,
+    boardPlayers,
+    deferredPlayerFinancialById,
+    gameResult,
+    storePlayers,
+  ])
   const currentPlayerState = boardPlayers[boardCurPlayer]
   const isCurrentPlayerBankrupt = currentPlayerState?.state === 'bankrupt'
   const isRollPhase = phase === 'rolling'
@@ -785,6 +864,7 @@ const GamePage: React.FC = () => {
               gamePhase={phase}
               allowAssetActions={canManageAssetsThisTurn}
               onBlockingModalChange={setIsBoardBlockingModalOpen}
+              onChanceMoneyEffect={handleChanceMoneyEffect}
               gameResult={gameResult}
               isGameOver={isGameOver}
               winnerId={winnerId}


### PR DESCRIPTION
## 🧠 Task 문서 (큰 작업이면 필수)
- `docs/ai/tasks/board-sot-sync/plan.md`
- `docs/ai/tasks/board-sot-sync/context.md`
- `docs/ai/tasks/board-sot-sync/checklist.md`

## 📋 TODO.md 연결
- task slug: `board-sot-sync`
- TODO status: `In Progress`
- TODO entry 확인: `TODO.md`의 `board-sot-sync` 항목 확인

## 📚 참고한 기준 문서
- `AGENTS.md`
- `docs/ai/manuals/common.md`
- `docs/rules.md`
- `docs/testing.md`
- `docs/ai/manuals/game-runtime.md`

## 🧪 실행한 검증
- `npx vitest run src/components/board/gameBoardEventQueueUtils.test.ts src/mocks/handlers/game.handler.test.ts`
- `npx vitest run src/pages/GamePage.test.tsx src/pages/GamePage.mockSoloPlay.test.tsx`
- `npx vitest run src/components/board/useBoardEventQueue.test.tsx src/components/board/gameBoardEventQueueUtils.test.ts src/components/board/GameBoard.test.tsx`
- `npm run lint`
- `npm run ai:check:game`
- `npm run ai:check:build`
- `npm run e2e:game`
- `npx playwright test e2e/game-runtime-roll-smoke.spec.ts --grep "@game" --project=chromium --headed`
- `npx playwright test e2e/chat-flow-game-room.spec.ts --grep "@game" --project=chromium --headed`
- `npx playwright test e2e/game-runtime-roll-smoke.spec.ts --grep "@game" --project=chromium --repeat-each=5`
- `npm run ai:self-review -- --files TODO.md docs/ai/tasks/board-sot-sync/checklist.md docs/ai/tasks/board-sot-sync/context.md e2e/game-runtime-roll-smoke.spec.ts src/components/board/BoardTile.tsx src/components/board/GameBoard.tsx src/components/board/gameBoardEventQueueUtils.test.ts src/components/board/gameBoardEventQueueUtils.ts src/components/board/useBoardEventQueue.test.tsx src/components/board/useBoardEventQueue.ts src/mocks/handlers/game.handler.test.ts src/mocks/handlers/game.handler.ts src/pages/GamePage.tsx`

## ⚠️ 남은 리스크
- `board-sot-sync` gate evidence 마지막 항목은 PR required checks 결과 확인 후 닫힘 처리 필요
- e2e 오버레이 구조 변경 시 selector 재점검 필요

## 🚧 후속 작업
1. PR required checks 확인 후 checklist 마감
2. `board-sot-sync` 완료 기준 재점검 후 `TODO.md` 상태 승격 여부 결정
3. 필요 시 런타임 장면별 Playwright 시나리오 분리