### PR TITLE
feat: 인게임 플레이어 룰북(아이콘+모달) 추가 및 자동 산출 표 적용

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,6 +6,8 @@
 
 ## In Progress
 
+- [ ] `in-game-rulebook-modal` - In-game Rulebook Modal (`docs/ai/tasks/in-game-rulebook-modal/`) - 인게임 우측 상단 `?` 아이콘으로 플레이어 룰북 모달을 열고 도시 가격/통행비/티어순을 board constants 기반 자동 산출로 제공
+
 ## Blocked
 
 ## Done

--- a/docs/ai/tasks/in-game-rulebook-modal/checklist.md
+++ b/docs/ai/tasks/in-game-rulebook-modal/checklist.md
@@ -1,0 +1,31 @@
+# Checklist
+
+## Implementation
+
+- [x] Re-read required manuals before edits.
+- [x] Add in-game rulebook entry point on `GamePage`.
+- [x] Add `GameRulebookModal` with close interactions (backdrop/Esc/button).
+- [x] Build city/toll/tier data from board constants and toll function.
+- [x] Prevent control collision by auto-closing rulebook on gameplay-critical modals.
+- [x] Keep socket/store/public contracts unchanged.
+
+## Testing
+
+- [x] `npx vitest run src/pages/game/gameRulebookModel.test.ts src/components/game/controls/RollButton.test.tsx src/pages/GamePage.test.tsx`
+- [x] `npm run lint`
+- [x] `npm run ai:check:game`
+- [x] `npm run ai:check:build`
+- [x] `npm run e2e:game`
+
+## Review
+
+- [x] Confirm R/P/C/U impact against `docs/rules.md`.
+- [x] Confirm task docs and TODO linkage are synchronized.
+- [x] Verify accessibility hooks (`aria-label`) used for stable tests.
+- [x] Record concrete validation evidence in task docs and PR body.
+- [x] Include changed files / executed validations / residual risks in final report.
+
+## Evidence (2026-04-09)
+
+- Rulebook model derivation uses `TILES`, `getTollCost`, `LEVEL_LABELS` only.
+- Rulebook open-state timer progression validated in both unit/integration and e2e.

--- a/docs/ai/tasks/in-game-rulebook-modal/context.md
+++ b/docs/ai/tasks/in-game-rulebook-modal/context.md
@@ -1,0 +1,67 @@
+# Context
+
+## Current Behavior
+
+- Game runtime UI had no in-game player rulebook entry point.
+- City price/toll/tier information existed only implicitly in board constants and runtime computation.
+- QA/support required repeated manual explanation for city economy rules during play.
+
+## Related Files
+
+- `src/pages/GamePage.tsx`
+- `src/components/game/modals/GameRulebookModal.tsx`
+- `src/pages/game/gameRulebookModel.ts`
+- `src/pages/game/gameRulebookModel.test.ts`
+- `src/pages/GamePage.test.tsx`
+- `src/components/game/controls/RollButton.tsx`
+- `e2e/game-runtime-roll-smoke.spec.ts`
+
+## Relevant Manuals
+
+- `AGENTS.md`
+- `docs/ai/manuals/common.md`
+- `docs/rules.md`
+- `docs/testing.md`
+- `docs/ai/manuals/game-runtime.md`
+
+## Constraints
+
+- Keep socket/store/public contracts unchanged.
+- Preserve gameplay semantics; rulebook is read-only UI.
+- Keep mock/real runtime behavior parity unchanged.
+- Use board constants/functions as source-of-truth for city economy table.
+
+## Decision Notes
+
+- Added a dedicated rulebook data builder module to avoid hardcoded modal table numbers.
+- Reused `LEVEL_LABELS` from board constants to keep toll labels canonical.
+- Added `aria-label` on timer for deterministic test/e2e selection instead of brittle selectors.
+- Rulebook auto-close uses existing gameplay modal visibility signals in `GamePage` only.
+
+## Session Handoff Notes
+
+- Current implementation is complete and validated; next step is PR review and merge.
+- If board constants/ruleset change, rerun rulebook model tests to detect drift immediately.
+
+## 2026-04-09 Implementation Update
+
+- Added `GameRulebookModal` with close-by-backdrop/Esc/button behaviors.
+- Added `?` icon trigger in top-right of `GamePage` (`aria-label: ���� ��� ����`).
+- Added `buildGameRulebookData()` and money formatter derived from board constants.
+- Added rulebook auto-close effect when board-blocking modal/prompt/exit modal opens.
+- Added unit tests for model derivation + formatting + tier ordering.
+- Added GamePage tests for open/close, auto-close triggers, and timer progression while open.
+- Extended `@game` smoke e2e with rulebook open/close and timer decrease verification.
+
+## 2026-04-09 Validation Evidence
+
+- `npx vitest run src/pages/game/gameRulebookModel.test.ts src/components/game/controls/RollButton.test.tsx src/pages/GamePage.test.tsx` (pass)
+- `npm run lint` (pass)
+- `npm run ai:check:game` (pass)
+- `npm run ai:check:build` (pass)
+- `npm run e2e:game` (pass)
+
+## Open Risks
+
+- Rulebook content text is static copy; future ruleset text-level changes need manual wording sync.
+- `@game` e2e still depends on runtime timing; CI resource contention can increase variability.

--- a/docs/ai/tasks/in-game-rulebook-modal/plan.md
+++ b/docs/ai/tasks/in-game-rulebook-modal/plan.md
@@ -1,0 +1,63 @@
+# Plan
+
+## Task
+
+- Task name: In-game Player Rulebook Modal
+- Task slug: in-game-rulebook-modal
+- Created at: 2026-04-09
+
+## Goal
+
+- Add a player-facing in-game rulebook opened by a corner `?` icon without changing runtime game meaning.
+- Show city price / toll / tier ordering with data derived from board source-of-truth code, not hardcoded UI numbers.
+
+## WAT Workflow
+
+1. Lock scope and source-of-truth references in task docs before edits.
+2. Implement rulebook model + modal + GamePage entry point with minimal boundary-safe changes.
+3. Add unit/integration/e2e coverage and record concrete validation evidence.
+
+## In Scope
+
+- `GamePage` corner help icon and rulebook modal open/close wiring.
+- Rulebook modal content sections for player gameplay guidance.
+- Auto-generated city/toll/tier table from `TILES`, `getTollCost`, `LEVEL_LABELS`.
+- Auto-close rulebook on board-blocking/prompt/exit modal to avoid control collision.
+- Timer visibility/assertability while rulebook is open.
+
+## Out Of Scope
+
+- Socket/store contract changes.
+- Backend API/schema/ruleset changes.
+- Runtime sequence changes for dice/event/prompt logic.
+
+## Target Files
+
+- `src/pages/GamePage.tsx`
+- `src/components/game/modals/GameRulebookModal.tsx`
+- `src/pages/game/gameRulebookModel.ts`
+- `src/pages/game/gameRulebookModel.test.ts`
+- `src/pages/GamePage.test.tsx`
+- `src/components/game/controls/RollButton.tsx`
+- `e2e/game-runtime-roll-smoke.spec.ts`
+
+## Task Tracking
+
+- TODO line: `- [ ] `in-game-rulebook-modal` - In-game Rulebook Modal (`docs/ai/tasks/in-game-rulebook-modal/`)`
+- Session brief: `npm run ai:session:brief -- in-game-rulebook-modal`
+- Reopen docs: `AGENTS.md`, `docs/ai/manuals/common.md`, `docs/rules.md`, `docs/testing.md`, `docs/ai/manuals/game-runtime.md`
+
+## Completion Criteria
+
+- Rulebook can open/close from game screen and does not block timer progression.
+- Rulebook city table is fully derived from board constants and toll function outputs.
+- Rulebook closes automatically when gameplay-critical modal surfaces appear.
+- Required validations pass and evidence is captured in task docs + PR body.
+
+## Test Plan
+
+- `npx vitest run src/pages/game/gameRulebookModel.test.ts src/components/game/controls/RollButton.test.tsx src/pages/GamePage.test.tsx`
+- `npm run lint`
+- `npm run ai:check:game`
+- `npm run ai:check:build`
+- `npm run e2e:game`

--- a/e2e/game-runtime-roll-smoke.spec.ts
+++ b/e2e/game-runtime-roll-smoke.spec.ts
@@ -35,6 +35,37 @@ test.describe('@game 게임 런타임 롤 스모크', () => {
     await page.getByRole('button', { name: /^시작$/ }).click()
     await expect(page).toHaveURL(/\/game\/game-room-\d+-\d+$/)
 
+    const rulebookOpenButton = page.getByRole('button', {
+      name: '게임 룰북 열기',
+    })
+    await expect(rulebookOpenButton).toBeVisible()
+    await rulebookOpenButton.click()
+
+    const rulebookDialog = page.getByRole('dialog', { name: '게임 룰북' })
+    await expect(rulebookDialog).toBeVisible()
+
+    const turnTimer = page.getByLabel('턴 타이머').first()
+    const beforeRulebookTimer = Number.parseInt(
+      ((await turnTimer.textContent()) ?? '').trim(),
+      10
+    )
+
+    await page.waitForTimeout(1_100)
+
+    const afterRulebookTimer = Number.parseInt(
+      ((await turnTimer.textContent()) ?? '').trim(),
+      10
+    )
+
+    expect(Number.isFinite(beforeRulebookTimer)).toBe(true)
+    expect(Number.isFinite(afterRulebookTimer)).toBe(true)
+    if (beforeRulebookTimer > 0) {
+      expect(afterRulebookTimer).toBeLessThan(beforeRulebookTimer)
+    }
+
+    await page.keyboard.press('Escape')
+    await expect(rulebookDialog).not.toBeVisible()
+
     const soloPlaySwitch = page.getByRole('switch', { name: '혼자 플레이' })
     const isSoloEnabled = await soloPlaySwitch.getAttribute('aria-checked')
     if (isSoloEnabled !== 'true') {

--- a/src/components/game/controls/RollButton.tsx
+++ b/src/components/game/controls/RollButton.tsx
@@ -96,7 +96,10 @@ const RollControl: React.FC<RollControlProps> = ({
         </div>
 
         <div className="absolute inset-0 flex items-center justify-center">
-          <span className="text-xl font-black tracking-tighter text-[#45556C]">
+          <span
+            aria-label="턴 타이머"
+            className="text-xl font-black tracking-tighter text-[#45556C]"
+          >
             {timeLeft}
           </span>
         </div>

--- a/src/components/game/modals/GameRulebookModal.tsx
+++ b/src/components/game/modals/GameRulebookModal.tsx
@@ -1,0 +1,204 @@
+import { useEffect } from 'react'
+import {
+  RULEBOOK_TOLL_LABELS,
+  type GameRulebookCityRow,
+  type GameRulebookTierSummary,
+} from '../../../pages/game/gameRulebookModel'
+
+interface GameRulebookModalProps {
+  open: boolean
+  tiers: GameRulebookTierSummary[]
+  cityRows: GameRulebookCityRow[]
+  onClose: () => void
+}
+
+const TILE_GUIDE_ROWS = [
+  {
+    label: '출발',
+    description: '시작 지점입니다. 보드를 한 바퀴 돌면 보상을 받습니다.',
+  },
+  {
+    label: '도시',
+    description: '구매/건설 가능한 칸입니다. 상대가 오면 통행비를 받습니다.',
+  },
+  {
+    label: '찬스',
+    description: '이동/금액/추가 턴 등 카드 효과가 즉시 적용됩니다.',
+  },
+  { label: '이벤트', description: '긍정/부정 이벤트 카드가 발동합니다.' },
+  { label: '여행', description: '원하는 칸으로 이동할 수 있는 특수 칸입니다.' },
+  {
+    label: '무인도/무인도로 이동',
+    description: '무인도는 3턴 휴식 상태이며, 더블이 나오면 즉시 탈출합니다.',
+  },
+]
+
+const TURN_FLOW_STEPS = [
+  '주사위를 굴립니다.',
+  '더블이면 더블 팝업 확인 후 추가 주사위 기회를 얻습니다.',
+  '말이 이동하고 도착 칸 효과(구매/통행비/찬스/이벤트)를 처리합니다.',
+  '처리가 끝나면 턴이 종료되고 다음 플레이어로 넘어갑니다.',
+]
+
+const GameRulebookModal = ({
+  open,
+  tiers,
+  cityRows,
+  onClose,
+}: GameRulebookModalProps) => {
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+
+    const handleEsc = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose()
+      }
+    }
+
+    window.addEventListener('keydown', handleEsc)
+    return () => {
+      window.removeEventListener('keydown', handleEsc)
+    }
+  }, [onClose, open])
+
+  if (!open) {
+    return null
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-40 flex items-center justify-center bg-black/50 px-4 py-6"
+      role="dialog"
+      aria-modal="true"
+      aria-label="게임 룰북"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) {
+          onClose()
+        }
+      }}
+    >
+      <div className="max-h-[92vh] w-full max-w-5xl overflow-hidden rounded-3xl bg-white shadow-[0_30px_120px_rgba(15,23,42,0.35)]">
+        <div className="flex items-center justify-between border-b border-[#E2E8F0] px-6 py-4">
+          <div>
+            <h2 className="text-xl font-black text-[#1F2A44]">게임 룰북</h2>
+            <p className="mt-1 text-sm font-semibold text-[#64748B]">
+              턴 진행, 칸 효과, 도시 가격/통행비/티어 정보를 확인하세요.
+            </p>
+          </div>
+          <button
+            type="button"
+            aria-label="룰북 닫기"
+            onClick={onClose}
+            className="rounded-lg border border-[#CBD5E1] px-3 py-1.5 text-sm font-bold text-[#334155] transition-colors hover:bg-[#F8FAFC]"
+          >
+            닫기
+          </button>
+        </div>
+
+        <div className="max-h-[calc(92vh-88px)] space-y-7 overflow-y-auto px-6 py-5">
+          <section>
+            <h3 className="text-lg font-black text-[#1F2A44]">기본 규칙</h3>
+            <ul className="mt-3 list-disc space-y-1.5 pl-5 text-sm font-medium leading-6 text-[#334155]">
+              <li>목표: 최종 총자산이 가장 높은 플레이어가 승리합니다.</li>
+              <li>파산 처리된 플레이어는 순위 계산에서 뒤로 밀립니다.</li>
+              <li>
+                턴 제한 시간(30초) 내 선택하지 않으면 자동 처리될 수 있습니다.
+              </li>
+            </ul>
+            <ol className="mt-4 list-decimal space-y-1.5 pl-5 text-sm font-medium leading-6 text-[#334155]">
+              {TURN_FLOW_STEPS.map((step) => (
+                <li key={step}>{step}</li>
+              ))}
+            </ol>
+          </section>
+
+          <section>
+            <h3 className="text-lg font-black text-[#1F2A44]">칸 종류 설명</h3>
+            <div className="mt-3 grid gap-2 md:grid-cols-2">
+              {TILE_GUIDE_ROWS.map((tileGuideRow) => (
+                <div
+                  key={tileGuideRow.label}
+                  className="rounded-xl border border-[#E2E8F0] bg-[#F8FAFC] px-3 py-2.5"
+                >
+                  <p className="text-sm font-black text-[#1E293B]">
+                    {tileGuideRow.label}
+                  </p>
+                  <p className="mt-1 text-xs font-medium leading-5 text-[#475569]">
+                    {tileGuideRow.description}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section>
+            <h3 className="text-lg font-black text-[#1F2A44]">도시 티어</h3>
+            <div className="mt-3 flex flex-wrap gap-2">
+              {tiers.map((tier) => (
+                <span
+                  key={tier.tier}
+                  className="rounded-full border border-[#BFDBFE] bg-[#EFF6FF] px-3 py-1 text-xs font-bold text-[#1D4ED8]"
+                >
+                  {tier.tierLabel}: {tier.basePriceDisplay}
+                </span>
+              ))}
+            </div>
+          </section>
+
+          <section>
+            <h3 className="text-lg font-black text-[#1F2A44]">
+              도시 가격 / 통행비 / 티어순
+            </h3>
+            <p className="mt-2 text-xs font-semibold text-[#64748B]">
+              정렬 기준: 티어 높은 순(티어 1 → 5), 같은 티어 내 보드
+              순서(tileId).
+            </p>
+            <div className="mt-3 overflow-x-auto rounded-2xl border border-[#E2E8F0]">
+              <table className="min-w-full text-left text-sm">
+                <thead className="bg-[#F8FAFC] text-[#334155]">
+                  <tr>
+                    <th className="px-3 py-2 font-black">티어</th>
+                    <th className="px-3 py-2 font-black">도시명</th>
+                    <th className="px-3 py-2 font-black">가격</th>
+                    <th className="px-3 py-2 font-black">
+                      통행비 (
+                      {`${RULEBOOK_TOLL_LABELS.land}/${RULEBOOK_TOLL_LABELS.villa}/${RULEBOOK_TOLL_LABELS.hotel}/${RULEBOOK_TOLL_LABELS.landmark}`}
+                      )
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {cityRows.map((row) => (
+                    <tr
+                      key={row.tileId}
+                      className="border-t border-[#EEF2F7] align-top text-[#1E293B]"
+                    >
+                      <td className="px-3 py-2.5 font-bold">{row.tierLabel}</td>
+                      <td className="px-3 py-2.5 font-semibold">
+                        {row.cityName}
+                      </td>
+                      <td className="px-3 py-2.5 font-semibold">
+                        {row.priceDisplay}
+                      </td>
+                      <td className="px-3 py-2.5 text-xs font-semibold leading-5 text-[#334155]">
+                        {RULEBOOK_TOLL_LABELS.land} {row.tollDisplay.land} /{' '}
+                        {RULEBOOK_TOLL_LABELS.villa} {row.tollDisplay.villa} /{' '}
+                        {RULEBOOK_TOLL_LABELS.hotel} {row.tollDisplay.hotel} /{' '}
+                        {RULEBOOK_TOLL_LABELS.landmark}{' '}
+                        {row.tollDisplay.landmark}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default GameRulebookModal

--- a/src/pages/GamePage.test.tsx
+++ b/src/pages/GamePage.test.tsx
@@ -9,6 +9,7 @@ import { useAuthStore } from '../features/auth/session/store'
 import { CHAT_MESSAGE_MAX_LENGTH } from '../constants/chat'
 import { createAuthSessionFixture } from '../test/fixtures'
 import { renderWithProviders } from '../test/renderWithProviders'
+import { useGameTimer } from '../hooks/game/useGameTimer'
 import type { Player } from '../types/domain'
 import type { WaitingRoomSnapshot } from './waiting-room/api/types'
 
@@ -182,7 +183,7 @@ vi.mock('../components/board/GameBoard', () => ({
 }))
 
 vi.mock('../components/game/controls/RollButton', () => ({
-  default: ({
+  default: function MockRollButton({
     isMyTurn,
     mode = 'roll',
     onRoll,
@@ -192,18 +193,29 @@ vi.mock('../components/game/controls/RollButton', () => ({
     mode?: 'roll' | 'end_turn'
     onRoll?: () => void
     onEndTurn?: () => void
-  }) => {
+  }) {
+    const turnTimeoutSec = useGameStore((state) => state.turnTimeoutSec)
+    const turnTimerKey = useGameStore((state) => state.turnTimerKey)
+    const [timeLeft] = useGameTimer({
+      initialTime: turnTimeoutSec,
+      resetSignal: turnTimerKey,
+    })
     const isEndTurnMode = mode === 'end_turn'
     const label = isEndTurnMode ? '턴 종료' : '주사위'
 
     return (
-      <button
-        type="button"
-        disabled={!isMyTurn}
-        onClick={isEndTurnMode ? onEndTurn : onRoll}
-      >
-        {label}
-      </button>
+      <div>
+        <span data-testid="mock-roll-timer" aria-label="턴 타이머">
+          {timeLeft}
+        </span>
+        <button
+          type="button"
+          disabled={!isMyTurn}
+          onClick={isEndTurnMode ? onEndTurn : onRoll}
+        >
+          {label}
+        </button>
+      </div>
     )
   },
 }))
@@ -491,6 +503,94 @@ describe('GamePage chat flow', () => {
     })
 
     expect(screen.getByRole('button', { name: 'Choice C' })).toBeEnabled()
+  })
+
+  it('게임 룰북 아이콘으로 모달을 열고 닫을 수 있다', async () => {
+    const user = userEvent.setup()
+
+    renderGamePage()
+
+    await user.click(screen.getByRole('button', { name: '게임 룰북 열기' }))
+    expect(
+      screen.getByRole('dialog', { name: '게임 룰북' })
+    ).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: '룰북 닫기' }))
+    expect(
+      screen.queryByRole('dialog', { name: '게임 룰북' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('룰북이 열린 상태에서 보드 블로킹 모달이 열리면 자동으로 닫힌다', async () => {
+    const user = userEvent.setup()
+
+    renderGamePage()
+
+    await user.click(screen.getByRole('button', { name: '게임 룰북 열기' }))
+    expect(
+      screen.getByRole('dialog', { name: '게임 룰북' })
+    ).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: '보드 막기' }))
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('dialog', { name: '게임 룰북' })
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  it('룰북이 열린 상태에서 prompt가 표시되면 자동으로 닫힌다', async () => {
+    const user = userEvent.setup()
+
+    renderGamePage()
+
+    await user.click(screen.getByRole('button', { name: '게임 룰북 열기' }))
+    expect(
+      screen.getByRole('dialog', { name: '게임 룰북' })
+    ).toBeInTheDocument()
+
+    setTestGameState({
+      prompt: {
+        id: 'rulebook-auto-close-prompt',
+        type: 'CONFIRM_ONLY',
+        playerId: 'user-1',
+        title: 'Prompt Open',
+        choices: [{ id: 'confirm', label: '확인', value: 'CONFIRM' }],
+      },
+    })
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('dialog', { name: '게임 룰북' })
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  it('룰북이 열린 상태에서도 턴 타이머는 계속 감소한다', async () => {
+    const user = userEvent.setup()
+
+    renderGamePage()
+
+    const timerNode = screen.getByTestId('mock-roll-timer')
+    const initial = Number.parseInt(timerNode.textContent ?? '0', 10)
+    expect(Number.isFinite(initial)).toBe(true)
+
+    await user.click(screen.getByRole('button', { name: '게임 룰북 열기' }))
+    expect(
+      screen.getByRole('dialog', { name: '게임 룰북' })
+    ).toBeInTheDocument()
+
+    await waitFor(
+      () => {
+        const next = Number.parseInt(
+          screen.getByTestId('mock-roll-timer').textContent ?? '0',
+          10
+        )
+        expect(next).toBeLessThan(initial)
+      },
+      { timeout: 2_500 }
+    )
   })
 
   it('우측 패널은 totalAssets를 우선 표시하고 그 기준으로 정렬과 왕관을 표시한다', () => {

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -1,10 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { ArrowLeft } from 'lucide-react'
+import { ArrowLeft, CircleHelp } from 'lucide-react'
 import toast from 'react-hot-toast'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
 import BoardGame, { BoardGameHandle } from '../components/board/GameBoard'
 import RollButton from '../components/game/controls/RollButton'
 import ExitGameModal from '../components/game/modals/ExitGameModal'
+import GameRulebookModal from '../components/game/modals/GameRulebookModal'
 import { isPromptHandledByBoardModal } from '../components/game/modals/promptModalMapping'
 import PlayerPanel from '../components/game/panels/PlayerPanel'
 import GlobalEffectModal from '../components/game/GlobalEffectModal'
@@ -38,6 +39,7 @@ import {
   mapStoreTilesToBoardTiles,
 } from './game/gameViewModel'
 import { normalizeChanceMoneyAmountToWon } from '../components/board/gameBoardEventQueueUtils'
+import { buildGameRulebookData } from './game/gameRulebookModel'
 import {
   consumePendingGameChatEcho,
   createOptimisticGameChatMessage,
@@ -335,6 +337,7 @@ const GamePage: React.FC = () => {
     setHasObservedBoardBlockingModalForDeferredFinancial,
   ] = useState(false)
   const [isExitModalOpen, setIsExitModalOpen] = useState(false)
+  const [isRulebookModalOpen, setIsRulebookModalOpen] = useState(false)
   const [isLeavePending, setIsLeavePending] = useState(false)
   const [isGlobalEffectModalOpen, setIsGlobalEffectModalOpen] = useState(false)
   const [isSoloPlayEnabled, setIsSoloPlayEnabled] = useState(false)
@@ -396,6 +399,7 @@ const GamePage: React.FC = () => {
     Math.max(round ?? 1, 1),
     MAX_ROUND_BADGE_VALUE
   )
+  const rulebookData = useMemo(() => buildGameRulebookData(), [])
   const activePlayerId = toComparablePlayerId(normalizedCurrentTurn)
   const canControlActiveMockTurn =
     USE_GAME_SOCKET_MOCK && (ALLOW_ALL_MOCK_TURNS || isSoloPlayEnabled)
@@ -504,6 +508,21 @@ const GamePage: React.FC = () => {
       socket.off('chat', handleChat)
     }
   }, [activeRoomId, currentUserId])
+
+  useEffect(() => {
+    if (!isRulebookModalOpen) {
+      return
+    }
+
+    if (isBoardBlockingModalOpen || isPromptVisible || isExitModalOpen) {
+      setIsRulebookModalOpen(false)
+    }
+  }, [
+    isBoardBlockingModalOpen,
+    isPromptVisible,
+    isExitModalOpen,
+    isRulebookModalOpen,
+  ])
 
   const handleSendMessage = (content: string) => {
     if (!activeRoomId) {
@@ -1062,6 +1081,16 @@ const GamePage: React.FC = () => {
           <ArrowLeft size={20} />
         </button>
       </div>
+      <div className="absolute right-6 top-6 z-70">
+        <button
+          type="button"
+          aria-label="게임 룰북 열기"
+          onClick={() => setIsRulebookModalOpen(true)}
+          className="flex h-10 w-10 items-center justify-center rounded-xl border border-[#E2E8F0] bg-white/90 text-[#245FE5] shadow-sm transition-colors hover:bg-white"
+        >
+          <CircleHelp size={20} />
+        </button>
+      </div>
 
       <div className="relative z-10 mx-auto flex h-full w-full items-center justify-between gap-8 pb-12 pt-4">
         <div className="flex h-[80%] min-h-0 w-[320px] shrink-0 flex-col">
@@ -1234,6 +1263,12 @@ const GamePage: React.FC = () => {
         isSubmitting={isLeavePending}
         onCancel={() => setIsExitModalOpen(false)}
         onConfirm={handleExitConfirm}
+      />
+      <GameRulebookModal
+        open={isRulebookModalOpen}
+        tiers={rulebookData.tiers}
+        cityRows={rulebookData.cityRows}
+        onClose={() => setIsRulebookModalOpen(false)}
       />
 
       <DevRoomChatControlPanel

--- a/src/pages/game/gameRulebookModel.test.ts
+++ b/src/pages/game/gameRulebookModel.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import { TILES, getTollCost } from '../../components/board/board.constants'
+import { buildGameRulebookData, formatRulebookMoney } from './gameRulebookModel'
+
+describe('gameRulebookModel', () => {
+  it('keeps rulebook city row count aligned with PROPERTY tiles', () => {
+    const data = buildGameRulebookData()
+    const propertyTileCount = TILES.filter(
+      (tile) => tile.type === 'PROPERTY'
+    ).length
+
+    expect(data.cityRows).toHaveLength(propertyTileCount)
+  })
+
+  it('builds city price and toll data from board constants', () => {
+    const data = buildGameRulebookData()
+    const cityRowsById = new Map(data.cityRows.map((row) => [row.tileId, row]))
+
+    for (const tile of TILES) {
+      if (tile.type !== 'PROPERTY' || typeof tile.price !== 'number') {
+        continue
+      }
+
+      const row = cityRowsById.get(tile.id)
+      expect(row).toBeDefined()
+      expect(row?.priceWon).toBe(tile.price)
+      expect(row?.tollByLevel.land).toBe(getTollCost(tile.price, 0))
+      expect(row?.tollByLevel.villa).toBe(getTollCost(tile.price, 1))
+      expect(row?.tollByLevel.hotel).toBe(getTollCost(tile.price, 2))
+      expect(row?.tollByLevel.landmark).toBe(getTollCost(tile.price, 3))
+    }
+  })
+
+  it('applies 5-tier classification and sorts rows by tier then tile id', () => {
+    const data = buildGameRulebookData()
+
+    expect(data.tiers).toHaveLength(5)
+
+    const tierSequence = data.cityRows.map((row) => row.tier)
+    const sortedTierSequence = [...tierSequence].sort(
+      (left, right) => left - right
+    )
+    expect(tierSequence).toEqual(sortedTierSequence)
+
+    for (let index = 1; index < data.cityRows.length; index += 1) {
+      const previous = data.cityRows[index - 1]
+      const current = data.cityRows[index]
+
+      if (previous.tier === current.tier) {
+        expect(previous.tileId).toBeLessThan(current.tileId)
+      }
+    }
+  })
+
+  it('formats money as 억 + 원 병기', () => {
+    expect(formatRulebookMoney(300_000_000)).toBe('3억 (300,000,000원)')
+    expect(formatRulebookMoney(150_000_000)).toBe('1.5억 (150,000,000원)')
+  })
+})

--- a/src/pages/game/gameRulebookModel.ts
+++ b/src/pages/game/gameRulebookModel.ts
@@ -1,0 +1,134 @@
+import {
+  LEVEL_LABELS,
+  TILES,
+  getTollCost,
+  type BuildingLevel,
+} from '../../components/board/board.constants'
+import { formatWon } from '../../lib/utils'
+
+const PROPERTY_BUILDING_LEVELS: readonly BuildingLevel[] = [0, 1, 2, 3]
+
+export const RULEBOOK_TOLL_LABELS = {
+  land: LEVEL_LABELS[0],
+  villa: LEVEL_LABELS[1],
+  hotel: LEVEL_LABELS[2],
+  landmark: LEVEL_LABELS[3],
+} as const
+
+export type GameRulebookCityTollByLevel = {
+  land: number
+  villa: number
+  hotel: number
+  landmark: number
+}
+
+export type GameRulebookCityTollDisplayByLevel = {
+  land: string
+  villa: string
+  hotel: string
+  landmark: string
+}
+
+export type GameRulebookCityRow = {
+  tileId: number
+  cityName: string
+  tier: number
+  tierLabel: string
+  priceWon: number
+  priceDisplay: string
+  tollByLevel: GameRulebookCityTollByLevel
+  tollDisplay: GameRulebookCityTollDisplayByLevel
+}
+
+export type GameRulebookTierSummary = {
+  tier: number
+  tierLabel: string
+  basePriceWon: number
+  basePriceDisplay: string
+}
+
+export type GameRulebookData = {
+  tiers: GameRulebookTierSummary[]
+  cityRows: GameRulebookCityRow[]
+}
+
+export const formatRulebookMoney = (won: number) =>
+  `${formatWon(won)} (${won.toLocaleString('ko-KR')}원)`
+
+const toTollByLevel = (basePriceWon: number): GameRulebookCityTollByLevel => {
+  const [land, villa, hotel, landmark] = PROPERTY_BUILDING_LEVELS.map((level) =>
+    getTollCost(basePriceWon, level)
+  ) as [number, number, number, number]
+
+  return {
+    land,
+    villa,
+    hotel,
+    landmark,
+  }
+}
+
+export const buildGameRulebookData = (): GameRulebookData => {
+  const propertyTiles = TILES.filter(
+    (tile): tile is (typeof TILES)[number] & { price: number } =>
+      tile.type === 'PROPERTY' &&
+      typeof tile.price === 'number' &&
+      Number.isFinite(tile.price)
+  )
+
+  const sortedTierPrices = [
+    ...new Set(propertyTiles.map((tile) => tile.price)),
+  ].sort((left, right) => right - left)
+
+  const tierByPrice = new Map<number, number>()
+  sortedTierPrices.forEach((priceWon, index) => {
+    tierByPrice.set(priceWon, index + 1)
+  })
+
+  const tiers = sortedTierPrices.map((priceWon, index) => {
+    const tier = index + 1
+    return {
+      tier,
+      tierLabel: `티어 ${tier}`,
+      basePriceWon: priceWon,
+      basePriceDisplay: formatRulebookMoney(priceWon),
+    }
+  })
+
+  const cityRows = propertyTiles
+    .map((tile) => {
+      const tier = tierByPrice.get(tile.price)
+      if (!tier) {
+        throw new Error(`Tier mapping is missing for city price: ${tile.price}`)
+      }
+
+      const tollByLevel = toTollByLevel(tile.price)
+
+      return {
+        tileId: tile.id,
+        cityName: tile.name,
+        tier,
+        tierLabel: `티어 ${tier}`,
+        priceWon: tile.price,
+        priceDisplay: formatRulebookMoney(tile.price),
+        tollByLevel,
+        tollDisplay: {
+          land: formatRulebookMoney(tollByLevel.land),
+          villa: formatRulebookMoney(tollByLevel.villa),
+          hotel: formatRulebookMoney(tollByLevel.hotel),
+          landmark: formatRulebookMoney(tollByLevel.landmark),
+        },
+      }
+    })
+    .sort((left, right) => {
+      if (left.tier !== right.tier) {
+        return left.tier - right.tier
+      }
+      return left.tileId - right.tileId
+    })
+
+  return {
+    tiers,
+    cityRows,
+  }
+}


### PR DESCRIPTION
## 🧠 Task 문서 (큰 작업이면 필수)

- plan: docs/ai/tasks/in-game-rulebook-modal/plan.md
- context: docs/ai/tasks/in-game-rulebook-modal/context.md
- checklist: docs/ai/tasks/in-game-rulebook-modal/checklist.md

## 📋 TODO.md 연결

- task slug: in-game-rulebook-modal
- TODO status: In Progress
- TODO entry 확인: TODO.md의 `in-game-rulebook-modal` 항목과 `docs/ai/tasks/in-game-rulebook-modal/`가 1:1로 연결됨

## 📚 참고한 기준 문서

- `AGENTS.md`
- `docs/ai/manuals/common.md`
- `docs/rules.md`
- `docs/testing.md`
- `docs/ai/manuals/game-runtime.md`

## 🧪 실행한 검증

- [x] `npx vitest run src/pages/game/gameRulebookModel.test.ts src/components/game/controls/RollButton.test.tsx src/pages/GamePage.test.tsx`
- [x] `npm run lint`
- [x] `npm run ai:check:game`
- [x] `npm run ai:check:build`
- [x] `npm run e2e:game`

## ⚠️ 남은 리스크

- 룰북 설명 문구는 정적 텍스트이므로 ruleset 정책 문구가 바뀌면 별도 문구 동기화가 필요함.
- `@game` E2E는 타이밍 의존 시나리오가 포함되어 CI 리소스 상황에 따라 수행 시간이 늘어날 수 있음.

## 🚧 후속 작업

- 머지 후 `in-game-rulebook-modal` TODO 상태를 `Done`으로 전환하고 task checklist를 최종 완료 상태로 동기화.
- ruleset 변경 주기마다 룰북 모델 테스트와 표 표시를 회귀 검증.
