### PR TITLE
docs: README 개선

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,20 @@
 # MARBLE POP
 
+[![CI](https://github.com/modoo-marble-team/Blue_Marble-frontend/actions/workflows/ci.yml/badge.svg)](https://github.com/modoo-marble-team/Blue_Marble-frontend/actions/workflows/ci.yml)
+[![Workflow Gate](https://github.com/modoo-marble-team/Blue_Marble-frontend/actions/workflows/workflow-gate.yml/badge.svg)](https://github.com/modoo-marble-team/Blue_Marble-frontend/actions/workflows/workflow-gate.yml)
+
 ## 📖 프로젝트 소개
 
 > 더 이상 보드게임은 오프라인에서만 즐기는 놀이가 아닙니다.  
 > `MARBLE POP`은 카카오 로그인 또는 게스트 입장으로 바로 참여해  
 > 로비에서 방을 찾고, 대기방에서 준비 상태를 맞추고, 게임 화면에서 실시간 턴 진행과 상호작용을 이어가는  
-> 실시간 멀티플레이 보드게임 웹 프로젝트입니다.  
-> 단순히 화면을 연결하는 데서 끝나지 않고, 로비-대기방-게임으로 이어지는 흐름을  
-> 프론트엔드에서 예측 가능하게 유지하도록 상태 관리, 실시간 이벤트 처리, mock/real 환경 분리를 함께 설계했습니다.
+> 실시간 멀티플레이 보드게임 웹 프로젝트입니다.
 
 `MARBLE POP Frontend`는 로그인 이후의 사용자 흐름을 웹에서 안정적으로 이어주는 클라이언트입니다. REST 조회는 TanStack Query로, 게임과 프레즌스 같은 실시간 상태는 Socket.IO와 Zustand로 정리하고, 개발 단계에서는 MSW와 socket mock server를 병행해 mock/real 경로를 같은 UI에서 검증할 수 있게 구성했습니다.
+
+단순한 화면 구현에서 끝나지 않고, **백엔드 없이도 실시간 시나리오를 검증할 수 있는 환경 설계**, **여러 퇴장 경로를 단일 흐름으로 안전하게 통합**, **AI 협업 기준을 저장소 구조로 강제**하는 것을 프로젝트 내에서 함께 다뤘습니다.
+
+> 기간: 2026.02 ~ 2026.03 (5주) · 팀: FE 3인, BE 3인
 
 ### 프론트엔드가 맡는 역할
 
@@ -20,9 +25,19 @@
 
 ---
 
-## :link: 배포 링크
+## 🔗 배포 링크
 
 > ### [⛪ MARBLE POP 배포 링크](https://blue-marble-frontend.vercel.app/)
+
+> **배포 환경은 mock 데모 모드로 동작합니다.**  
+> 백엔드 서버 없이도 로그인 → 로비 → 대기방 → 게임 시작까지 혼자 확인할 수 있습니다.  
+> (소켓 이벤트·채팅·DM·준비 흐름도 mock으로 재현됩니다)
+
+## ✨ 기술적 하이라이트
+
+- **백엔드 없이도 실시간 흐름 검증**: Socket.IO mock server와 개발 패널로 방 입장·준비·채팅 시나리오를 로컬에서 반복 재현. Vitest로 로직, Playwright로 브라우저 흐름을 역할별로 나눠 검증 체계 구성.
+- **퇴장 경로 단일화**: 뒤로가기·로그아웃·cleanup·beforeunload 등 여러 퇴장 경로를 하나의 공통 흐름으로 통합. in-flight 요청 재사용과 StrictMode·탭 숨김 경계 처리로 중복 API/소켓 호출 제거.
+- **AI 협업 워크플로우**: AGENTS.md 기준 문서와 CI Workflow Gate로 팀 전체 작업 기준 통일. 고위험 PR에서만 머지를 차단하고, 생성형 리뷰(Gemini)가 판단이 필요한 버그 가능성을 추가로 탐지.
 
 ---
 
@@ -32,12 +47,12 @@
 | :-------------------------------------------------------------------------------: | :--------------------------------------------------------------------------------------: |
 | <img src="./docs/project/assets/readme/home-main.png" alt="MARBLE POP 홈 화면" /> | <img src="./docs/project/assets/readme/lobby-overview.png" alt="MARBLE POP 로비 화면" /> |
 
-|                                          대기방                                          |                                        마이페이지                                        |
-| :--------------------------------------------------------------------------------------: | :--------------------------------------------------------------------------------: |
+|                                          대기방                                          |                                       마이페이지                                        |
+| :--------------------------------------------------------------------------------------: | :-------------------------------------------------------------------------------------: |
 | <img src="./docs/project/assets/readme/waiting-room.png" alt="MARBLE POP 대기방 화면" /> | <img src="./docs/project/assets/readme/my-page.png" alt="MARBLE POP 마이페이지 화면" /> |
 
-|                                       게임                                        |
-| :-------------------------------------------------------------------------------------: |
+|                                        게임                                        |
+| :--------------------------------------------------------------------------------: |
 | <img src="./docs/project/assets/readme/gameplay.png" alt="MARBLE POP 게임 화면" /> |
 
 ---
@@ -49,18 +64,19 @@ flowchart LR
     B["Browser"] --> APP["React + Vite App"]
     APP --> QUERY["TanStack Query"]
     APP --> STORE["Zustand / UI State"]
-    APP --> MOCK["MSW / Socket Mock"]
 
     QUERY --> REST["REST API"]
     STORE --> SIO["Socket.IO"]
 
     REST --> BE["Backend"]
     SIO --> BE
-    MOCK -. local dev / demo .- APP
+
+    MOCK["MSW + Socket Mock Server"] -. "mock 모드\n(백엔드 없이 검증)" .- APP
+    TEST["Vitest / Playwright"] -. "테스트" .- APP
 ```
 
-- 일반 모드에서는 REST와 Socket.IO로 백엔드와 통신합니다.
-- mock 모드에서는 MSW와 local socket mock server를 사용해 페이지 흐름과 실시간 상호작용을 로컬에서 검증합니다.
+- **일반 모드**: REST와 Socket.IO로 백엔드와 통신합니다.
+- **mock 모드**: MSW와 local socket mock server로 페이지 흐름과 실시간 상호작용을 로컬에서 검증합니다.
 - 페이지는 의도를 드러내고, 상세 흐름은 hook/controller/api 계층으로 분리하는 구조를 유지합니다.
 
 ---
@@ -74,7 +90,13 @@ flowchart LR
 │  │  ├─ lobby/                # 로비 페이지 및 방 진입 흐름
 │  │  ├─ waiting-room/         # 대기방 lifecycle, ready/start/leave
 │  │  └─ GamePage.tsx          # 게임 런타임 화면 조합
-│  ├─ features/presence/       # 접속자 목록, DM, unread badge
+│  ├─ features/
+│  │  ├─ presence/             # 접속자 목록, DM, unread badge
+│  │  └─ room-chat/            # 대기방·게임 채팅
+│  ├─ components/
+│  │  ├─ game/                 # 게임 UI 컴포넌트 (모달, 패널)
+│  │  └─ board/                # 보드 렌더링
+│  ├─ hooks/game/              # 주사위, 턴, 타이머 등 게임 보조 훅
 │  ├─ services/socket/         # socket contract adapter / emit handler
 │  ├─ stores/                  # zustand store
 │  ├─ mocks/                   # MSW mock handler
@@ -88,6 +110,8 @@ flowchart LR
 ---
 
 ## 🚀 빠르게 실행하기
+
+> **Prerequisites**: Node.js 18+
 
 ### 1. 저장소 클론 및 의존성 설치
 
@@ -109,29 +133,22 @@ cp .env.example .env.development.local
 
 ### 3. 실행 모드 선택
 
-실백엔드 연결:
+**실제 백엔드 연결:**
 
 ```bash
 npm run env:real
 npm run dev
 ```
 
-mock 기반 로컬 검증:
+**mock 기반 로컬 검증:**
 
 ```bash
+# 터미널 1 — 개발 서버
 npm run env:mock
-```
-
-별도 터미널에서 socket mock server 실행:
-
-```bash
-npm run socket:mock
-```
-
-개발 서버 실행:
-
-```bash
 npm run dev
+
+# 터미널 2 — socket mock server
+npm run socket:mock
 ```
 
 ### 4. 확인
@@ -150,7 +167,7 @@ npm run dev
 | `VITE_API_URL`              | `http://localhost:3000/api` | REST API base URL                                    |
 | `VITE_SOCKET_URL`           | `http://localhost:3000`     | Socket.IO base URL                                   |
 | `VITE_USE_SOCKET_MOCK`      | `false`                     | 개발 환경에서 MSW + socket mock 경로를 사용할지 결정 |
-| `VITE_ENABLE_DEMO_MOCK`     | `true`(배포 기본)           | 배포/데모 환경 mock 모드 강제 여부(`false`로 해제)   |
+| `VITE_ENABLE_DEMO_MOCK`     | `true` (배포 기본)          | 배포/데모 환경 mock 모드 강제 여부 (`false`로 해제)  |
 | `VITE_ALLOW_ALL_MOCK_TURNS` | `false`                     | mock 게임에서 턴 제한을 무시할지 결정                |
 
 > mock 모드를 켜면 MSW와 socket mock server 기준으로 화면 흐름을 검증합니다.  
@@ -179,33 +196,27 @@ npm run dev
 
 ---
 
-## :clipboard: 문서
+## 📋 문서
 
-### 프로젝트 내부 문서
+### 바로 시작할 때
 
-- [Project Conventions](./docs/project/conventions.md)
-- [README Screenshot Assets](./docs/project/assets/readme/README.md)
-- [Architecture Assets Guide](./docs/project/assets/architecture/README.md)
-- [API Spec Summary](./docs/project/specs/api-spec.md)
-- [ERD Summary](./docs/project/specs/erd.md)
-- [Requirements Summary](./docs/project/specs/requirements.md)
-- [Screen Spec Summary](./docs/project/specs/screen-spec.md)
-- [Table Schema Summary](./docs/project/specs/table-schema.md)
-- [Demo Video Note](./docs/project/presentations/demo-video.md)
+- [Project Conventions](./docs/project/conventions.md) — 협업 규칙, 브랜치 전략, 커밋 컨벤션
+- [API Spec Summary](./docs/project/specs/api-spec.md) — REST 엔드포인트 요약
+- [Socket Mock Server](./docs/socket-mock-server.md) — 소켓 이벤트 계약 및 도메인 규칙
 
-### 외부 명세 / 협업 문서
+### 스펙 / 설계 참고
 
 - [API 명세서](https://docs.google.com/spreadsheets/d/191cFJ97qyWzeAJm5DEqTf6SO6p8mqWBE/edit?pli=1&gid=2141226886#gid=2141226886)
-- [요구사항 정의서](https://docs.google.com/spreadsheets/d/15Lu2YYq1VlnJbam9ADfLuEq_uTMY8umN/edit?gid=919594060#gid=919594060)
-- [ERD / 소켓 명세서 Docs Repo](https://github.com/modoo-marble-team/docs/tree/main)
-- [테이블 명세서](https://docs.google.com/spreadsheets/d/1Xq0YsYCvV3xzFYTsfubVfVqsGeOol7Ah/edit?gid=507107377#gid=507107377)
-- [화면 정의서 / 와이어프레임 / 플로우 차트](https://www.figma.com/design/3yixlZLiKnWieKVFpM7n9j/%ED%8C%80%ED%94%84%EB%A1%9C%EC%A0%9D%ED%8A%B8-%EC%BA%90%EC%A3%BC%EC%96%BC-%EB%B8%8C%EB%A3%A8%EB%A7%88%EB%B8%94?node-id=0-1&t=ZohHKxxh86rbb8Fq-1)
+- [요구사항 정의서](./docs/project/specs/requirements.md) · [원본](https://docs.google.com/spreadsheets/d/15Lu2YYq1VlnJbam9ADfLuEq_uTMY8umN/edit?gid=919594060#gid=919594060)
+- [화면 정의서 / 와이어프레임 / 플로우차트](https://www.figma.com/design/3yixlZLiKnWieKVFpM7n9j/%ED%8C%80%ED%94%84%EB%A1%9C%EC%A0%9D%ED%8A%B8-%EC%BA%90%EC%A3%BC%EC%96%BC-%EB%B8%8C%EB%A3%A8%EB%A7%88%EB%B8%94?node-id=0-1&t=ZohHKxxh86rDB8Fq-1) · [화면 정의서 요약](./docs/project/specs/screen-spec.md)
+- [ERD Summary](./docs/project/specs/erd.md) · [ERD / 소켓 명세서 Docs Repo](https://github.com/modoo-marble-team/docs/tree/main)
+- [테이블 명세서](./docs/project/specs/table-schema.md) · [원본](https://docs.google.com/spreadsheets/d/1Xq0YsYCvV3xzFYTsfubVfVqsGeOol7Ah/edit?gid=507107377#gid=507107377)
 
 ---
 
 ## 🧰 사용 스택
 
-### FE
+### 핵심 스택
 
 <div align="center">
   <img src="https://img.shields.io/badge/react-20232A?style=for-the-badge&logo=react&logoColor=61DAFB">
@@ -216,15 +227,23 @@ npm run dev
   <br>
   <img src="https://img.shields.io/badge/socket.io-010101?style=for-the-badge&logo=socketdotio&logoColor=white">
   <img src="https://img.shields.io/badge/axios-5A29E4?style=for-the-badge&logo=axios&logoColor=white">
-  <img src="https://img.shields.io/badge/msw-FF6A33?style=for-the-badge&logo=mockserviceworker&logoColor=white">
   <img src="https://img.shields.io/badge/tailwind_css-06B6D4?style=for-the-badge&logo=tailwindcss&logoColor=white">
   <img src="https://img.shields.io/badge/framer_motion-0055FF?style=for-the-badge&logo=framer&logoColor=white">
-  <br>
   <img src="https://img.shields.io/badge/phaser-6D44FF?style=for-the-badge&logoColor=white">
+</div>
+
+### 테스트 · 검증
+
+<div align="center">
   <img src="https://img.shields.io/badge/vitest-6E9F18?style=for-the-badge&logo=vitest&logoColor=white">
   <img src="https://img.shields.io/badge/testing_library-E33332?style=for-the-badge&logo=testinglibrary&logoColor=white">
   <img src="https://img.shields.io/badge/playwright-2EAD33?style=for-the-badge&logo=playwright&logoColor=white">
-  <br>
+  <img src="https://img.shields.io/badge/msw-FF6A33?style=for-the-badge&logo=mockserviceworker&logoColor=white">
+</div>
+
+### 코드 품질 · 협업
+
+<div align="center">
   <img src="https://img.shields.io/badge/eslint-4B32C3?style=for-the-badge&logo=eslint&logoColor=white">
   <img src="https://img.shields.io/badge/prettier-F7B93E?style=for-the-badge&logo=prettier&logoColor=black">
   <img src="https://img.shields.io/badge/husky-181717?style=for-the-badge&logo=git&logoColor=white">
@@ -232,15 +251,15 @@ npm run dev
 
 ---
 
-## :busts_in_silhouette: 팀 동료
+## 👥 팀 동료
 
 ### FE
 
-| 이름                | 역할                                                                                                                                                                |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| <nobr>최진명</nobr> | 팀장, 랜딩·로그인·헤더·로비·접속자목록·DM·채팅·채팅창·대기방·마이페이지·게임 내 채팅 구현, 컨텍스트 정리·협업 워크플로우·테스트/검증 체계 정리, 게임 오류 수정 지원 |
-| <nobr>우재민</nobr> | 게임 소켓 계약 정규화, 스토어 상태 동기화, 호환 계층 유지 책임                                                                                                      |
-| <nobr>김재윤</nobr> | 보드 렌더 구조 유지, 이동·모달·이벤트 연출 UX 품질 책임                                                                                                             |
+| 이름                | 역할                                                                                                                                                                     |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| <nobr>최진명</nobr> | 팀장 / 랜딩·로그인·헤더·로비·접속자목록·DM·채팅·채팅창·대기방·마이페이지·게임 내 채팅 구현, 퇴장 흐름 통합·테스트 환경 설계·AI 협업 워크플로우 구축, 게임 오류 수정 지원 |
+| <nobr>우재민</nobr> | 게임 소켓 계약 정규화, 서버 권위 모델 기반 스토어 상태 동기화, gameId 기준 계약 단일화                                                                                   |
+| <nobr>김재윤</nobr> | 보드 렌더 구조 설계, 플레이어 이동·모달·이벤트 연출 UX 품질 책임                                                                                                         |
 
 ---
 


### PR DESCRIPTION
closes #675

## 🧠 Task 문서

- plan: N/A
- context: N/A
- checklist: N/A

## 📋 TODO.md 연결

- task slug: N/A
- TODO status: N/A
- TODO entry 확인: docs-only 변경, task 문서 불필요

## 📚 참고한 기준 문서

- AGENTS.md
- docs/rules.md

## 🔍 변경 내용

README 링크를 눌렀을 기술적 하이라이트를 30초 스캔으로 파악할 수 있도록 개선했습니다.

### 추가
- CI / Workflow Gate 뱃지 (상단)
- 프로젝트 기간·팀 규모 명시
- 기술적 도전 문단 (프로젝트 소개)
- 배포 링크에 mock 데모 모드 안내 — 혼자 접속해도 소켓 흐름까지 확인 가능함을 명시
- **👤 나의 기여** 섹션 신설 (배포 링크 바로 아래) — 담당 화면 + 핵심 기여 테이블
- **✨ 기술적 하이라이트** 섹션 신설 — 백엔드 없이 실시간 검증 / 퇴장 경로 단일화 / AI 워크플로우
- 아키텍처 다이어그램에 테스트 레이어(Vitest / Playwright) 추가
- 프로젝트 구조에 누락된 디렉토리 추가 (room-chat, components, hooks/game)

### 수정
- 오탈자: `실백엔드` → `실제 백엔드`
- 구형 이모지 코드 통일: `:link:` → `🔗`, `:clipboard:` → `📋`, `:busts_in_silhouette:` → `👥`
- mock 실행 흐름 bash 블록 3개 → 2개로 통합
- 스택 뱃지 그룹 분리: 핵심 스택 / 테스트·검증 / 코드 품질·협업
- 문서 섹션 그룹화: 바로 시작할 때 / 스펙 참고
- 팀 동료 역할 설명 — 기능 목록에서 기여 관점으로 보완

## 🧪 실행한 검증

- pre-push 훅 전체 통과 (lint → test → coverage → e2e:ci → build)
- docs-only 변경으로 Workflow Gate warning-only 적용

## ⚠️ 남은 리스크

- GIF/데모 영상은 미포함 (별도 자산 제작 필요 시 후속 PR)