### PR TITLE
test : mock 런타임 의미 동일성 회귀 가드 추가 및 전환 task 동기화

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,14 +4,13 @@
 
 ## Ready
 
-- [ ] `runtime-parity-regression-guard` - Runtime Parity Regression Guard (`docs/ai/tasks/runtime-parity-regression-guard/`)
-
 ## In Progress
 
 ## Blocked
 
 ## Done
 
+- [x] `runtime-parity-regression-guard` - Runtime Parity Regression Guard (`docs/ai/tasks/runtime-parity-regression-guard/`) - mock/real 런타임 의미 동일성 회귀 가드(보드 SoT drift 테스트, tile_type/transportType 테스트, e2e 오버레이 클릭 안정화) 추가
 - [x] `board-sot-sync` - Board SoT sync + initial full sync (`docs/ai/tasks/board-sot-sync/`) - 보드판 SoT를 백엔드 기준으로 전환하고 최초 sync knownRevision=-1 요청 반영
 - [x] `mypage-nickname-change` - MyPage Nickname Change (`docs/ai/tasks/mypage-nickname-change/`) - 게스트 제한은 유지하고 카카오 사용자는 마이페이지에서 닉네임을 반복 변경할 수 있게 정리
 - [x] `git-flow-template-source-of-truth` - Git Flow Template Source Of Truth (`docs/ai/tasks/git-flow-template-source-of-truth/`) - ai:git-flow가 .github 템플릿을 직접 읽어 issue/PR 제목, labels, 본문을 생성하도록 정렬

--- a/docs/ai/tasks/runtime-parity-regression-guard/checklist.md
+++ b/docs/ai/tasks/runtime-parity-regression-guard/checklist.md
@@ -2,25 +2,30 @@
 
 ## Implementation
 
-- [ ] Re-read required manuals before edits.
-- [ ] Define drift-detection rule and record source-of-truth references.
-- [ ] Add/adjust adapter parity regression tests for `tile_type` and `transportType`.
-- [ ] Harden smoke scenario helper for modal overlay interception edge cases.
-- [ ] Keep contract types/mock behavior/test assertions aligned.
+- [x] Re-read required manuals before edits.
+- [x] Define drift-detection rule and record source-of-truth references.
+- [x] Add/adjust adapter parity regression tests for `tile_type` and `transportType`.
+- [x] Harden smoke scenario helper for modal overlay interception edge cases.
+- [x] Keep contract types/mock behavior/test assertions aligned.
 
 ## Testing
 
-- [ ] `npx vitest run src/components/board/gameBoardEventQueueUtils.test.ts src/services/socket/gameContractAdapters.test.ts`
-- [ ] `npm run lint`
-- [ ] `npm run ai:check:game`
-- [ ] `npm run ai:check:build`
-- [ ] `npm run e2e:game`
-- [ ] `npx playwright test e2e/game-runtime-roll-smoke.spec.ts --grep "@game" --project=chromium --repeat-each=5`
+- [x] `npx vitest run src/components/board/board.constants.parity.test.ts src/components/board/gameBoardEventQueueUtils.test.ts src/services/socket/gameContractAdapters.test.ts`
+- [x] `npm run lint`
+- [x] `npm run ai:check:game`
+- [x] `npm run ai:check:build`
+- [x] `npm run e2e:game`
+- [x] `npx playwright test e2e/game-runtime-roll-smoke.spec.ts --grep "@game" --project=chromium --repeat-each=5`
 
 ## Review
 
-- [ ] Validate R/P/C/U impact with `docs/rules.md`.
-- [ ] Confirm TODO/task-doc status synchronization.
-- [ ] Update context + handoff notes with concrete evidence.
-- [ ] Verify `npm run ai:session:brief -- runtime-parity-regression-guard` reflects latest state.
-- [ ] Report changed files, validations run, and residual risks.
+- [x] Validate R/P/C/U impact with `docs/rules.md`.
+- [x] Confirm TODO/task-doc status synchronization.
+- [x] Update context + handoff notes with concrete evidence.
+- [x] Verify `npm run ai:session:brief -- runtime-parity-regression-guard` reflects latest state.
+- [x] Report changed files, validations run, and residual risks.
+
+## Evidence (2026-04-03)
+
+- Backend SoT reference checked: `modoo-marble-backend/develop/app/game/rulesets/default.v1.json` (`board` tile id/name/tile_type baseline).
+- Workflow audit: `npm run ai:workflow:audit` (Warnings: none).

--- a/docs/ai/tasks/runtime-parity-regression-guard/context.md
+++ b/docs/ai/tasks/runtime-parity-regression-guard/context.md
@@ -41,6 +41,25 @@
 - Confirm target files and test scope before coding.
 - Record evidence links/run IDs in checklist after execution.
 
+## 2026-04-03 Implementation Update
+
+- Added board drift guard test: `src/components/board/board.constants.parity.test.ts`
+  - Asserts static `TILES` and `mockTiles` both match backend `default.v1.json` board order/name/type.
+- Added adapter regression case: `src/services/socket/gameContractAdapters.test.ts`
+  - Asserts `normalizePatchEnvelopePayload` preserves `transportType` when tile objects are set with `tile_type` aliases (`TRAVEL`, `EVENT`).
+- Hardened smoke scenario modal click helper: `e2e/game-runtime-roll-smoke.spec.ts`
+  - Uses safer action-button click helper with fallback to `force` click after normal click failure to reduce overlay interception flake.
+
+## 2026-04-03 Validation Evidence
+
+- `npx vitest run src/components/board/board.constants.parity.test.ts src/components/board/gameBoardEventQueueUtils.test.ts src/services/socket/gameContractAdapters.test.ts` (pass)
+- `npm run lint` (pass)
+- `npm run ai:check:game` (pass)
+- `npm run ai:check:build` (pass)
+- `npm run e2e:game` (pass)
+- `npx playwright test e2e/game-runtime-roll-smoke.spec.ts --grep "@game" --project=chromium --repeat-each=5` (pass)
+- `npm run ai:workflow:audit` (Warnings: none)
+
 ## Open Risks
 
 - Backend ruleset updates can reintroduce tile metadata/name drifts.

--- a/e2e/game-runtime-roll-smoke.spec.ts
+++ b/e2e/game-runtime-roll-smoke.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test, type Locator } from '@playwright/test'
 import { ensureDevControlPanelOpen } from './helpers/devPanel'
 import { loginAsGuest, resetSessionAndOpenHome } from './helpers/session'
 
@@ -45,23 +45,35 @@ test.describe('@game 게임 런타임 롤 스모크', () => {
     const rollButton = page.getByRole('button', { name: /ROLL|END/ })
     await expect(rollButton).toBeVisible()
 
+    const clickActionButton = async (button: Locator) => {
+      await button.scrollIntoViewIfNeeded()
+
+      try {
+        await button.click({ timeout: 1200 })
+      } catch {
+        await button.click({ timeout: 1200, force: true })
+      }
+    }
+
     const consumePromptIfVisible = async () => {
       const topModalOverlay = page
         .locator('div.fixed.inset-0:has(button:enabled)')
         .last()
 
       if ((await topModalOverlay.count()) > 0) {
-        const modalActionButtons = topModalOverlay.locator('button:enabled')
+        const modalActionButtons = topModalOverlay.locator(
+          'button:enabled:visible'
+        )
         const buttonCount = await modalActionButtons.count()
 
         for (let index = buttonCount - 1; index >= 0; index -= 1) {
           const button = modalActionButtons.nth(index)
-          if (!(await button.isVisible()) || !(await button.isEnabled())) {
+          if (!(await button.isEnabled())) {
             continue
           }
 
           try {
-            await button.click({ timeout: 1200 })
+            await clickActionButton(button)
             await page.waitForTimeout(350)
             return true
           } catch {
@@ -72,8 +84,12 @@ test.describe('@game 게임 런타임 롤 스모크', () => {
 
       for (const promptPattern of PROMPT_BUTTONS) {
         const button = page.getByRole('button', { name: promptPattern }).first()
-        if ((await button.count()) > 0 && (await button.isVisible())) {
-          await button.click({ timeout: 1200 })
+        if (
+          (await button.count()) > 0 &&
+          (await button.isVisible()) &&
+          (await button.isEnabled())
+        ) {
+          await clickActionButton(button)
           await page.waitForTimeout(350)
           return true
         }
@@ -114,7 +130,7 @@ test.describe('@game 게임 런타임 롤 스모크', () => {
         (await endTurnButton.count()) > 0 &&
         (await endTurnButton.isVisible())
       ) {
-        await endTurnButton.click()
+        await clickActionButton(endTurnButton)
       }
 
       await page.waitForTimeout(400)

--- a/src/components/board/board.constants.parity.test.ts
+++ b/src/components/board/board.constants.parity.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+import { mockTiles } from '../../mocks/gameMockData'
+import { TILES } from './board.constants'
+
+type BackendBoardTileType =
+  | 'START'
+  | 'PROPERTY'
+  | 'CHANCE'
+  | 'EVENT'
+  | 'ISLAND'
+  | 'TRAVEL'
+  | 'MOVE_TO_ISLAND'
+
+type BackendBoardTile = {
+  tileId: number
+  name: string
+  tileType: BackendBoardTileType
+}
+
+// Source of truth:
+// https://github.com/modoo-marble-team/modoo-marble-backend/blob/develop/app/game/rulesets/default.v1.json
+// Verified on 2026-04-03.
+const BACKEND_DEFAULT_V1_BOARD: readonly BackendBoardTile[] = [
+  { tileId: 0, name: '\uCD9C\uBC1C', tileType: 'START' },
+  { tileId: 1, name: '\uC218\uC6D0', tileType: 'PROPERTY' },
+  { tileId: 2, name: '\uC6A9\uC778', tileType: 'PROPERTY' },
+  { tileId: 3, name: '\uCC2C\uC2A4', tileType: 'CHANCE' },
+  { tileId: 4, name: '\uAD70\uC0B0', tileType: 'PROPERTY' },
+  { tileId: 5, name: '\uD0DC\uBC31', tileType: 'PROPERTY' },
+  { tileId: 6, name: '\uC6B8\uC0B0', tileType: 'PROPERTY' },
+  { tileId: 7, name: '\uC774\uBCA4\uD2B8', tileType: 'EVENT' },
+  { tileId: 8, name: '\uBB34\uC778\uB3C4', tileType: 'ISLAND' },
+  { tileId: 9, name: '\uACBD\uC8FC', tileType: 'PROPERTY' },
+  { tileId: 10, name: '\uCC2C\uC2A4', tileType: 'CHANCE' },
+  { tileId: 11, name: '\uD3EC\uD56D', tileType: 'PROPERTY' },
+  { tileId: 12, name: '\uB300\uAD6C', tileType: 'PROPERTY' },
+  { tileId: 13, name: '\uCC3D\uC6D0', tileType: 'PROPERTY' },
+  { tileId: 14, name: '\uC775\uC0B0', tileType: 'PROPERTY' },
+  { tileId: 15, name: '\uBD80\uC0B0', tileType: 'PROPERTY' },
+  { tileId: 16, name: '\uC5EC\uD589', tileType: 'TRAVEL' },
+  { tileId: 17, name: '\uC81C\uC8FC', tileType: 'PROPERTY' },
+  { tileId: 18, name: '\uC5EC\uC218', tileType: 'PROPERTY' },
+  { tileId: 19, name: '\uAD11\uC8FC', tileType: 'PROPERTY' },
+  { tileId: 20, name: '\uC774\uBCA4\uD2B8', tileType: 'EVENT' },
+  { tileId: 21, name: '\uCD98\uCC9C', tileType: 'PROPERTY' },
+  { tileId: 22, name: '\uAC15\uB989', tileType: 'PROPERTY' },
+  { tileId: 23, name: '\uC804\uC8FC', tileType: 'PROPERTY' },
+  {
+    tileId: 24,
+    name: '\uBB34\uC778\uB3C4\uB85C \uC774\uB3D9',
+    tileType: 'MOVE_TO_ISLAND',
+  },
+  { tileId: 25, name: '\uCCAD\uC8FC', tileType: 'PROPERTY' },
+  { tileId: 26, name: '\uCC9C\uC548', tileType: 'PROPERTY' },
+  { tileId: 27, name: '\uCC2C\uC2A4', tileType: 'CHANCE' },
+  { tileId: 28, name: '\uB300\uC804', tileType: 'PROPERTY' },
+  { tileId: 29, name: '\uC778\uCC9C', tileType: 'PROPERTY' },
+  { tileId: 30, name: '\uC774\uBCA4\uD2B8', tileType: 'EVENT' },
+  { tileId: 31, name: '\uC11C\uC6B8', tileType: 'PROPERTY' },
+]
+
+const BACKEND_TO_MOCK_TILE_TYPE: Record<BackendBoardTileType, string> = {
+  START: 'start',
+  PROPERTY: 'property',
+  CHANCE: 'chance',
+  EVENT: 'event',
+  ISLAND: 'island',
+  TRAVEL: 'travel',
+  MOVE_TO_ISLAND: 'go_to_island',
+}
+
+describe('board.constants parity guard', () => {
+  it('keeps static fallback tile order/name/type aligned with backend default.v1 board', () => {
+    const frontendBoard = TILES.map((tile) => ({
+      tileId: tile.id,
+      name: tile.name,
+      tileType: tile.type,
+    }))
+
+    expect(frontendBoard).toEqual(BACKEND_DEFAULT_V1_BOARD)
+  })
+
+  it('keeps mock tile order/name/type aligned with backend default.v1 board', () => {
+    const frontendMockBoard = mockTiles.map((tile) => ({
+      tileId: tile.index,
+      name: tile.name,
+      tileType: tile.type,
+    }))
+
+    const expectedMockBoard = BACKEND_DEFAULT_V1_BOARD.map((tile) => ({
+      tileId: tile.tileId,
+      name: tile.name,
+      tileType: BACKEND_TO_MOCK_TILE_TYPE[tile.tileType],
+    }))
+
+    expect(frontendMockBoard).toEqual(expectedMockBoard)
+  })
+})

--- a/src/services/socket/gameContractAdapters.test.ts
+++ b/src/services/socket/gameContractAdapters.test.ts
@@ -291,6 +291,55 @@ describe('gameContractAdapters', () => {
     ])
   })
 
+  it('preserves transportType when set patch replaces tile objects using tile_type aliases', () => {
+    const normalized = normalizePatchEnvelopePayload({
+      gameId: 'game-tile-transport-patch',
+      revision: 95,
+      patch: [
+        {
+          op: 'set',
+          path: 'tiles.16',
+          value: {
+            tile_id: 16,
+            name: 'travel',
+            tile_type: 'TRAVEL',
+          },
+        },
+        {
+          op: 'set',
+          path: 'tiles.20',
+          value: {
+            tile_id: 20,
+            name: 'event',
+            tile_type: 'EVENT',
+          },
+        },
+      ],
+      events: [],
+    })
+
+    expect(normalized.patch).toEqual([
+      {
+        op: 'set',
+        path: 'tiles.16',
+        value: expect.objectContaining({
+          index: 16,
+          type: 'travel',
+          transportType: 'TRAVEL',
+        }),
+      },
+      {
+        op: 'set',
+        path: 'tiles.20',
+        value: expect.objectContaining({
+          index: 20,
+          type: 'event',
+          transportType: 'EVENT',
+        }),
+      },
+    ])
+  })
+
   it('normalizes active global effect from snapshot aliases', () => {
     const normalized = normalizeSnapshotPayload(
       {


### PR DESCRIPTION
## 📌 관련 이슈

> closes #670

---

## 📝 작업 내용

- mock/real 런타임 의미 동일성 회귀 방지를 위해 guard 테스트를 추가했습니다.
- backend ruleset(default.v1) 기준으로 보드 tile id/name/type drift를 감지하는 테스트를 추가했습니다.
- `tile_type -> transportType` 정합성 회귀 테스트를 보강했습니다.
- `e2e/game-runtime-roll-smoke` 모달 오버레이 클릭 인터셉트 flake를 줄이기 위해 클릭 fallback(`force`)을 추가했습니다.
- task 문서와 TODO 상태를 `runtime-parity-regression-guard` 완료 기준으로 동기화했습니다.

---

## 🧠 Task 문서 (큰 작업이면 필수)

- plan: `docs/ai/tasks/runtime-parity-regression-guard/plan.md`
- context: `docs/ai/tasks/runtime-parity-regression-guard/context.md`
- checklist: `docs/ai/tasks/runtime-parity-regression-guard/checklist.md`

---

## 📋 TODO.md 연결

- task slug: `runtime-parity-regression-guard`
- TODO status: `Done`
- TODO entry 확인: `TODO.md` Done 섹션에 `runtime-parity-regression-guard` 반영 완료

---

## 📚 참고한 기준 문서

- `AGENTS.md`
- `docs/rules.md`
- `docs/testing.md`
- `docs/ai/manuals/common.md`
- `docs/ai/manuals/game-runtime.md`
- `docs/socket-mock-server.md`

---

## 🧪 실행한 검증

- `npx vitest run src/components/board/board.constants.parity.test.ts src/components/board/gameBoardEventQueueUtils.test.ts src/services/socket/gameContractAdapters.test.ts`
- `npm run lint`
- `npm run ai:check:game`
- `npm run ai:check:build`
- `npm run e2e:game`
- `npx playwright test e2e/game-runtime-roll-smoke.spec.ts --grep "@game" --project=chromium --repeat-each=5`
- `npm run ai:workflow:audit`

---

## ⚠️ 남은 리스크

- backend `default.v1.json` board가 변경되면 parity 테스트가 실패하므로, 실패 시 FE 보드 상수/mock 데이터 동기화가 필요합니다.
- 모달/오버레이 DOM 구조가 바뀌면 smoke 시나리오 selector/클릭 fallback 재조정이 필요할 수 있습니다.

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 console.log 제거
- [x] 관련 이슈 연결 완료
- [x] 큰 작업이면 task 문서 링크를 남겼다
- [x] 큰 작업이면 `TODO.md` / task slug 연결을 PR 본문에 남겼다
- [x] 참고한 기준 문서를 PR 본문에 남겼다
- [x] 실행한 검증과 남은 리스크를 PR 본문에 적었다

---

## 📸 스크린샷 (선택)

- N/A (테스트/문서/가드 중심 변경)
