### PR TITLE
fix(game-runtime): 목 런타임 더블/이동/찬스 타이밍 동기화

### DIFF
--- a/src/components/board/GameBoard.doubleOrder.test.tsx
+++ b/src/components/board/GameBoard.doubleOrder.test.tsx
@@ -225,6 +225,27 @@ describe('GameBoard double ordering', () => {
     ).toBeInTheDocument()
   })
 
+  it('does not open double popup for non-local player double roll', async () => {
+    renderGameBoard()
+
+    const handler = getBoardQueueCallbacks().onEventConsumed
+    const result = handler?.({
+      type: 'DICE_ROLLED',
+      playerId: 2,
+      payload: {
+        dice: [4, 4],
+        isDouble: true,
+        is_double: true,
+        doubleCount: 1,
+      },
+    } as ServerEvent)
+
+    expect(result).toBeUndefined()
+    expect(
+      screen.queryByRole('button', { name: 'double-confirm' })
+    ).not.toBeInTheDocument()
+  })
+
   it('keeps follow-up move queued until double popup confirm', async () => {
     useGameStore.getState().enqueueEvents([
       {

--- a/src/components/board/GameBoard.doubleOrder.test.tsx
+++ b/src/components/board/GameBoard.doubleOrder.test.tsx
@@ -1,0 +1,288 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+import GameBoard from './GameBoard'
+import type { PlayerState } from './board.constants'
+import type { GamePrompt, ServerEvent } from '../../types/domain'
+import { useGameStore } from '../../stores/game.store'
+
+vi.mock('./BoardTile', () => ({
+  default: ({ tile }: { tile: { id: number; name?: string } }) => (
+    <div>{tile.name ?? `tile-${tile.id}`}</div>
+  ),
+  PlayerToken: () => null,
+}))
+
+const useBoardEventQueueMock = vi.fn()
+
+vi.mock('./useBoardEventQueue', () => ({
+  useBoardEventQueue: (params: unknown) => {
+    useBoardEventQueueMock(params)
+    return undefined
+  },
+}))
+
+vi.mock('../../lib/bgm', () => ({
+  playLongSfx: vi.fn(),
+  stopLongSfx: vi.fn(),
+}))
+
+vi.mock('../../services/socket/game.handler', () => ({
+  emitGameAction: vi.fn(),
+}))
+
+vi.mock('../game/GlobalEffectOverlay', () => ({
+  default: () => null,
+}))
+
+vi.mock('../game/modals/BuyModal', () => ({
+  default: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="buy-modal">buy-modal</div> : null,
+}))
+
+vi.mock('../game/modals/BuildModal', () => ({
+  default: () => null,
+}))
+
+vi.mock('../game/modals/CardModal', () => ({
+  default: () => null,
+}))
+
+vi.mock('../game/modals/TravelModal', () => ({
+  default: () => null,
+}))
+
+vi.mock('../game/modals/CityAcquisitionModals', () => ({
+  default: () => null,
+}))
+
+vi.mock('../game/modals/CitySellModal', () => ({
+  default: () => null,
+}))
+
+vi.mock('../game/modals/InsufficientFundsModal', () => ({
+  default: () => null,
+}))
+
+vi.mock('../game/modals/TollModal', () => ({
+  default: () => null,
+}))
+
+vi.mock('../game/modals/BankruptModal', () => ({
+  default: () => null,
+}))
+
+vi.mock('../game/modals/DoubleDicePopup', () => ({
+  default: ({ open, onConfirm }: { open: boolean; onConfirm?: () => void }) =>
+    open ? (
+      <button type="button" onClick={onConfirm}>
+        double-confirm
+      </button>
+    ) : null,
+}))
+
+vi.mock('../game/modals/GameResultModal', () => ({
+  default: () => null,
+}))
+
+vi.mock('../game/modals/GoToIslandModal', () => ({
+  default: () => null,
+}))
+
+vi.mock('../game/modals/IslandModal', () => ({
+  default: () => null,
+}))
+
+const players: PlayerState[] = [
+  {
+    id: 1,
+    name: 'player-1',
+    color: '#ff0000',
+    pos: 0,
+    money: 1000,
+    skipTurns: 0,
+  },
+  {
+    id: 2,
+    name: 'player-2',
+    color: '#00ff00',
+    pos: 3,
+    money: 1000,
+    skipTurns: 0,
+  },
+]
+
+const renderGameBoard = (options?: { activePrompt?: GamePrompt | null }) =>
+  render(
+    <GameBoard
+      gameId="game-1"
+      players={players}
+      curPlayer={0}
+      round={1}
+      gamePhase="rolling"
+      allowAssetActions={true}
+      activePrompt={options?.activePrompt ?? null}
+      tiles={[]}
+      localPlayerId={1}
+    />
+  )
+
+const getBoardQueueCallbacks = () => {
+  const lastCall = useBoardEventQueueMock.mock.lastCall?.[0] as
+    | {
+        onEventConsumed?: (event: ServerEvent) => void
+      }
+    | undefined
+
+  if (!lastCall?.onEventConsumed) {
+    throw new Error('GameBoard queue callbacks were not captured')
+  }
+
+  return lastCall
+}
+
+const consumeQueuedBoardEvent = async () => {
+  await act(async () => {
+    const nextEvent = useGameStore.getState().consumeNextEvent()
+    if (!nextEvent) {
+      throw new Error('No queued board event to consume')
+    }
+    getBoardQueueCallbacks().onEventConsumed?.(nextEvent)
+    await Promise.resolve()
+  })
+}
+
+beforeAll(() => {
+  class ResizeObserverMock {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+
+  class AudioMock {
+    play() {
+      return Promise.resolve()
+    }
+  }
+
+  vi.stubGlobal('ResizeObserver', ResizeObserverMock)
+  vi.stubGlobal('Audio', AudioMock)
+  vi.stubGlobal('requestAnimationFrame', ((callback: FrameRequestCallback) =>
+    window.setTimeout(
+      () => callback(performance.now()),
+      16
+    )) as typeof requestAnimationFrame)
+  vi.stubGlobal('cancelAnimationFrame', ((handle: number) =>
+    window.clearTimeout(handle)) as typeof cancelAnimationFrame)
+})
+
+afterAll(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('GameBoard double ordering', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    useGameStore.getState().resetGame()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('opens double popup when dice values are equal even if double flags are false', async () => {
+    useGameStore.getState().enqueueEvents([
+      {
+        type: 'DICE_ROLLED',
+        playerId: 1,
+        payload: {
+          dice: [3, 3],
+          isDouble: false,
+          is_double: false,
+          doubleCount: 0,
+        },
+      } as ServerEvent,
+    ])
+
+    renderGameBoard()
+    await consumeQueuedBoardEvent()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500)
+    })
+
+    expect(
+      screen.getByRole('button', { name: 'double-confirm' })
+    ).toBeInTheDocument()
+  })
+
+  it('keeps follow-up move queued until double popup confirm', async () => {
+    useGameStore.getState().enqueueEvents([
+      {
+        type: 'DICE_ROLLED',
+        playerId: 1,
+        payload: {
+          dice: [5, 5],
+          total: 10,
+          isDouble: false,
+          is_double: false,
+          doubleCount: 0,
+        },
+      } as ServerEvent,
+      {
+        type: 'PLAYER_MOVED',
+        playerId: 1,
+        tileIndex: 1,
+        payload: {
+          fromIndex: 0,
+        },
+      } as ServerEvent,
+    ])
+
+    renderGameBoard({
+      activePrompt: {
+        id: 'buy-1',
+        type: 'BUY_OR_SKIP',
+        payload: { tileId: 1 },
+        choices: [
+          { id: 'buy', label: 'BUY', value: 'BUY' },
+          { id: 'skip', label: 'SKIP', value: 'SKIP' },
+        ],
+      },
+    })
+
+    await consumeQueuedBoardEvent()
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500)
+    })
+
+    expect(useGameStore.getState().eventQueue).toHaveLength(1)
+    expect(
+      screen.getByRole('button', { name: 'double-confirm' })
+    ).toBeInTheDocument()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(700)
+    })
+    expect(useGameStore.getState().eventQueue).toHaveLength(1)
+
+    fireEvent.click(screen.getByRole('button', { name: 'double-confirm' }))
+    await consumeQueuedBoardEvent()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1600)
+      await vi.advanceTimersByTimeAsync(16)
+    })
+
+    expect(useGameStore.getState().eventQueue).toHaveLength(0)
+  })
+})

--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -767,6 +767,10 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       (event: ServerEvent): boolean | void => {
         const normalizedType =
           typeof event.type === 'string' ? event.type.trim().toUpperCase() : ''
+        const isLocalPlayerEvent =
+          localPlayerId == null ||
+          event.playerId == null ||
+          String(event.playerId) === String(localPlayerId)
         if (normalizedType === 'DICE_ROLLED') {
           if (rollAnimationIntervalRef.current !== null) {
             freezeDiceRollValues()
@@ -789,7 +793,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
           }
 
           const doubleInfo = resolveDoubleDiceInfo(event)
-          if (doubleInfo.isDouble) {
+          if (isLocalPlayerEvent && doubleInfo.isDouble) {
             setDoubleDiceModal({
               open: true,
               extraRollCount:
@@ -978,11 +982,6 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
               steps: chanceMoveHint.steps,
             }
           }
-
-          const isLocalPlayerEvent =
-            localPlayerId == null ||
-            event.playerId == null ||
-            String(event.playerId) === String(localPlayerId)
 
           if (!isLocalPlayerEvent) {
             return

--- a/src/components/board/GameBoard.tsx
+++ b/src/components/board/GameBoard.tsx
@@ -443,11 +443,30 @@ const resolveDoubleDiceInfo = (event: ServerEvent) => {
     payloadRecord?.isDouble ??
     eventRecord?.is_double ??
     eventRecord?.isDouble
+  const rawDice =
+    payloadRecord?.dice ??
+    payloadRecord?.dices ??
+    eventRecord?.dice ??
+    eventRecord?.dices
+
+  const parsedDice = Array.isArray(rawDice)
+    ? rawDice
+        .slice(0, 2)
+        .map((value) => toFiniteNumber(value))
+        .filter((value): value is number => value != null)
+    : []
+  const inferredDoubleFromDice =
+    parsedDice.length >= 2 && parsedDice[0] === parsedDice[1]
 
   const extraRollCount = toFiniteNumber(rawDoubleCount)
-  const hasSignal = rawIsDouble !== undefined || rawDoubleCount !== undefined
+  const explicitDoubleFlag = toBooleanOrNull(rawIsDouble)
+  const hasSignal =
+    rawIsDouble !== undefined ||
+    rawDoubleCount !== undefined ||
+    inferredDoubleFromDice
   const isDouble =
-    toBooleanOrNull(rawIsDouble) ??
+    inferredDoubleFromDice ||
+    explicitDoubleFlag === true ||
     (extraRollCount != null ? extraRollCount > 0 : false)
 
   return {
@@ -692,6 +711,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
           direction?: BoardMoveDirection
         }
       ) => {
+        isAnimatingRef.current = true
         setIsMoving(true)
         const totalTiles = boardTiles.length
         const direction = options?.direction ?? 'clockwise'
@@ -738,19 +758,15 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
           delete next[String(playerId)]
           return next
         })
+        isAnimatingRef.current = false
         setIsMoving(false)
       },
       [boardTiles.length]
     )
     const handleBoardEventConsumed = useCallback(
-      (event: ServerEvent) => {
+      (event: ServerEvent): boolean | void => {
         const normalizedType =
           typeof event.type === 'string' ? event.type.trim().toUpperCase() : ''
-        const isLocalPlayerEvent =
-          localPlayerId == null ||
-          event.playerId == null ||
-          String(event.playerId) === String(localPlayerId)
-
         if (normalizedType === 'DICE_ROLLED') {
           if (rollAnimationIntervalRef.current !== null) {
             freezeDiceRollValues()
@@ -773,11 +789,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
           }
 
           const doubleInfo = resolveDoubleDiceInfo(event)
-          if (
-            isLocalPlayerEvent &&
-            doubleInfo.hasSignal &&
-            doubleInfo.isDouble
-          ) {
+          if (doubleInfo.isDouble) {
             setDoubleDiceModal({
               open: true,
               extraRollCount:
@@ -786,6 +798,8 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
                   ? doubleInfo.extraRollCount
                   : null,
             })
+            // Pause queue immediately so PLAYER_MOVED waits for double confirm.
+            return true
           }
         }
 
@@ -900,6 +914,11 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
             }
           }
 
+          if (playerKey && playerKey !== 'null') {
+            // Keep prompt surface pinned to pre-move position until movement completes.
+            lastMovePositionRef.current[playerKey] = fromIndex
+          }
+
           const isTravelMove = [
             'travel',
             'move_to_island',
@@ -959,6 +978,11 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
               steps: chanceMoveHint.steps,
             }
           }
+
+          const isLocalPlayerEvent =
+            localPlayerId == null ||
+            event.playerId == null ||
+            String(event.playerId) === String(localPlayerId)
 
           if (!isLocalPlayerEvent) {
             return
@@ -1052,18 +1076,34 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
         const key = String(player.id)
         const isAnimatingPlayer = animatedPositions[key] != null
         const hasPendingMove = pendingMovePlayerIdSet.has(key)
+        const pendingStartIndex = pendingMoveStartIndexByPlayerId[key]
 
         if (nextPositions[key] == null) {
-          nextPositions[key] = player.pos
+          nextPositions[key] =
+            pendingStartIndex != null ? pendingStartIndex : player.pos
           continue
         }
 
-        if (!isAnimatingPlayer && !hasPendingMove) {
-          nextPositions[key] = player.pos
+        if (isAnimatingPlayer) {
+          continue
         }
+
+        if (hasPendingMove) {
+          if (pendingStartIndex != null) {
+            nextPositions[key] = pendingStartIndex
+          }
+          continue
+        }
+
+        nextPositions[key] = player.pos
       }
       lastMovePositionRef.current = nextPositions
-    }, [animatedPositions, pendingMovePlayerIdSet, players])
+    }, [
+      animatedPositions,
+      pendingMovePlayerIdSet,
+      pendingMoveStartIndexByPlayerId,
+      players,
+    ])
     const derivedTileOwners = useMemo(
       () => buildTileOwnersFromProps(tiles, players),
       [tiles, players]
@@ -1406,7 +1446,8 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
         promptPlayerId != null ? animatedPositions[promptPlayerId] : undefined
       const promptPlayerPendingPosition =
         promptPlayerId != null && pendingMovePlayerIdSet.has(promptPlayerId)
-          ? lastMovePositionRef.current[promptPlayerId]
+          ? (pendingMoveStartIndexByPlayerId[promptPlayerId] ??
+            lastMovePositionRef.current[promptPlayerId])
           : undefined
       const promptPlayerSettledPosition =
         promptPlayerId != null
@@ -1443,6 +1484,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       isTravelPromptOpen,
       isMoving,
       pendingMovePlayerIdSet,
+      pendingMoveStartIndexByPlayerId,
       players,
       rolling,
       travelModal.open,
@@ -1935,7 +1977,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
 
     const scaledBoardSize = BOARD_RENDER_BASE_SIZE * boardScale
 
-    const hasAnimationBlocking = isMoving || rolling
+    const hasAnimationBlocking = isMoving || isAnimatingRef.current || rolling
     const canShowModal = !hasAnimationBlocking
     const boardActionAnimationBlocking =
       hasAnimationBlocking || boardActionModalBarrier
@@ -1961,7 +2003,8 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
     const promptPlayerPendingPosition =
       activePromptPlayerId != null &&
       pendingMovePlayerIdSet.has(activePromptPlayerId)
-        ? lastMovePositionRef.current[activePromptPlayerId]
+        ? (pendingMoveStartIndexByPlayerId[activePromptPlayerId] ??
+          lastMovePositionRef.current[activePromptPlayerId])
         : undefined
     const promptPlayerSettledPosition =
       activePromptPlayerId != null
@@ -1984,32 +2027,50 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       promptPlayerRenderedPosition !== promptTileId
     const canRevealPostMovePromptSurface =
       canRevealPostMoveSurface && !hasPromptTilePositionMismatch
-    const cardModalVisible = canRevealPreMoveSurface && cardModal.open
-    const travelModalVisible = canRevealPreMoveSurface && travelModal.open
+    const isDoubleModalPendingOrVisible = doubleDiceModal.open
+    const cardModalVisible =
+      !isDoubleModalPendingOrVisible &&
+      canRevealPreMoveSurface &&
+      cardModal.open
+    const travelModalVisible =
+      !isDoubleModalPendingOrVisible &&
+      canRevealPreMoveSurface &&
+      travelModal.open
     const goToIslandModalVisible =
-      (canRevealPostMovePromptSurface && isGoToIslandPromptOpen) ||
-      (canRevealPreMoveSurface && goToIslandModal.open)
+      !isDoubleModalPendingOrVisible &&
+      ((canRevealPostMovePromptSurface && isGoToIslandPromptOpen) ||
+        (canRevealPreMoveSurface && goToIslandModal.open))
     const islandModalVisible =
-      canRevealPostMovePromptSurface && (isIslandPromptOpen || islandModal.open)
+      !isDoubleModalPendingOrVisible &&
+      canRevealPostMovePromptSurface &&
+      (isIslandPromptOpen || islandModal.open)
 
     const buyModalVisible =
+      !isDoubleModalPendingOrVisible &&
       canRevealPostMovePromptSurface &&
       buyModalOpen &&
       !isBuyPromptDismissed &&
       !insufficientFundsModal.open
     const buildModalVisible =
+      !isDoubleModalPendingOrVisible &&
       canRevealPostMovePromptSurface &&
       buildModalOpen &&
       !isBuildPromptDismissed &&
       !insufficientFundsModal.open
-    const tollModalVisible = canRevealPostMovePromptSurface && tollModalOpen
+    const tollModalVisible =
+      !isDoubleModalPendingOrVisible &&
+      canRevealPostMovePromptSurface &&
+      tollModalOpen
     const acquisitionModalOpen =
+      !isDoubleModalPendingOrVisible &&
       canRevealPostMovePromptSurface &&
       acquisitionModalOpenRaw &&
       !tollModalOpen &&
       !insufficientFundsModal.open
     const sellModalVisible =
-      canRevealPostMovePromptSurface && (citySellModal.open || isSellPromptOpen)
+      !isDoubleModalPendingOrVisible &&
+      canRevealPostMovePromptSurface &&
+      (citySellModal.open || isSellPromptOpen)
 
     const doubleDiceModalVisible = canShowModal && doubleDiceModal.open
 
@@ -2066,7 +2127,7 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
       aiModal.open ||
       goToIslandModalVisible ||
       islandModalVisible ||
-      doubleDiceModalVisible ||
+      isDoubleModalPendingOrVisible ||
       bankruptModal.open ||
       gameResultModal.open
     const isEventQueuePaused =
@@ -2387,7 +2448,8 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
                 const playerKey = String(p.id)
                 const animatedPos = animatedPositions[playerKey]
                 const pendingPos = pendingMoveStartIndexByPlayerId[playerKey]
-                const pos = animatedPos ?? pendingPos ?? p.pos
+                const stablePos = lastMovePositionRef.current[playerKey]
+                const pos = animatedPos ?? pendingPos ?? stablePos ?? p.pos
                 const { row, col } = getTileGridPos(pos)
                 const tokensAtThisPos = players.filter((pl) => {
                   if (pl.state === 'bankrupt') {
@@ -2396,7 +2458,9 @@ const GameBoard = forwardRef<BoardGameHandle, GameBoardProps>(
                   const key = String(pl.id)
                   const plAnimatedPos = animatedPositions[key]
                   const plPendingPos = pendingMoveStartIndexByPlayerId[key]
-                  const renderPos = plAnimatedPos ?? plPendingPos ?? pl.pos
+                  const plStablePos = lastMovePositionRef.current[key]
+                  const renderPos =
+                    plAnimatedPos ?? plPendingPos ?? plStablePos ?? pl.pos
                   return renderPos === pos
                 })
                 const pIdx = players.findIndex((pl) => pl.id === p.id)

--- a/src/components/board/gameBoardEventQueueUtils.test.ts
+++ b/src/components/board/gameBoardEventQueueUtils.test.ts
@@ -514,7 +514,7 @@ describe('gameBoardEventQueueUtils', () => {
     expect(resolveChanceMoneyEffectFromEvent(event)).toEqual({
       playerId: '1',
       chanceType: 'GAIN_MONEY',
-      amount: 20000,
+      amount: 200000000,
     })
   })
 
@@ -533,7 +533,26 @@ describe('gameBoardEventQueueUtils', () => {
     expect(resolveChanceMoneyEffectFromEvent(event)).toEqual({
       playerId: 'guest-2',
       chanceType: 'LOSE_MONEY',
-      amount: 15000,
+      amount: 150000000,
+    })
+  })
+
+  it('keeps already-won amount as-is for chance money effect', () => {
+    const event = {
+      type: 'CHANCE_RESOLVED',
+      playerId: 'guest-3',
+      payload: {
+        chance: {
+          type: 'GAIN_MONEY',
+          power: 100000000,
+        },
+      },
+    } as ServerEvent
+
+    expect(resolveChanceMoneyEffectFromEvent(event)).toEqual({
+      playerId: 'guest-3',
+      chanceType: 'GAIN_MONEY',
+      amount: 100000000,
     })
   })
 

--- a/src/components/board/gameBoardEventQueueUtils.ts
+++ b/src/components/board/gameBoardEventQueueUtils.ts
@@ -32,6 +32,9 @@ export type ChanceMoneyEffect = {
   amount: number
 }
 
+const MONEY_UNIT_SCALE = 10_000
+const MONEY_ALREADY_WON_THRESHOLD = 10_000_000
+
 export const FAST_MOVE_ANIMATION_OPTIONS = {
   initialDelayMs: 200,
   stepDelayMs: 80,
@@ -321,6 +324,23 @@ const getRecordNumber = (
   return null
 }
 
+const normalizeChanceMoneyAmountToWon = (value: number | null) => {
+  if (value == null || !Number.isFinite(value)) {
+    return null
+  }
+
+  const raw = Math.trunc(Math.abs(value))
+  if (raw <= 0) {
+    return null
+  }
+
+  if (raw >= MONEY_ALREADY_WON_THRESHOLD) {
+    return raw
+  }
+
+  return raw * MONEY_UNIT_SCALE
+}
+
 const getEventTileRecord = (
   event: ServerEvent
 ): Record<string, unknown> | null => {
@@ -484,9 +504,9 @@ export const resolveChanceMoneyEffectFromEvent = (
   const rawAmount =
     getRecordNumber(chanceRecord, ['power', 'amount']) ??
     getPayloadNumber(event.payload, ['power', 'amount'])
-  const amount = Math.trunc(Math.abs(rawAmount ?? 0))
+  const amount = normalizeChanceMoneyAmountToWon(rawAmount)
 
-  if (!Number.isFinite(amount) || amount <= 0) {
+  if (amount == null || !Number.isFinite(amount) || amount <= 0) {
     return null
   }
 

--- a/src/components/board/gameBoardEventQueueUtils.ts
+++ b/src/components/board/gameBoardEventQueueUtils.ts
@@ -32,8 +32,8 @@ export type ChanceMoneyEffect = {
   amount: number
 }
 
-const MONEY_UNIT_SCALE = 10_000
-const MONEY_ALREADY_WON_THRESHOLD = 10_000_000
+export const MONEY_UNIT_SCALE = 10_000
+export const MONEY_ALREADY_WON_THRESHOLD = 10_000_000
 
 export const FAST_MOVE_ANIMATION_OPTIONS = {
   initialDelayMs: 200,
@@ -324,7 +324,7 @@ const getRecordNumber = (
   return null
 }
 
-const normalizeChanceMoneyAmountToWon = (value: number | null) => {
+export const normalizeChanceMoneyAmountToWon = (value: number | null) => {
   if (value == null || !Number.isFinite(value)) {
     return null
   }

--- a/src/components/board/useBoardEventQueue.test.tsx
+++ b/src/components/board/useBoardEventQueue.test.tsx
@@ -37,7 +37,7 @@ const setupHook = ({
 }: {
   enabled?: boolean
   paused?: boolean
-  onEventConsumed?: (event: { type: string }) => void
+  onEventConsumed?: (event: { type: string }) => boolean | void
 } = {}) => {
   const setStatus = vi.fn()
   const setDice1 = vi.fn()
@@ -80,6 +80,72 @@ const setupHook = ({
       rerender({
         isEnabled: nextEnabled,
         isPaused: nextPaused,
+      }),
+  }
+}
+
+const setupHookWithDynamicCallback = ({
+  enabled = true,
+  paused = false,
+  onEventConsumed,
+}: {
+  enabled?: boolean
+  paused?: boolean
+  onEventConsumed?: (event: { type: string }) => boolean | void
+}) => {
+  const setStatus = vi.fn()
+  const setDice1 = vi.fn()
+  const setDice2 = vi.fn()
+  const onEventAnimation = vi.fn()
+
+  const { rerender } = renderHook(
+    ({
+      isEnabled,
+      isPaused,
+      callback,
+    }: {
+      isEnabled: boolean
+      isPaused: boolean
+      callback?: (event: { type: string }) => boolean | void
+    }) =>
+      useBoardEventQueue({
+        enabled: isEnabled,
+        paused: isPaused,
+        playersRef,
+        tiles,
+        setStatus,
+        setDice1,
+        setDice2,
+        onEventAnimation,
+        onEventConsumed: callback,
+      }),
+    {
+      initialProps: {
+        isEnabled: enabled,
+        isPaused: paused,
+        callback: onEventConsumed,
+      },
+    }
+  )
+
+  return {
+    setStatus,
+    setDice1,
+    setDice2,
+    onEventAnimation,
+    rerender: ({
+      enabled: nextEnabled = enabled,
+      paused: nextPaused = paused,
+      onEventConsumed: nextOnEventConsumed = onEventConsumed,
+    }: {
+      enabled?: boolean
+      paused?: boolean
+      onEventConsumed?: (event: { type: string }) => boolean | void
+    } = {}) =>
+      rerender({
+        isEnabled: nextEnabled,
+        isPaused: nextPaused,
+        callback: nextOnEventConsumed,
       }),
   }
 }
@@ -227,5 +293,115 @@ describe('useBoardEventQueue', () => {
 
     expect(onEventConsumed).toHaveBeenCalledTimes(1)
     expect(useGameStore.getState().eventQueue).toHaveLength(0)
+  })
+
+  it('does not auto-consume next event when onEventConsumed requests immediate pause', () => {
+    useGameStore.getState().enqueueEvents([
+      {
+        type: 'DICE_ROLLED',
+        playerId: 1,
+        payload: { dice: [4, 4], total: 8 },
+      },
+      {
+        type: 'PLAYER_MOVED',
+        playerId: 1,
+        tileIndex: 1,
+      },
+    ])
+
+    const onEventConsumed = vi.fn((event: { type: string }) => {
+      if (event.type === 'DICE_ROLLED') {
+        return true
+      }
+      return undefined
+    })
+
+    const { rerender } = setupHook({ onEventConsumed })
+
+    expect(useGameStore.getState().eventQueue).toHaveLength(1)
+
+    vi.advanceTimersByTime(2000)
+    expect(useGameStore.getState().eventQueue).toHaveLength(1)
+
+    rerender({ paused: true })
+    expect(useGameStore.getState().eventQueue).toHaveLength(1)
+
+    rerender({ paused: false })
+    expect(useGameStore.getState().eventQueue).toHaveLength(0)
+    expect(onEventConsumed).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps queue paused even when new events are enqueued before paused prop updates', () => {
+    useGameStore.getState().enqueueEvents([
+      {
+        type: 'DICE_ROLLED',
+        playerId: 1,
+        payload: { dice: [6, 6], total: 12 },
+      },
+    ])
+
+    const onEventConsumed = vi.fn((event: { type: string }) => {
+      if (event.type === 'DICE_ROLLED') {
+        return true
+      }
+      return undefined
+    })
+
+    const { rerender } = setupHook({ onEventConsumed })
+
+    useGameStore.getState().enqueueEvents([
+      {
+        type: 'PLAYER_MOVED',
+        playerId: 1,
+        tileIndex: 1,
+      },
+    ])
+
+    vi.advanceTimersByTime(2000)
+    expect(useGameStore.getState().eventQueue).toHaveLength(1)
+
+    rerender({ paused: true })
+    rerender({ paused: false })
+    expect(useGameStore.getState().eventQueue).toHaveLength(0)
+    expect(onEventConsumed).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps immediate pause even if onEventConsumed callback identity changes', () => {
+    useGameStore.getState().enqueueEvents([
+      {
+        type: 'DICE_ROLLED',
+        playerId: 1,
+        payload: { dice: [2, 2], total: 4 },
+      },
+      {
+        type: 'PLAYER_MOVED',
+        playerId: 1,
+        tileIndex: 1,
+        payload: { fromIndex: 0, toIndex: 1 },
+      },
+    ])
+
+    const callbackV1 = vi.fn((event: { type: string }) =>
+      event.type === 'DICE_ROLLED' ? true : undefined
+    )
+    const callbackV2 = vi.fn((event: { type: string }) =>
+      event.type === 'DICE_ROLLED' ? true : undefined
+    )
+
+    const { rerender } = setupHookWithDynamicCallback({
+      onEventConsumed: callbackV1,
+    })
+
+    expect(useGameStore.getState().eventQueue).toHaveLength(1)
+
+    rerender({ onEventConsumed: callbackV2 })
+    vi.advanceTimersByTime(2000)
+    expect(useGameStore.getState().eventQueue).toHaveLength(1)
+
+    rerender({ paused: true, onEventConsumed: callbackV2 })
+    rerender({ paused: false, onEventConsumed: callbackV2 })
+    expect(useGameStore.getState().eventQueue).toHaveLength(0)
+    expect(callbackV1).toHaveBeenCalledTimes(1)
+    expect(callbackV2).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/components/board/useBoardEventQueue.ts
+++ b/src/components/board/useBoardEventQueue.ts
@@ -20,7 +20,7 @@ interface UseBoardEventQueueParams {
   setDice1: Dispatch<SetStateAction<number>>
   setDice2: Dispatch<SetStateAction<number>>
   onEventAnimation?: (kind: BoardEventAnimationKind) => void
-  onEventConsumed?: (event: ServerEvent) => void
+  onEventConsumed?: (event: ServerEvent) => boolean | void
 }
 
 export function useBoardEventQueue({
@@ -36,6 +36,30 @@ export function useBoardEventQueue({
 }: UseBoardEventQueueParams) {
   const consumingRef = useRef(false)
   const consumeTimerRef = useRef<number | null>(null)
+  const pausedRef = useRef(paused)
+  const immediatePauseRef = useRef(false)
+  const immediatePauseObservedExternalPauseRef = useRef(false)
+  pausedRef.current = paused
+  if (immediatePauseRef.current) {
+    if (paused) {
+      immediatePauseObservedExternalPauseRef.current = true
+    } else if (immediatePauseObservedExternalPauseRef.current) {
+      immediatePauseRef.current = false
+      immediatePauseObservedExternalPauseRef.current = false
+    }
+  }
+
+  useEffect(() => {
+    return () => {
+      if (consumeTimerRef.current !== null) {
+        window.clearTimeout(consumeTimerRef.current)
+        consumeTimerRef.current = null
+      }
+      consumingRef.current = false
+      immediatePauseRef.current = false
+      immediatePauseObservedExternalPauseRef.current = false
+    }
+  }, [])
 
   useEffect(() => {
     if (!enabled) {
@@ -55,7 +79,12 @@ export function useBoardEventQueue({
     }
 
     const consumeIfPossible = () => {
-      if (disposed || consumingRef.current || paused) {
+      if (
+        disposed ||
+        consumingRef.current ||
+        pausedRef.current ||
+        immediatePauseRef.current
+      ) {
         return
       }
 
@@ -72,10 +101,15 @@ export function useBoardEventQueue({
         return
       }
 
-      onEventConsumed?.(nextEvent)
+      const shouldPauseImmediately = onEventConsumed?.(nextEvent) === true
+      if (shouldPauseImmediately) {
+        immediatePauseRef.current = true
+        if (pausedRef.current) {
+          immediatePauseObservedExternalPauseRef.current = true
+        }
+      }
 
-      // Keep the event visible to render logic during consume callback execution.
-      // This avoids a frame where pending move data disappears before animation starts.
+      const animationKind = resolveBoardEventAnimationKind(nextEvent)
       useGameStore.getState().consumeNextEvent()
 
       if (import.meta.env.DEV) {
@@ -97,7 +131,12 @@ export function useBoardEventQueue({
         setStatus(statusText)
       }
 
-      onEventAnimation?.(resolveBoardEventAnimationKind(nextEvent))
+      onEventAnimation?.(animationKind)
+
+      if (shouldPauseImmediately) {
+        consumingRef.current = false
+        return
+      }
 
       const delayMs = getBoardEventConsumeDelayMs(nextEvent)
       consumeTimerRef.current = window.setTimeout(() => {

--- a/src/components/board/useBoardEventQueue.ts
+++ b/src/components/board/useBoardEventQueue.ts
@@ -40,14 +40,6 @@ export function useBoardEventQueue({
   const immediatePauseRef = useRef(false)
   const immediatePauseObservedExternalPauseRef = useRef(false)
   pausedRef.current = paused
-  if (immediatePauseRef.current) {
-    if (paused) {
-      immediatePauseObservedExternalPauseRef.current = true
-    } else if (immediatePauseObservedExternalPauseRef.current) {
-      immediatePauseRef.current = false
-      immediatePauseObservedExternalPauseRef.current = false
-    }
-  }
 
   useEffect(() => {
     return () => {
@@ -60,6 +52,22 @@ export function useBoardEventQueue({
       immediatePauseObservedExternalPauseRef.current = false
     }
   }, [])
+
+  useEffect(() => {
+    if (!immediatePauseRef.current) {
+      return
+    }
+
+    if (paused) {
+      immediatePauseObservedExternalPauseRef.current = true
+      return
+    }
+
+    if (immediatePauseObservedExternalPauseRef.current) {
+      immediatePauseRef.current = false
+      immediatePauseObservedExternalPauseRef.current = false
+    }
+  }, [paused])
 
   useEffect(() => {
     if (!enabled) {

--- a/src/components/game/controls/RollButton.test.tsx
+++ b/src/components/game/controls/RollButton.test.tsx
@@ -2,21 +2,89 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import RollButton from './RollButton'
 
+const rollButtonRuntime = {
+  turnTimeoutSec: 30,
+  turnTimerKey: 1,
+  timeLeft: 30,
+}
+
 vi.mock('../../../stores/game.store', () => ({
   useGameStore: (
     selector: (state: {
       turnTimeoutSec: number
       turnTimerKey: number
     }) => unknown
-  ) => selector({ turnTimeoutSec: 30, turnTimerKey: 1 }),
+  ) =>
+    selector({
+      turnTimeoutSec: rollButtonRuntime.turnTimeoutSec,
+      turnTimerKey: rollButtonRuntime.turnTimerKey,
+    }),
 }))
 
 vi.mock('../../../hooks/game/useGameTimer', () => ({
-  useGameTimer: () => [30],
+  useGameTimer: () => [rollButtonRuntime.timeLeft],
 }))
 
 describe('RollButton', () => {
-  it('기본 모드에서 ROLL 버튼이 onRoll을 호출한다', () => {
+  it('0초가 되면 roll 모드에서 onRoll을 자동으로 1회 호출한다', () => {
+    rollButtonRuntime.timeLeft = 0
+    rollButtonRuntime.turnTimerKey = 1
+    const onRoll = vi.fn()
+
+    const { rerender } = render(<RollButton isMyTurn={true} onRoll={onRoll} />)
+
+    expect(onRoll).toHaveBeenCalledTimes(1)
+
+    rerender(<RollButton isMyTurn={true} onRoll={onRoll} />)
+    expect(onRoll).toHaveBeenCalledTimes(1)
+  })
+
+  it('0초 자동 호출은 turnTimerKey가 바뀌면 같은 모드에서 다시 1회 호출된다', () => {
+    rollButtonRuntime.timeLeft = 0
+    rollButtonRuntime.turnTimerKey = 3
+    const onRoll = vi.fn()
+
+    const { rerender } = render(<RollButton isMyTurn={true} onRoll={onRoll} />)
+    expect(onRoll).toHaveBeenCalledTimes(1)
+
+    rollButtonRuntime.turnTimerKey = 4
+    rerender(<RollButton isMyTurn={true} onRoll={onRoll} />)
+
+    expect(onRoll).toHaveBeenCalledTimes(2)
+  })
+
+  it('0초가 되면 end_turn 모드에서 onEndTurn을 자동으로 1회 호출한다', () => {
+    rollButtonRuntime.timeLeft = 0
+    rollButtonRuntime.turnTimerKey = 5
+    const onRoll = vi.fn()
+    const onEndTurn = vi.fn()
+
+    render(
+      <RollButton
+        isMyTurn={true}
+        mode="end_turn"
+        onRoll={onRoll}
+        onEndTurn={onEndTurn}
+      />
+    )
+
+    expect(onEndTurn).toHaveBeenCalledTimes(1)
+    expect(onRoll).not.toHaveBeenCalled()
+  })
+
+  it('0초여도 조작 권한이 없으면 자동 호출하지 않는다', () => {
+    rollButtonRuntime.timeLeft = 0
+    rollButtonRuntime.turnTimerKey = 6
+    const onRoll = vi.fn()
+
+    render(<RollButton isMyTurn={false} onRoll={onRoll} />)
+
+    expect(onRoll).not.toHaveBeenCalled()
+  })
+
+  it('기본 모드에서 ROLL 버튼은 onRoll을 호출한다', () => {
+    rollButtonRuntime.timeLeft = 30
+    rollButtonRuntime.turnTimerKey = 7
     const onRoll = vi.fn()
 
     render(<RollButton isMyTurn={true} onRoll={onRoll} />)
@@ -26,7 +94,9 @@ describe('RollButton', () => {
     expect(screen.getByText('ROLL')).toBeInTheDocument()
   })
 
-  it('end_turn 모드에서 END 버튼이 onEndTurn을 호출한다', () => {
+  it('end_turn 모드에서 END 버튼은 onEndTurn을 호출한다', () => {
+    rollButtonRuntime.timeLeft = 30
+    rollButtonRuntime.turnTimerKey = 8
     const onRoll = vi.fn()
     const onEndTurn = vi.fn()
 
@@ -45,7 +115,9 @@ describe('RollButton', () => {
     expect(screen.getByText('END')).toBeInTheDocument()
   })
 
-  it('end_turn 모드에서 onEndTurn이 없으면 버튼이 비활성화된다', () => {
+  it('end_turn 모드에서 onEndTurn이 없으면 버튼은 비활성화된다', () => {
+    rollButtonRuntime.timeLeft = 30
+    rollButtonRuntime.turnTimerKey = 9
     const onRoll = vi.fn()
 
     render(<RollButton isMyTurn={true} mode="end_turn" onRoll={onRoll} />)

--- a/src/components/game/controls/RollButton.tsx
+++ b/src/components/game/controls/RollButton.tsx
@@ -29,6 +29,7 @@ const RollControl: React.FC<RollControlProps> = ({
   const dashArray = 251 // Approx circumference for r=40
   const dashOffset = dashArray * (1 - timeLeft / (turnTimeoutSec || 30))
   const previousTimeLeftRef = useRef<number | null>(null)
+  const lastAutoActionKeyRef = useRef<string | null>(null)
   const [shouldAnimate, setShouldAnimate] = useState(false)
 
   useEffect(() => {
@@ -41,6 +42,26 @@ const RollControl: React.FC<RollControlProps> = ({
 
     previousTimeLeftRef.current = timeLeft
   }, [timeLeft])
+
+  useEffect(() => {
+    if (timeLeft !== 0 || !canClick) {
+      return
+    }
+
+    const autoActionKey = `${turnTimerKey}:${mode}`
+    if (lastAutoActionKeyRef.current === autoActionKey) {
+      return
+    }
+
+    lastAutoActionKeyRef.current = autoActionKey
+
+    if (isEndTurnMode) {
+      onEndTurn?.()
+      return
+    }
+
+    onRoll()
+  }, [canClick, isEndTurnMode, mode, onEndTurn, onRoll, timeLeft, turnTimerKey])
 
   return (
     <div className="flex items-center gap-6">

--- a/src/hooks/game/useGameState.test.tsx
+++ b/src/hooks/game/useGameState.test.tsx
@@ -6,6 +6,8 @@ type SetupOptions = {
   mockEnabled?: boolean
   socketConnected?: boolean
   localGameId?: string | null
+  sessionGameId?: string | null
+  sessionSyncedAt?: string | null
   currentTurn?: string | number | null
   revision?: number
   playersLength?: number
@@ -23,6 +25,8 @@ async function setupUseGameState(options: SetupOptions) {
   const runtime = {
     accessToken: options.accessToken,
     localGameId: options.localGameId ?? null,
+    sessionGameId: options.sessionGameId ?? options.localGameId ?? null,
+    sessionSyncedAt: options.sessionSyncedAt ?? null,
     currentTurn: options.currentTurn ?? null,
     revision: options.revision ?? 0,
     playersLength: options.playersLength ?? 0,
@@ -33,6 +37,7 @@ async function setupUseGameState(options: SetupOptions) {
 
   const socketHandlers = new Map<string, (...args: unknown[]) => void>()
   const connectSocketWithAuthIfNeeded = vi.fn()
+  const socketDisconnectMock = vi.fn()
   const emitGameSync = vi.fn()
   const emitGameSyncTimer = vi.fn()
   const teardownHandlers = vi.fn()
@@ -63,7 +68,7 @@ async function setupUseGameState(options: SetupOptions) {
           socketHandlers.delete(event)
         }
       }),
-      disconnect: vi.fn(),
+      disconnect: socketDisconnectMock,
     },
     connectSocketWithAuthIfNeeded,
   }))
@@ -73,20 +78,24 @@ async function setupUseGameState(options: SetupOptions) {
     emitGameSyncTimer,
   }))
   vi.doMock('../../stores/game.store', () => {
+    const buildState = () => ({
+      currentPlayerId: runtime.currentTurn,
+      currentTurn: runtime.currentTurn,
+      phase: runtime.phase,
+      isGameOver: runtime.isGameOver,
+      gameId: runtime.localGameId,
+      players: createPlayers(runtime.playersLength),
+      session: {
+        roomId: 'room-1',
+        gameId: runtime.sessionGameId,
+        transport: 'event-socket',
+        syncedAt: runtime.sessionSyncedAt,
+      },
+    })
+
     const useGameStore = (
-      selector: (state: {
-        currentPlayerId: string | number | null
-        currentTurn: string | number | null
-        phase: string
-        isGameOver: boolean
-      }) => unknown
-    ) =>
-      selector({
-        currentPlayerId: runtime.currentTurn,
-        currentTurn: runtime.currentTurn,
-        phase: runtime.phase,
-        isGameOver: runtime.isGameOver,
-      })
+      selector: (state: ReturnType<typeof buildState>) => unknown
+    ) => selector(buildState())
 
     ;(
       useGameStore as typeof useGameStore & {
@@ -97,6 +106,12 @@ async function setupUseGameState(options: SetupOptions) {
           revision: number
           phase: string
           isGameOver: boolean
+          session: {
+            roomId: string | null
+            gameId: string | null
+            transport: string | null
+            syncedAt: string | null
+          }
         }
       }
     ).getState = () => ({
@@ -108,6 +123,12 @@ async function setupUseGameState(options: SetupOptions) {
       revision: runtime.revision,
       phase: runtime.phase,
       isGameOver: runtime.isGameOver,
+      session: {
+        roomId: 'room-1',
+        gameId: runtime.sessionGameId,
+        transport: 'event-socket',
+        syncedAt: runtime.sessionSyncedAt,
+      },
     })
 
     return { useGameStore }
@@ -119,6 +140,7 @@ async function setupUseGameState(options: SetupOptions) {
     useGameState,
     runtime,
     socketHandlers,
+    socketDisconnectMock,
     connectSocketWithAuthIfNeeded,
     emitGameSync,
     emitGameSyncTimer,
@@ -156,7 +178,7 @@ describe('useGameState', () => {
     expect(emitGameSyncTimer).not.toHaveBeenCalled()
   })
 
-  it('소켓 reconnect 시 기존 local state가 있어도 current revision 기준으로 game sync를 재요청한다', async () => {
+  it('reconnect 시에는 local state 유무와 무관하게 full sync를 재요청한다', async () => {
     const {
       useGameState,
       socketHandlers,
@@ -168,6 +190,8 @@ describe('useGameState', () => {
       mockEnabled: false,
       socketConnected: false,
       localGameId: 'game-2',
+      sessionGameId: 'game-2',
+      sessionSyncedAt: '2026-04-09T00:00:00.000Z',
       revision: 3,
       playersLength: 2,
       tilesLength: 2,
@@ -192,7 +216,7 @@ describe('useGameState', () => {
     expect(emitGameSync).toHaveBeenCalledTimes(2)
     expect(emitGameSync).toHaveBeenNthCalledWith(2, {
       gameId: 'game-2',
-      knownRevision: 3,
+      knownRevision: -1,
     })
     expect(emitGameSyncTimer).toHaveBeenCalledTimes(2)
   })
@@ -288,6 +312,7 @@ describe('useGameState', () => {
       localGameId: 'game-old',
       revision: 9,
       playersLength: 4,
+      tilesLength: 4,
     })
 
     renderHook(() => useGameState('game-new'))
@@ -296,5 +321,32 @@ describe('useGameState', () => {
       gameId: 'game-new',
       knownRevision: -1,
     })
+  })
+
+  it('mock 모드에서 초기 동기화 전에는 isInitialSyncPending=true를 반환한다', async () => {
+    const { useGameState, runtime, socketDisconnectMock } =
+      await setupUseGameState({
+        accessToken: null,
+        mockEnabled: true,
+        localGameId: null,
+        sessionGameId: null,
+        sessionSyncedAt: null,
+        playersLength: 0,
+        tilesLength: 0,
+      })
+
+    const { result, rerender } = renderHook(() => useGameState('game-mock'))
+
+    expect(socketDisconnectMock).toHaveBeenCalledTimes(1)
+    expect(result.current.isInitialSyncPending).toBe(true)
+
+    runtime.localGameId = 'game-mock'
+    runtime.sessionGameId = 'game-mock'
+    runtime.sessionSyncedAt = '2026-04-09T00:00:00.000Z'
+    runtime.playersLength = 2
+    runtime.tilesLength = 2
+    rerender()
+
+    expect(result.current.isInitialSyncPending).toBe(false)
   })
 })

--- a/src/hooks/game/useGameState.ts
+++ b/src/hooks/game/useGameState.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { IS_SOCKET_MOCK_ENABLED } from '../../config/env'
 import { useAuthStore } from '../../features/auth/session/store'
 import { connectSocketWithAuthIfNeeded, socket } from '../../lib/socket'
@@ -21,7 +21,35 @@ export const useGameState = (gameId: string | null) => {
   const currentTurn = useGameStore((state) => {
     return state.currentPlayerId ?? state.currentTurn
   })
+  const storeGameId = useGameStore((state) => state.gameId)
+  const sessionGameId = useGameStore((state) => state.session.gameId)
+  const sessionSyncedAt = useGameStore((state) => state.session.syncedAt)
+  const playerCount = useGameStore((state) => state.players.length)
   const isGameFinished = isGameOver || phase === 'finished'
+  const [isInitialSyncPending, setIsInitialSyncPending] = useState(false)
+
+  useEffect(() => {
+    if (!USE_GAME_SOCKET_MOCK || !gameId || isGameFinished) {
+      setIsInitialSyncPending(false)
+      return
+    }
+
+    const resolvedStoreGameId = storeGameId ?? sessionGameId
+    const isSyncedForCurrentGame =
+      resolvedStoreGameId != null &&
+      String(resolvedStoreGameId) === String(gameId) &&
+      playerCount > 0 &&
+      sessionSyncedAt != null
+
+    setIsInitialSyncPending(!isSyncedForCurrentGame)
+  }, [
+    gameId,
+    isGameFinished,
+    playerCount,
+    sessionGameId,
+    sessionSyncedAt,
+    storeGameId,
+  ])
 
   useEffect(() => {
     if (!gameId) {
@@ -66,7 +94,7 @@ export const useGameState = (gameId: string | null) => {
 
       if (!force && !gameChanged && hasUsableLocalState) return
 
-      const shouldForceFullSync = gameChanged || !hasUsableLocalState
+      const shouldForceFullSync = force || gameChanged || !hasUsableLocalState
 
       emitGameSync({
         gameId,
@@ -126,5 +154,5 @@ export const useGameState = (gameId: string | null) => {
     emitGameSyncTimer({ gameId })
   }, [gameId, currentTurn, isGameFinished])
 
-  return {}
+  return { isInitialSyncPending }
 }

--- a/src/lib/bgm.test.ts
+++ b/src/lib/bgm.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+class AudioMock {
+  static instances: AudioMock[] = []
+
+  src: string
+  loop = false
+  volume = 1
+  paused = true
+  currentTime = 0
+  play = vi.fn(async () => {
+    this.paused = false
+  })
+  pause = vi.fn(() => {
+    this.paused = true
+  })
+
+  constructor(src: string) {
+    this.src = src
+    AudioMock.instances.push(this)
+  }
+}
+
+const getLastAudioInstance = () => {
+  const instance = AudioMock.instances[AudioMock.instances.length - 1]
+  if (!instance) {
+    throw new Error('Expected Audio instance to be created')
+  }
+  return instance
+}
+
+describe('bgm manager', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    AudioMock.instances = []
+    vi.stubGlobal('Audio', AudioMock as unknown as typeof Audio)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('retries playback on interaction while play is requested', async () => {
+    const { playBgm } = await import('./bgm')
+
+    playBgm()
+    await Promise.resolve()
+
+    const audio = getLastAudioInstance()
+    expect(audio.play).toHaveBeenCalledTimes(1)
+
+    audio.paused = true
+    document.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+    await Promise.resolve()
+    expect(audio.play).toHaveBeenCalledTimes(2)
+  })
+
+  it('stops interaction-driven replay after stopBgm', async () => {
+    const { playBgm, stopBgm } = await import('./bgm')
+
+    playBgm()
+    await Promise.resolve()
+
+    const audio = getLastAudioInstance()
+    expect(audio.play).toHaveBeenCalledTimes(1)
+
+    stopBgm()
+    audio.paused = true
+    document.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+    await Promise.resolve()
+    expect(audio.play).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/lib/bgm.ts
+++ b/src/lib/bgm.ts
@@ -1,9 +1,8 @@
 /**
- * ?�� 글로벌 BGM 매니?�
- *
- * 1) initBgm(): ???�작 ???�출. ?��???�??�터?�션?�로 ?�디?��? 미리 unlock.
- * 2) playBgm(): 게임 ?�이지 진입 ???�출. unlock ?�어 ?�으�?즉시 ?�생.
- * 3) stopBgm(): 게임 ?�장 ???�출. ?��?.
+ * Global BGM manager.
+ * 1) initBgm(): register interaction listeners to unlock media playback.
+ * 2) playBgm(): request continuous gameplay BGM.
+ * 3) stopBgm(): stop playback and reset position.
  */
 
 const BGM_SRC = '/audio/game-bgm.mp3'
@@ -23,11 +22,11 @@ function getOrCreateAudio(): HTMLAudioElement {
 }
 
 /**
- * ?��? ?�터?�션 ???�디??unlock (+ ?�생 ?��?중이�?바로 ?�생)
+ * Unlock media playback on first user interaction.
  */
 function onInteraction() {
   if (unlocked) {
-    // ?��? unlock ?? ?�생 ?��??�태�??�생 ?�도.
+    // Already unlocked: if BGM should be playing, retry playback.
     if (wantPlay) {
       const a = getOrCreateAudio()
       if (a.paused) {
@@ -37,7 +36,7 @@ function onInteraction() {
     return
   }
 
-  // unlock ?�도
+  // Attempt unlock by starting muted playback once.
   const a = getOrCreateAudio()
   const savedVolume = a.volume
   a.volume = 0
@@ -70,15 +69,15 @@ function addListeners() {
 }
 
 /**
- * ???�작 ???�출. ?��? ?�터?�션 감�?�??�작?�니??
- * ?�디???�일?� ?�직 로드?��? ?�습?�다.
+ * Initialize listeners for user interaction unlock flow.
+ * Audio instance is lazily created only when needed.
  */
 export function initBgm() {
   addListeners()
 }
 
 /**
- * BGM ?�생 ?�작.
+ * Start BGM playback.
  */
 export function playBgm() {
   wantPlay = true
@@ -89,13 +88,12 @@ export function playBgm() {
       unlocked = true
     })
     .catch(() => {
-      // ?�동?�생 차단 ???�터?�션 리스?�로 ?��?
       // interaction listeners stay active while BGM should play
     })
 }
 
 /**
- * BGM ?��?.
+ * Stop BGM playback.
  */
 export function stopBgm() {
   wantPlay = false

--- a/src/lib/bgm.ts
+++ b/src/lib/bgm.ts
@@ -1,9 +1,9 @@
 /**
- * 🎵 글로벌 BGM 매니저
+ * ?�� 글로벌 BGM 매니?�
  *
- * 1) initBgm(): 앱 시작 시 호출. 유저의 첫 인터랙션으로 오디오를 미리 unlock.
- * 2) playBgm(): 게임 페이지 진입 시 호출. unlock 되어 있으면 즉시 재생.
- * 3) stopBgm(): 게임 퇴장 시 호출. 정지.
+ * 1) initBgm(): ???�작 ???�출. ?��???�??�터?�션?�로 ?�디?��? 미리 unlock.
+ * 2) playBgm(): 게임 ?�이지 진입 ???�출. unlock ?�어 ?�으�?즉시 ?�생.
+ * 3) stopBgm(): 게임 ?�장 ???�출. ?��?.
  */
 
 const BGM_SRC = '/audio/game-bgm.mp3'
@@ -23,11 +23,11 @@ function getOrCreateAudio(): HTMLAudioElement {
 }
 
 /**
- * 유저 인터랙션 시 오디오 unlock (+ 재생 대기 중이면 바로 재생)
+ * ?��? ?�터?�션 ???�디??unlock (+ ?�생 ?��?중이�?바로 ?�생)
  */
 function onInteraction() {
   if (unlocked) {
-    // 이미 unlock 됨. 재생 대기 상태면 재생 시도.
+    // ?��? unlock ?? ?�생 ?��??�태�??�생 ?�도.
     if (wantPlay) {
       const a = getOrCreateAudio()
       if (a.paused) {
@@ -37,7 +37,7 @@ function onInteraction() {
     return
   }
 
-  // unlock 시도
+  // unlock ?�도
   const a = getOrCreateAudio()
   const savedVolume = a.volume
   a.volume = 0
@@ -49,7 +49,6 @@ function onInteraction() {
         a.currentTime = 0
       }
       a.volume = savedVolume
-      removeListeners()
     })
     .catch(() => {
       a.volume = savedVolume
@@ -71,32 +70,32 @@ function addListeners() {
 }
 
 /**
- * 앱 시작 시 호출. 유저 인터랙션 감지를 시작합니다.
- * 오디오 파일은 아직 로드하지 않습니다.
+ * ???�작 ???�출. ?��? ?�터?�션 감�?�??�작?�니??
+ * ?�디???�일?� ?�직 로드?��? ?�습?�다.
  */
 export function initBgm() {
   addListeners()
 }
 
 /**
- * BGM 재생 시작.
+ * BGM ?�생 ?�작.
  */
 export function playBgm() {
   wantPlay = true
+  addListeners()
   const a = getOrCreateAudio()
   a.play()
     .then(() => {
       unlocked = true
-      removeListeners()
     })
     .catch(() => {
-      // 자동재생 차단 → 인터랙션 리스너로 대기
-      addListeners()
+      // ?�동?�생 차단 ???�터?�션 리스?�로 ?��?
+      // interaction listeners stay active while BGM should play
     })
 }
 
 /**
- * BGM 정지.
+ * BGM ?��?.
  */
 export function stopBgm() {
   wantPlay = false

--- a/src/pages/GamePage.chanceDeferred.test.tsx
+++ b/src/pages/GamePage.chanceDeferred.test.tsx
@@ -1,0 +1,314 @@
+import { forwardRef, useEffect } from 'react'
+import { Route, Routes } from 'react-router-dom'
+import { act, cleanup, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import GamePage from './GamePage'
+import { useAuthStore } from '../features/auth/session/store'
+import { useGameStore } from '../stores/game.store'
+import { createAuthSessionFixture } from '../test/fixtures'
+import { renderWithProviders } from '../test/renderWithProviders'
+import type { Player, ServerEvent } from '../types/domain'
+
+const { useGameStateMock } = vi.hoisted(() => ({
+  useGameStateMock: vi.fn(),
+}))
+
+vi.mock('../config/env', () => ({
+  IS_DEMO_MOCK_ENABLED: false,
+  IS_SOCKET_MOCK_ENABLED: false,
+  SHOW_GAME_DEBUG_OVERLAY: false,
+  SHOULD_ENABLE_MSW: true,
+}))
+
+vi.mock('react-router-dom', async () => {
+  const actual =
+    await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return {
+    ...actual,
+    useNavigate: () => vi.fn(),
+  }
+})
+
+vi.mock('../hooks/game/useGameState', () => ({
+  useGameState: useGameStateMock,
+}))
+
+vi.mock('../hooks/game/useDiceRoll', () => ({
+  useDiceRoll: () => vi.fn(),
+}))
+
+vi.mock('../hooks/game/useTurn', () => ({
+  useTurn: () => true,
+}))
+
+vi.mock('../lib/socket', () => ({
+  socket: {
+    on: vi.fn(),
+    off: vi.fn(),
+    connected: true,
+    disconnect: vi.fn(),
+  },
+}))
+
+vi.mock('../lib/bgm', () => ({
+  playBgm: vi.fn(),
+  stopBgm: vi.fn(),
+}))
+
+vi.mock('../services/socket/game.handler', () => ({
+  emitPromptResponse: vi.fn(),
+  emitGameAction: vi.fn(),
+}))
+
+vi.mock('../pages/waiting-room/socket/socket', () => ({
+  sendWaitingRoomChat: vi.fn(),
+}))
+
+vi.mock('../features/presence/online-users/onlineUsersSocket', () => ({
+  requestOnlineUsersSnapshotSync: vi.fn(),
+}))
+
+vi.mock('./game/api', () => ({
+  leaveRoomFromGame: vi.fn(),
+  getGameLeaveErrorMessage: vi.fn(() => 'leave failed'),
+}))
+
+vi.mock('../components/game/modals/promptModalMapping', () => ({
+  isPromptHandledByBoardModal: () => false,
+}))
+
+vi.mock('../components/game/controls/RollButton', () => ({
+  default: () => null,
+}))
+
+vi.mock('../components/game/modals/ExitGameModal', () => ({
+  default: () => null,
+}))
+
+vi.mock('../components/game/GlobalEffectModal', () => ({
+  default: () => null,
+}))
+
+vi.mock('../features/room-chat/RoomChat', () => ({
+  default: () => null,
+}))
+
+vi.mock('../features/room-chat/DevRoomChatControlPanel', () => ({
+  DevRoomChatControlPanel: () => null,
+}))
+
+vi.mock('../components/game/panels/PlayerPanel', () => ({
+  default: ({
+    player,
+  }: {
+    player: { id: string; money: number; totalAssets: number }
+  }) => (
+    <div data-testid={`panel-${player.id}`}>
+      money:{player.money}|assets:{player.totalAssets}
+    </div>
+  ),
+}))
+
+vi.mock('../components/board/GameBoard', () => ({
+  default: forwardRef<
+    HTMLDivElement,
+    {
+      onBlockingModalChange?: (blocked: boolean) => void
+      onChanceMoneyEffect?: (effect: {
+        playerId: string
+        chanceType: 'GAIN_MONEY' | 'LOSE_MONEY'
+        amount: number
+      }) => void
+    }
+  >(function MockBoard({ onBlockingModalChange, onChanceMoneyEffect }, ref) {
+    useEffect(() => {
+      onBlockingModalChange?.(false)
+    }, [onBlockingModalChange])
+
+    return (
+      <div ref={ref}>
+        <button
+          data-testid="trigger-chance-gain"
+          type="button"
+          onClick={() =>
+            onChanceMoneyEffect?.({
+              playerId: 'user-1',
+              chanceType: 'GAIN_MONEY',
+              amount: 200,
+            })
+          }
+        >
+          chance
+        </button>
+        <button
+          data-testid="board-block"
+          type="button"
+          onClick={() => onBlockingModalChange?.(true)}
+        >
+          block
+        </button>
+        <button
+          data-testid="board-unblock"
+          type="button"
+          onClick={() => onBlockingModalChange?.(false)}
+        >
+          unblock
+        </button>
+      </div>
+    )
+  }),
+}))
+
+const createPlayer = (overrides: Partial<Player> = {}): Player => ({
+  id: 'user-1',
+  nickname: 'player-1',
+  color: '#ff0000',
+  position: 0,
+  balance: 1_000,
+  totalAssets: 1_000,
+  owned_tiles: [],
+  is_in_jail: false,
+  jail_turn_count: 0,
+  is_bankrupt: false,
+  state: 'normal',
+  ...overrides,
+})
+
+const runStoreUpdate = (callback: () => void) => {
+  act(() => {
+    callback()
+  })
+}
+
+const renderGamePage = () =>
+  renderWithProviders(
+    <Routes>
+      <Route path="/game/:gameId" element={<GamePage />} />
+    </Routes>,
+    {
+      initialEntries: [
+        {
+          pathname: '/game/game-1',
+          state: {
+            gameId: 'game-1',
+            roomId: 'room-1',
+          },
+        },
+      ],
+    }
+  )
+
+describe('GamePage chance deferred financial display', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useGameStateMock.mockReturnValue({ isInitialSyncPending: false })
+    runStoreUpdate(() => {
+      useAuthStore.setState({
+        session: createAuthSessionFixture({
+          userId: 'user-1',
+          nickname: 'player-1',
+        }),
+      })
+      useGameStore.getState().resetGame()
+      useGameStore.getState().setGameState({
+        roomId: 'room-1',
+        gameId: 'game-1',
+        currentTurn: 'user-1',
+        players: [
+          createPlayer({
+            id: 'user-1',
+            balance: 1_200,
+            totalAssets: 1_200,
+          }),
+          createPlayer({
+            id: 'user-2',
+            nickname: 'player-2',
+            color: '#0000ff',
+            balance: 1_000,
+            totalAssets: 1_000,
+          }),
+        ],
+        tiles: [],
+        messages: [],
+        phase: 'prompt',
+      })
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    runStoreUpdate(() => {
+      useAuthStore.setState({ session: null })
+      useGameStore.getState().resetGame()
+    })
+  })
+
+  it('keeps deferred chance amount until board blocking modal opens and closes once', async () => {
+    const user = userEvent.setup()
+
+    renderGamePage()
+
+    expect(screen.getByTestId('panel-user-1')).toHaveTextContent(
+      'money:1200|assets:1200'
+    )
+
+    await user.click(screen.getByTestId('trigger-chance-gain'))
+
+    expect(screen.getByTestId('panel-user-1')).toHaveTextContent(
+      'money:1000|assets:1000'
+    )
+
+    await user.click(screen.getByTestId('board-block'))
+
+    await user.click(screen.getByTestId('board-unblock'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('panel-user-1')).toHaveTextContent(
+        'money:1200|assets:1200'
+      )
+    })
+  })
+
+  it('keeps panel financials pre-effect while CHANCE_RESOLVED is queued', async () => {
+    const queuedChanceEvent: ServerEvent = {
+      type: 'CHANCE_RESOLVED',
+      playerId: 'user-1',
+      payload: {
+        chance: {
+          type: 'GAIN_MONEY',
+          amount: 200_000_000,
+        },
+      },
+    }
+
+    runStoreUpdate(() => {
+      useGameStore.getState().setGameState({
+        players: [
+          createPlayer({
+            id: 'user-1',
+            balance: 1_200_000_000,
+            totalAssets: 1_200_000_000,
+          }),
+        ],
+      })
+      useGameStore.getState().enqueueEvents([queuedChanceEvent])
+    })
+
+    renderGamePage()
+
+    expect(screen.getByTestId('panel-user-1')).toHaveTextContent(
+      'money:1000000000|assets:1000000000'
+    )
+
+    runStoreUpdate(() => {
+      useGameStore.getState().consumeNextEvent()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('panel-user-1')).toHaveTextContent(
+        'money:1200000000|assets:1200000000'
+      )
+    })
+  })
+})

--- a/src/pages/GamePage.mockSoloPlay.test.tsx
+++ b/src/pages/GamePage.mockSoloPlay.test.tsx
@@ -21,12 +21,14 @@ const {
   diceRollMock,
   emitPromptResponseMock,
   emitGameActionMock,
+  useGameStateMock,
   navigateMock,
   boardRollDiceMock,
 } = vi.hoisted(() => ({
   diceRollMock: vi.fn(),
   emitPromptResponseMock: vi.fn(),
   emitGameActionMock: vi.fn(),
+  useGameStateMock: vi.fn(),
   navigateMock: vi.fn(),
   boardRollDiceMock: vi.fn(),
 }))
@@ -58,7 +60,7 @@ vi.mock('../features/presence/online-users/onlineUsersSocket', () => ({
 }))
 
 vi.mock('../hooks/game/useGameState', () => ({
-  useGameState: vi.fn(),
+  useGameState: useGameStateMock,
 }))
 
 vi.mock('../hooks/game/useDiceRoll', () => ({
@@ -229,6 +231,7 @@ function renderGamePage() {
 describe('GamePage mock solo play', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    useGameStateMock.mockReturnValue({ isInitialSyncPending: false })
     class MockAudio {
       play() {
         return Promise.resolve()
@@ -352,5 +355,24 @@ describe('GamePage mock solo play', () => {
       choice: 'CONFIRM',
       payload: undefined,
     })
+  })
+
+  it('holds game board render while mock initial sync is pending', () => {
+    useGameStateMock.mockReturnValue({ isInitialSyncPending: true })
+    resetAndSetTestGameState({
+      roomId: 'room-1',
+      gameId: 'game-1',
+      currentTurn: 'user-1',
+      phase: 'rolling',
+      players: [],
+      tiles: [],
+      messages: [],
+      prompt: null,
+      pendingAction: null,
+    })
+
+    renderGamePage()
+
+    expect(screen.queryByTestId('mock-board-game')).not.toBeInTheDocument()
   })
 })

--- a/src/pages/GamePage.test.tsx
+++ b/src/pages/GamePage.test.tsx
@@ -29,6 +29,7 @@ const {
   sendWaitingRoomChatMock,
   emitChatEvent,
   emitGameActionMock,
+  useGameStateMock,
   socketOnMock,
   socketOffMock,
   navigateMock,
@@ -43,6 +44,7 @@ const {
   return {
     sendWaitingRoomChatMock: vi.fn(),
     emitGameActionMock: vi.fn(),
+    useGameStateMock: vi.fn(),
     socketOnMock: vi.fn(
       (event: string, handler: (payload: unknown) => void) => {
         const nextHandlers = handlers.get(event) ?? new Set()
@@ -101,7 +103,7 @@ vi.mock('../features/presence/online-users/onlineUsersSocket', () => ({
 }))
 
 vi.mock('../hooks/game/useGameState', () => ({
-  useGameState: vi.fn(),
+  useGameState: useGameStateMock,
 }))
 
 vi.mock('../hooks/game/useDiceRoll', () => ({
@@ -392,6 +394,7 @@ describe('GamePage chat flow', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     useTurnMock.mockReturnValue(false)
+    useGameStateMock.mockReturnValue({ isInitialSyncPending: false })
     setTestGameDebugOverlayVisible(false)
 
     setTestAuthSession(

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -26,7 +26,12 @@ import {
   emitPromptResponse,
 } from '../services/socket/game.handler'
 import { useGameStore } from '../stores/game.store'
-import type { GamePromptChoice, GameRanking, PlayerId } from '../types/domain'
+import type {
+  GamePromptChoice,
+  GameRanking,
+  PlayerId,
+  ServerEvent,
+} from '../types/domain'
 import {
   findBoardCurrentPlayerIndex,
   mapStorePlayersToBoardPlayers,
@@ -40,6 +45,11 @@ import {
   type PendingGameChatEcho,
 } from './game/gameChat'
 import { getGameLeaveErrorMessage, leaveRoomFromGame } from './game/api'
+import {
+  clearMockGameResumeContext,
+  readMockGameResumeContext,
+  writeMockGameResumeContext,
+} from './game/mockGameResumeStorage'
 import { sendWaitingRoomChat } from './waiting-room/socket/socket'
 import type {
   ChatEventPayload,
@@ -91,6 +101,115 @@ type ChanceMoneyEffectPayload = {
   playerId: string
   chanceType: 'GAIN_MONEY' | 'LOSE_MONEY'
   amount: number
+}
+
+const MONEY_UNIT_SCALE = 10_000
+const MONEY_ALREADY_WON_THRESHOLD = 10_000_000
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null
+
+const getRecordString = (
+  record: Record<string, unknown> | null | undefined,
+  keys: string[]
+) => {
+  if (!record) {
+    return null
+  }
+
+  for (const key of keys) {
+    const raw = record[key]
+    if (typeof raw === 'string' && raw.trim() !== '') {
+      return raw
+    }
+  }
+
+  return null
+}
+
+const getRecordNumber = (
+  record: Record<string, unknown> | null | undefined,
+  keys: string[]
+) => {
+  if (!record) {
+    return null
+  }
+
+  for (const key of keys) {
+    const raw = record[key]
+    if (typeof raw === 'number' && Number.isFinite(raw)) {
+      return raw
+    }
+    if (typeof raw === 'string' && raw.trim() !== '') {
+      const parsed = Number.parseFloat(raw)
+      if (Number.isFinite(parsed)) {
+        return parsed
+      }
+    }
+  }
+
+  return null
+}
+
+const normalizeChanceMoneyAmountToWon = (value: number | null) => {
+  if (value == null || !Number.isFinite(value)) {
+    return null
+  }
+
+  const normalized = Math.trunc(Math.abs(value))
+  if (normalized <= 0) {
+    return null
+  }
+
+  if (normalized >= MONEY_ALREADY_WON_THRESHOLD) {
+    return normalized
+  }
+
+  return normalized * MONEY_UNIT_SCALE
+}
+
+const resolveQueuedChanceMoneyEffect = (
+  event: ServerEvent
+): ChanceMoneyEffectPayload | null => {
+  if (typeof event.type !== 'string') {
+    return null
+  }
+
+  if (event.type.trim().toUpperCase() !== 'CHANCE_RESOLVED') {
+    return null
+  }
+
+  if (event.playerId == null) {
+    return null
+  }
+
+  const eventRecord = isRecord(event) ? event : null
+  const payloadRecord = isRecord(event.payload) ? event.payload : null
+  const chanceRecord =
+    (isRecord(eventRecord?.chance) ? eventRecord.chance : null) ??
+    (isRecord(payloadRecord?.chance) ? payloadRecord.chance : null)
+  const chanceType = getRecordString(chanceRecord, ['type'])
+    ?.trim()
+    .toUpperCase()
+
+  if (chanceType !== 'GAIN_MONEY' && chanceType !== 'LOSE_MONEY') {
+    return null
+  }
+
+  const rawAmount =
+    getRecordNumber(chanceRecord, ['power', 'amount']) ??
+    getRecordNumber(payloadRecord, ['power', 'amount'])
+  const amount = normalizeChanceMoneyAmountToWon(rawAmount)
+
+  if (amount == null || amount <= 0) {
+    return null
+  }
+
+  return {
+    playerId: String(event.playerId),
+    chanceType,
+    amount,
+  }
 }
 
 const toComparablePlayerId = (playerId: PlayerId | null | undefined) =>
@@ -174,6 +293,7 @@ const GamePage: React.FC = () => {
   const messages = useGameStore((s) => s.messages)
   const storePlayers = useGameStore((s) => s.players)
   const storeTiles = useGameStore((s) => s.tiles)
+  const eventQueue = useGameStore((s) => s.eventQueue)
   const gameResult = useGameStore((s) => s.gameResult)
   const isGameOver = useGameStore((s) => s.isGameOver)
   const winnerId = useGameStore((s) => s.winnerId)
@@ -187,13 +307,37 @@ const GamePage: React.FC = () => {
   const clearPrompt = useGameStore((s) => s.clearPrompt)
   const activeGlobalEffect = useGameStore((s) => s.activeGlobalEffect)
   const resetGame = useGameStore((s) => s.resetGame)
+  const mockResumeContext = useMemo(() => {
+    if (!USE_GAME_SOCKET_MOCK) {
+      return null
+    }
+
+    const storedContext = readMockGameResumeContext()
+    if (!storedContext) {
+      return null
+    }
+
+    if (
+      routeGameId != null &&
+      String(storedContext.gameId) !== String(routeGameId)
+    ) {
+      return null
+    }
+
+    return storedContext
+  }, [routeGameId])
   const activeGameId =
     locationState?.gameId ??
     routeGameId ??
     storeGameId ??
     gameSession.gameId ??
+    mockResumeContext?.gameId ??
     null
-  const activeRoomId = locationState?.roomId ?? gameSession.roomId ?? null
+  const activeRoomId =
+    locationState?.roomId ??
+    gameSession.roomId ??
+    mockResumeContext?.roomId ??
+    null
   const lastRoomSnapshot = locationState?.lastRoomSnapshot ?? null
   const [promptSubmittingChoice, setPromptSubmittingChoice] = useState<
     string | null
@@ -205,6 +349,10 @@ const GamePage: React.FC = () => {
     useState(false)
   const [deferredPlayerFinancialById, setDeferredPlayerFinancialById] =
     useState<Record<string, DeferredPlayerFinancialSnapshot>>({})
+  const [
+    hasObservedBoardBlockingModalForDeferredFinancial,
+    setHasObservedBoardBlockingModalForDeferredFinancial,
+  ] = useState(false)
   const [isExitModalOpen, setIsExitModalOpen] = useState(false)
   const [isLeavePending, setIsLeavePending] = useState(false)
   const [isGlobalEffectModalOpen, setIsGlobalEffectModalOpen] = useState(false)
@@ -223,7 +371,19 @@ const GamePage: React.FC = () => {
     }
   }, [])
 
-  useGameState(activeGameId)
+  const { isInitialSyncPending } = useGameState(activeGameId)
+
+  useEffect(() => {
+    if (!USE_GAME_SOCKET_MOCK || !activeGameId || !activeRoomId) {
+      return
+    }
+
+    writeMockGameResumeContext({
+      gameId: String(activeGameId),
+      roomId: String(activeRoomId),
+      updatedAt: Date.now(),
+    })
+  }, [activeGameId, activeRoomId])
 
   useEffect(() => {
     if (
@@ -435,6 +595,7 @@ const GamePage: React.FC = () => {
           : currentTotalAssets + amount
       const playerId = String(targetPlayer.id)
 
+      setHasObservedBoardBlockingModalForDeferredFinancial(false)
       setDeferredPlayerFinancialById((previous) => ({
         ...previous,
         [playerId]: {
@@ -447,23 +608,92 @@ const GamePage: React.FC = () => {
   )
 
   useEffect(() => {
-    if (isBoardBlockingModalOpen) {
+    const hasDeferredFinancial =
+      Object.keys(deferredPlayerFinancialById).length > 0
+
+    if (!hasDeferredFinancial) {
+      if (hasObservedBoardBlockingModalForDeferredFinancial) {
+        setHasObservedBoardBlockingModalForDeferredFinancial(false)
+      }
       return
     }
 
-    if (Object.keys(deferredPlayerFinancialById).length === 0) {
+    if (isBoardBlockingModalOpen) {
+      if (!hasObservedBoardBlockingModalForDeferredFinancial) {
+        setHasObservedBoardBlockingModalForDeferredFinancial(true)
+      }
+      return
+    }
+
+    if (!hasObservedBoardBlockingModalForDeferredFinancial) {
       return
     }
 
     setDeferredPlayerFinancialById({})
-  }, [deferredPlayerFinancialById, isBoardBlockingModalOpen])
+    setHasObservedBoardBlockingModalForDeferredFinancial(false)
+  }, [
+    deferredPlayerFinancialById,
+    hasObservedBoardBlockingModalForDeferredFinancial,
+    isBoardBlockingModalOpen,
+  ])
+
+  const queuedChanceDeferredById = useMemo(() => {
+    if (eventQueue.length <= 0) {
+      return {}
+    }
+
+    const deferredById: Record<string, DeferredPlayerFinancialSnapshot> = {}
+
+    for (const event of eventQueue) {
+      const chanceMoneyEffect = resolveQueuedChanceMoneyEffect(event)
+      if (!chanceMoneyEffect) {
+        continue
+      }
+
+      const playerId = String(chanceMoneyEffect.playerId)
+      if (deferredById[playerId] != null) {
+        continue
+      }
+
+      const targetPlayer = storePlayers.find(
+        (player) => String(player.id) === playerId
+      )
+      if (!targetPlayer) {
+        continue
+      }
+
+      if (targetPlayer.is_bankrupt || targetPlayer.state === 'bankrupt') {
+        continue
+      }
+
+      const currentMoney = targetPlayer.balance ?? 0
+      const currentTotalAssets = targetPlayer.totalAssets ?? currentMoney
+      const previousMoney =
+        chanceMoneyEffect.chanceType === 'GAIN_MONEY'
+          ? currentMoney - chanceMoneyEffect.amount
+          : currentMoney + chanceMoneyEffect.amount
+      const previousTotalAssets =
+        chanceMoneyEffect.chanceType === 'GAIN_MONEY'
+          ? currentTotalAssets - chanceMoneyEffect.amount
+          : currentTotalAssets + chanceMoneyEffect.amount
+
+      deferredById[playerId] = {
+        money: Math.max(0, previousMoney),
+        totalAssets: Math.max(0, previousTotalAssets),
+      }
+    }
+
+    return deferredById
+  }, [eventQueue, storePlayers])
 
   const panelPlayers = useMemo(() => {
     const basePanelPlayers: PlayerPanelViewModel[] = storePlayers.map(
       (storePlayer, index) => {
         const boardPlayer = boardPlayers[index]
         const playerId = String(storePlayer.id)
-        const deferredFinancial = deferredPlayerFinancialById[playerId]
+        const deferredFinancial =
+          deferredPlayerFinancialById[playerId] ??
+          queuedChanceDeferredById[playerId]
         const money =
           deferredFinancial?.money ??
           storePlayer.balance ??
@@ -574,6 +804,7 @@ const GamePage: React.FC = () => {
     boardPlayers,
     deferredPlayerFinancialById,
     gameResult,
+    queuedChanceDeferredById,
     storePlayers,
   ])
   const currentPlayerState = boardPlayers[boardCurPlayer]
@@ -646,6 +877,9 @@ const GamePage: React.FC = () => {
     }
 
     if (!activeRoomId) {
+      if (USE_GAME_SOCKET_MOCK) {
+        clearMockGameResumeContext()
+      }
       resetGame()
       setIsExitModalOpen(false)
       navigate('/lobby', { replace: true })
@@ -663,6 +897,9 @@ const GamePage: React.FC = () => {
       requestOnlineUsersSnapshotSync({
         includeFollowUpRefresh: true,
       })
+      if (USE_GAME_SOCKET_MOCK) {
+        clearMockGameResumeContext()
+      }
       resetGame()
       setIsExitModalOpen(false)
       navigate('/lobby', { replace: true })
@@ -676,6 +913,9 @@ const GamePage: React.FC = () => {
   }
 
   const handleGameResultConfirm = () => {
+    if (USE_GAME_SOCKET_MOCK) {
+      clearMockGameResumeContext()
+    }
     resetGame()
 
     if (activeRoomId) {
@@ -750,12 +990,19 @@ const GamePage: React.FC = () => {
     isGameOver || phase === 'finished' || gameResult != null
 
   useEffect(() => {
-    if (!isFatalGameRouteError || hasFinishedGameState) {
+    if (
+      !isFatalGameRouteError ||
+      hasFinishedGameState ||
+      isInitialSyncPending
+    ) {
       return
     }
 
     setIsRecoveringFromFatalGameRoute(true)
 
+    if (USE_GAME_SOCKET_MOCK) {
+      clearMockGameResumeContext()
+    }
     resetGame()
 
     if (activeRoomId) {
@@ -772,17 +1019,25 @@ const GamePage: React.FC = () => {
   }, [
     activeRoomId,
     hasFinishedGameState,
+    isInitialSyncPending,
     isFatalGameRouteError,
     navigate,
     resetGame,
   ])
 
-  const isWaitingForServerState =
-    !USE_GAME_SOCKET_MOCK &&
+  const isWaitingForInitialMockSync =
+    USE_GAME_SOCKET_MOCK &&
     !hasFinishedGameState &&
     !isFatalGameRouteError &&
     !isRecoveringFromFatalGameRoute &&
-    storePlayers.length === 0
+    isInitialSyncPending
+  const isWaitingForServerState =
+    isWaitingForInitialMockSync ||
+    (!USE_GAME_SOCKET_MOCK &&
+      !hasFinishedGameState &&
+      !isFatalGameRouteError &&
+      !isRecoveringFromFatalGameRoute &&
+      storePlayers.length === 0)
 
   if (
     (isFatalGameRouteError || isRecoveringFromFatalGameRoute) &&

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -37,6 +37,7 @@ import {
   mapStorePlayersToBoardPlayers,
   mapStoreTilesToBoardTiles,
 } from './game/gameViewModel'
+import { normalizeChanceMoneyAmountToWon } from '../components/board/gameBoardEventQueueUtils'
 import {
   consumePendingGameChatEcho,
   createOptimisticGameChatMessage,
@@ -103,9 +104,6 @@ type ChanceMoneyEffectPayload = {
   amount: number
 }
 
-const MONEY_UNIT_SCALE = 10_000
-const MONEY_ALREADY_WON_THRESHOLD = 10_000_000
-
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null
 
@@ -149,23 +147,6 @@ const getRecordNumber = (
   }
 
   return null
-}
-
-const normalizeChanceMoneyAmountToWon = (value: number | null) => {
-  if (value == null || !Number.isFinite(value)) {
-    return null
-  }
-
-  const normalized = Math.trunc(Math.abs(value))
-  if (normalized <= 0) {
-    return null
-  }
-
-  if (normalized >= MONEY_ALREADY_WON_THRESHOLD) {
-    return normalized
-  }
-
-  return normalized * MONEY_UNIT_SCALE
 }
 
 const resolveQueuedChanceMoneyEffect = (

--- a/src/pages/game/mockGameResumeStorage.test.ts
+++ b/src/pages/game/mockGameResumeStorage.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  clearMockGameResumeContext,
+  readMockGameResumeContext,
+  writeMockGameResumeContext,
+} from './mockGameResumeStorage'
+
+describe('mockGameResumeStorage', () => {
+  afterEach(() => {
+    window.localStorage.clear()
+  })
+
+  it('writes and reads a valid resume context', () => {
+    writeMockGameResumeContext({
+      gameId: 'game-1',
+      roomId: 'room-1',
+      updatedAt: 1_775_200_000_000,
+    })
+
+    expect(readMockGameResumeContext()).toEqual({
+      gameId: 'game-1',
+      roomId: 'room-1',
+      updatedAt: 1_775_200_000_000,
+    })
+  })
+
+  it('returns null when stored value is invalid', () => {
+    window.localStorage.setItem('mock-game-resume-context-v1', '{"foo":1}')
+
+    expect(readMockGameResumeContext()).toBeNull()
+  })
+
+  it('clears stored context', () => {
+    writeMockGameResumeContext({
+      gameId: 'game-2',
+      roomId: 'room-2',
+      updatedAt: 1_775_200_000_001,
+    })
+
+    clearMockGameResumeContext()
+
+    expect(readMockGameResumeContext()).toBeNull()
+  })
+})

--- a/src/pages/game/mockGameResumeStorage.ts
+++ b/src/pages/game/mockGameResumeStorage.ts
@@ -1,0 +1,86 @@
+export type MockGameResumeContext = {
+  gameId: string
+  roomId: string
+  updatedAt: number
+}
+
+const MOCK_GAME_RESUME_STORAGE_KEY = 'mock-game-resume-context-v1'
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null
+
+const canUseStorage = () => typeof window !== 'undefined'
+
+const normalizeStoredContext = (
+  value: unknown
+): MockGameResumeContext | null => {
+  if (!isRecord(value)) {
+    return null
+  }
+
+  const gameId =
+    typeof value.gameId === 'string' && value.gameId.trim() !== ''
+      ? value.gameId
+      : null
+  const roomId =
+    typeof value.roomId === 'string' && value.roomId.trim() !== ''
+      ? value.roomId
+      : null
+  const updatedAt =
+    typeof value.updatedAt === 'number' && Number.isFinite(value.updatedAt)
+      ? Math.trunc(value.updatedAt)
+      : null
+
+  if (!gameId || !roomId || updatedAt == null) {
+    return null
+  }
+
+  return {
+    gameId,
+    roomId,
+    updatedAt,
+  }
+}
+
+export const readMockGameResumeContext = (): MockGameResumeContext | null => {
+  if (!canUseStorage()) {
+    return null
+  }
+
+  const rawValue = window.localStorage.getItem(MOCK_GAME_RESUME_STORAGE_KEY)
+  if (!rawValue) {
+    return null
+  }
+
+  try {
+    return normalizeStoredContext(JSON.parse(rawValue))
+  } catch {
+    return null
+  }
+}
+
+export const writeMockGameResumeContext = (
+  context: MockGameResumeContext
+): void => {
+  if (!canUseStorage()) {
+    return
+  }
+
+  const normalizedContext = normalizeStoredContext(context)
+  if (!normalizedContext) {
+    return
+  }
+
+  window.localStorage.setItem(
+    MOCK_GAME_RESUME_STORAGE_KEY,
+    JSON.stringify(normalizedContext)
+  )
+}
+
+export const clearMockGameResumeContext = (): void => {
+  if (!canUseStorage()) {
+    return
+  }
+
+  window.localStorage.removeItem(MOCK_GAME_RESUME_STORAGE_KEY)
+}

--- a/src/services/socket/game.handler.ts
+++ b/src/services/socket/game.handler.ts
@@ -262,10 +262,10 @@ export const setupGameHandlers = (
         console.debug('[game:patch] events to enqueue', normalizedEvents)
       }
 
-      gameStore.replaceFromSnapshot(normalizedSnapshot)
-      if (normalizedEvents.length > 0) {
-        gameStore.enqueueEvents(normalizedEvents)
-      }
+      gameStore.replaceFromSnapshotAndEnqueueEvents(
+        normalizedSnapshot,
+        normalizedEvents
+      )
       return
     }
 

--- a/src/stores/game.store.test.ts
+++ b/src/stores/game.store.test.ts
@@ -316,6 +316,59 @@ describe('game store partial updates', () => {
     expect(nextState.pendingAction).toBeNull()
   })
 
+  it('applies snapshot and events atomically in a single store update', () => {
+    const store = useGameStore.getState()
+
+    store.setGameState({
+      prompt: {
+        id: 'prompt-before',
+        type: 'BUY_OR_SKIP',
+      },
+      pendingAction: {
+        actionId: 'action-before',
+        type: 'ROLL_DICE',
+        requestedAt: Date.now(),
+      },
+      eventQueue: [],
+    })
+
+    store.replaceFromSnapshotAndEnqueueEvents(
+      {
+        roomId: 'room-1',
+        gameId: 'game-1',
+        revision: 12,
+        phase: 'prompt',
+        players: [createPlayer()],
+        tiles: [createTile()],
+        currentPlayerId: 'player-1',
+        currentTurn: 'player-1',
+        round: 4,
+        turnTimeoutSec: 30,
+        prompt: {
+          id: 'prompt-after',
+          type: 'BUY_OR_SKIP',
+        },
+        gameResult: null,
+        isGameOver: false,
+        winnerId: null,
+      },
+      [
+        {
+          type: 'DICE_ROLLED',
+          playerId: 'player-1',
+          payload: { dice: [3, 2], total: 5 },
+        },
+      ]
+    )
+
+    const nextState = useGameStore.getState()
+
+    expect(nextState.prompt?.id).toBe('prompt-after')
+    expect(nextState.pendingAction).toBeNull()
+    expect(nextState.eventQueue).toHaveLength(1)
+    expect(nextState.eventQueue[0]?.type).toBe('DICE_ROLLED')
+  })
+
   it('applies revision 0 patch envelopes and keeps current revision value', () => {
     const store = useGameStore.getState()
 

--- a/src/stores/game.store.ts
+++ b/src/stores/game.store.ts
@@ -27,6 +27,10 @@ interface GameActions {
   setGameResult: (result: GameResult) => void
   addMessage: (message: ChatMessage) => void
   replaceFromSnapshot: (snapshot: GameSnapshot) => void
+  replaceFromSnapshotAndEnqueueEvents: (
+    snapshot: GameSnapshot,
+    events: ServerEvent[]
+  ) => void
   applyPatchEnvelope: (envelope: GamePatchEnvelope) => void
   applyTimerSync: (timerSync: GameTimerSync) => void
   setPendingAction: (action: PendingGameAction | null) => void
@@ -380,6 +384,25 @@ export const useGameStore = create<GameStoreState>()(
         }
         if (!('pendingAction' in snapshot)) {
           draft.pendingAction = null
+        }
+        draft.session.roomId = snapshot.roomId ?? draft.session.roomId
+        draft.session.gameId = snapshot.gameId ?? draft.session.gameId
+        draft.session.transport = 'event-socket'
+        draft.session.syncedAt = new Date().toISOString()
+        draft.turnTimerKey = Date.now()
+      }),
+
+    replaceFromSnapshotAndEnqueueEvents: (snapshot, events) =>
+      set((draft) => {
+        Object.assign(draft, normalizeState(snapshot))
+        if (!('prompt' in snapshot)) {
+          draft.prompt = null
+        }
+        if (!('pendingAction' in snapshot)) {
+          draft.pendingAction = null
+        }
+        if (events.length > 0) {
+          draft.eventQueue.push(...events)
         }
         draft.session.roomId = snapshot.roomId ?? draft.session.roomId
         draft.session.gameId = snapshot.gameId ?? draft.session.gameId


### PR DESCRIPTION
## 🔗 관련 이슈

> closes #N/A

---

## 🛠 작업 내용

- mock 런타임에서 `DICE_ROLLED -> (더블 팝업) -> PLAYER_MOVED -> LANDED` 순서를 강제하도록 이벤트 큐 pause 타이밍을 보정했습니다.
- `useBoardEventQueue`의 effect 재실행(cleanup)에서 immediate pause 상태가 사라져 `PLAYER_MOVED`가 확인 클릭 전에 소비되던 경로를 차단했습니다.
- `GamePage`에서 `CHANCE_RESOLVED` 큐 대기 중에도 패널 금액을 pre-effect 값으로 표시하도록 deferred 계산을 보강했습니다.
- 이동 앵커(`fromIndex`) 우선 사용으로 말이 먼저 목적지에 보였다가 되돌아오는 점프 모션을 줄였습니다.
- mock 새로고침 복구 컨텍스트 저장/복구 유틸과 초기 full sync 경로를 추가해 세션 복원 안정성을 높였습니다.
- 위 변경에 대한 GamePage/GameBoard/useBoardEventQueue 회귀 테스트를 추가/보강했습니다.

---

## 🧠 Task 문서 (큰 작업이면 필수)

- plan: `docs/ai/tasks/runtime-parity-regression-guard/plan.md`
- context: `docs/ai/tasks/runtime-parity-regression-guard/context.md`
- checklist: `docs/ai/tasks/runtime-parity-regression-guard/checklist.md`

---

## 📋 TODO.md 연결

- task slug: `runtime-parity-regression-guard`
- TODO status: `Done`
- TODO entry 확인: `TODO.md`에 `- [x] \`runtime-parity-regression-guard\`` 항목 존재 확인

---

## 📚 참고한 기준 문서

- `AGENTS.md`
- `docs/ai/manuals/common.md`
- `docs/rules.md`
- `docs/testing.md`
- `docs/ai/manuals/game-runtime.md`
- `docs/socket-mock-server.md`

---

## 🧪 실행한 검증

- [x] `npm run test -- src/pages/GamePage.test.tsx src/pages/GamePage.mockSoloPlay.test.tsx src/pages/GamePage.chanceDeferred.test.tsx src/components/board/GameBoard.test.tsx src/components/board/GameBoard.doubleOrder.test.tsx src/components/board/useBoardEventQueue.test.tsx` (6 files, 54 tests passed)
- [x] `npm run test -- src/components/board/useBoardEventQueue.test.tsx src/components/board/GameBoard.doubleOrder.test.tsx` (2 files, 10 tests passed)
- [x] `npm run lint`
- [x] `npm run ai:check:game` (4 files, 55 tests passed)
- [x] `npm run ai:check:build` (build passed)
- [x] `npm run e2e:game` (2 passed)

---

## ⚠️ 남은 리스크

- mock 수동 플레이에서 더블 연속 케이스를 장시간 반복할 때, 확인 클릭 전 `PLAYER_MOVED` 로그가 재발하는지 추가 모니터링이 필요합니다.
- 이번 PR은 mock 중심 안정화이며, 실백엔드 연결 상태에서 동일 시나리오를 별도 smoke로 재검증해야 합니다.

---

## 🚧 후속 작업

- `@game` Playwright에 “더블 팝업 확인 전 PLAYER_MOVED 미소비” 단언을 추가해 재발을 자동 차단합니다.
- `runtime-parity-regression-guard` checklist에 수동 QA 증적(로그/영상) 링크를 누적합니다.
- 실서버 재연동 시점에 동일 시나리오로 mock/real parity 비교 리포트를 업데이트합니다.
